### PR TITLE
[llama] Enable flash attention path

### DIFF
--- a/sharktank/sharktank/models/llama/llama.py
+++ b/sharktank/sharktank/models/llama/llama.py
@@ -339,6 +339,7 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         keys = xk.transpose(1, 2)
         values = xv.transpose(1, 2)
 
+        # Flash attention.
         attn_output = torch.nn.functional.scaled_dot_product_attention(xq, keys, values, attention_mask)
         attn_output = attn_output.transpose(1, 2).reshape(bs, batch_seq_len, -1)
 

--- a/sharktank/sharktank/models/llama/llama.py
+++ b/sharktank/sharktank/models/llama/llama.py
@@ -340,7 +340,9 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         values = xv.transpose(1, 2)
 
         # Flash attention.
-        attn_output = torch.nn.functional.scaled_dot_product_attention(xq, keys, values, attention_mask)
+        attn_output = torch.nn.functional.scaled_dot_product_attention(
+            xq, keys, values, attention_mask
+        )
         attn_output = attn_output.transpose(1, 2).reshape(bs, batch_seq_len, -1)
 
         # Project.

--- a/sharktank/sharktank/models/llama/llama_ref.py
+++ b/sharktank/sharktank/models/llama/llama_ref.py
@@ -209,18 +209,8 @@ class LlamaAttentionBlock(ThetaLayer):
         values = values.transpose(1, 2)
 
         # Flash attention.
-        attn_weights = torch.matmul(xq, keys.transpose(2, 3)) / math.sqrt(self.head_dim)
+        attn_output = torch.nn.functional.scaled_dot_product_attention(xq, keys, values, attention_mask)
 
-        # Apply attention mask.
-        if attention_mask is not None:
-            expected_mask_shape = (bs, 1, q_len, kv_seq_len)
-            assert (
-                attention_mask.shape == expected_mask_shape
-            ), f"Attention mask should be of size {expected_mask_shape}, but is {attention_mask.shape}"
-            attn_weights = attn_weights + attention_mask
-
-        attn_weights = F.softmax(attn_weights.float(), dim=-1).type_as(xq)
-        attn_output = torch.matmul(attn_weights, values)  # (bs, heads, slen, head_dim)
         attn_output = attn_output.transpose(1, 2).reshape(bs, q_len, -1)
 
         # Project.

--- a/sharktank/sharktank/models/llama/llama_ref.py
+++ b/sharktank/sharktank/models/llama/llama_ref.py
@@ -209,7 +209,9 @@ class LlamaAttentionBlock(ThetaLayer):
         values = values.transpose(1, 2)
 
         # Flash attention.
-        attn_output = torch.nn.functional.scaled_dot_product_attention(xq, keys, values, attention_mask)
+        attn_output = torch.nn.functional.scaled_dot_product_attention(
+            xq, keys, values, attention_mask
+        )
         attn_output = attn_output.transpose(1, 2).reshape(bs, q_len, -1)
 
         # Project.

--- a/sharktank/sharktank/models/llama/llama_ref.py
+++ b/sharktank/sharktank/models/llama/llama_ref.py
@@ -210,7 +210,6 @@ class LlamaAttentionBlock(ThetaLayer):
 
         # Flash attention.
         attn_output = torch.nn.functional.scaled_dot_product_attention(xq, keys, values, attention_mask)
-
         attn_output = attn_output.transpose(1, 2).reshape(bs, q_len, -1)
 
         # Project.


### PR DESCRIPTION
We can use `torch.nn.functional.scaled_dot_product_attention` to target hte `iree` flash attention path. Substitution is a numerically identical behavior that hits `linalg_ext.attention`.