### PR TITLE
Fix in-place elementwise ops and add addition test that runs with IREE

### DIFF
--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -133,11 +133,15 @@ def elementwise_unary(operator, x, *args, **kwargs):
         IsOfType(Tensor, PrimitiveTensor), IsOfType(Tensor, PrimitiveTensor, Number)
     )
 )
-def elementwise_binary(operator, x, y, *args, **kwargs):
+def elementwise_binary(
+    operator, x, y, out: Optional[Tensor | PrimitiveTensor] = None, *args, **kwargs
+):
     x = unbox_tensor(x)
     if isinstance(y, PrimitiveTensor):
         y = unbox_tensor(y)
-    return operator(x, y, *args, **kwargs)
+    if isinstance(out, PrimitiveTensor):
+        out = unbox_tensor(out)
+    return operator(x, y, *args, out=out, **kwargs)
 
 
 @elementwise.override(

--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -300,11 +300,28 @@ def split_elementwise_binary(
 
 @elementwise.override(SplitPrimitiveTensor, Number)
 def elementwise_binary_split_lhs_scalar_rhs(
-    operator, x: SplitPrimitiveTensor, y: Number, *args, **kwargs
+    operator,
+    x: SplitPrimitiveTensor,
+    y: Number,
+    out: SplitPrimitiveTensor = None,
+    *args,
+    **kwargs,
 ):
-    pt_xs = [unbox_tensor(pt) for pt in x.shards]
-    partials = [operator(pt_x, y, *args, **kwargs) for pt_x in pt_xs]
-    return SplitPrimitiveTensor(shard_dim=x.shard_dim, shape=x.shape, ts=partials)
+    x_shards = [unbox_tensor(pt) for pt in x.shards]
+    out_shards = (
+        [None] * len(x.shards)
+        if out is None
+        else [unbox_tensor(shard) for shard in out.shards]
+    )
+    partials = [
+        operator(x_shard, y, out=out_shard, *args, **kwargs)
+        for x_shard, out_shard in zip(x_shards, out_shards)
+    ]
+    return SplitPrimitiveTensor(
+        shard_dim=x.shard_dim,
+        shape=x.shape,
+        ts=partials,
+    )
 
 
 @elementwise.override(SplitPrimitiveTensor, Tensor)
@@ -352,6 +369,22 @@ def elementwise_binary_split_lhs_replicated_rhs(
 
     y_sharded = reshard_like(y, like=x)
     return elementwise(operator, x, y_sharded, *args, **kwargs)
+
+
+@elementwise.override(ReplicatedTensor, Number)
+def elementwise_binary_replicated_lhs_scalar_rhs(
+    operator,
+    x: ReplicatedTensor,
+    y: Number,
+    *args,
+    **kwargs,
+):
+    shards = [
+        operator(unbox_tensor(x_shard), y, *args, **kwargs) for x_shard in x.shards
+    ]
+    return ReplicatedTensor(
+        ts=shards,
+    )
 
 
 @elementwise.override(ReplicatedTensor, UnreducedTensor)

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -208,18 +208,18 @@ def elementwise(operator, *args, **kwargs) -> AnyTensor:
 
 @elementwise.trampoline
 def _elementwise_trampoline(d: SignatureDispatcher, operator, *args, **kwargs):
-    tensors = []
+    dispatch_args = []
     for a in args:
-        if isinstance(a, (Tensor, InferenceTensor)):
-            tensors.append(a)
+        if isinstance(a, (Tensor, InferenceTensor, Number)):
+            dispatch_args.append(a)
         else:
             break
-    for override in d.find_overrides(tensors):
+    for override in d.find_overrides(dispatch_args):
         result = override(operator, *args, **kwargs)
         if result is not NotImplemented:
             return override, result
     else:
-        d.fail(tensors)
+        d.fail(dispatch_args)
 
 
 @overridable

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -395,6 +395,11 @@ class InferenceTensor(ABC):
         # numbers on the lhs.
         return self.__add__(lhs)
 
+    def __iadd__(self, rhs):
+        from ..ops import elementwise
+
+        return elementwise(torch.add, self, rhs, out=self)
+
     def __mod__(self, rhs):
         from ..ops import elementwise
 

--- a/sharktank/tests/models/llama/sharded_llama_test.py
+++ b/sharktank/tests/models/llama/sharded_llama_test.py
@@ -24,6 +24,7 @@ from sharktank.utils.iree import (
     run_iree_module_function,
     prepare_iree_module_function_args,
     call_torch_module_function,
+    iree_to_torch,
 )
 import tempfile
 import torch
@@ -32,10 +33,6 @@ from iree.turbine.aot import FxProgramsBuilder, export
 import iree.runtime
 import numpy as np
 import os
-
-
-def iree_to_torch(*tensors: iree.runtime.DeviceArray) -> List[torch.Tensor]:
-    return [torch.tensor(tensor.to_host()) for tensor in tensors]
 
 
 @pytest.mark.usefixtures("caching", "path_prefix")

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -6,13 +6,23 @@
 
 import unittest
 from parameterized import parameterized
-
+import tempfile
+import pytest
+from copy import deepcopy
 import torch
 
 from sharktank import ops
 from sharktank.types import *
 from sharktank.types import sharding
 from sharktank.layers import Conv2DLayer
+from sharktank.utils.iree import (
+    get_iree_devices,
+    load_iree_module,
+    run_iree_module_function,
+    prepare_iree_module_function_args,
+    iree_to_torch,
+)
+from iree.turbine.aot import FxProgramsBuilder, export
 
 
 class AllGatherTest(unittest.TestCase):
@@ -233,6 +243,7 @@ class ConvTest(unittest.TestCase):
         assert ops.equal(expected_result, actual_result)
 
 
+@pytest.mark.usefixtures("path_prefix")
 class ElementwiseTest(unittest.TestCase):
     def testRhsAndLhsShardedAdd(self):
         a = torch.rand(4, 5, 6, dtype=torch.float32)
@@ -311,6 +322,83 @@ class ElementwiseTest(unittest.TestCase):
         assert sharded_result.shard_count == sharded_a.shard_count
         assert sharded_result.shard_dim == sharded_a.shard_dim
         actual_result = ops.reshard_like(sharded_result, expected_result)
+        torch.testing.assert_close(actual_result, expected_result)
+
+    def testInPlaceAddWithIree(self):
+        if self.path_prefix is not None:
+            self.runTestInPlaceAddWithIree(
+                path_prefix=self.path_prefix, dump_enabled=True
+            )
+        else:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                self.runTestInPlaceAddWithIree(
+                    path_prefix=f"{temp_dir}/", dump_enabled=False
+                )
+
+    def runTestInPlaceAddWithIree(self, path_prefix: str, dump_enabled: bool):
+        dtype = torch.float32
+
+        class Module(torch.nn.Module):
+            def main(self, tensor: torch.Tensor) -> torch.Tensor:
+                tensor += 1
+                # TODO: figure out why when not returning anything the export fails.
+                return torch.empty([1], dtype=dtype)
+
+        tensor = torch.tensor([1, 2, 3], dtype=dtype)
+        expected_result = torch.tensor([2, 3, 4], dtype=dtype)
+
+        module = Module()
+        fxb = FxProgramsBuilder(module)
+
+        @fxb.export_program(
+            args=(tensor,),
+            name="main",
+            strict=False,
+        )
+        def _(model, *args, **kwargs):
+            return model.main(*args, **kwargs)
+
+        if dump_enabled:
+            for program_name, ep in fxb.programs.items():
+                with open(
+                    f"{path_prefix}{program_name}.torch.fx.txt",
+                    "w",
+                ) as f:
+                    print(str(ep), file=f)
+
+        output = export(fxb)
+        if dump_enabled:
+            output.save_mlir(f"{path_prefix}program.mlir")
+
+        iree_module_path = f"{path_prefix}program.vmfb"
+        output.session.set_flags("--iree-hal-target-device=llvm-cpu")
+        output.compile(
+            save_to=iree_module_path,
+            target_backends=None,
+        )
+
+        iree_driver = "local-task"
+        iree_devices = get_iree_devices(
+            driver=iree_driver,
+            device_count=1,
+        )
+        iree_module, vm_context, vm_instance = load_iree_module(
+            module_path=iree_module_path,
+            devices=iree_devices,
+        )
+        iree_args = prepare_iree_module_function_args(
+            args=[deepcopy(tensor)], devices=iree_devices
+        )
+        run_iree_module_function(
+            args=iree_args,
+            function_name="main",
+            module=iree_module,
+            vm_context=vm_context,
+            driver=iree_driver,
+            trace_path_prefix=path_prefix if dump_enabled else None,
+            # trace_path_prefix=None
+        )
+        actual_result = iree_to_torch(*iree_args)[0]
         torch.testing.assert_close(actual_result, expected_result)
 
 


### PR DESCRIPTION
This also circumvents a potential issue with `iree.runtime.DeviceArray.to_host()` wrongly caching its results.
See https://github.com/iree-org/iree/issues/18870.