### PR TITLE
Add trace_tensors op

### DIFF
--- a/sharktank/pyproject.toml
+++ b/sharktank/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = ["iree-turbine"]
 dynamic = ["version"]  # the version is set via the `setup.py`
 
 [project.optional-dependencies]
-testing = ["pytest"]
+testing = ["pytest", "safetensors"]
 
 [project.urls]
 Repository = "https://github.com/nod-ai/SHARK-Platform"

--- a/sharktank/requirements-tests.txt
+++ b/sharktank/requirements-tests.txt
@@ -2,3 +2,4 @@ datasets==3.0.0
 parameterized
 pytest==8.0.0
 pytest-html
+safetensors==0.4.5

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -25,6 +25,7 @@ from ..types.tensors import unbox_tensor, AnyTensor
 from ._registry import AllOfType, AllOfExprs, AllOfExprsVariadic, IsOfType
 from .signatures import *
 import iree.turbine.ops.iree
+from ..utils import debugging
 
 
 @cat.override(AllOfType(Tensor, PrimitiveTensor))
@@ -434,6 +435,13 @@ def softmax_default(
 @to.override(Tensor)
 def to_default(tensor: Tensor, *args, **kwargs):
     return unbox_tensor(tensor).to(*args, **kwargs)
+
+
+@trace_tensors.override(AllOfExprsVariadic(IsOfType(Tensor, InferenceTensor)))
+def trace_tensors(key: str, *tensors: tuple[AnyTensor]):
+    if len(tensors) != 1:
+        raise ValueError("Tracing more than one tensor at a time is not supported.")
+    iree.turbine.ops.iree.trace_tensor(key, unshard(tensors[0]))
 
 
 @transfer_to_logical_device.override(Tensor)

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -53,6 +53,7 @@ __all__ = [
     "sharded_sum",
     "softmax",
     "to",
+    "trace_tensors",
     "transfer_to_logical_device",
     "transpose",
     "unflatten",
@@ -975,6 +976,23 @@ def _to_trampoline(d: SignatureDispatcher, tensor: AnyTensor, *args, **kwargs):
             return override, result
     else:
         d.fail(dispatch_args)
+
+
+@overridable
+def trace_tensors(key: str, *tensors: tuple[AnyTensor]):
+    ...
+
+
+@trace_tensors.trampoline
+def _transfer_to_logical_device_trampoline(
+    d: SignatureDispatcher, key: str, *tensors: tuple[AnyTensor]
+):
+    for override in d.find_overrides(tensors):
+        result = override(key, *tensors)
+        if result is not NotImplemented:
+            return override, result
+    else:
+        d.fail(tensors)
 
 
 @overridable


### PR DESCRIPTION
We don't have an op that dispatches to the underlying iree.turbine.ops.iree.trace_tensor.

This sets the default tracing callback to use the existing tracing functionality where we use safetensors.