### PR TITLE
[shortfin] Implement async alloc/dealloc of buffers.

### DIFF
--- a/shortfin/src/shortfin/array/array.h
+++ b/shortfin/src/shortfin/array/array.h
@@ -216,7 +216,9 @@ class SHORTFIN_API device_array
   void AddAsInvocationArgument(local::ProgramInvocation *inv,
                                local::ProgramResourceBarrier barrier) override;
   static device_array CreateFromInvocationResultRef(
-      local::ProgramInvocation *inv, iree::vm_opaque_ref ref);
+      local::ProgramInvocation *inv,
+      local::CoarseInvocationTimelineImporter *timeline_importer,
+      iree::vm_opaque_ref ref);
   static iree_vm_ref_type_t invocation_marshalable_type();
   friend class shortfin::local::ProgramInvocationMarshalableFactory;
 };

--- a/shortfin/src/shortfin/local/fiber.h
+++ b/shortfin/src/shortfin/local/fiber.h
@@ -127,8 +127,9 @@ class SHORTFIN_API Fiber : public std::enable_shared_from_this<Fiber> {
     return ScopedDevice(*this, DeviceAffinity(d));
   }
   detail::Scheduler &scheduler() { return scheduler_; }
-  detail::TimelineResource::Ref NewTimelineResource() {
-    return scheduler().NewTimelineResource(shared_ptr());
+  detail::TimelineResource::Ref NewTimelineResource(
+      detail::TimelineResourceDestructor destructor = nullptr) {
+    return scheduler().NewTimelineResource(shared_ptr(), std::move(destructor));
   }
 
  private:

--- a/shortfin/src/shortfin/local/program_interfaces.h
+++ b/shortfin/src/shortfin/local/program_interfaces.h
@@ -16,6 +16,7 @@
 
 namespace shortfin::local {
 
+class CoarseInvocationTimelineImporter;
 class ProgramInvocation;
 
 // The type of barrier that should be managed for a program resource.
@@ -63,9 +64,12 @@ class SHORTFIN_API ProgramInvocationMarshalableFactory {
   // iree::vm_opaque_ref)` static method. The type `T` must be friends with this
   // class.
   template <typename T>
-  static T CreateFromInvocationResultRef(ProgramInvocation *inv,
-                                         iree::vm_opaque_ref ref) {
-    return T::CreateFromInvocationResultRef(inv, std::move(ref));
+  static T CreateFromInvocationResultRef(
+      ProgramInvocation *inv,
+      CoarseInvocationTimelineImporter *timeline_importer,
+      iree::vm_opaque_ref ref) {
+    return T::CreateFromInvocationResultRef(inv, timeline_importer,
+                                            std::move(ref));
   }
 
   // Gets the type id that corresponds to this marshalable type.

--- a/shortfin/src/shortfin/support/iree_helpers.cc
+++ b/shortfin/src/shortfin/support/iree_helpers.cc
@@ -7,6 +7,7 @@
 #include "shortfin/support/iree_helpers.h"
 
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 
 #include <atomic>
 #include <unordered_map>
@@ -104,6 +105,15 @@ void error::AppendStatusMessage() {
   } else {
     message_.append(": <<could not print iree_status_t>>");
   }
+}
+
+std::string DebugPrintSemaphoreList(iree_hal_semaphore_list_t &sl) {
+  std::vector<std::string> parts;
+  for (unsigned i = 0; i < sl.count; ++i) {
+    parts.push_back(fmt::format("{}@{}", static_cast<void *>(sl.semaphores[i]),
+                                sl.payload_values[i]));
+  }
+  return fmt::format("({})", fmt::join(parts, ", "));
 }
 
 }  // namespace shortfin::iree

--- a/shortfin/src/shortfin/support/iree_helpers.h
+++ b/shortfin/src/shortfin/support/iree_helpers.h
@@ -354,6 +354,12 @@ using vm_opaque_ref = ::iree::vm::opaque_ref;
 template <typename T>
 using vm_ref = ::iree::vm::ref<T>;
 
+// -------------------------------------------------------------------------- //
+// Debugging
+// -------------------------------------------------------------------------- //
+
+std::string DebugPrintSemaphoreList(iree_hal_semaphore_list_t &sl);
+
 }  // namespace iree
 }  // namespace shortfin
 

--- a/shortfin/tests/invocation/mobilenet_program_test.py
+++ b/shortfin/tests/invocation/mobilenet_program_test.py
@@ -89,6 +89,7 @@ def test_invoke_mobilenet_single_per_fiber(lsys, fiber0, mobilenet_program_funct
         device_input = get_mobilenet_ref_input(device)
         (device_output,) = await mobilenet_program_function(device_input, fiber=fiber0)
         await assert_mobilenet_ref_output(device, device_output)
+        del device_output
 
     lsys.run(main())
 
@@ -106,6 +107,7 @@ def test_invoke_mobilenet_single_per_call(
             device_input, fiber=fiber0
         )
         await assert_mobilenet_ref_output(device, device_output)
+        del device_output
 
     lsys.run(main())
 
@@ -123,12 +125,14 @@ def test_invoke_mobilenet_chained_per_fiber(lsys, fiber0, mobilenet_program_func
             for _ in range(5)
         ]
 
-        await asyncio.gather(
+        gather = asyncio.gather(
             *[
                 assert_mobilenet_ref_output(device, device_output)
                 for (device_output,) in results
             ]
         )
+        del results
+        await gather
 
     lsys.run(main())
 
@@ -157,12 +161,14 @@ def test_invoke_mobilenet_parallel_per_call(
             ]
         )
 
-        await asyncio.gather(
+        gather = asyncio.gather(
             *[
                 assert_mobilenet_ref_output(device, device_output)
                 for (device_output,) in results
             ]
         )
+        del results
+        await gather
 
     lsys.run(main())
 
@@ -189,12 +195,14 @@ def test_invoke_mobilenet_parallel_per_call_explicit(
             ]
         )
 
-        await asyncio.gather(
+        gather = asyncio.gather(
             *[
                 assert_mobilenet_ref_output(device, device_output)
                 for (device_output,) in results
             ]
         )
+        del results
+        await gather
 
     lsys.run(main())
 
@@ -221,6 +229,7 @@ def test_invoke_mobilenet_multi_fiber_per_fiber(lsys, mobilenet_program_function
             )
             print(f"{self}: Program complete (+{duration()}ms)")
             await assert_mobilenet_ref_output(device, device_output)
+            del device_output
             print(f"{self} End (+{duration()}ms)")
 
     async def main():


### PR DESCRIPTION
* Device allocations are now async, queue ordered alloc/dealloc.
* Program invocations asynchronously deallocate function call results if it can. If it ever cannot, then a small tracy zone `SyncImportTimelineResource` will be emitted per result that cannot be async deallocated.
* Adds `ProgramInvocation.assume_no_alias` instance boolean to disable the assumption which allows async deallocation to work.
* Adds global `ProgramIncovation.global_no_alias` property to control process-wide.

This is a very fiddly optimization which requires (esp in multi-device cases) a number of things to line up. Tested on amdgpu and CPU with a number of sample workloads (with logging enabled and visually confirmed).

See #980 for detailed analysis and further work required.