### PR TITLE
Group llm integration test output using github ::group::

### DIFF
--- a/.github/workflows/ci-shark-ai.yml
+++ b/.github/workflows/ci-shark-ai.yml
@@ -51,15 +51,25 @@ jobs:
           path: ${{ env.PIP_CACHE_DIR }}
           key: pip-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('*requirements.txt') }}
 
-      - name: Install pip deps
+      - name: Install Pip Dependencies
         run: |
           python -m pip install --no-compile --upgrade pip
           # Note: We install in three steps in order to satisfy requirements
           # from non default locations first. Installing the PyTorch CPU
           # wheels saves multiple minutes and a lot of bandwidth on runner setup.
           pip install --no-compile -r pytorch-cpu-requirements.txt
-          pip install --no-compile -r requirements.txt -e sharktank/ shortfin/
+          pip install --no-compile -r requirements.txt
 
+      - name: Install sharktank
+        run: |
+          pip install --no-compile -e sharktank/
+
+      - name: Install shortfin
+        run: |
+          pip install --no-compile -e shortfin/
+
+      - name: Ensure iree-turbine is latest and iree are latest nightly
+        run: |
           # Install latest iree-tubrine.
           pip install --no-compile -f https://iree.dev/pip-release-links.html --src deps \
             -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"

--- a/.github/workflows/ci-shark-ai.yml
+++ b/.github/workflows/ci-shark-ai.yml
@@ -51,25 +51,15 @@ jobs:
           path: ${{ env.PIP_CACHE_DIR }}
           key: pip-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('*requirements.txt') }}
 
-      - name: Install Pip Dependencies
+      - name: Install pip deps
         run: |
           python -m pip install --no-compile --upgrade pip
           # Note: We install in three steps in order to satisfy requirements
           # from non default locations first. Installing the PyTorch CPU
           # wheels saves multiple minutes and a lot of bandwidth on runner setup.
           pip install --no-compile -r pytorch-cpu-requirements.txt
-          pip install --no-compile -r requirements.txt
+          pip install --no-compile -r requirements.txt -e sharktank/ shortfin/
 
-      - name: Install sharktank
-        run: |
-          pip install --no-compile -e sharktank/
-
-      - name: Install shortfin
-        run: |
-          pip install --no-compile -e shortfin/
-
-      - name: Ensure iree-turbine is latest and iree is latest nightly
-        run: |
           # Install latest iree-tubrine.
           pip install --no-compile -f https://iree.dev/pip-release-links.html --src deps \
             -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"

--- a/.github/workflows/ci-shark-ai.yml
+++ b/.github/workflows/ci-shark-ai.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           pip install --no-compile -e shortfin/
 
-      - name: Ensure iree-turbine is latest and iree are latest nightly
+      - name: Ensure iree-turbine is latest and iree is latest nightly
         run: |
           # Install latest iree-tubrine.
           pip install --no-compile -f https://iree.dev/pip-release-links.html --src deps \

--- a/app_tests/integration_tests/llm/conftest.py
+++ b/app_tests/integration_tests/llm/conftest.py
@@ -24,6 +24,13 @@ from .utils import (
 logger = logging.getLogger(__name__)
 
 
+def ghstartgroup(msg):
+    # check if we are in github ci
+    if os.environ.get("GITHUB_ACTIONS") != "true":
+        return ""
+    return f"\n::group::{msg}"
+
+
 @pytest.fixture(scope="module")
 def model_test_dir(request, tmp_path_factory):
     """Prepare model artifacts for starting the LLM server.
@@ -40,7 +47,9 @@ def model_test_dir(request, tmp_path_factory):
     Yields:
         Tuple[Path, Path]: The paths to the Hugging Face home and the temp dir.
     """
-    logger.info("::group::Preparing model artifacts...")
+    logger.info(
+        "Preparing model artifacts..." + ghstartgroup("Preparing model artifacts")
+    )
 
     repo_id = request.param["repo_id"]
     model_file = request.param["model_file"]
@@ -110,7 +119,7 @@ def llm_server(request, model_test_dir, available_port):
     Yields:
         subprocess.Popen: The server process that was started.
     """
-    logger.info("::group::Starting LLM server...")
+    logger.info("Starting LLM server..." + ghstartgroup("Starting LLM server"))
     hf_home, tmp_dir = model_test_dir
     model_file = request.param["model_file"]
     settings = request.param["settings"]

--- a/app_tests/integration_tests/llm/conftest.py
+++ b/app_tests/integration_tests/llm/conftest.py
@@ -40,7 +40,7 @@ def model_test_dir(request, tmp_path_factory):
     Yields:
         Tuple[Path, Path]: The paths to the Hugging Face home and the temp dir.
     """
-    logger.info("Preparing model artifacts...")
+    logger.info("::group::Preparing model artifacts...")
 
     repo_id = request.param["repo_id"]
     model_file = request.param["model_file"]
@@ -110,7 +110,7 @@ def llm_server(request, model_test_dir, available_port):
     Yields:
         subprocess.Popen: The server process that was started.
     """
-    logger.info("Starting LLM server...")
+    logger.info("::group::Starting LLM server...")
     hf_home, tmp_dir = model_test_dir
     model_file = request.param["model_file"]
     settings = request.param["settings"]

--- a/app_tests/integration_tests/llm/conftest.py
+++ b/app_tests/integration_tests/llm/conftest.py
@@ -19,23 +19,11 @@ from .utils import (
     compile_model,
     find_available_port,
     start_llm_server,
+    start_log_group,
+    end_log_group,
 )
 
 logger = logging.getLogger(__name__)
-
-
-def ghstartgroup(msg):
-    # check if we are in github ci
-    if os.environ.get("GITHUB_ACTIONS") != "true":
-        return ""
-    return f"\n::group::{msg}"
-
-
-def ghendgroup():
-    # check if we are in github ci
-    if os.environ.get("GITHUB_ACTIONS") != "true":
-        return ""
-    return "\n::endgroup::"
 
 
 @pytest.fixture(scope="module")
@@ -55,7 +43,7 @@ def model_test_dir(request, tmp_path_factory):
         Tuple[Path, Path]: The paths to the Hugging Face home and the temp dir.
     """
     logger.info(
-        "Preparing model artifacts..." + ghstartgroup("Preparing model artifacts")
+        "Preparing model artifacts..." + start_log_group("Preparing model artifacts")
     )
 
     repo_id = request.param["repo_id"]
@@ -101,7 +89,7 @@ def model_test_dir(request, tmp_path_factory):
         logger.info(f"Config: {json.dumps(config, indent=2)}")
         with open(edited_config_path, "w") as f:
             json.dump(config, f)
-        logger.info("Model artifacts setup successfully" + ghendgroup())
+        logger.info("Model artifacts setup successfully" + end_log_group())
         yield hf_home, tmp_dir
     finally:
         shutil.rmtree(tmp_dir)
@@ -126,7 +114,7 @@ def llm_server(request, model_test_dir, available_port):
     Yields:
         subprocess.Popen: The server process that was started.
     """
-    logger.info("Starting LLM server..." + ghstartgroup("Starting LLM server"))
+    logger.info("Starting LLM server..." + start_log_group("Starting LLM server"))
     hf_home, tmp_dir = model_test_dir
     model_file = request.param["model_file"]
     settings = request.param["settings"]
@@ -145,7 +133,7 @@ def llm_server(request, model_test_dir, available_port):
         parameters_path,
         settings,
     )
-    logger.info("LLM server started!" + ghendgroup())
+    logger.info("LLM server started!" + end_log_group())
     yield server_process
     # Teardown: kill the server
     server_process.terminate()

--- a/app_tests/integration_tests/llm/conftest.py
+++ b/app_tests/integration_tests/llm/conftest.py
@@ -31,6 +31,13 @@ def ghstartgroup(msg):
     return f"\n::group::{msg}"
 
 
+def ghendgroup():
+    # check if we are in github ci
+    if os.environ.get("GITHUB_ACTIONS") != "true":
+        return ""
+    return "\n::endgroup::"
+
+
 @pytest.fixture(scope="module")
 def model_test_dir(request, tmp_path_factory):
     """Prepare model artifacts for starting the LLM server.
@@ -94,7 +101,7 @@ def model_test_dir(request, tmp_path_factory):
         logger.info(f"Config: {json.dumps(config, indent=2)}")
         with open(edited_config_path, "w") as f:
             json.dump(config, f)
-        logger.info("Model artifacts setup successfully")
+        logger.info("Model artifacts setup successfully" + ghendgroup())
         yield hf_home, tmp_dir
     finally:
         shutil.rmtree(tmp_dir)
@@ -138,6 +145,7 @@ def llm_server(request, model_test_dir, available_port):
         parameters_path,
         settings,
     )
+    logger.info("LLM server started!" + ghendgroup())
     yield server_process
     # Teardown: kill the server
     server_process.terminate()

--- a/app_tests/integration_tests/llm/cpu_llm_server_test.py
+++ b/app_tests/integration_tests/llm/cpu_llm_server_test.py
@@ -82,9 +82,18 @@ def test_llm_server(llm_server, available_port):
     # Here you would typically make requests to your server
     # and assert on the responses
     assert llm_server.poll() is None
-    output = do_generate("1 2 3 4 5 ", available_port)
-    logger.info(output)
+    PROMPT = "1 2 3 4 5 "
     expected_output_prefix = "6 7 8"
+    logger.info("::group::Sending HTTP Generation Request")
+    output = do_generate(PROMPT, available_port)
+    # log to GITHUB_STEP_SUMMARY if we are in a GitHub Action
+    # using equivalent of echo "{name}={value}" >> "$GITHUB_OUTPUT"
+    if "GITHUB_ACTION" in os.environ:
+        with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+            # log prompt
+            f.write(f"- llm_prompt:`{PROMPT}`\n")
+            f.write(f"- llm_output:`{output}`\n")
+    logger.info(output)
     if not output.startswith(expected_output_prefix):
         raise AccuracyValidationException(
             f"Expected '{output}' to start with '{expected_output_prefix}'"

--- a/app_tests/integration_tests/llm/cpu_llm_server_test.py
+++ b/app_tests/integration_tests/llm/cpu_llm_server_test.py
@@ -87,10 +87,10 @@ def test_llm_server(llm_server, available_port):
     logger.info("::group::Sending HTTP Generation Request")
     output = do_generate(PROMPT, available_port)
     # log to GITHUB_STEP_SUMMARY if we are in a GitHub Action
-    # using equivalent of echo "{name}={value}" >> "$GITHUB_OUTPUT"
     if "GITHUB_ACTION" in os.environ:
-        with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+        with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
             # log prompt
+            f.write("LLM results:\n")
             f.write(f"- llm_prompt:`{PROMPT}`\n")
             f.write(f"- llm_output:`{output}`\n")
     logger.info(output)

--- a/app_tests/integration_tests/llm/cpu_llm_server_test.py
+++ b/app_tests/integration_tests/llm/cpu_llm_server_test.py
@@ -10,7 +10,7 @@ import pytest
 import requests
 import uuid
 
-from .utils import AccuracyValidationException
+from .utils import AccuracyValidationException, start_log_group, end_log_group
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +84,10 @@ def test_llm_server(llm_server, available_port):
     assert llm_server.poll() is None
     PROMPT = "1 2 3 4 5 "
     expected_output_prefix = "6 7 8"
-    logger.info("::group::Sending HTTP Generation Request")
+    logger.info(
+        "Sending HTTP Generation Request"
+        + start_log_group("Sending HTTP Generation Request")
+    )
     output = do_generate(PROMPT, available_port)
     # log to GITHUB_STEP_SUMMARY if we are in a GitHub Action
     if "GITHUB_ACTION" in os.environ:
@@ -98,3 +101,4 @@ def test_llm_server(llm_server, available_port):
         raise AccuracyValidationException(
             f"Expected '{output}' to start with '{expected_output_prefix}'"
         )
+    logger.info("HTTP Generation Request Successful" + end_log_group())

--- a/app_tests/integration_tests/llm/cpu_llm_server_test.py
+++ b/app_tests/integration_tests/llm/cpu_llm_server_test.py
@@ -37,7 +37,7 @@ def do_generate(prompt, port):
     # Create a GenerateReqInput-like structure
     data = {
         "text": prompt,
-        "sampling_params": {"max_completion_tokens": 50, "temperature": 0.7},
+        "sampling_params": {"max_completion_tokens": 15, "temperature": 0.7},
         "rid": uuid.uuid4().hex,
         "return_logprob": False,
         "logprob_start_len": -1,

--- a/app_tests/integration_tests/llm/utils.py
+++ b/app_tests/integration_tests/llm/utils.py
@@ -178,3 +178,17 @@ def start_llm_server(
     # Wait for server to start
     wait_for_server(f"http://localhost:{port}", timeout)
     return server_process
+
+
+def start_log_group(headline):
+    # check if we are in github ci
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        return f"\n::group::{headline}"
+    return ""
+
+
+def end_log_group():
+    # check if we are in github ci
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        return "\n::endgroup::"
+    return ""


### PR DESCRIPTION
Use the ::group:: [GitHub Workflow Command](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions) to make it easier to navigate integration logs.

Also adds a summary to easily look at what the generation results are.