### PR TITLE
Recommend installing torch cpu ahead of shark-ai.

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -39,6 +39,10 @@ Setup your Python environment with the following commands:
 # Set up a virtual environment to isolate packages from other envs.
 python3.11 -m venv 3.11.venv
 source 3.11.venv/bin/activate
+
+# Optional: faster installation of torch with just CPU support.
+# See other options at https://pytorch.org/get-started/locally/
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
 ```
 
 ## Install SHARK and its dependencies


### PR DESCRIPTION
The default `torch` install pulls in multiple gigabytes of packages (mostly CUDA), which are not needed.

We'll eventually
* Remove the implicit dep on default-torch in https://github.com/iree-org/iree-turbine
* Rework shortfin_apps to not depend on torch

For now, suggest that users install the torch package of their choosing before installing any of our packages.