### PR TITLE
Update version back to 3.0.0 for stable release.

### DIFF
--- a/sharktank/version.json
+++ b/sharktank/version.json
@@ -1,3 +1,3 @@
 {
-  "package-version": "2.9.2.dev"
+  "package-version": "3.0.0.dev"
 }

--- a/shortfin/version.json
+++ b/shortfin/version.json
@@ -1,3 +1,3 @@
 {
-  "package-version": "2.9.2.dev"
+  "package-version": "3.0.0.dev"
 }

--- a/tuner/version.json
+++ b/tuner/version.json
@@ -1,3 +1,3 @@
 {
-  "package-version": "2.9.2.dev"
+  "package-version": "3.0.0.dev"
 }


### PR DESCRIPTION
Reverts nod-ai/shark-ai#547

We'll want to merge this prior to kicking off a stable release build. We can use either a regularly scheduled nightly release or `workflow_dispatch` of https://github.com/nod-ai/shark-ai/actions/workflows/build_packages.yml.