### PR TITLE
[tuner] Use `ir.(Integer|Float)Type` for element types

### DIFF
--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -517,48 +517,52 @@ def tune(
 
     with ir.Context() as ctx:
         tuner_context = TunerContext(ctx, tune_logger)
-        mlir_module: ir.Module = parse_mlir(mlir_text, tuner_context)
-        # Save the input file as the first candidate.
-        with open(path.join(output, f"0.mlir"), "w") as f:
-            f.write(mlir_text)
+        with parse_mlir(mlir_text, tuner_context) as mlir_module:
+            # Save the input file as the first candidate.
+            with open(path.join(output, f"0.mlir"), "w") as f:
+                f.write(mlir_text)
 
-        dispatch_tuner_registry = DispatchTunerRegistry()
-        dispatch_tuner_registry.register(
-            [
-                MmtTuner(),
-                ConvTuner(),
-                ContractionTuner(lhs_dims, rhs_dims, tile_dims),
-                BatchMmtTuner(),
-                BatchMatmulTuner(lhs_dims, rhs_dims, tile_dims),
-            ]
-        )
+            dispatch_tuner_registry = DispatchTunerRegistry()
+            dispatch_tuner_registry.register(
+                [
+                    MmtTuner(),
+                    ConvTuner(),
+                    ContractionTuner(lhs_dims, rhs_dims, tile_dims),
+                    BatchMmtTuner(),
+                    BatchMatmulTuner(lhs_dims, rhs_dims, tile_dims),
+                ]
+            )
 
-        walk_result: OpWalkResult = walk_mlir_op(mlir_module, dispatch_tuner_registry)
+            walk_result: OpWalkResult = walk_mlir_op(
+                mlir_module, dispatch_tuner_registry
+            )
 
-        dispatch_tuner = walk_result.dispatch_tuner
-        assert dispatch_tuner, "No suitable dispatch tuner found"
-        problem_size: ProblemSize = dispatch_tuner.get_shapes(mlir_template)
-        tune_logger.debug(str(problem_size))
-        configs = []
-        for i, config in enumerate(
-            generate_solutions(tuner_context, problem_size, num_subgroups)
-        ):
-            if i >= limit:
-                break
-            tune_logger.info(f"Solution #{i+1}: {config}")
-            configs.append(config)
-            tf_mlir = dispatch_tuner.apply_params(problem_size, mlir_template, config)
+            dispatch_tuner = walk_result.dispatch_tuner
+            assert dispatch_tuner, "No suitable dispatch tuner found"
+            problem_size: ProblemSize = dispatch_tuner.get_shapes(mlir_template)
+            tune_logger.debug(str(problem_size))
+            configs = []
+            for i, config in enumerate(
+                generate_solutions(tune_logger, problem_size, num_subgroups)
+            ):
+                if i >= limit:
+                    break
+                tune_logger.info(f"Solution #{i+1}: {config}")
+                configs.append(config)
+                tf_mlir = dispatch_tuner.apply_params(
+                    problem_size, mlir_template, config
+                )
 
-            with open(path.join(output, f"{i+1}.mlir"), "w") as f:
-                f.write(tf_mlir.modified)
-            with open(path.join(output, f"{i+1}_config.mlir"), "w") as f:
-                f.write(tf_mlir.embeddable)
+                with open(path.join(output, f"{i+1}.mlir"), "w") as f:
+                    f.write(tf_mlir.modified)
+                with open(path.join(output, f"{i+1}_config.mlir"), "w") as f:
+                    f.write(tf_mlir.embeddable)
 
-        with open(path.join(output, "configs.pkl"), "wb") as file:
-            pickle.dump(configs, file)
+            with open(path.join(output, "configs.pkl"), "wb") as file:
+                pickle.dump(configs, file)
 
-        tune_logger.info(f"Generated {len(configs)} candidates")
-        tune_logger.info(f"Configurations .pkl is stored in {output}/configs.pkl")
+            tune_logger.info(f"Generated {len(configs)} candidates")
+            tune_logger.info(f"Configurations .pkl is stored in {output}/configs.pkl")
 
 
 def main():

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -203,22 +203,6 @@ def get_pipeline_config(configuration: Configuration) -> str:
     return extra_config
 
 
-class MlirRegex(Enum):
-    ssa_value = r"%[a-zA-Z0-9-_]+"
-    tensor_type = r"tensor<(([0-9]+x)+((f|i)[0-9]+))>"
-
-    def __str__(self) -> str:
-        return self.value
-
-    @staticmethod
-    def dps_ins_two_args() -> str:
-        return rf"ins\({MlirRegex.ssa_value}, {MlirRegex.ssa_value} : (?P<LHS>{MlirRegex.tensor_type}), (?P<RHS>{MlirRegex.tensor_type})\)"
-
-    @staticmethod
-    def dps_outs_one_arg() -> str:
-        return rf"outs\({MlirRegex.ssa_value} : (?P<RES>{MlirRegex.tensor_type})\)"
-
-
 def read_input_mlir(filename: str) -> list[str]:
     with open(filename, "r") as f:
         return f.readlines()

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -13,10 +13,27 @@ from typing import Optional
 from iree.compiler import ir  # type: ignore
 
 
+class CommonTypes:
+    def __init__(self, ctx: ir.Context):
+        assert ctx
+        self.i1 = ir.IntegerType.get_signless(1, ctx)
+        self.i8 = ir.IntegerType.get_signless(8, ctx)
+        self.i16 = ir.IntegerType.get_signless(16, ctx)
+        self.i32 = ir.IntegerType.get_signless(32, ctx)
+
+        self.f8E4M3FNUZ = ir.Float8E4M3FNUZType.get(ctx)
+        self.f8E5M2FNUZ = ir.Float8E5M2FNUZType.get(ctx)
+        self.f16 = ir.F16Type.get(ctx)
+        self.f32 = ir.F32Type.get(ctx)
+
+        self.bf16 = ir.BF16Type.get(ctx)
+
+
 class TunerContext:
     def __init__(self, mlir_ctx: ir.Context, logger: logging.Logger):
-        self.mlir_ctx = mlir_ctx
-        self.logger = logger
+        self.mlir_ctx: ir.Context = mlir_ctx
+        self.logger: logging.Logger = logger
+        self.type: CommonTypes = CommonTypes(mlir_ctx)
 
 
 class DispatchKind(Enum):
@@ -28,40 +45,17 @@ class DispatchKind(Enum):
     broadcast_rhs_mmt = 6
 
 
-class ElementType(Enum):
-    i8 = 1
-    i32 = 2
-    f8 = 3
-    f16 = 4
-    f32 = 5
-
-    @property
-    def bitwidth(self) -> int:
-        match self:
-            case ElementType.i8 | ElementType.f8:
-                return 8
-            case ElementType.f16:
-                return 16
-            case ElementType.i32 | ElementType.f32:
-                return 32
-            case _:
-                assert False, "unhandled case"
-
-    def __str__(self) -> str:
-        return self.name
-
-
 @dataclass
 class ShapedType:
     shape: list[int]
-    element_type: ElementType
+    element_type: ir.IntegerType | ir.FloatType
 
     def rank(self) -> int:
         return len(self.shape)
 
     @property
     def bitwidth(self) -> int:
-        return self.element_type.bitwidth
+        return self.element_type.width
 
     def __str__(self) -> str:
         dim_to_str = lambda dim: str(dim) if dim != -1 else "?"
@@ -91,11 +85,11 @@ class ProblemSize:
 
 @dataclass
 class MfmaIntrinsic:
-    output_type: ElementType
+    output_type: ir.IntegerType | ir.FloatType
     m: int
     n: int
     k: int
-    input_type: ElementType
+    input_type: ir.IntegerType | ir.FloatType
 
     def __str__(self) -> str:
         input = str(self.input_type).upper()
@@ -104,19 +98,27 @@ class MfmaIntrinsic:
 
     @staticmethod
     def mfma_f32_16x16x16_f16():
-        return MfmaIntrinsic(ElementType.f32, 16, 16, 16, ElementType.f16)
+        f16 = ir.F16Type.get()
+        f32 = ir.F32Type.get()
+        return MfmaIntrinsic(f32, 16, 16, 16, f16)
 
     @staticmethod
     def mfma_f32_32x32x8_f16():
-        return MfmaIntrinsic(ElementType.f32, 32, 32, 8, ElementType.f16)
+        f16 = ir.F16Type.get()
+        f32 = ir.F32Type.get()
+        return MfmaIntrinsic(f32, 32, 32, 8, f16)
 
     @staticmethod
     def mfma_i32_16x16x32_i8():
-        return MfmaIntrinsic(ElementType.i32, 16, 16, 32, ElementType.i8)
+        i32 = ir.IntegerType.get_signless(32)
+        i8 = ir.IntegerType.get_signless(8)
+        return MfmaIntrinsic(i32, 16, 16, 32, i8)
 
     @staticmethod
     def mfma_i32_32x32x16_i8():
-        return MfmaIntrinsic(ElementType.i32, 32, 32, 16, ElementType.i8)
+        i32 = ir.IntegerType.get_signless(32)
+        i8 = ir.IntegerType.get_signless(8)
+        return MfmaIntrinsic(i32, 32, 32, 16, i8)
 
     @staticmethod
     def all():
@@ -251,8 +253,7 @@ def parse_tensor_type(tensor_type: str) -> ShapedType:
     dims_and_elem = shape_str.split("x")
     dims = [int(x) for x in dims_and_elem[:-1]]
     elem = dims_and_elem[-1]
-    str_to_elem_ty = {x.name: x for x in ElementType}
-    return ShapedType(dims, str_to_elem_ty[elem])
+    return ShapedType(dims, ir.Type.parse(elem))
 
 
 @dataclass

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -245,17 +245,6 @@ class ConvDimInfo:
         return ConvDimInfo.from_rhs_res(problem_size.rhs_type, problem_size.res_type)
 
 
-def parse_tensor_type(tensor_type: str) -> ShapedType:
-    shape_match = re.search(str(MlirRegex.tensor_type), tensor_type)
-    assert shape_match
-
-    shape_str = shape_match.group(1)
-    dims_and_elem = shape_str.split("x")
-    dims = [int(x) for x in dims_and_elem[:-1]]
-    elem = dims_and_elem[-1]
-    return ShapedType(dims, ir.Type.parse(elem))
-
-
 @dataclass
 class MLIRTransformation:
     """Transformation of MLIR context"""

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -11,27 +11,47 @@ Usage: python -m pytest candidate_gen_test.py
 import pytest
 from . import common
 
+from typing import Generator
 
-def test_get_shaped_type_element_bitwidth() -> None:
-    assert common.ShapedType([1024, 2048], common.ElementType.i8).bitwidth == 8
-    assert common.ShapedType([2048], common.ElementType.i32).bitwidth == 32
-    assert common.ShapedType([2048, 512, 384], common.ElementType.f8).bitwidth == 8
-    assert common.ShapedType([1, 1], common.ElementType.f16).bitwidth == 16
+from iree.compiler import ir  # type: ignore
 
 
-def test_get_shaped_type_to_str() -> None:
-    assert str(common.ShapedType([1024, 2048], common.ElementType.i8)) == "1024x2048xi8"
-    assert str(common.ShapedType([1024], common.ElementType.f32)) == "1024xf32"
-    assert str(common.ShapedType([1, 2, 3], common.ElementType.f16)) == "1x2x3xf16"
-    assert str(common.ShapedType([-1, 2, 3], common.ElementType.f16)) == "?x2x3xf16"
+@pytest.fixture
+def tuner_ctx() -> Generator[common.TunerContext, None, None]:
+    from logging import Logger
+    from unittest.mock import MagicMock
+
+    with ir.Context() as ctx:
+        logger: Logger = MagicMock(spec=Logger)
+        yield common.TunerContext(ctx, logger)
 
 
-def test_parse_tensor_type() -> None:
+@pytest.fixture
+def mlir_ctx() -> Generator[ir.Context, None, None]:
+    with ir.Context() as ctx:
+        yield ctx
+
+
+def test_get_shaped_type_element_bitwidth(tuner_ctx: common.TunerContext) -> None:
+    assert common.ShapedType([1024, 2048], tuner_ctx.type.i8).bitwidth == 8
+    assert common.ShapedType([2048], tuner_ctx.type.i32).bitwidth == 32
+    assert common.ShapedType([2048, 512, 384], tuner_ctx.type.f8E4M3FNUZ).bitwidth == 8
+    assert common.ShapedType([1, 1], tuner_ctx.type.f16).bitwidth == 16
+
+
+def test_get_shaped_type_to_str(tuner_ctx: common.TunerContext) -> None:
+    assert str(common.ShapedType([1024, 2048], tuner_ctx.type.i8)) == "1024x2048xi8"
+    assert str(common.ShapedType([1024], tuner_ctx.type.f32)) == "1024xf32"
+    assert str(common.ShapedType([1, 2, 3], tuner_ctx.type.f16)) == "1x2x3xf16"
+    assert str(common.ShapedType([-1, 2, 3], tuner_ctx.type.f16)) == "?x2x3xf16"
+
+
+def test_parse_tensor_type(tuner_ctx: common.TunerContext) -> None:
     assert common.parse_tensor_type("tensor<1x2x3xf32>") == common.ShapedType(
-        [1, 2, 3], common.ElementType.f32
+        [1, 2, 3], tuner_ctx.type.f32
     )
     assert common.parse_tensor_type("tensor<123xi8>") == common.ShapedType(
-        [123], common.ElementType.i8
+        [123], tuner_ctx.type.i8
     )
 
 
@@ -59,7 +79,7 @@ def test_gpu_pipeline_options() -> None:
     )
 
 
-def test_get_pipeline_config() -> None:
+def test_get_pipeline_config(mlir_ctx: ir.Context) -> None:
     config = common.Configuration(
         subgroup_size=32,
         workgroup_size=[16, 16, 1],
@@ -85,18 +105,18 @@ def test_get_pipeline_config() -> None:
     )
 
 
-def test_mfma_intrinsic_to_str() -> None:
+def test_mfma_intrinsic_to_str(mlir_ctx: ir.Context) -> None:
     assert str(common.MfmaIntrinsic.mfma_f32_16x16x16_f16()) == "MFMA_F32_16x16x16_F16"
     assert str(common.MfmaIntrinsic.mfma_i32_32x32x16_i8()) == "MFMA_I32_32x32x16_I8"
 
 
-def test_get_compatible_mfma_intrinsics() -> None:
+def test_get_compatible_mfma_intrinsics(tuner_ctx: common.TunerContext) -> None:
     assert common.get_compatible_mfma_intrinsics(
         common.ProblemSize(
             common.MatmulSize(2048, 1280, 1280),
-            common.ShapedType([2048, 1280], common.ElementType.f16),
-            common.ShapedType([1280, 1280], common.ElementType.f16),
-            common.ShapedType([2048, 1280], common.ElementType.f32),
+            common.ShapedType([2048, 1280], tuner_ctx.type.f16),
+            common.ShapedType([1280, 1280], tuner_ctx.type.f16),
+            common.ShapedType([2048, 1280], tuner_ctx.type.f32),
             common.DispatchKind.mmt,
         )
     ) == [
@@ -107,9 +127,9 @@ def test_get_compatible_mfma_intrinsics() -> None:
     assert common.get_compatible_mfma_intrinsics(
         common.ProblemSize(
             common.MatmulSize(2048, 1280, 1280),
-            common.ShapedType([2048, 1280], common.ElementType.i8),
-            common.ShapedType([1280, 1280], common.ElementType.i8),
-            common.ShapedType([2048, 1280], common.ElementType.i32),
+            common.ShapedType([2048, 1280], tuner_ctx.type.i8),
+            common.ShapedType([1280, 1280], tuner_ctx.type.i8),
+            common.ShapedType([2048, 1280], tuner_ctx.type.i32),
             common.DispatchKind.mmt,
         )
     ) == [
@@ -120,9 +140,9 @@ def test_get_compatible_mfma_intrinsics() -> None:
     assert common.get_compatible_mfma_intrinsics(
         common.ProblemSize(
             common.MatmulSize(968, 320, 640, 64),
-            common.ShapedType([64, 968, 640], common.ElementType.f32),
-            common.ShapedType([64, 640, 320], common.ElementType.f32),
-            common.ShapedType([64, 968, 320], common.ElementType.f32),
+            common.ShapedType([64, 968, 640], tuner_ctx.type.f32),
+            common.ShapedType([64, 640, 320], tuner_ctx.type.f32),
+            common.ShapedType([64, 968, 320], tuner_ctx.type.f32),
             common.DispatchKind.batch_matmul,
         )
     ) == [

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -46,15 +46,6 @@ def test_get_shaped_type_to_str(tuner_ctx: common.TunerContext) -> None:
     assert str(common.ShapedType([-1, 2, 3], tuner_ctx.type.f16)) == "?x2x3xf16"
 
 
-def test_parse_tensor_type(tuner_ctx: common.TunerContext) -> None:
-    assert common.parse_tensor_type("tensor<1x2x3xf32>") == common.ShapedType(
-        [1, 2, 3], tuner_ctx.type.f32
-    )
-    assert common.parse_tensor_type("tensor<123xi8>") == common.ShapedType(
-        [123], tuner_ctx.type.i8
-    )
-
-
 def test_gpu_pipeline_options() -> None:
     options = common.GpuPipelineOptions()
     assert options.all_default()

--- a/tuner/tuner/dispatch_constraints.py
+++ b/tuner/tuner/dispatch_constraints.py
@@ -130,10 +130,10 @@ def generate_constraints(
 
 
 def generate_solutions(
-    ctx: TunerContext, problem_size: ProblemSize, num_subgrups: int
+    logger: logging.Logger, problem_size: ProblemSize, num_subgrups: int
 ) -> Iterator[Configuration]:
     M, N, K = problem_size.MNK
-    ctx.logger.info(f"{M},{N},{K}")
+    logger.info(f"{M},{N},{K}")
     m, n, k = z3.Int("m"), z3.Int("n"), z3.Int("k")
     subgroup_size = z3.Int("subgroup_size")
     intrinsic_mn = z3.Int("intrinsic_mn")
@@ -170,7 +170,7 @@ def generate_solutions(
         waves_per_eu,
     )
     solver.add(z3.simplify(z3.And(constraints)))
-    ctx.logger.debug(f"Initial constraints: {solver}")
+    logger.debug(f"Initial constraints: {solver}")
     i = 0
     while solver.check() == z3.sat:
         model = solver.model()

--- a/tuner/tuner/dispatch_parser.py
+++ b/tuner/tuner/dispatch_parser.py
@@ -41,6 +41,22 @@ def get_batch_mmt_tile_sizes(configuration: Configuration) -> list[int]:
     return [1] + configuration.tile_sizes
 
 
+class MlirRegex(Enum):
+    ssa_value = r"%[a-zA-Z0-9-_]+"
+    tensor_type = r"tensor<([^>]+)>"
+
+    def __str__(self) -> str:
+        return self.value
+
+    @staticmethod
+    def dps_ins_two_args() -> str:
+        return rf"ins\({MlirRegex.ssa_value}, {MlirRegex.ssa_value} : (?P<LHS>{MlirRegex.tensor_type}), (?P<RHS>{MlirRegex.tensor_type})\)"
+
+    @staticmethod
+    def dps_outs_one_arg() -> str:
+        return rf"outs\({MlirRegex.ssa_value} : (?P<RES>{MlirRegex.tensor_type})\)"
+
+
 def parse_mlir(mlir_text: str, ctx: TunerContext) -> ir.Module:
     mlir_module = None
     try:

--- a/tuner/tuner/dispatch_parser.py
+++ b/tuner/tuner/dispatch_parser.py
@@ -14,6 +14,12 @@ from abc import ABCMeta, abstractmethod
 from .common import *
 
 
+def parse_tensor_type(tensor_type: str) -> ShapedType:
+    shaped_ty = ir.RankedTensorType(ir.Type.parse(tensor_type))
+    assert shaped_ty
+    return ShapedType(shaped_ty.shape, shaped_ty.element_type)
+
+
 def get_mmt_tile_sizes(configuration: Configuration):
     return configuration.tile_sizes
 

--- a/tuner/tuner/dispatch_parser_test.py
+++ b/tuner/tuner/dispatch_parser_test.py
@@ -29,6 +29,15 @@ def tuner_ctx() -> Generator[common.TunerContext, None, None]:
         yield common.TunerContext(ctx, logger)
 
 
+def test_parse_tensor_type(tuner_ctx: common.TunerContext) -> None:
+    assert dispatch_parser.parse_tensor_type("tensor<1x2x3xf32>") == common.ShapedType(
+        [1, 2, 3], tuner_ctx.type.f32
+    )
+    assert dispatch_parser.parse_tensor_type("tensor<123xi8>") == common.ShapedType(
+        [123], tuner_ctx.type.i8
+    )
+
+
 def test_get_mmt_tile_sizes(tuner_ctx: common.TunerContext) -> None:
     config = dispatch_parser.Configuration(
         subgroup_size=0,


### PR DESCRIPTION
This follows the general goal of using the IREE/MLIR bindings instead of working with textual IR.