### PR TITLE
[tuner] Refactor tuner flow to use unified functions for models and dispatches

### DIFF
--- a/tuner/examples/test/README.md
+++ b/tuner/examples/test/README.md
@@ -1,0 +1,32 @@
+# Example Tuner Test
+
+Example of tuning a dispatch and full model.
+
+## Environments
+Follow instructions in [`/tuner/README.md`](../README.md)
+
+## Running the Tuner
+
+### Choose a model to tune
+This example uses the simple `double_mmt.mlir` file.
+
+### Generate a benchmark file
+Use the usual `iree-compile` command for your model and add
+`--iree-hal-dump-executable-files-to=dump`. For example:
+```shell
+iree-compile double_mmt.mlir --iree-hal-target-backends=rocm --iree-hip-target=gfx942 --iree-hal-dump-executable-files-to=dump -o /dev/null
+```
+
+Next, copy the `*_benchmark.mlir` file to some temporary directory of choice.
+This will be the input to the dispatch tuner. In the example, the `mmt_benchmark.mlir` example file (from double_mmt.mlir) can be used.
+
+### Recommended Trial Run
+For an initial trial to test the tuning loop, use:
+```shell
+python -m examples.test double_mmt.mlir mmt_benchmark.mlir --num-candidates=20
+```
+
+### Basic Usage
+```shell
+python -m examples.test double_mmt.mlir mmt_benchmark.mlir
+```

--- a/tuner/examples/test/__init__.py
+++ b/tuner/examples/test/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/tuner/examples/test/__main__.py
+++ b/tuner/examples/test/__main__.py
@@ -1,0 +1,9 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from . import tuner_test
+
+tuner_test.main()

--- a/tuner/examples/test/conv_benchmark.mlir
+++ b/tuner/examples/test/conv_benchmark.mlir
@@ -1,0 +1,68 @@
+module {
+  util.global private @__device_0 = #hal.device.target<"hip", {legacy_sync}, [#hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<MFMA_F32_16x16x4_F32>, <MFMA_F32_16x16x16_F16>, <MFMA_F32_32x32x8_F16>, <MFMA_F64_16x16x4_F64>, <MFMA_F32_16x16x16_BF16>, <MFMA_F32_32x32x8_BF16>, <MFMA_F32_16x16x32_F8E5M2FNUZ>, <MFMA_F32_16x16x32_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_16x16x32_F8E4M3FNUZ>, <MFMA_F32_16x16x32_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_F32_32x32x16_F8E5M2FNUZ>, <MFMA_F32_32x32x16_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_32x32x16_F8E4M3FNUZ>, <MFMA_F32_32x32x16_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_I32_16x16x32_I8>, <MFMA_I32_32x32x16_I8>], subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>]> : !hal.device
+  hal.executable private @main_0_dispatch_0 {
+    hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb", {abi = "hip", iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<MFMA_F32_16x16x4_F32>, <MFMA_F32_16x16x16_F16>, <MFMA_F32_32x32x8_F16>, <MFMA_F64_16x16x4_F64>, <MFMA_F32_16x16x16_BF16>, <MFMA_F32_32x32x8_BF16>, <MFMA_F32_16x16x32_F8E5M2FNUZ>, <MFMA_F32_16x16x32_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_16x16x32_F8E4M3FNUZ>, <MFMA_F32_16x16x32_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_F32_32x32x16_F8E5M2FNUZ>, <MFMA_F32_32x32x16_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_32x32x16_F8E4M3FNUZ>, <MFMA_F32_32x32x16_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_I32_16x16x32_I8>, <MFMA_I32_32x32x16_I8>], subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>) {
+      hal.executable.export public @main_0_dispatch_0_conv_2d_nhwc_hwcf_2x32x32x1280x3x3x1280_i8xi8xi32 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) {
+      ^bb0(%arg0: !hal.device):
+        %x, %y, %z = flow.dispatch.workgroup_count_from_slice 
+        hal.return %x, %y, %z : index, index, index
+      }
+      builtin.module {
+        func.func @main_0_dispatch_0_conv_2d_nhwc_hwcf_2x32x32x1280x3x3x1280_i8xi8xi32() attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {}>} {
+          %cst = arith.constant 0.000000e+00 : f16
+          %c0 = arith.constant 0 : index
+          %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !flow.dispatch.tensor<readonly:tensor<2x34x34x1280xi8>>
+          %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !flow.dispatch.tensor<readonly:tensor<3x3x1280x1280xi8>>
+          %2 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c0) flags(Indirect) : !flow.dispatch.tensor<writeonly:tensor<2x32x32x1280xi32>>
+          %3 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 34, 34, 1280], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x34x34x1280xi8>> -> tensor<2x34x34x1280xi8>
+          %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 3, 1280, 1280], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x3x1280x1280xi8>> -> tensor<3x3x1280x1280xi8>
+          %5 = tensor.empty() : tensor<2x32x32x1280xi32>
+          %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<2x32x32x1280xi32>) -> tensor<2x32x32x1280xi32>
+          %7 = linalg.conv_2d_nhwc_hwcf {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>, promote_operands = [0, 1], reduction = [0, 0, 0, 0, 1, 1, 64], subgroup_m_count = 1 : i64, subgroup_n_count = 4 : i64, workgroup = [1, 1, 32, 256, 0, 0, 0]}>} ins(%3, %4 : tensor<2x34x34x1280xi8>, tensor<3x3x1280x1280xi8>) outs(%6 : tensor<2x32x32x1280xi32>) -> tensor<2x32x32x1280xi32>
+          flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [2, 32, 32, 1280], strides = [1, 1, 1, 1] : tensor<2x32x32x1280xi32> -> !flow.dispatch.tensor<writeonly:tensor<2x32x32x1280xi32>>
+          return
+        }
+      }
+    }
+  }
+  util.global private mutable @main_0_dispatch_0_rocm_hsaco_fb_main_0_dispatch_0_conv_2d_nhwc_hwcf_2x32x32x1280x3x3x1280_i8xi8xi32_buffer : !hal.buffer
+  util.initializer {
+    %c28190720 = arith.constant 28190720 : index
+    %device, %queue_affinity = hal.device.resolve on(<@__device_0>) : !hal.device, i64
+    %allocator = hal.device.allocator<%device : !hal.device> : !hal.allocator
+    %buffer = hal.allocator.allocate<%allocator : !hal.allocator> affinity(%queue_affinity) type("DeviceVisible|DeviceLocal") usage("TransferSource|TransferTarget|Transfer|DispatchStorageRead|DispatchStorageWrite|DispatchStorage") : !hal.buffer{%c28190720}
+    util.global.store %buffer, @main_0_dispatch_0_rocm_hsaco_fb_main_0_dispatch_0_conv_2d_nhwc_hwcf_2x32x32x1280x3x3x1280_i8xi8xi32_buffer : !hal.buffer
+    util.return
+  }
+  util.func public @main_0_dispatch_0_rocm_hsaco_fb_main_0_dispatch_0_conv_2d_nhwc_hwcf_2x32x32x1280x3x3x1280_i8xi8xi32(%arg0: i32) attributes {iree.abi.stub, iree.reflection = {iree.benchmark = "dispatch"}} {
+    %c-1_i32 = arith.constant -1 : i32
+    %0 = util.null : !hal.fence
+    %c1 = arith.constant 1 : index
+    %c10485760 = arith.constant 10485760 : index
+    %c17704960 = arith.constant 17704960 : index
+    %c14745600 = arith.constant 14745600 : index
+    %c2959360 = arith.constant 2959360 : index
+    %c0 = arith.constant 0 : index
+    %1 = arith.index_cast %arg0 : i32 to index
+    %device, %queue_affinity = hal.device.resolve on(<@__device_0>) : !hal.device, i64
+    %cmd = hal.command_buffer.create device(%device : !hal.device) mode("OneShot|AllowInlineExecution") categories(Dispatch) affinity(%queue_affinity) : !hal.command_buffer
+    %main_0_dispatch_0_rocm_hsaco_fb_main_0_dispatch_0_conv_2d_nhwc_hwcf_2x32x32x1280x3x3x1280_i8xi8xi32_buffer = util.global.load @main_0_dispatch_0_rocm_hsaco_fb_main_0_dispatch_0_conv_2d_nhwc_hwcf_2x32x32x1280x3x3x1280_i8xi8xi32_buffer : !hal.buffer
+    %workgroup_x, %workgroup_y, %workgroup_z = hal.executable.calculate_workgroups device(%device : !hal.device) target(@main_0_dispatch_0::@rocm_hsaco_fb::@main_0_dispatch_0_conv_2d_nhwc_hwcf_2x32x32x1280x3x3x1280_i8xi8xi32) : index, index, index
+    %exe = hal.executable.lookup device(%device : !hal.device) executable(@main_0_dispatch_0) : !hal.executable
+    %ordinal = hal.executable.export.ordinal target(@main_0_dispatch_0::@rocm_hsaco_fb::@main_0_dispatch_0_conv_2d_nhwc_hwcf_2x32x32x1280x3x3x1280_i8xi8xi32) : index
+    scf.for %arg1 = %c0 to %1 step %c1 {
+      hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%exe : !hal.executable)[%ordinal] workgroups([%workgroup_x, %workgroup_y, %workgroup_z]) bindings([
+        (%main_0_dispatch_0_rocm_hsaco_fb_main_0_dispatch_0_conv_2d_nhwc_hwcf_2x32x32x1280x3x3x1280_i8xi8xi32_buffer : !hal.buffer)[%c0, %c2959360], 
+        (%main_0_dispatch_0_rocm_hsaco_fb_main_0_dispatch_0_conv_2d_nhwc_hwcf_2x32x32x1280x3x3x1280_i8xi8xi32_buffer : !hal.buffer)[%c2959360, %c14745600], 
+        (%main_0_dispatch_0_rocm_hsaco_fb_main_0_dispatch_0_conv_2d_nhwc_hwcf_2x32x32x1280x3x3x1280_i8xi8xi32_buffer : !hal.buffer)[%c17704960, %c10485760]
+      ]) flags("None")
+      hal.command_buffer.execution_barrier<%cmd : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
+    }
+    hal.command_buffer.finalize<%cmd : !hal.command_buffer>
+    %fence = hal.fence.create device(%device : !hal.device) flags("None") : !hal.fence
+    hal.device.queue.execute<%device : !hal.device> affinity(%queue_affinity) wait(%0) signal(%fence) commands([%cmd])
+    %status = hal.fence.await until([%fence]) timeout_millis(%c-1_i32) : i32
+    util.status.check_ok %status, "failed to wait on timepoint"
+    util.return
+  }
+}

--- a/tuner/examples/test/conv_nhwc.mlir
+++ b/tuner/examples/test/conv_nhwc.mlir
@@ -1,0 +1,11 @@
+!convA_0 = tensor<2x34x34x1280xi8>
+!convB_0 = tensor<3x3x1280x1280xi8>
+!convC_0 = tensor<2x32x32x1280xi32>
+
+func.func @main_0(%arg0: !convA_0, %arg1: !convB_0) -> !convC_0 {
+  %cst = arith.constant 0.000000e+00 : f16
+  %5 = tensor.empty() : !convC_0
+  %6 = linalg.fill ins(%cst : f16) outs(%5 : !convC_0) -> !convC_0
+  %8 = linalg.conv_2d_nhwc_hwcf ins(%arg0, %arg1 : !convA_0, !convB_0) outs(%6 : !convC_0) -> !convC_0
+  return %8 : !convC_0
+}

--- a/tuner/examples/test/double_mmt.mlir
+++ b/tuner/examples/test/double_mmt.mlir
@@ -1,0 +1,16 @@
+!matA_0 = tensor<2048x2048xf16>
+!matB_0 = tensor<2048x2048xf16>
+!matC_0 = tensor<2048x2048xf32>
+
+!matC_1 = tensor<2048x2048xf32>
+
+func.func @main(%arg0: !matA_0, %arg1: !matB_0) -> !matC_1 {
+  %cst = arith.constant 0.000000e+00 : f32
+  %5 = tensor.empty() : !matC_0
+  %6 = linalg.fill ins(%cst : f32) outs(%5 : !matC_0) -> !matC_0
+  %7 = linalg.matmul_transpose_b ins(%arg0, %arg1 : !matA_0, !matB_0) outs(%6 : !matC_0) -> !matC_0
+  %8 = tensor.empty() : !matC_1
+  %9 = linalg.fill ins(%cst : f32) outs(%8 : !matC_1) -> !matC_1
+  %10 = linalg.matmul_transpose_b ins(%7, %7 : !matC_0, !matC_0) outs(%9 : !matC_1) -> !matC_1
+  return %10 : !matC_1
+}

--- a/tuner/examples/test/mmt_benchmark.mlir
+++ b/tuner/examples/test/mmt_benchmark.mlir
@@ -1,0 +1,73 @@
+module {
+  util.global private @__device_0 = #hal.device.target<"hip", {legacy_sync}, [#hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<MFMA_F32_16x16x4_F32>, <MFMA_F32_16x16x16_F16>, <MFMA_F32_32x32x8_F16>, <MFMA_F64_16x16x4_F64>, <MFMA_F32_16x16x16_BF16>, <MFMA_F32_32x32x8_BF16>, <MFMA_F32_16x16x32_F8E5M2FNUZ>, <MFMA_F32_16x16x32_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_16x16x32_F8E4M3FNUZ>, <MFMA_F32_16x16x32_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_F32_32x32x16_F8E5M2FNUZ>, <MFMA_F32_32x32x16_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_32x32x16_F8E4M3FNUZ>, <MFMA_F32_32x32x16_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_I32_16x16x32_I8>, <MFMA_I32_32x32x16_I8>], subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>]> : !hal.device
+  hal.executable private @main_dispatch_0 {
+    hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb", {abi = "hip", iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<MFMA_F32_16x16x4_F32>, <MFMA_F32_16x16x16_F16>, <MFMA_F32_32x32x8_F16>, <MFMA_F64_16x16x4_F64>, <MFMA_F32_16x16x16_BF16>, <MFMA_F32_32x32x8_BF16>, <MFMA_F32_16x16x32_F8E5M2FNUZ>, <MFMA_F32_16x16x32_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_16x16x32_F8E4M3FNUZ>, <MFMA_F32_16x16x32_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_F32_32x32x16_F8E5M2FNUZ>, <MFMA_F32_32x32x16_F8E5M2FNUZ_F8E4M3FNUZ>, <MFMA_F32_32x32x16_F8E4M3FNUZ>, <MFMA_F32_32x32x16_F8E4M3FNUZ_F8E5M2FNUZ>, <MFMA_I32_16x16x32_I8>, <MFMA_I32_32x32x16_I8>], subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128, simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none"}>) {
+      hal.executable.export public @main_dispatch_0_matmul_transpose_b_2048x2048x2048_f16xf16xf32 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) {
+      ^bb0(%arg0: !hal.device):
+        %x, %y, %z = flow.dispatch.workgroup_count_from_slice 
+        hal.return %x, %y, %z : index, index, index
+      }
+      builtin.module {
+        func.func @main_dispatch_0_matmul_transpose_b_2048x2048x2048_f16xf16xf32() attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {}>} {
+          %cst = arith.constant 0.000000e+00 : f32
+          %c0 = arith.constant 0 : index
+          %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !flow.dispatch.tensor<readonly:tensor<2048x2048xf16>>
+          %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !flow.dispatch.tensor<readonly:tensor<2048x2048xf16>>
+          %2 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c0) flags(Indirect) : !flow.dispatch.tensor<writeonly:tensor<2048x2048xf32>>
+          %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x2048xf16>> -> tensor<2048x2048xf16>
+          %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x2048xf16>> -> tensor<2048x2048xf16>
+          %5 = tensor.empty() : tensor<2048x2048xf32>
+          %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2048x2048xf32>) -> tensor<2048x2048xf32>
+          %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<2048x2048xf16>, tensor<2048x2048xf16>) outs(%6 : tensor<2048x2048xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, promote_operands = [0, 1], reduction = [0, 0, 64], subgroup_m_count = 2 : i64, subgroup_n_count = 2 : i64, workgroup = [64, 128, 0]}>} {
+          ^bb0(%in: f16, %in_0: f16, %out: f32):
+            %8 = arith.extf %in : f16 to f32
+            %9 = arith.extf %in_0 : f16 to f32
+            %10 = arith.mulf %8, %9 : f32
+            %11 = arith.addf %out, %10 : f32
+            linalg.yield %11 : f32
+          } -> tensor<2048x2048xf32>
+          flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : tensor<2048x2048xf32> -> !flow.dispatch.tensor<writeonly:tensor<2048x2048xf32>>
+          return
+        }
+      }
+    }
+  }
+  util.global private mutable @main_dispatch_0_rocm_hsaco_fb_main_dispatch_0_matmul_transpose_b_2048x2048x2048_f16xf16xf32_buffer : !hal.buffer
+  util.initializer {
+    %c33554432 = arith.constant 33554432 : index
+    %device, %queue_affinity = hal.device.resolve on(<@__device_0>) : !hal.device, i64
+    %allocator = hal.device.allocator<%device : !hal.device> : !hal.allocator
+    %buffer = hal.allocator.allocate<%allocator : !hal.allocator> affinity(%queue_affinity) type("DeviceVisible|DeviceLocal") usage("TransferSource|TransferTarget|Transfer|DispatchStorageRead|DispatchStorageWrite|DispatchStorage") : !hal.buffer{%c33554432}
+    util.global.store %buffer, @main_dispatch_0_rocm_hsaco_fb_main_dispatch_0_matmul_transpose_b_2048x2048x2048_f16xf16xf32_buffer : !hal.buffer
+    util.return
+  }
+  util.func public @main_dispatch_0_rocm_hsaco_fb_main_dispatch_0_matmul_transpose_b_2048x2048x2048_f16xf16xf32(%arg0: i32) attributes {iree.abi.stub, iree.reflection = {iree.benchmark = "dispatch"}} {
+    %c-1_i32 = arith.constant -1 : i32
+    %0 = util.null : !hal.fence
+    %c1 = arith.constant 1 : index
+    %c16777216 = arith.constant 16777216 : index
+    %c8388608 = arith.constant 8388608 : index
+    %c0 = arith.constant 0 : index
+    %1 = arith.index_cast %arg0 : i32 to index
+    %device, %queue_affinity = hal.device.resolve on(<@__device_0>) : !hal.device, i64
+    %cmd = hal.command_buffer.create device(%device : !hal.device) mode("OneShot|AllowInlineExecution") categories(Dispatch) affinity(%queue_affinity) : !hal.command_buffer
+    %main_dispatch_0_rocm_hsaco_fb_main_dispatch_0_matmul_transpose_b_2048x2048x2048_f16xf16xf32_buffer = util.global.load @main_dispatch_0_rocm_hsaco_fb_main_dispatch_0_matmul_transpose_b_2048x2048x2048_f16xf16xf32_buffer : !hal.buffer
+    %workgroup_x, %workgroup_y, %workgroup_z = hal.executable.calculate_workgroups device(%device : !hal.device) target(@main_dispatch_0::@rocm_hsaco_fb::@main_dispatch_0_matmul_transpose_b_2048x2048x2048_f16xf16xf32) : index, index, index
+    %exe = hal.executable.lookup device(%device : !hal.device) executable(@main_dispatch_0) : !hal.executable
+    %ordinal = hal.executable.export.ordinal target(@main_dispatch_0::@rocm_hsaco_fb::@main_dispatch_0_matmul_transpose_b_2048x2048x2048_f16xf16xf32) : index
+    scf.for %arg1 = %c0 to %1 step %c1 {
+      hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%exe : !hal.executable)[%ordinal] workgroups([%workgroup_x, %workgroup_y, %workgroup_z]) bindings([
+        (%main_dispatch_0_rocm_hsaco_fb_main_dispatch_0_matmul_transpose_b_2048x2048x2048_f16xf16xf32_buffer : !hal.buffer)[%c0, %c8388608], 
+        (%main_dispatch_0_rocm_hsaco_fb_main_dispatch_0_matmul_transpose_b_2048x2048x2048_f16xf16xf32_buffer : !hal.buffer)[%c8388608, %c8388608], 
+        (%main_dispatch_0_rocm_hsaco_fb_main_dispatch_0_matmul_transpose_b_2048x2048x2048_f16xf16xf32_buffer : !hal.buffer)[%c16777216, %c16777216]
+      ]) flags("None")
+      hal.command_buffer.execution_barrier<%cmd : !hal.command_buffer> source("Dispatch|CommandRetire") target("CommandIssue|Dispatch") flags("None")
+    }
+    hal.command_buffer.finalize<%cmd : !hal.command_buffer>
+    %fence = hal.fence.create device(%device : !hal.device) flags("None") : !hal.fence
+    hal.device.queue.execute<%device : !hal.device> affinity(%queue_affinity) wait(%0) signal(%fence) commands([%cmd])
+    %status = hal.fence.await until([%fence]) timeout_millis(%c-1_i32) : i32
+    util.status.check_ok %status, "failed to wait on timepoint"
+    util.return
+  }
+}

--- a/tuner/examples/test/tuner_test.py
+++ b/tuner/examples/test/tuner_test.py
@@ -1,0 +1,165 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+Sample Usage:
+
+python -m examples.test double_mmt.mlir mmt_benchmark.mlir --devices=hip://0,hip://1 --num-candidates=64
+
+
+Recommended Trial Run:
+
+python -m examples.test double_mmt.mlir mmt_benchmark.mlir --num-candidates=10
+
+
+Dry Run Test (no gpu required, not currently working):
+
+python -m examples.test double_mmt.mlir mmt_benchmark.mlir --num-candidates=64 --dry-run
+
+"""
+
+from tuner import libtuner
+from pathlib import Path, PurePath
+import argparse
+import os
+
+
+class TestTuner(libtuner.TuningClient):
+    def __init__(self):
+        self.compile_flags = [
+            "--iree-hip-target=gfx942",
+            "--compile-from=executable-sources",
+        ]
+        self.benchmark_flags = [
+            "--benchmark_repetitions=3",
+            "--benchmark_format=json",
+        ]
+
+    def get_compile_timeout_s(self) -> int:
+        return 10
+
+    def get_iree_compile_flags(self) -> list[str]:
+        return self.compile_flags
+
+    def get_benchmark_timeout_s(self) -> int:
+        return 15
+
+    def get_iree_benchmark_module_flags(
+        self,
+    ) -> list[str]:
+        return self.benchmark_flags
+
+    # TODO(Max191): Remove the following unused abstract functions once they
+    # are removed from the TuningClient definition.
+    def get_dispatch_benchmark_timeout_s(self) -> int:
+        return 0
+
+    def get_dispatch_compile_timeout_s(self) -> int:
+        return 0
+
+    def get_dispatch_compile_command(
+        self, candidate_tracker: libtuner.CandidateTracker
+    ) -> list[str]:
+        return []
+
+    def get_dispatch_benchmark_command(
+        self,
+        candidate_tracker: libtuner.CandidateTracker,
+    ) -> list[str]:
+        return []
+
+    def get_model_compile_timeout_s(self) -> int:
+        return 0
+
+    def get_model_compile_command(
+        self, candidate_tracker: libtuner.CandidateTracker
+    ) -> list[str]:
+        return []
+
+    def get_model_benchmark_timeout_s(self) -> int:
+        return 0
+
+    def get_model_benchmark_command(
+        self, candidate_tracker: libtuner.CandidateTracker
+    ) -> list[str]:
+        return []
+
+
+def main():
+    # Custom arguments for the test file.
+    parser = argparse.ArgumentParser(description="Autotune test script")
+    test_args = parser.add_argument_group("Example Test Options")
+    test_args.add_argument(
+        "model_file", type=Path, help="Path to the model file to benchmark (.mlir)"
+    )
+    # Remaining arguments come from libtuner
+    args = libtuner.parse_arguments(parser)
+
+    path_config = libtuner.PathConfig()
+    path_config.base_dir.mkdir(parents=True, exist_ok=True)
+    path_config.output_unilog.touch()
+    candidate_trackers: list[libtuner.CandidateTracker] = []
+    test_tuner = TestTuner()
+    stop_after_phase: str = args.stop_after
+
+    print("Setup logging")
+    libtuner.setup_logging(args, path_config)
+    print(path_config.run_log, end="\n\n")
+
+    if not args.dry_run:
+        print("Validating devices")
+        libtuner.validate_devices(args.devices)
+        print("Validation successful!\n")
+
+    print("Generating candidates...")
+    candidates = libtuner.generate_candidate_specs(args, path_config, candidate_trackers)
+    print(f"Stored candidates in {path_config.candidates_dir}\n")
+    if stop_after_phase == libtuner.ExecutionPhases.generate_candidates:
+        return
+
+    print("Compiling candidates...")
+    compiled_candidates = libtuner.compile(
+        args, path_config, candidates, candidate_trackers, test_tuner
+    )
+    print(f"Compiled files are stored in {path_config.compiled_dir}\n")
+    if stop_after_phase == libtuner.ExecutionPhases.compile_dispatches:
+        return
+
+    print("Benchmarking compiled candidates...")
+    top_candidates = libtuner.benchmark(
+        args, path_config, compiled_candidates, candidate_trackers, test_tuner
+    )
+    print(f"\nStored kernel results in {path_config.output_unilog.resolve()}\n")
+    if stop_after_phase == libtuner.ExecutionPhases.benchmark_dispatches:
+        return
+
+    print("Compiling model with top candidates...")
+    test_tuner.compile_flags = [
+        "--iree-hip-target=gfx942",
+    ]
+    compiled_model_candidates = libtuner.compile(
+        args, path_config, candidates, candidate_trackers, test_tuner, args.model_file
+    )
+
+    print("Benchmarking compiled model candidates...")
+    test_tuner.benchmark_flags.append("--input=2048x2048xf16")
+    test_tuner.benchmark_flags.append("--input=2048x2048xf16")
+    test_tuner.benchmark_flags.append("--function=main")
+    top_candidates = libtuner.benchmark(
+        args, path_config, compiled_candidates, candidate_trackers, test_tuner
+    )
+    print(f"\nStored model results in {path_config.output_unilog.resolve()}\n")
+    if stop_after_phase == libtuner.ExecutionPhases.benchmark_models:
+        return
+    
+    libtuner.save_pickle(path_config.candidate_trackers_pkl, candidate_trackers)
+    print(f"Candidate trackers are saved in {path_config.candidate_trackers_pkl}\n")
+
+    print("Check the detailed execution logs in:")
+    print(path_config.run_log.resolve())
+
+    for candidate in candidate_trackers:
+        libtuner.logging.debug(candidate)

--- a/tuner/pyproject.toml
+++ b/tuner/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "SHARK Tuner"
+name = "SHARK-Tuner"
 authors = [
   {name = "SHARK Authors"},
 ]

--- a/tuner/tuner/op_matchers.py
+++ b/tuner/tuner/op_matchers.py
@@ -1,0 +1,94 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This code implements matcher functions for MLIR modules using python bindings.
+
+from .common import *
+from iree.turbine.transforms.rewriter import *
+from iree.turbine.transforms.builder import *
+
+class LinalgIteratorType(str, Enum):
+    parallel = "#linalg.iterator_type<parallel>"
+    reduction = "#linalg.iterator_type<reduction>"
+
+
+def has_iterator_types(attr: ir.ArrayAttr, iterators: list[LinalgIteratorType]):
+    if len(attr) != len(iterators):
+        return False
+    for i, a in enumerate(attr):
+        if str(a) != iterators[i]:
+            return False
+    return True
+
+
+def has_indexing_maps(attr: ir.ArrayAttr, maps: list[ir.AffineMap]):
+    if len(attr) != len(maps):
+        return False
+    map_attrs = []
+    for map in maps:
+        map_attrs.append(ir.AffineMapAttr.get(map))
+    for i, map_attr in enumerate(attr):
+        if map_attrs[i] != map_attr:
+            return False
+    return True
+
+
+def get_mmt_iterator_types(context: ir.Context):
+    return [
+        LinalgIteratorType.parallel,
+        LinalgIteratorType.parallel,
+        LinalgIteratorType.reduction,
+    ]
+
+
+def has_mmt_iterator_types(attr: ir.ArrayAttr):
+    mmt_iterators = get_mmt_iterator_types(attr.context)
+    return has_iterator_types(attr, mmt_iterators)
+
+
+def get_mmt_indexing_maps(context: ir.Context):
+    m = ir.AffineDimExpr.get(0)
+    n = ir.AffineDimExpr.get(1)
+    k = ir.AffineDimExpr.get(2)
+    lhs_exprs = [m, k]
+    lhs_map = ir.AffineMap.get(3, 0, exprs=lhs_exprs, context=context)
+    rhs_exprs = [n, k]
+    rhs_map = ir.AffineMap.get(3, 0, exprs=rhs_exprs, context=context)
+    acc_exprs = [m, n]
+    acc_map = ir.AffineMap.get(3, 0, exprs=acc_exprs, context=context)
+    return [lhs_map, rhs_map, acc_map]
+
+
+def has_mmt_indexing_maps(attr: ir.ArrayAttr):
+    if len(attr) != 3:
+        return False
+    mmt_maps = get_mmt_indexing_maps(attr.context)
+    return has_indexing_maps(attr, mmt_maps)
+
+class MmtMatcher(NamedOpMatcher):
+    def __init__(self, builder: Builder):
+        super().__init__("linalg.generic")
+        self.builder = builder
+
+    def match(self, op: ir.Operation):
+        if (len(op.operands) != 3):
+            return None
+        lhs_dims = self.builder.get_tensor_dims(op.operands[0].type)
+        if (len(lhs_dims) != 2):
+            return None
+        rhs_dims = self.builder.get_tensor_dims(op.operands[1].type)
+        if (len(rhs_dims) != 2):
+            return None
+        acc_dims = self.builder.get_tensor_dims(op.operands[2].type)
+        if (len(acc_dims) != 2):
+            return None
+        for attr in op.opview.attributes:
+            if attr.name == "iterator_types" and not has_mmt_iterator_types(attr.attr):
+                return None
+            if (attr.name == "indexing_maps" and not has_mmt_indexing_maps(attr.attr)):
+                return None
+        # TODO(Max191): Check the op body
+        return OpMatchResult(op)


### PR DESCRIPTION
This PR refactors the tuner flow into a unified compilation + benchmark path, and adds an example test showing how to use the new flow. The PR does not remove any of the code from the old paths, because the new path requires a newer version of iree-compiler, which is not compatible with most of the tuner code yet. This PR is quite lengthy so the new flow is described below:

### Goals and Motivations ###
The purpose of this PR is first to unify the model and dispatch compilation and benchmark flow, and second to remove much of the spooky action at a distance between tuner clients and the internal tuner implementation. The first is accomplished by having a single compile and benchmark function, and the second is greatly improved by attempting to hide as much of the CandidateTracker information from the client as possible.

### Candidate Generation ###
Candidate generation uses the same constraint logic to determine a set of potential configurations, and then directly generates transform dialect specs based on the input mlir file, and the generated constraints. The TD specs are created by matching specific operation types in the input mlir file, and then creating a `transform.iree.match.cast_compatible_dag_from_root` in the TD named sequence matcher. This uses a mix of python bindings for matching root ops, and string formatting for building the TD spec, but can eventually be shifted to using exclusively python bindings.

The main difference in the new candidate generation is that only TD specs are created, instead of generating the full configured source for compilation later. The source will be stripped of compilation info and compiled with the TD spec during the compile step.

### Candidate Compilation ###
Candidates are now compiled with a single function for both models and dispatches. There are a few primary differences here:
 - Candidates are stripped of their compilation info with the `iree-codegen-strip-compilation-info` pass before compilation. This allows dispatches to be compiled in the same way as models.
 - The TuningClient has a new function called `get_iree_compile_flags`, which is used in place of `get_dispatch_compile_command` and `get_model_compile_command`. This new function hides the candidate trackers from the client, and is only meant to return some additional iree-compile flags (not including the source file path or `iree-hal-target-backends`). This simplifies the TuningClient implementations significantly, and makes it much easier to understand how to create one.
 - The compile function takes an optional argument to use as the compilation input. This overwrites whatever benchmark file was used for candidate generation during compilation. This allows using the same compile command for the full model by overwriting the input with the model ir.

### Candidate Benchmarking ###
Similar to the compilation, the `get_dispatch_benchmark_command` and `get_model_benchmark_command` are replaced by a single `get_iree_benchmark_module_flags` function. This function hides the candidate trackers from the client, and simply expects a list of extra flags for iree-benchmark-module (not including `--device`, `--module`, or `--benchmark_format`). The benchmark parsing also needed to be rewritten to match the new benchmarking command.