### PR TITLE
[tuner]: use python binding to select mma intrinsics

### DIFF
--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -30,7 +30,7 @@ from abc import abstractmethod
 
 from iree.compiler import ir  # type: ignore
 
-from iree.compiler.dialects import iree_codegen
+from iree.compiler.dialects import iree_codegen  # type: ignore
 
 from .common import *
 from .dispatch_constraints import *
@@ -538,7 +538,7 @@ def tune(
         walk_result: OpWalkResult = walk_mlir_op(mlir_module, dispatch_tuner_registry)
 
         variant_op_list = iree_codegen.get_executable_variant_ops(mlir_module)
-        assert len(variant_op_list) == 1, "Support only one op in one disptach"
+        assert len(variant_op_list) == 1, "Expect one executable variant op"
         variant_op = variant_op_list[0]
         # Get the MMA intrinisic intructions supported by the target.
         mma_list = iree_codegen.query_mma_intrinsics(variant_op)

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -12,6 +12,8 @@ from typing import Optional
 
 from iree.compiler import ir  # type: ignore
 
+from iree.compiler.dialects import iree_gpu
+
 
 class CommonTypes:
     def __init__(self, ctx: ir.Context):
@@ -130,7 +132,12 @@ class MfmaIntrinsic:
         ]
 
 
-def get_compatible_mfma_intrinsics(problem_size: ProblemSize) -> list[MfmaIntrinsic]:
+def get_compatible_mfma_intrinsics(
+    problem_size: ProblemSize,
+    mma_intrinsics: Optional[list[iree_gpu.MMAIntrinsic]] = None,
+) -> list[MfmaIntrinsic]:
+    mma_list_target = {str(mma) for mma in mma_intrinsics} if mma_intrinsics else None
+
     def is_compatible(intrinsic: MfmaIntrinsic) -> bool:
         if problem_size.res_type.element_type != intrinsic.output_type:
             return False
@@ -139,6 +146,10 @@ def get_compatible_mfma_intrinsics(problem_size: ProblemSize) -> list[MfmaIntrin
                 return False
             if problem_size.rhs_type.element_type != intrinsic.input_type:
                 return False
+
+        if mma_list_target is not None and str(intrinsic) not in mma_list_target:
+            return False
+
         return True
 
     return list(filter(is_compatible, MfmaIntrinsic.all()))

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -12,7 +12,7 @@ from typing import Optional
 
 from iree.compiler import ir  # type: ignore
 
-from iree.compiler.dialects import iree_gpu
+from iree.compiler.dialects import iree_gpu  # type: ignore
 
 
 class CommonTypes:
@@ -134,9 +134,9 @@ class MfmaIntrinsic:
 
 def get_compatible_mfma_intrinsics(
     problem_size: ProblemSize,
-    mma_intrinsics: Optional[list[iree_gpu.MMAIntrinsic]] = None,
+    mma_intrinsics: list[iree_gpu.MMAIntrinsic],
 ) -> list[MfmaIntrinsic]:
-    mma_list_target = {str(mma) for mma in mma_intrinsics} if mma_intrinsics else None
+    available_mma_intrinsics = [str(mma) for mma in mma_intrinsics]
 
     def is_compatible(intrinsic: MfmaIntrinsic) -> bool:
         if problem_size.res_type.element_type != intrinsic.output_type:
@@ -147,7 +147,7 @@ def get_compatible_mfma_intrinsics(
             if problem_size.rhs_type.element_type != intrinsic.input_type:
                 return False
 
-        if mma_list_target is not None and str(intrinsic) not in mma_list_target:
+        if available_mma_intrinsics and str(intrinsic) not in available_mma_intrinsics:
             return False
 
         return True

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -147,7 +147,7 @@ def get_compatible_mfma_intrinsics(
             if problem_size.rhs_type.element_type != intrinsic.input_type:
                 return False
 
-        if available_mma_intrinsics and str(intrinsic) not in available_mma_intrinsics:
+        if str(intrinsic) not in available_mma_intrinsics:
             return False
 
         return True

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -153,3 +153,35 @@ def test_get_compatible_mfma_intrinsics(tuner_ctx: common.TunerContext) -> None:
         common.MfmaIntrinsic.mfma_f32_16x16x16_f16(),
         common.MfmaIntrinsic.mfma_f32_32x32x8_f16(),
     ]
+
+    assert common.get_compatible_mfma_intrinsics(
+        common.ProblemSize(
+            common.MatmulSize(968, 320, 640, 64),
+            common.ShapedType([64, 968, 640], tuner_ctx.type.f32),
+            common.ShapedType([64, 640, 320], tuner_ctx.type.f32),
+            common.ShapedType([64, 968, 320], tuner_ctx.type.f32),
+            common.DispatchKind.batch_matmul,
+        ),
+        [
+            iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
+        ],
+    ) == [
+        common.MfmaIntrinsic.mfma_f32_32x32x8_f16(),
+    ]
+
+    assert (
+        common.get_compatible_mfma_intrinsics(
+            common.ProblemSize(
+                common.MatmulSize(968, 320, 640, 64),
+                common.ShapedType([64, 968, 640], tuner_ctx.type.f32),
+                common.ShapedType([64, 640, 320], tuner_ctx.type.f32),
+                common.ShapedType([64, 968, 320], tuner_ctx.type.f32),
+                common.DispatchKind.batch_matmul,
+            ),
+            [
+                iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
+                iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
+            ],
+        )
+        == []
+    )

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -109,7 +109,8 @@ def test_get_compatible_mfma_intrinsics(tuner_ctx: common.TunerContext) -> None:
             common.ShapedType([1280, 1280], tuner_ctx.type.f16),
             common.ShapedType([2048, 1280], tuner_ctx.type.f32),
             common.DispatchKind.mmt,
-        )
+        ),
+        [],
     ) == [
         common.MfmaIntrinsic.mfma_f32_16x16x16_f16(),
         common.MfmaIntrinsic.mfma_f32_32x32x8_f16(),
@@ -122,7 +123,8 @@ def test_get_compatible_mfma_intrinsics(tuner_ctx: common.TunerContext) -> None:
             common.ShapedType([1280, 1280], tuner_ctx.type.i8),
             common.ShapedType([2048, 1280], tuner_ctx.type.i32),
             common.DispatchKind.mmt,
-        )
+        ),
+        [],
     ) == [
         common.MfmaIntrinsic.mfma_i32_16x16x32_i8(),
         common.MfmaIntrinsic.mfma_i32_32x32x16_i8(),
@@ -135,7 +137,8 @@ def test_get_compatible_mfma_intrinsics(tuner_ctx: common.TunerContext) -> None:
             common.ShapedType([64, 640, 320], tuner_ctx.type.f32),
             common.ShapedType([64, 968, 320], tuner_ctx.type.f32),
             common.DispatchKind.batch_matmul,
-        )
+        ),
+        [],
     ) == [
         common.MfmaIntrinsic.mfma_f32_16x16x16_f16(),
         common.MfmaIntrinsic.mfma_f32_32x32x8_f16(),

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -14,6 +14,7 @@ from . import common
 from typing import Generator
 
 from iree.compiler import ir  # type: ignore
+from iree.compiler.dialects import iree_gpu  # type: ignore
 
 
 @pytest.fixture
@@ -110,7 +111,10 @@ def test_get_compatible_mfma_intrinsics(tuner_ctx: common.TunerContext) -> None:
             common.ShapedType([2048, 1280], tuner_ctx.type.f32),
             common.DispatchKind.mmt,
         ),
-        [],
+        [
+            iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
+            iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
+        ],
     ) == [
         common.MfmaIntrinsic.mfma_f32_16x16x16_f16(),
         common.MfmaIntrinsic.mfma_f32_32x32x8_f16(),
@@ -124,7 +128,10 @@ def test_get_compatible_mfma_intrinsics(tuner_ctx: common.TunerContext) -> None:
             common.ShapedType([2048, 1280], tuner_ctx.type.i32),
             common.DispatchKind.mmt,
         ),
-        [],
+        [
+            iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
+            iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
+        ],
     ) == [
         common.MfmaIntrinsic.mfma_i32_16x16x32_i8(),
         common.MfmaIntrinsic.mfma_i32_32x32x16_i8(),
@@ -138,7 +145,10 @@ def test_get_compatible_mfma_intrinsics(tuner_ctx: common.TunerContext) -> None:
             common.ShapedType([64, 968, 320], tuner_ctx.type.f32),
             common.DispatchKind.batch_matmul,
         ),
-        [],
+        [
+            iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
+            iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
+        ],
     ) == [
         common.MfmaIntrinsic.mfma_f32_16x16x16_f16(),
         common.MfmaIntrinsic.mfma_f32_32x32x8_f16(),

--- a/tuner/tuner/dispatch_constraints.py
+++ b/tuner/tuner/dispatch_constraints.py
@@ -10,6 +10,10 @@
 import z3  # type: ignore
 from typing import Iterator
 
+
+from iree.compiler import ir
+from iree.compiler.dialects import iree_codegen, iree_gpu
+
 from .common import *
 
 
@@ -18,8 +22,9 @@ def get_mfma_intrinsic_constraints(
     intrinsic_m: z3.ArithRef,
     intrinsic_n: z3.ArithRef,
     intrinsic_k: z3.ArithRef,
+    mma_intrinsics: Optional[list[iree_gpu.MMAIntrinsic]] = None,
 ) -> z3.BoolRef:
-    compatible_intrinsics = get_compatible_mfma_intrinsics(problem_size)
+    compatible_intrinsics = get_compatible_mfma_intrinsics(problem_size, mma_intrinsics)
     assert len(compatible_intrinsics) > 0, "No compatible intrinsics found"
     return z3.Or(
         *(
@@ -68,6 +73,7 @@ def generate_constraints(
     subgroup_m_count,
     subgroup_n_count,
     waves_per_eu,
+    mma_intrinsics: Optional[list[iree_gpu.MMAIntrinsic]] = None,
 ):
     M, N, K = (
         problem_size.matmul_size.M,
@@ -82,7 +88,7 @@ def generate_constraints(
     constraints += [subgroup_size == 64, wg_threads <= 1024]
     constraints += [
         get_mfma_intrinsic_constraints(
-            problem_size, intrinsic_mn, intrinsic_mn, intrinsic_k
+            problem_size, intrinsic_mn, intrinsic_mn, intrinsic_k, mma_intrinsics
         )
     ]
     subgroup_k_count = 1
@@ -130,7 +136,10 @@ def generate_constraints(
 
 
 def generate_solutions(
-    logger: logging.Logger, problem_size: ProblemSize, num_subgrups: int
+    logger: logging.Logger,
+    problem_size: ProblemSize,
+    num_subgrups: int,
+    mma_intrinsics: Optional[list[iree_gpu.MMAIntrinsic]] = None,
 ) -> Iterator[Configuration]:
     M, N, K = problem_size.MNK
     logger.info(f"{M},{N},{K}")
@@ -168,6 +177,7 @@ def generate_solutions(
         sg_m_cnt,
         sg_n_cnt,
         waves_per_eu,
+        mma_intrinsics,
     )
     solver.add(z3.simplify(z3.And(constraints)))
     logger.debug(f"Initial constraints: {solver}")

--- a/tuner/tuner/dispatch_constraints.py
+++ b/tuner/tuner/dispatch_constraints.py
@@ -11,8 +11,7 @@ import z3  # type: ignore
 from typing import Iterator
 
 
-from iree.compiler import ir
-from iree.compiler.dialects import iree_codegen, iree_gpu
+from iree.compiler.dialects import iree_gpu  # type: ignore
 
 from .common import *
 
@@ -22,7 +21,7 @@ def get_mfma_intrinsic_constraints(
     intrinsic_m: z3.ArithRef,
     intrinsic_n: z3.ArithRef,
     intrinsic_k: z3.ArithRef,
-    mma_intrinsics: Optional[list[iree_gpu.MMAIntrinsic]] = None,
+    mma_intrinsics: list[iree_gpu.MMAIntrinsic],
 ) -> z3.BoolRef:
     compatible_intrinsics = get_compatible_mfma_intrinsics(problem_size, mma_intrinsics)
     assert len(compatible_intrinsics) > 0, "No compatible intrinsics found"
@@ -73,7 +72,7 @@ def generate_constraints(
     subgroup_m_count,
     subgroup_n_count,
     waves_per_eu,
-    mma_intrinsics: Optional[list[iree_gpu.MMAIntrinsic]] = None,
+    mma_intrinsics: list[iree_gpu.MMAIntrinsic],
 ):
     M, N, K = (
         problem_size.matmul_size.M,
@@ -139,7 +138,7 @@ def generate_solutions(
     logger: logging.Logger,
     problem_size: ProblemSize,
     num_subgrups: int,
-    mma_intrinsics: Optional[list[iree_gpu.MMAIntrinsic]] = None,
+    mma_intrinsics: list[iree_gpu.MMAIntrinsic],
 ) -> Iterator[Configuration]:
     M, N, K = problem_size.MNK
     logger.info(f"{M},{N},{K}")

--- a/tuner/tuner/dispatch_constraints_test.py
+++ b/tuner/tuner/dispatch_constraints_test.py
@@ -14,6 +14,7 @@ import z3  # type: ignore
 from typing import Generator
 
 from iree.compiler import ir  # type: ignore
+from iree.compiler.dialects import iree_gpu  # type: ignore
 
 from . import common
 from . import dispatch_constraints
@@ -117,7 +118,12 @@ def test_generate_constraints_valid_input(tuner_ctx: common.TunerContext) -> Non
         sg_m_cnt,
         sg_n_cnt,
         waves_per_eu,
-        [],
+        [
+            iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
+            iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
+            iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
+            iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
+        ],
     )
 
     solver = z3.Solver()
@@ -163,7 +169,12 @@ def test_generate_constraints_invalid_input(tuner_ctx: common.TunerContext) -> N
         sg_m_cnt,
         sg_n_cnt,
         waves_per_eu,
-        [],
+        [
+            iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
+            iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
+            iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
+            iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
+        ],
     )
     constraints.append(m > 1000)  # Adding an additional unsatisfiable constraint
 

--- a/tuner/tuner/dispatch_constraints_test.py
+++ b/tuner/tuner/dispatch_constraints_test.py
@@ -39,8 +39,17 @@ def test_generate_solutions(tuner_ctx: common.TunerContext) -> None:
         matmul_size, lhs_type, rhs_type, res_type, common.DispatchKind.mmt
     )
     configs = dispatch_constraints.generate_solutions(
-        tuner_ctx.logger, problem_size, 4, []
+        tuner_ctx.logger,
+        problem_size,
+        4,
+        [
+            iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
+            iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
+            iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
+            iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
+        ],
     )
+
     assert configs is not None
 
 

--- a/tuner/tuner/dispatch_constraints_test.py
+++ b/tuner/tuner/dispatch_constraints_test.py
@@ -37,7 +37,9 @@ def test_generate_solutions(tuner_ctx: common.TunerContext) -> None:
     problem_size = common.ProblemSize(
         matmul_size, lhs_type, rhs_type, res_type, common.DispatchKind.mmt
     )
-    configs = dispatch_constraints.generate_solutions(tuner_ctx.logger, problem_size, 4)
+    configs = dispatch_constraints.generate_solutions(
+        tuner_ctx.logger, problem_size, 4, []
+    )
     assert configs is not None
 
 
@@ -115,6 +117,7 @@ def test_generate_constraints_valid_input(tuner_ctx: common.TunerContext) -> Non
         sg_m_cnt,
         sg_n_cnt,
         waves_per_eu,
+        [],
     )
 
     solver = z3.Solver()
@@ -160,6 +163,7 @@ def test_generate_constraints_invalid_input(tuner_ctx: common.TunerContext) -> N
         sg_m_cnt,
         sg_n_cnt,
         waves_per_eu,
+        [],
     )
     constraints.append(m > 1000)  # Adding an additional unsatisfiable constraint
 


### PR DESCRIPTION
This PR is relevant to the task in https://github.com/nod-ai/shark-ai/issues/453: " Use IREE attributes for MFMA intrinsics in the tuner".