### PR TITLE
Add Baseline for SGLang Benchmark Test

### DIFF
--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -183,7 +183,7 @@ jobs:
             --env "HF_TOKEN={{ secrets.HF_TOKEN }}" \
             lmsysorg/sglang:v0.3.5.post1-rocm620 \
             python3 -m sglang.launch_server \
-            --model-path meta-llama/Llama-3.1-8b \
+            --model-path meta-llama/Llama-3.1-8B-Instruct \
             --host 0.0.0.0 \
             --port 30000 \
             --tp 1 \

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -25,64 +25,65 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  benchmark_shortfin:
-    if: ${{ github.repository_owner == 'nod-ai' || github.event_name != 'schedule' }}
-    name: "SGLang Serving Benchmark With Shortfin"
-    strategy:
-      matrix:
-        version: [3.11]
-      fail-fast: false
-    runs-on: llama-mi300x-3
-    defaults:
-      run:
-        shell: bash
-    env:
-      PIP_CACHE_DIR: "${{ github.workspace }}/.pip-cache"
-    steps:
-      - name: Get Current Date
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+  # TODO: Uncomment after verification
+  # benchmark_shortfin:
+  #   if: ${{ github.repository_owner == 'nod-ai' || github.event_name != 'schedule' }}
+  #   name: "SGLang Serving Benchmark With Shortfin"
+  #   strategy:
+  #     matrix:
+  #       version: [3.11]
+  #     fail-fast: false
+  #   runs-on: llama-mi300x-3
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   env:
+  #     PIP_CACHE_DIR: "${{ github.workspace }}/.pip-cache"
+  #   steps:
+  #     - name: Get Current Date
+  #       id: date
+  #       run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
-      - name: "Setting up Python"
-        id: setup_python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
-        with:
-          python-version: ${{matrix.version}}
+  #     - name: "Setting up Python"
+  #       id: setup_python
+  #       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+  #       with:
+  #         python-version: ${{matrix.version}}
 
-      - name: "Checkout Code"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  #     - name: "Checkout Code"
+  #       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Cache Pip Packages
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
-        id: cache-pip
-        with:
-          path: ${{ env.PIP_CACHE_DIR }}
-          key: pip-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('*requirements.txt') }}
+  #     - name: Cache Pip Packages
+  #       uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+  #       id: cache-pip
+  #       with:
+  #         path: ${{ env.PIP_CACHE_DIR }}
+  #         key: pip-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('*requirements.txt') }}
 
-      - name: Install pip deps
-        run: |
-          python -m pip install --no-compile --upgrade pip
-          # Note: We install in three steps in order to satisfy requirements
-          # from non default locations first. Installing the PyTorch CPU
-          # wheels saves multiple minutes and a lot of bandwidth on runner setup.
-          pip install --no-compile -r pytorch-cpu-requirements.txt
-          pip install --no-compile -f https://iree.dev/pip-release-links.html --src deps \
-            -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
-          pip install --no-compile -r requirements.txt -e sharktank/ shortfin/
+  #     - name: Install pip deps
+  #       run: |
+  #         python -m pip install --no-compile --upgrade pip
+  #         # Note: We install in three steps in order to satisfy requirements
+  #         # from non default locations first. Installing the PyTorch CPU
+  #         # wheels saves multiple minutes and a lot of bandwidth on runner setup.
+  #         pip install --no-compile -r pytorch-cpu-requirements.txt
+  #         pip install --no-compile -f https://iree.dev/pip-release-links.html --src deps \
+  #           -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
+  #         pip install --no-compile -r requirements.txt -e sharktank/ shortfin/
 
-          # Try with the latest nightly releases, not what iree-turbine pins.
-          # We could also pin to a known working or stable version.
-          # This should eventually stabilize. Do the best we can for now.
-          pip install -f https://iree.dev/pip-release-links.html --upgrade \
-            iree-base-compiler==3.0.0rc20241118 \
-            iree-base-runtime==3.0.0rc20241118 \
-            "numpy<2.0"
+  #         # Try with the latest nightly releases, not what iree-turbine pins.
+  #         # We could also pin to a known working or stable version.
+  #         # This should eventually stabilize. Do the best we can for now.
+  #         pip install -f https://iree.dev/pip-release-links.html --upgrade \
+  #           iree-base-compiler==3.0.0rc20241118 \
+  #           iree-base-runtime==3.0.0rc20241118 \
+  #           "numpy<2.0"
 
-      - name: Install SGLang
-        run: pip install "git+https://github.com/nod-ai/sglang.git#subdirectory=python"
+  #     - name: Install SGLang
+  #       run: pip install "git+https://github.com/nod-ai/sglang.git#subdirectory=python"
 
-      - name: Run Shortfin Benchmark Tests
-        run: pytest -v app_tests/benchmark_tests/llm/sglang_benchmarks/shortfin_benchmark_test.py --log-cli-level=INFO --html=out/llm/shortfin/index.html
+  #     - name: Run Shortfin Benchmark Tests
+  #       run: pytest -v app_tests/benchmark_tests/llm/sglang_benchmarks/shortfin_benchmark_test.py --log-cli-level=INFO --html=out/llm/shortfin/index.html
 
       # TODO: Uncomment after verification
       # - name: Deploy to GitHub Pages
@@ -96,7 +97,8 @@ jobs:
   benchmark_sglang:
     if: ${{ github.repository_owner == 'nod-ai' || github.event_name != 'schedule' }}
     name: "SGLang Serving Benchmark With SGLang"
-    needs: benchmark_shortfin
+    # TODO: Uncomment after verifying
+    # needs: benchmark_shortfin
     strategy:
       matrix:
         version: [3.11]

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Run SGLang Server
         run: |
-          docker run -d --rm  \
+          docker run -d  \
             --name=sglang-server \
             --device=/dev/kfd \
             --device=/dev/dri \

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -181,7 +181,7 @@ jobs:
             -v /data:/data \
             -p 30000:30000 \
             -v ~/.cache/huggingface:/root/.cache/huggingface \
-            --env "HF_TOKEN={{ secrets.HF_TOKEN }}" \
+            --env HF_TOKEN={{ secrets.HF_TOKEN }} \
             lmsysorg/sglang:v0.3.5.post1-rocm620 \
             python3 -m sglang.launch_server \
             --model-path meta-llama/Llama-3.1-8B-Instruct \

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -14,7 +14,7 @@ on:
     # Weekdays at 6:00 AM UTC = 11:00 PM PST.
     # This is a pretty GPU intensive test, so want to avoid conflicting
     # with other potentially scheduled tests.
-    - cron: "0 6 * * 1-5"
+    - cron: "0 4 * * 1-5"
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
@@ -33,7 +33,7 @@ jobs:
   #     matrix:
   #       version: [3.11]
   #     fail-fast: false
-  #   runs-on: llama-mi300x-4
+  #   runs-on: mi300x-4
   #   defaults:
   #     run:
   #       shell: bash
@@ -103,7 +103,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: llama-mi300x-4
+    runs-on: mi300x-4
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -110,9 +110,6 @@ jobs:
     env:
       PIP_CACHE_DIR: "${{ github.workspace }}/.pip-cache"
     steps:
-      - name: Set HF_TOKEN
-        run: echo "HF_TOKEN=${{ secrets.HF_TOKEN }}" >> $GITHUB_ENV
-
       - name: Get Current Date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
@@ -184,7 +181,7 @@ jobs:
             -v /data:/data \
             -p 30000:30000 \
             -v ~/.cache/huggingface:/root/.cache/huggingface \
-            --env HF_TOKEN=$HF_TOKEN \
+            --env HF_TOKEN=${{ secrets.HF_TOKEN }} \
             lmsysorg/sglang:v0.3.5.post1-rocm620 \
             python3 -m sglang.launch_server \
             --model-path meta-llama/Llama-3.1-8B-Instruct \

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -120,6 +120,35 @@ jobs:
         with:
           python-version: ${{matrix.version}}
 
+      - name: "Checkout Code"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Cache Pip Packages
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+        id: cache-pip
+        with:
+          path: ${{ env.PIP_CACHE_DIR }}
+          key: pip-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('*requirements.txt') }}
+
+      - name: Install pip deps
+        run: |
+          python -m pip install --no-compile --upgrade pip
+          # Note: We install in three steps in order to satisfy requirements
+          # from non default locations first. Installing the PyTorch CPU
+          # wheels saves multiple minutes and a lot of bandwidth on runner setup.
+          pip install --no-compile -r pytorch-cpu-requirements.txt
+          pip install --no-compile -f https://iree.dev/pip-release-links.html --src deps \
+            -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
+          pip install --no-compile -r requirements.txt -e sharktank/ shortfin/
+
+          # Try with the latest nightly releases, not what iree-turbine pins.
+          # We could also pin to a known working or stable version.
+          # This should eventually stabilize. Do the best we can for now.
+          pip install -f https://iree.dev/pip-release-links.html --upgrade \
+            iree-base-compiler==3.0.0rc20241118 \
+            iree-base-runtime==3.0.0rc20241118 \
+            "numpy<2.0"
+
       - name: Install SGLang
         run: pip install "git+https://github.com/nod-ai/sglang.git#subdirectory=python"
 

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -33,7 +33,7 @@ jobs:
   #     matrix:
   #       version: [3.11]
   #     fail-fast: false
-  #   runs-on: llama-mi300x-3
+  #   runs-on: llama-mi300x-4
   #   defaults:
   #     run:
   #       shell: bash
@@ -103,7 +103,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: llama-mi300x-3
+    runs-on: llama-mi300x-4
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -162,9 +162,20 @@ jobs:
       #   HIP (Heterogeneous-computing Interface for Portability) for AMD
       #   => base docker rocm/vllm-dev:20241022, not from public vllm whl
       #   srt_hip = ["sglang[runtime_common]", "torch", "vllm==0.6.3.dev13"]
-      - name: Pull SGLang Image (Had issues with sglang:v0.3.5.post1-rocm620)
+      - name: Pull SGLang Image (Had issues with sglang:v0.3.5.post2-rocm620)
         run: |
           docker pull lmsysorg/sglang:v0.3.5.post1-rocm620
+
+      - name: Check HF_TOKEN
+        run: |
+          if [ -z "$HF_TOKEN" ]; then
+            echo "Error: HF_TOKEN is not set or empty."
+            exit 1
+          else
+            echo "HF_TOKEN is set"
+          fi
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
       - name: Run SGLang Server
         run: |

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -7,10 +7,14 @@
 name: SGLang Llama Benchmarking Tests
 
 on:
+  # TODO: Remove PR trigger after verification
+  pull_request:
   workflow_dispatch:
   schedule:
-    # Weekdays at 4:00 AM UTC = 9:00 PM PST.
-    - cron: "0 4 * * 1-5"
+    # Weekdays at 6:00 AM UTC = 11:00 PM PST.
+    # This is a pretty GPU intensive test, so want to avoid conflicting
+    # with other potentially scheduled tests.
+    - cron: "0 6 * * 1-5"
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
@@ -21,9 +25,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  sglang_bench_serve:
+  benchmark_shortfin:
     if: ${{ github.repository_owner == 'nod-ai' || github.event_name != 'schedule' }}
-    name: "SGLang Serving Benchmark Tests"
+    name: "SGLang Serving Benchmark With Shortfin"
     strategy:
       matrix:
         version: [3.11]
@@ -77,13 +81,98 @@ jobs:
       - name: Install SGLang
         run: pip install "git+https://github.com/nod-ai/sglang.git#subdirectory=python"
 
-      - name: Launch Shortfin Server
-        run: pytest -v app_tests/benchmark_tests/llm/sglang_benchmark_test.py --log-cli-level=INFO --html=out/llm/sglang/index.html
+      - name: Run Shortfin Benchmark Tests
+        run: pytest -v app_tests/benchmark_tests/llm/sglang_benchmarks/shortfin_benchmark_test.py --log-cli-level=INFO --html=out/llm/shortfin/index.html
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+      # TODO: Uncomment after verification
+      # - name: Deploy to GitHub Pages
+      #   uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+      #   with:
+      #     github_token: ${{ secrets.SHARK_PLATFORM_GH_TOKEN }}
+      #     publish_dir: ./out/llm/sgl_benchmark/shortfin
+      #     destination_dir: ./llm/sgl_benchmark/shortfin
+      #     keep_files: true
+
+  benchmark_sglang:
+    if: ${{ github.repository_owner == 'nod-ai' || github.event_name != 'schedule' }}
+    name: "SGLang Serving Benchmark With SGLang"
+    needs: benchmark_shortfin
+    strategy:
+      matrix:
+        version: [3.11]
+      fail-fast: false
+    runs-on: llama-mi300x-3
+    defaults:
+      run:
+        shell: bash
+    env:
+      PIP_CACHE_DIR: "${{ github.workspace }}/.pip-cache"
+    steps:
+      - name: Get Current Date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
+      - name: "Setting up Python"
+        id: setup_python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
-          github_token: ${{ secrets.SHARK_PLATFORM_GH_TOKEN }}
-          publish_dir: ./out/llm/sglang
-          destination_dir: ./llm/sglang
-          keep_files: true
+          python-version: ${{matrix.version}}
+
+      - name: Install SGLang
+        run: pip install "git+https://github.com/nod-ai/sglang.git#subdirectory=python"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Instruction for SGLang image sourced from here:
+      #   https://sgl-project.github.io/start/install.html#method-3-using-docker
+      # We have to run in a docker container due to their vLLM dependency.
+      # From their pyproject.toml:
+      #   HIP (Heterogeneous-computing Interface for Portability) for AMD
+      #   => base docker rocm/vllm-dev:20241022, not from public vllm whl
+      #   srt_hip = ["sglang[runtime_common]", "torch", "vllm==0.6.3.dev13"]
+      - name: Pull SGLang Image (Had issues with sglang:v0.3.5.post1-rocm620)
+        run: |
+          docker pull lmsysorg/sglang:v0.3.5.post1-rocm620
+
+      - name: Run SGLang Server
+        run: |
+          docker run -d --rm  \
+            --device=/dev/kfd \
+            --device=/dev/dri \
+            --ipc=host \
+            --shm-size 16G \
+            --group-add video \
+            --cap-add=SYS_PTRACE \
+            --security-opt seccomp=unconfined \
+            -v $HOME/dockerx:/dockerx \
+            -v /data:/data \
+            -p 30000:30000 \
+            -v ~/.cache/huggingface:/root/.cache/huggingface \
+            --env "HF_TOKEN={{ secrets.HF_TOKEN }}" \
+            lmsysorg/sglang:v0.3.5.post1-rocm620 \
+            python3 -m sglang.launch_server \
+            --model-path meta-llama/Llama-3.1-8b \
+            --host 0.0.0.0 \
+            --port 30000 \
+            --tp 1 \
+            --dtype float16
+
+      - name: Run SGLang Benchmark Tests
+        run: |
+          pytest -v app_tests/benchmark_tests/llm/sglang_benchmarks/sglang_benchmark_test.py --port 30000 --log-cli-level=INFO --html=out/llm/sglang/index.html
+
+      - name: Stop sglang-server
+        run: docker stop sglang-server || true # Stop container if it's running
+
+      - name: Cleanup SGLang Image
+        run: docker image rm lmsysorg/sglang:v0.3.5.post1-rocm620
+
+      # TODO: Uncomment after verifying
+      # - name: Deploy to GitHub Pages
+      #   uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+      #   with:
+      #     github_token: ${{ secrets.SHARK_PLATFORM_GH_TOKEN }}
+      #     publish_dir: ./out/llm/sgl_benchmark/sglang
+      #     destination_dir: ./llm/sgl_benchmark/sglang
+      #     keep_files: true

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -169,6 +169,7 @@ jobs:
       - name: Run SGLang Server
         run: |
           docker run -d --rm  \
+            --name=sglang-server \
             --device=/dev/kfd \
             --device=/dev/dri \
             --ipc=host \
@@ -187,7 +188,8 @@ jobs:
             --host 0.0.0.0 \
             --port 30000 \
             --tp 1 \
-            --dtype float16
+            --dtype float16 \
+            --disable-cuda-graph
 
       - name: Run SGLang Benchmark Tests
         run: |

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -110,6 +110,9 @@ jobs:
     env:
       PIP_CACHE_DIR: "${{ github.workspace }}/.pip-cache"
     steps:
+      - name: Set HF_TOKEN
+        run: echo "HF_TOKEN=${{ secrets.HF_TOKEN }}" >> $GITHUB_ENV
+
       - name: Get Current Date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
@@ -181,7 +184,7 @@ jobs:
             -v /data:/data \
             -p 30000:30000 \
             -v ~/.cache/huggingface:/root/.cache/huggingface \
-            --env HF_TOKEN={{ secrets.HF_TOKEN }} \
+            --env HF_TOKEN=$HF_TOKEN \
             lmsysorg/sglang:v0.3.5.post1-rocm620 \
             python3 -m sglang.launch_server \
             --model-path meta-llama/Llama-3.1-8B-Instruct \

--- a/.github/workflows/ci-sglang-integration-tests.yml
+++ b/.github/workflows/ci-sglang-integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: llama-mi300x-4
+    runs-on: mi300x-4
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci-sglang-integration-tests.yml
+++ b/.github/workflows/ci-sglang-integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: llama-mi300x-3
+    runs-on: llama-mi300x-4
     defaults:
       run:
         shell: bash

--- a/app_tests/benchmark_tests/llm/sglang_benchmarks/__init__.py
+++ b/app_tests/benchmark_tests/llm/sglang_benchmarks/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/app_tests/benchmark_tests/llm/sglang_benchmarks/conftest.py
+++ b/app_tests/benchmark_tests/llm/sglang_benchmarks/conftest.py
@@ -9,7 +9,9 @@ import os
 import pytest
 import sys
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+sys.path.append(
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+)
 from integration_tests.llm.utils import compile_model, export_paged_llm_v1
 
 
@@ -44,3 +46,17 @@ def pre_process_model(request, tmp_path_factory):
     compile_model(mlir_path, vmfb_path, settings)
 
     return tmp_dir
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--port",
+        action="store",
+        default="30000",
+        help="Port that SGLang server is running on",
+    )
+
+
+@pytest.fixture(scope="module")
+def sglang_args(request):
+    return request.config.getoption("--port")

--- a/app_tests/benchmark_tests/llm/sglang_benchmarks/conftest.py
+++ b/app_tests/benchmark_tests/llm/sglang_benchmarks/conftest.py
@@ -12,20 +12,28 @@ import sys
 sys.path.append(
     os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 )
-from integration_tests.llm.utils import compile_model, export_paged_llm_v1
+from integration_tests.llm.utils import (
+    compile_model,
+    export_paged_llm_v1,
+    download_with_hf_datasets,
+)
 
 
 @pytest.fixture(scope="module")
 def pre_process_model(request, tmp_path_factory):
     tmp_dir = tmp_path_factory.mktemp("sglang_benchmark_test")
 
-    model_path = request.param["model_path"]
+    model_name = request.param["model_name"]
+    model_param_file_name = request.param["model_param_file_name"]
     settings = request.param["settings"]
     batch_sizes = request.param["batch_sizes"]
 
     mlir_path = tmp_dir / "model.mlir"
     config_path = tmp_dir / "config.json"
     vmfb_path = tmp_dir / "model.vmfb"
+
+    model_path = tmp_dir / model_param_file_name
+    download_with_hf_datasets(tmp_dir, model_name)
 
     export_paged_llm_v1(mlir_path, config_path, model_path, batch_sizes)
 

--- a/app_tests/benchmark_tests/llm/sglang_benchmarks/sglang_benchmark_test.py
+++ b/app_tests/benchmark_tests/llm/sglang_benchmarks/sglang_benchmark_test.py
@@ -1,0 +1,66 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import logging
+from pathlib import Path
+import pytest
+import time
+from unittest.mock import patch
+
+pytest.importorskip("sglang")
+from sglang import bench_serving
+
+from .utils import SGLangBenchmarkArgs, log_jsonl_result
+
+from integration_tests.llm.utils import wait_for_server
+
+logger = logging.getLogger(__name__)
+
+TOKENIZER_DIR = Path("/data/llama3.1/8b/")
+
+
+@pytest.mark.parametrize(
+    "request_rate",
+    [1, 2, 4, 8, 16, 32],
+)
+def test_sglang_benchmark(request_rate, sglang_args, tmp_path_factory):
+    tmp_dir = tmp_path_factory.mktemp("sglang_benchmark_test")
+    logger.info("Beginning SGLang benchmark test...")
+
+    port = sglang_args
+    base_url = f"http://localhost:{port}"
+
+    # Setting a high timeout gives enough time for downloading model artifacts
+    # and starting up server... Takes a little longer than shortfin.
+    wait_for_server(base_url, timeout=600)
+
+    benchmark_args = SGLangBenchmarkArgs(
+        backend="sglang",
+        num_prompt=10,
+        base_url=f"http://localhost:{port}",
+        tokenizer=TOKENIZER_DIR,
+        request_rate=request_rate,
+    )
+    output_file = (
+        tmp_dir
+        / f"{benchmark_args.backend}_{benchmark_args.num_prompt}_{benchmark_args.request_rate}.jsonl"
+    )
+    benchmark_args.output_file = output_file
+
+    logger.info("Running SGLang Benchmark with the following args:")
+    logger.info(benchmark_args)
+
+    try:
+        start = time.time()
+        with patch.object(bench_serving, "print", side_effect=logger.info):
+            bench_serving.run_benchmark(
+                benchmark_args.as_namespace(),
+            )
+        logger.info(f"Benchmark run completed in {str(time.time() - start)} seconds")
+        logger.info("======== RESULTS ========")
+        log_jsonl_result(benchmark_args.output_file)
+    except Exception as e:
+        logger.error(e)

--- a/app_tests/benchmark_tests/llm/sglang_benchmarks/sglang_benchmark_test.py
+++ b/app_tests/benchmark_tests/llm/sglang_benchmarks/sglang_benchmark_test.py
@@ -22,12 +22,12 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.parametrize(
     "request_rate,model_name",
-    [(req_rate, "llama3_8b_f16") for req_rate in [1, 2, 4, 8, 16, 32]],
+    [(req_rate, "llama3_8B_fp16") for req_rate in [1, 2, 4, 8, 16, 32]],
 )
 def test_sglang_benchmark(request_rate, model_name, sglang_args, tmp_path_factory):
     tmp_dir = tmp_path_factory.mktemp("sglang_benchmark_test")
 
-    # Download tokenizer for llama3_8b_f16
+    # Download tokenizer for llama3_8B_fp16
     download_with_hf_datasets(tmp_dir, model_name)
 
     logger.info("Beginning SGLang benchmark test...")

--- a/app_tests/benchmark_tests/llm/sglang_benchmarks/shortfin_benchmark_test.py
+++ b/app_tests/benchmark_tests/llm/sglang_benchmarks/shortfin_benchmark_test.py
@@ -15,7 +15,7 @@ from unittest.mock import patch
 pytest.importorskip("sglang")
 from sglang import bench_serving
 
-from app_tests.benchmark_tests.llm.sglang_benchmarks.utils import (
+from .utils import (
     SGLangBenchmarkArgs,
     log_jsonl_result,
 )

--- a/app_tests/benchmark_tests/llm/sglang_benchmarks/utils.py
+++ b/app_tests/benchmark_tests/llm/sglang_benchmarks/utils.py
@@ -6,7 +6,11 @@
 
 from argparse import Namespace
 from dataclasses import dataclass
+import json
+import logging
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -54,3 +58,12 @@ class SGLangBenchmarkArgs:
             f"Tokenizer: {self.tokenizer}\n"
             f"Request Rate: {self.request_rate}"
         )
+
+
+def log_jsonl_result(file_path):
+    with open(file_path, "r") as file:
+        json_string = file.readline().strip()
+
+    json_data = json.loads(json_string)
+    for key, val in json_data.items():
+        logger.info(f"{key.upper()}: {val}")

--- a/app_tests/integration_tests/llm/utils.py
+++ b/app_tests/integration_tests/llm/utils.py
@@ -15,7 +15,7 @@ import time
 import requests
 from transformers import AutoTokenizer
 
-logger = logging.getLogger("__name__")
+logger = logging.getLogger(__name__)
 
 
 class AccuracyValidationException(RuntimeError):


### PR DESCRIPTION
# Description

The SGLang Benchmark Test has been running for awhile, but only benchmarks the shortfin server itself. In order to get a baseline metric and enable long-term convergence in-terms of performance, we need to be able to track metrics of the SGLang server using the same benchmark method.

This adds an `sglang_benchmark_test` to complement the `shortfin_benchmark_test`. Also restructures `app_tests/benchmark_tests/llm` -> `app_tests/benchmark_tests/llm/sglang_benchmarks`. This keeps the benchmark tests organized and allows for the folder to be extended with other types of benchmarks in the future.

# Why are we using docker to start the SGLang server?

Currently, the pyprompt.toml file inside of SGLang requires `vllm==0.6.3.dev13` to run on ROCm. I looked into potentially building vLLM from source for this test, but couldn't find a branch, tag, or release that matched that signature. From their own comments inside of `pyproject.toml`, it appears to only be available inside of a `ROCm` base image:

```toml
# HIP (Heterogeneous-computing Interface for Portability) for AMD
# => base docker rocm/vllm-dev:20241022, not from public vllm whl
srt_hip = ["sglang[runtime_common]", "torch", "vllm==0.6.3.dev13"]
```

Their [instructions](https://sgl-project.github.io/start/install.html#method-3-using-docker) on installing SGLang and running for ROCm also appear to suggest the docker method:

## Instructions from their docs for running with ROCm

```
docker build --build-arg SGL_BRANCH=v0.3.5.post2 -t v0.3.5.post2-rocm620 -f Dockerfile.rocm .

alias drun='docker run -it --rm --network=host --device=/dev/kfd --device=/dev/dri --ipc=host \
    --shm-size 16G --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
    -v $HOME/dockerx:/dockerx -v /data:/data'

drun -p 30000:30000 \
    -v ~/.cache/huggingface:/root/.cache/huggingface \
    --env "HF_TOKEN=<secret>" \
    v0.3.5.post2-rocm620 \
    python3 -m sglang.launch_server --model-path meta-llama/Llama-3.1-8B-Instruct --host 0.0.0.0 --port 30000
```

The workflow file handles starting the container and cleaning up once the workflow is done. I set the timeout for waiting for the server to start to `10 minutes` to give the SGLang server enough time to load necessary model weights and startup.