### PR TITLE
remove presubmit for large llama tests

### DIFF
--- a/.github/workflows/ci-llama-large-tests.yaml
+++ b/.github/workflows/ci-llama-large-tests.yaml
@@ -8,7 +8,6 @@ name: Llama Benchmarking Tests
 
 on:
   workflow_dispatch:
-  pull_request:
   schedule:
     # Weekdays at 4:00 AM UTC = 9:00 PM PST.
     - cron: "0 4 * * 1-5"


### PR DESCRIPTION
Accidentally added as part of https://github.com/nod-ai/shark-ai/pull/580