### PR TITLE
[shortfin] Pin pydantic-core to 2.27.0

### DIFF
--- a/shortfin/requirements-tests-nogil.txt
+++ b/shortfin/requirements-tests-nogil.txt
@@ -1,4 +1,5 @@
 pytest
 requests
 fastapi
+pydantic-core==2.27.0 # 2.27.1 fails to build
 uvicorn


### PR DESCRIPTION
Pins pydantic-core to 2.27.0, as building 2.27.1 fails to build for Python 3.13t.