### PR TITLE
[shortfin] Remove fastapi from 3.13t requirements

### DIFF
--- a/shortfin/requirements-tests-nogil.txt
+++ b/shortfin/requirements-tests-nogil.txt
@@ -1,4 +1,3 @@
 pytest
 requests
-fastapi
 uvicorn


### PR DESCRIPTION
This removes fastapi as a requirements as it pulls in pydantic which depends on pydantic-core. The latter cannot be build for a free-threaded Python and as part of the 0.27.1 release bumped PyO3 to 0.22.6 to prevent accidental installs on free-threaded Python.

Supersedes and closes #595.