### PR TITLE
[tuner] Add direct TD spec generation for candidates

### DIFF
--- a/tuner/examples/test/__init__.py
+++ b/tuner/examples/test/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/tuner/examples/test/__main__.py
+++ b/tuner/examples/test/__main__.py
@@ -1,0 +1,9 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from . import tuner_test
+
+tuner_test.main()

--- a/tuner/examples/test/tuner_test.py
+++ b/tuner/examples/test/tuner_test.py
@@ -1,0 +1,40 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from tuner import libtuner
+
+
+def main():
+    args = libtuner.parse_arguments()
+
+    path_config = libtuner.PathConfig()
+    path_config.base_dir.mkdir(parents=True, exist_ok=True)
+    path_config.output_unilog.touch()
+    candidate_trackers: list[libtuner.CandidateTracker] = []
+    stop_after_phase: str = args.stop_after
+
+    print("Setup logging")
+    libtuner.setup_logging(args, path_config)
+    print(path_config.run_log, end="\n\n")
+
+    if not args.dry_run:
+        print("Validating devices")
+        libtuner.validate_devices(args.devices)
+        print("Validation successful!\n")
+
+    print("Generating candidates...")
+    candidates = libtuner.generate_candidate_specs(
+        args, path_config, candidate_trackers
+    )
+    print(f"Stored candidate specs in {path_config.specs_dir}\n")
+    if stop_after_phase == libtuner.ExecutionPhases.generate_candidates:
+        return
+
+    print("Check the detailed execution logs in:")
+    print(path_config.run_log.resolve())
+
+    for candidate in candidate_trackers:
+        libtuner.logging.debug(candidate)

--- a/tuner/tuner/candidate_gen_test.py
+++ b/tuner/tuner/candidate_gen_test.py
@@ -15,9 +15,11 @@ from typing import Generator
 from iree.compiler import ir  # type: ignore
 from iree.compiler.dialects import iree_gpu  # type: ignore
 from iree.compiler.dialects import iree_codegen  # type: ignore
+from iree.compiler.dialects import transform  # type: ignore
 
 from . import candidate_gen
 from . import common
+from . import op_matchers
 
 
 @pytest.fixture
@@ -33,6 +35,183 @@ def tuner_ctx() -> Generator[common.TunerContext, None, None]:
 def remove_comments(mlir: str) -> str:
     return "\n".join(
         filter(lambda x: not x.lstrip().startswith("//"), mlir.splitlines())
+    )
+
+
+def test_get_td_spec_contraction(tuner_ctx: common.TunerContext) -> None:
+    context = tuner_ctx.mlir_ctx
+    module_str = """
+        builtin.module{
+            func.func @test(%arg0: tensor<2048x2048xf16>, %arg1: tensor<2048x2048xf16>) -> tensor<2048x2048xf32> {
+                %cst = arith.constant 0.000000e+00 : f32
+                %0 = tensor.empty() : tensor<2048x2048xf32>
+                %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<2048x2048xf32>) -> tensor<2048x2048xf32>
+                %2 = linalg.generic {
+                    indexing_maps = [
+                        affine_map<(d0, d1, d2) -> (d0, d2)>,
+                        affine_map<(d0, d1, d2) -> (d1, d2)>,
+                        affine_map<(d0, d1, d2) -> (d0, d1)>],
+                    iterator_types = ["parallel", "parallel", "reduction"]}
+                    {root_op}
+                    ins(%arg0, %arg1 : tensor<2048x2048xf16>, tensor<2048x2048xf16>)
+                    outs(%1 : tensor<2048x2048xf32>) {
+                ^bb0(%in: f16, %in_0: f16, %out: f32):
+                    %3 = arith.extf %in : f16 to f32
+                    %4 = arith.extf %in_0 : f16 to f32
+                    %5 = arith.mulf %3, %4 : f32
+                    %6 = arith.addf %out, %5 : f32
+                    linalg.yield %6 : f32
+                } -> tensor<2048x2048xf32>
+                return %2 : tensor<2048x2048xf32>
+            }
+        }"""
+
+    mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16
+    mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
+    lowering_config = common.get_lowering_config(
+        tuner_ctx=tuner_ctx,
+        mma_kind=mma_attr,
+        workgroup=[8, 8, 0],
+        reduction=[0, 0, 8],
+        subgroup_m_count=16,
+        subgroup_n_count=16,
+    )
+    pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
+    )
+    pipeline_options = iree_gpu.PipelineOptionsAttr.get(prefetch_shared_memory=True)
+    config_dict = common.get_translation_info_config(pipeline_options, waves_per_eu=8)
+    translation_info = iree_codegen.TranslationInfoAttr.get(
+        pipeline_attr, None, [16, 16, 1], 16, config_dict
+    )
+    compilation_info = iree_codegen.CompilationInfoAttr.get(
+        lowering_config, translation_info
+    )
+
+    ir_module = ir.Module.parse(module_str, context)
+
+    tuner = candidate_gen.ContractionOpInterfaceTuner()
+    td_spec_module = tuner.get_td_spec(ir_module, compilation_info)
+    assert td_spec_module
+
+    named_sequence_ops: list[
+        transform.NamedSequenceOp
+    ] = op_matchers.get_ops_from_module(
+        module=td_spec_module,
+        fn=lambda op: isinstance(op.opview, transform.NamedSequenceOp),
+    )
+    apply_config_sequence = None
+    matcher_sequence = None
+    entry_point = None
+    for op in named_sequence_ops:
+        if str(op.opview.sym_name) == '"apply_op_config"':
+            apply_config_sequence = op
+        elif str(op.opview.sym_name) == '"__kernel_config"':
+            entry_point = op
+        else:
+            matcher_sequence = op
+
+    assert apply_config_sequence
+    assert matcher_sequence
+    assert entry_point
+    matcher_sequence_str = str(matcher_sequence)
+
+    assert (
+        "mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>" in matcher_sequence_str
+    )
+    assert "subgroup_m_count = 16" in matcher_sequence_str
+    assert "subgroup_n_count = 16" in matcher_sequence_str
+    assert "pipeline = LLVMGPUVectorDistribute" in matcher_sequence_str
+    assert "workgroup_size = [16, 16, 1]" in matcher_sequence_str
+    assert "subgroup_size = 16" in matcher_sequence_str
+    assert "workgroup = [8, 8, 0]" in matcher_sequence_str
+    assert "reduction = [0, 0, 8]" in matcher_sequence_str
+    assert (
+        "gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true>"
+        in matcher_sequence_str
+    )
+    assert 'llvm_func_attrs = {"amdgpu-waves-per-eu" = "8"}' in matcher_sequence_str
+
+
+def test_get_td_spec_convolution(tuner_ctx: common.TunerContext) -> None:
+    context = tuner_ctx.mlir_ctx
+    module_str = """
+        builtin.module{
+            func.func @test(%arg0: tensor<2x34x34x2048xi8>, %arg1: tensor<3x3x2048x2048xi8>) -> tensor<2x32x32x2048xi32> {
+                %cst = arith.constant 0 : i32
+                %0 = tensor.empty() : tensor<2x32x32x2048xi32>
+                %1 = linalg.fill ins(%cst : i32) outs(%0 : tensor<2x32x32x2048xi32>) -> tensor<2x32x32x2048xi32>
+                %2 = linalg.conv_2d_nhwc_hwcf {root_op}
+                    ins(%arg0, %arg1 : tensor<2x34x34x2048xi8>, tensor<3x3x2048x2048xi8>)
+                    outs(%1 : tensor<2x32x32x2048xi32>) -> tensor<2x32x32x2048xi32>
+                return %2 : tensor<2x32x32x2048xi32>
+            }
+        }"""
+
+    mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16
+    mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
+    lowering_config = common.get_lowering_config(
+        tuner_ctx=tuner_ctx,
+        mma_kind=mma_attr,
+        workgroup=[1, 1, 464, 320, 0, 0, 0],
+        reduction=[0, 0, 0, 0, 1, 1, 16],
+        subgroup_m_count=1,
+        subgroup_n_count=4,
+    )
+    pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
+    )
+    pipeline_options = iree_gpu.PipelineOptionsAttr.get(prefetch_shared_memory=False)
+    config_dict = common.get_translation_info_config(pipeline_options, waves_per_eu=2)
+    translation_info = iree_codegen.TranslationInfoAttr.get(
+        pipeline_attr, None, [256, 1, 1], 64, config_dict
+    )
+    compilation_info = iree_codegen.CompilationInfoAttr.get(
+        lowering_config, translation_info
+    )
+
+    ir_module = ir.Module.parse(module_str, context)
+
+    tuner = candidate_gen.ConvolutionOpInterfaceTuner()
+    td_spec_module = tuner.get_td_spec(ir_module, compilation_info)
+    assert td_spec_module
+
+    named_sequence_ops: list[
+        transform.NamedSequenceOp
+    ] = op_matchers.get_ops_from_module(
+        module=td_spec_module,
+        fn=lambda op: isinstance(op.opview, transform.NamedSequenceOp),
+    )
+    apply_config_sequence = None
+    matcher_sequence = None
+    entry_point = None
+    for op in named_sequence_ops:
+        if str(op.opview.sym_name) == '"apply_op_config"':
+            apply_config_sequence = op
+        elif str(op.opview.sym_name) == '"__kernel_config"':
+            entry_point = op
+        else:
+            matcher_sequence = op
+
+    assert apply_config_sequence
+    assert matcher_sequence
+    assert entry_point
+
+    matcher_sequence_str = str(matcher_sequence)
+
+    assert (
+        "mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>" in matcher_sequence_str
+    )
+    assert "subgroup_m_count = 1" in matcher_sequence_str
+    assert "subgroup_n_count = 4" in matcher_sequence_str
+    assert "pipeline = LLVMGPUVectorDistribute" in matcher_sequence_str
+    assert "workgroup_size = [256, 1, 1]" in matcher_sequence_str
+    assert "subgroup_size = 64" in matcher_sequence_str
+    assert "workgroup = [1, 1, 464, 320, 0, 0, 0]" in matcher_sequence_str
+    assert "reduction = [0, 0, 0, 0, 1, 1, 16]" in matcher_sequence_str
+    assert (
+        "gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = false>"
+        in matcher_sequence_str
     )
 
 

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -79,6 +79,14 @@ class MatmulSize:
 
 
 @dataclass
+class ContractionDimensions:
+    batch: list[int]
+    m: list[int]
+    n: list[int]
+    k: list[int]
+
+
+@dataclass
 class ProblemSize:
     matmul_size: MatmulSize
     lhs_type: ShapedType
@@ -98,13 +106,12 @@ def get_compatible_mfma_intrinsics(
     def is_comptible(mma_intrinsic: iree_gpu.MMAIntrinsic) -> bool:
         mma_attr = iree_gpu.MMAIntrinsicAttr.get(mma_intrinsic).mma
         a_type, b_type, c_type = mma_attr.abc_element_types
-        if problem_size.res_type.element_type != c_type:
+        if not isinstance(problem_size.res_type.element_type, type(c_type)):
             return False
         if problem_size.dispatch_kind != DispatchKind.batch_matmul:
-            if (
-                problem_size.lhs_type.element_type != a_type
-                or problem_size.rhs_type.element_type != b_type
-            ):
+            if not isinstance(
+                problem_size.lhs_type.element_type, type(a_type)
+            ) or not isinstance(problem_size.rhs_type.element_type, type(b_type)):
                 return False
         return True
 

--- a/tuner/tuner/dispatch_constraints.py
+++ b/tuner/tuner/dispatch_constraints.py
@@ -157,9 +157,9 @@ def getMMAAttr(
         a_type, b_type, c_type = mma_attr.abc_element_types
         mnk = mma_attr.mnk_shape
         if (
-            a_type == lhs_type
-            and b_type == rhs_type
-            and c_type == output_type
+            isinstance(a_type, type(lhs_type))
+            and isinstance(b_type, type(rhs_type))
+            and isinstance(c_type, type(output_type))
             and m == mnk[0]
             and n == mnk[1]
             and k == mnk[2]

--- a/tuner/tuner/dispatch_parser.py
+++ b/tuner/tuner/dispatch_parser.py
@@ -11,6 +11,7 @@ import math
 import re
 from abc import ABCMeta, abstractmethod
 
+from .op_matchers import *
 from .common import *
 
 
@@ -87,6 +88,99 @@ class DispatchParser(metaclass=ABCMeta):
     def get_shapes(self, template: list[str]) -> ProblemSize:
         """Extract problem size of the operation."""
         pass
+
+
+# TODO(Max191): Support linalg named op versions of contraction ops. The
+# current matchers only work for linalg.generic ops.
+class ContractionOpInterfaceParser(DispatchParser):
+    def supports(self, op_name: str) -> bool:
+        return (
+            "matmul_like" in op_name
+            or "batch_matmul" in op_name
+            or "batch_matmul_transpose_b" in op_name
+            or "matmul_transpose_b" in op_name
+        )
+
+    def get_contraction_operation(
+        self,
+        ir_module: ir.Module,
+    ) -> Optional[ir.Operation]:
+        return match_root_op(ir_module, ContractionOpInterfaceMatcher())
+
+    # TODO(Max191): Pass the ir_module directly instead of the template str.
+    def get_shapes(self, template: list[str]) -> ProblemSize:
+        matcher = ContractionOpInterfaceMatcher()
+        with ir.Context() as ctx:
+            ir_module = ir.Module.parse("\n".join(template), ctx)
+        contraction_op = match_root_op(ir_module, matcher)
+        assert contraction_op is not None, f"contraction op not found"
+        cdims = matcher.contraction_dimensions
+        assert cdims, "no contraction dimensions"
+        assert matcher.lhs_dims, "no lhs dimensions"
+        assert matcher.rhs_dims, "no rhs dimensions"
+        assert matcher.res_dims, "no result dimensions"
+        assert len(cdims.batch) <= 1, f"must have at most 1 batch dimension"
+        assert len(cdims.m) == 1, f"must have a single m dimension"
+        assert len(cdims.n) == 1, f"must have a single n dimension"
+        assert len(cdims.k) == 1, f"must have a single k dimension"
+        lhs_type = ir.RankedTensorType(contraction_op.operands[0].type)
+        rhs_type = ir.RankedTensorType(contraction_op.operands[1].type)
+        res_type = ir.RankedTensorType(contraction_op.operands[2].type)
+        matmul_size = MatmulSize(
+            lhs_type.shape[matcher.lhs_dims.index(cdims.m[0])],
+            rhs_type.shape[matcher.rhs_dims.index(cdims.n[0])],
+            lhs_type.shape[matcher.lhs_dims.index(cdims.k[0])],
+        )
+        if len(cdims.batch) == 1:
+            matmul_size.B = lhs_type.shape[matcher.lhs_dims.index(cdims.batch[0])]
+        return ProblemSize(
+            matmul_size,
+            lhs_type=ShapedType(lhs_type.shape, lhs_type.element_type),
+            rhs_type=ShapedType(rhs_type.shape, rhs_type.element_type),
+            res_type=ShapedType(res_type.shape, res_type.element_type),
+            dispatch_kind=DispatchKind.contraction,
+        )
+
+
+# TODO(Max191): Support more convolution types. Only NHWC convs are supported.
+class ConvolutionOpInterfaceParser(DispatchParser):
+    def __init__(self):
+        self.supported_ops = ["linalg.conv_2d_nhwc_hwcf"]
+
+    def supports(self, op_name: str) -> bool:
+        for supported_op_name in self.supported_ops:
+            if supported_op_name.split(".")[-1] in op_name:
+                return True
+        return False
+
+    def get_conv_operation(
+        self,
+        ir_module: ir.Module,
+    ) -> Optional[ir.Operation]:
+        return match_root_op(ir_module, NamedOpMatcher(self.supported_ops))
+
+    # TODO(Max191): Pass the ir_module directly instead of the template str.
+    def get_shapes(self, template: list[str]) -> ProblemSize:
+        with ir.Context() as ctx:
+            ir_module = ir.Module.parse("\n".join(template), ctx)
+        conv_op = match_root_op(ir_module, NamedOpMatcher(self.supported_ops))
+        assert conv_op is not None, f"convolution op not found"
+        lhs_type = ir.RankedTensorType(conv_op.operands[0].type)
+        rhs_type = ir.RankedTensorType(conv_op.operands[1].type)
+        res_type = ir.RankedTensorType(conv_op.operands[2].type)
+        dim_info = ConvDimInfo.from_rhs_res(rhs_type, res_type)
+        return ProblemSize(
+            MatmulSize(
+                M=dim_info.oh * dim_info.ow,
+                N=dim_info.oc,
+                K=dim_info.fh * dim_info.fw * dim_info.ic,
+                B=dim_info.n,
+            ),
+            lhs_type=ShapedType(lhs_type.shape, lhs_type.element_type),
+            rhs_type=ShapedType(rhs_type.shape, rhs_type.element_type),
+            res_type=ShapedType(res_type.shape, res_type.element_type),
+            dispatch_kind=DispatchKind.conv,
+        )
 
 
 class MmtParser(DispatchParser):

--- a/tuner/tuner/op_matchers.py
+++ b/tuner/tuner/op_matchers.py
@@ -1,0 +1,178 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This code implements matcher functions for MLIR modules using python bindings.
+
+from abc import ABCMeta, abstractmethod
+
+from .common import *
+from iree.compiler import ir  # type: ignore
+
+
+class OpMatcher(metaclass=ABCMeta):
+    @abstractmethod
+    def match(self, op: ir.Operation) -> bool:
+        """Check if the op passes the matching criteria."""
+        pass
+
+
+def walk_collect_ops(
+    op: ir.Operation,
+    ops: list[ir.Operation],
+    fn,
+) -> ir.WalkResult:
+    if fn(op):
+        ops.append(op)
+    return ir.WalkResult.ADVANCE
+
+
+def get_ops_from_module(module: ir.Module, fn):
+    ops: list[ir.Operation] = []
+    for op in module.body.operations:
+        op.walk(
+            lambda op: walk_collect_ops(op, ops, fn),
+            ir.WalkOrder.POST_ORDER,
+        )
+    return ops
+
+
+def is_root_op(op: ir.Operation) -> bool:
+    for attr in op.opview.attributes:
+        if attr.name == "root_op":
+            return True
+    return False
+
+
+def match_root_op(
+    ir_module: ir.Module,
+    matcher: OpMatcher,
+) -> Optional[ir.Operation]:
+    root_ops: list[ir.Operation] = get_ops_from_module(ir_module, is_root_op)
+    if len(root_ops) != 1:
+        return None
+    if not matcher.match(root_ops[0].operation):
+        return None
+    return root_ops[0]
+
+
+class NamedOpMatcher(OpMatcher):
+    def __init__(self, op_names: list[str]):
+        self.op_names = op_names
+
+    def match(self, op: ir.Operation) -> bool:
+        return op.name in self.op_names
+
+
+# TODO(Max191): Add logic to match the body of the generic op.
+class GenericOpMatcher(NamedOpMatcher):
+    def __init__(self):
+        super().__init__(["linalg.generic"])
+
+    @abstractmethod
+    def match_operands(self, operands: ir.OpOperandList) -> bool:
+        """Match the operands of the linalg op."""
+        pass
+
+    @abstractmethod
+    def match_indexing_maps(self, maps: list[ir.AffineMap]) -> bool:
+        """Match the indexing_maps of the linalg op."""
+        pass
+
+    def match(self, op: ir.Operation) -> bool:
+        if not super().match(op):
+            return False
+
+        if not self.match_operands(op.operands):
+            return False
+
+        maps_attr = None
+        for attr in op.opview.attributes:
+            if attr.name == "indexing_maps" and isinstance(attr.attr, ir.ArrayAttr):
+                maps_attr = attr.attr
+        if maps_attr is None:
+            return False
+
+        maps: list[ir.AffineMap] = []
+        for map in maps_attr:
+            maps.append(map.value)
+        if not self.match_indexing_maps(maps):
+            return False
+
+        return True
+
+
+def get_map_result_dim_positions(map: ir.AffineMap):
+    exprs = []
+    if not map.is_projected_permutation:
+        return None
+    for expr in map.results:
+        dim_str = str(expr)
+        if len(dim_str) < 1:
+            return None
+        if dim_str[0] != "d":
+            return None
+        if not dim_str[1:].isdigit():
+            return None
+        dim_position = int(dim_str[1:])
+        exprs.append(dim_position)
+    return exprs
+
+
+class ContractionOpInterfaceMatcher(GenericOpMatcher):
+    def __init__(self):
+        super().__init__()
+        self.contraction_dimensions: Optional[ContractionDimensions] = None
+        self.lhs_dims: Optional[list[int]] = None
+        self.rhs_dims: Optional[list[int]] = None
+        self.res_dims: Optional[list[int]] = None
+
+    def match_operands(self, operands: ir.OpOperandList) -> bool:
+        if len(operands) != 3:
+            return False
+        for operand in operands:
+            if not isinstance(operand.type, ir.ShapedType):
+                return False
+        return True
+
+    def match_indexing_maps(self, maps: list[ir.AffineMap]) -> bool:
+        if len(maps) != 3:
+            return False
+        lhs_dims = get_map_result_dim_positions(maps[0])
+        rhs_dims = get_map_result_dim_positions(maps[1])
+        res_dims = get_map_result_dim_positions(maps[2])
+        if lhs_dims is None or rhs_dims is None or res_dims is None:
+            return False
+
+        batch_dims = []
+        m_dims = []
+        n_dims = []
+        k_dims = []
+
+        for d in range(maps[0].n_dims):
+            if d in lhs_dims and d in rhs_dims and d in res_dims:
+                batch_dims.append(d)
+                continue
+            if d in lhs_dims and d in res_dims:
+                m_dims.append(d)
+                continue
+            if d in rhs_dims and d in res_dims:
+                n_dims.append(d)
+                continue
+            if d in lhs_dims and d in rhs_dims:
+                k_dims.append(d)
+                continue
+            return False
+
+        self.contraction_dimensions = ContractionDimensions(
+            batch=batch_dims,
+            m=m_dims,
+            n=n_dims,
+            k=k_dims,
+        )
+        self.lhs_dims = lhs_dims
+        self.rhs_dims = rhs_dims
+        self.res_dims = res_dims
+        return True

--- a/tuner/tuner/spec_builder.py
+++ b/tuner/tuner/spec_builder.py
@@ -1,0 +1,62 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Given an input dispatch, this code modifies the hyperparameters
+# in the code and runs it.
+
+from iree.compiler import ir  # type: ignore
+from iree.compiler.dialects import iree_codegen  # type: ignore
+
+from .common import *
+from .dispatch_constraints import *
+from .dispatch_parser import *
+
+
+# TODO(Max191): Use python bindings to build the transform dialect spec module
+# instead of using string formatting.
+def build_td_spec(
+    context: ir.Context,
+    op: ir.Operation,
+    compilation_info: iree_codegen.CompilationInfoAttr,
+    func_name: str,
+) -> ir.Module:
+    bbargs = []
+    for operand in op.operands:
+        ssa_name = operand.get_name()
+        operand_type = operand.type
+        bbargs.append(f"{ssa_name}: {operand_type}")
+    bbargs_str = ", ".join(bbargs)
+    root_operation = str(op)
+    spec_text = f"""
+        module attributes {{ transform.with_named_sequence }} {{
+            // Annotation Transform
+            transform.named_sequence @apply_op_config(%op: !transform.any_op {{transform.readonly}},
+                                                        %config: !transform.any_param {{transform.readonly}}) {{
+                transform.annotate %op "compilation_info" = %config : !transform.any_op, !transform.any_param
+                transform.yield
+            }}
+
+            // Custom Op Matcher
+            transform.named_sequence @{func_name}(%cont: !transform.any_op {{transform.readonly}})
+                -> (!transform.any_op, !transform.any_param) {{
+                %ins, %outs = transform.iree.match.cast_compatible_dag_from_root %cont {{
+                ^bb0({bbargs_str}):
+                {root_operation}
+                }} : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
+                %config = transform.param.constant {compilation_info} -> !transform.any_param
+                transform.yield %cont, %config : !transform.any_op, !transform.any_param
+            }}
+
+            // Entry Point
+            transform.named_sequence @__kernel_config(%variant_op: !transform.any_op {{transform.consumed}}) {{
+                transform.foreach_match in %variant_op
+                    @{func_name} -> @apply_op_config
+                : (!transform.any_op) -> (!transform.any_op)
+                transform.yield
+            }}
+        }}
+        """
+    return ir.Module.parse(spec_text, context)


### PR DESCRIPTION
This PR adds direct transform dialect spec generation for candidate configurations. This is the first part of the large refactoring described in https://github.com/nod-ai/shark-ai/pull/577. The way TD specs are generated is by matching against certain types of operations, and then creating a named sequence with `transform.iree.match.cast_compatible_dag_from_root` based on the matched operation. This is done for each configuration found, and the specs are saved to the temporary tuning directory to be used later in tuning.

One main difference in the flow of candidate generation is that state is no longer tracked by saving files to a temporary directory. Instead, ir modules are passed to each function, and only at the very end of candidate generation are the transform dialect specs written to files. This makes things cleaner, since there no longer needs to be a coordination of file paths.