### PR TITLE
Add T5 encoder bfloat16 support

### DIFF
--- a/sharktank/conftest.py
+++ b/sharktank/conftest.py
@@ -153,16 +153,28 @@ def pytest_addoption(parser):
     #     --outtype=f32 \
     #     t5-v1_1-small
     parser.addoption(
-        "--google-t5-v1-1-small-fp32-model-path",
+        "--google-t5-v1-1-small-f32-model-path",
         type=Path,
-        default="/data/t5/small/google__t5-v1_1-small_fp32.gguf",
-        help="Google T5 v1.1 small fp32 model path",
+        default="/data/t5/small/google__t5-v1_1-small_f32.gguf",
+        help="Google T5 v1.1 small float32 model path",
     )
     parser.addoption(
-        "--google-t5-v1-1-xxl-fp32-model-path",
+        "--google-t5-v1-1-small-bf16-model-path",
         type=Path,
-        default="/data/t5/xxl/google__t5-v1_1-xxl_fp32.gguf",
-        help="Google T5 v1.1 XXL fp32 model path",
+        default="/data/t5/small/google__t5-v1_1-small_bf16.gguf",
+        help="Google T5 v1.1 small bfloat16 model path",
+    )
+    parser.addoption(
+        "--google-t5-v1-1-xxl-f32-model-path",
+        type=Path,
+        default="/data/t5/xxl/google__t5-v1_1-xxl_f32.gguf",
+        help="Google T5 v1.1 XXL float32 model path",
+    )
+    parser.addoption(
+        "--google-t5-v1-1-xxl-bf16-model-path",
+        type=Path,
+        default="/data/t5/xxl/google__t5-v1_1-xxl_bf16.gguf",
+        help="Google T5 v1.1 XXL bfloat16 model path",
     )
 
     parser.addoption(
@@ -288,15 +300,20 @@ def get_model_artifacts(request: FixtureRequest):
     model_path["llama3_405b_fp8_model_path"] = set_fixture_from_cli_option(
         request, "--llama3-405b-fp8-model-path", "llama3_405b_fp8_model"
     )
-    model_path["google__t5_v1_1_small_fp32_model_path"] = set_fixture_from_cli_option(
+    model_path["google__t5_v1_1_small_f32_model_path"] = set_fixture_from_cli_option(
         request,
-        "--google-t5-v1-1-small-fp32-model-path",
-        "google__t5_v1_1_small_fp32_model",
+        "--google-t5-v1-1-small-f32-model-path",
+        "google__t5_v1_1_small_f32_model",
     )
-    model_path["google__t5_v1_1_xxl_fp32_model_path"] = set_fixture_from_cli_option(
+    model_path["google__t5_v1_1_small_bf16_model_path"] = set_fixture_from_cli_option(
         request,
-        "--google-t5-v1-1-xxl-fp32-model-path",
-        "google__t5_v1_1_xxl_fp32_model",
+        "--google-t5-v1-1-small-bf16-model-path",
+        "google__t5_v1_1_small_bf16_model",
+    )
+    model_path["google__t5_v1_1_xxl_f32_model_path"] = set_fixture_from_cli_option(
+        request,
+        "--google-t5-v1-1-xxl-f32-model-path",
+        "google__t5_v1_1_xxl_f32_model",
     )
     return model_path
 

--- a/sharktank/requirements.txt
+++ b/sharktank/requirements.txt
@@ -1,7 +1,7 @@
 iree-turbine
 
 # Runtime deps.
-gguf==0.6.0
+gguf==0.10.0
 numpy<2.0
 
 # Needed for newer gguf versions (TODO: remove when gguf package includes this)

--- a/sharktank/sharktank/layers/configs/llm_configs.py
+++ b/sharktank/sharktank/layers/configs/llm_configs.py
@@ -227,6 +227,8 @@ class T5Config:
             == properties["t5.attention.layer_norm_rms_epsilon"]
         )
 
+        all_kwargs = {"vocab_size": None, "feed_forward_proj": None}
+
         gguf_to_config_names_map = {
             "t5.context_length": ["context_length"],
             "t5.embedding_length": ["d_model"],
@@ -236,11 +238,9 @@ class T5Config:
             "t5.attention.key_length": ["d_kv"],
             "t5.attention.layer_norm_epsilon": ["layer_norm_epsilon"],
             "t5.attention.relative_buckets_count": ["relative_attention_num_buckets"],
-            "t5.decoder_start_token_id": ["decoder_start_token_id"],
             "tokenizer.ggml.eos_token_id": ["eos_token_id"],
             "tokenizer.ggml.padding_token_id": ["pad_token_id"],
         }
-        all_kwargs = {"vocab_size": None, "feed_forward_proj": None}
         all_kwargs.update(
             {
                 config_name: properties[gguf_name]
@@ -248,6 +248,19 @@ class T5Config:
                 for config_name in config_names
             }
         )
+
+        gguf_to_optional_config_names_map = {
+            "t5.decoder_start_token_id": ["decoder_start_token_id"],
+        }
+        all_kwargs.update(
+            {
+                config_name: properties[gguf_name]
+                for gguf_name, config_names in gguf_to_optional_config_names_map.items()
+                for config_name in config_names
+                if gguf_name in properties
+            }
+        )
+
         if "tokenizer.ggml.tokens" in properties:
             all_kwargs["vocab_size"] = len(properties["tokenizer.ggml.tokens"])
         all_kwargs.update(kwargs)

--- a/sharktank/sharktank/layers/token_embedding.py
+++ b/sharktank/sharktank/layers/token_embedding.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import torch
+from typing import Optional
 
 from .. import ops
 from .base import Theta, ThetaLayer
@@ -16,7 +17,7 @@ class TokenEmbeddingLayer(ThetaLayer):
         theta: Theta,
         *,
         weight_name: str = "weight",
-        dtype: torch.dtype = torch.float32,
+        dtype: Optional[torch.dtype] = torch.float32,
     ):
         super().__init__(theta)
         self.weight = self.theta_tensor(weight_name)

--- a/sharktank/sharktank/models/t5/t5.py
+++ b/sharktank/sharktank/models/t5/t5.py
@@ -684,7 +684,9 @@ class T5Stack(BaseLayer):
         self.add_module(
             "final_layer_norm",
             RMSNormLayer(
-                theta(f"{theta_prefix}.output_norm"), epsilon=config.layer_norm_epsilon
+                theta(f"{theta_prefix}.output_norm"),
+                epsilon=config.layer_norm_epsilon,
+                dtype=config.activation_dtype,
             ),
         )
 
@@ -1046,7 +1048,9 @@ class T5Encoder(BaseLayer):
         super().__init__()
         self.add_module(
             "token_embedding",
-            TokenEmbeddingLayer(theta("token_embd"), dtype=config.activation_dtype),
+            TokenEmbeddingLayer(
+                theta("token_embd"), dtype=theta("token_embd").tensor("weight").dtype
+            ),
         )
 
         encoder_config = copy.deepcopy(config)

--- a/sharktank/sharktank/transforms/dataset/__init__.py
+++ b/sharktank/sharktank/transforms/dataset/__init__.py
@@ -5,3 +5,4 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .sharding import *
+from .dataset import *

--- a/sharktank/sharktank/transforms/dataset/dataset.py
+++ b/sharktank/sharktank/transforms/dataset/dataset.py
@@ -1,0 +1,19 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import torch
+
+from ...types.tensors import InferenceTensor, PrimitiveTensor, DefaultPrimitiveTensor
+from ... import ops
+
+
+def set_float_dtype(tensor: InferenceTensor, dtype: torch.dtype) -> InferenceTensor:
+    if isinstance(tensor, PrimitiveTensor) and tensor.dtype.is_floating_point:
+        return DefaultPrimitiveTensor(
+            name=tensor.name, data=ops.to(tensor, dtype=dtype)
+        )
+
+    return tensor

--- a/sharktank/sharktank/types/gguf_interop/base.py
+++ b/sharktank/sharktank/types/gguf_interop/base.py
@@ -118,6 +118,15 @@ def _wrap_tensor(
             name=name, data=_externalize_tensor(name, data, logical_shape)
         )
 
+    if type_name == "BF16":
+        assert data.dtype == np.uint8
+        return DefaultPrimitiveTensor(
+            name=name,
+            data=_externalize_tensor(name, data.view(np.int16), logical_shape).view(
+                dtype=torch.bfloat16
+            ),
+        )
+
     quantized_type = _quantized_types.get(type_name)
     if quantized_type is not None:
         return quantized_type(

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -41,6 +41,7 @@ __all__ = [
     "AnyTensor",
     "DefaultPrimitiveTensor",
     "dtype_to_serialized_name",
+    "dtype_to_serialized_short_name",
     "flatten_tensor_tree",
     "InferenceTensor",
     "MetaDataValueType",
@@ -51,6 +52,7 @@ __all__ = [
     "register_quantized_layout",
     "ReplicatedTensor",
     "serialized_name_to_dtype",
+    "serialized_short_name_to_dtype",
     "ShardedTensor",
     "SplitPrimitiveTensor",
     "torch_tree_flatten",
@@ -1286,12 +1288,30 @@ def dtype_to_serialized_name(dtype: torch.dtype) -> str:
         ) from e
 
 
+def dtype_to_serialized_short_name(dtype: torch.dtype) -> str:
+    try:
+        return _DTYPE_TO_SHORT_NAME[dtype]
+    except KeyError as e:
+        raise KeyError(
+            f"Missing mapping for dtype {dtype}. Please add to the _SHORT_NAME_TO_DTYPE dict"
+        ) from e
+
+
 def serialized_name_to_dtype(dtype_name: str) -> torch.dtype:
     try:
         return _NAME_TO_DTYPE[dtype_name]
     except KeyError as e:
         raise KeyError(
             f"Missing mapping for dtype '{dtype_name}'. Please add to the _NAME_TO_DTYPE dict"
+        ) from e
+
+
+def serialized_short_name_to_dtype(dtype_name: str) -> torch.dtype:
+    try:
+        return _SHORT_NAME_TO_DTYPE[dtype_name]
+    except KeyError as e:
+        raise KeyError(
+            f"Missing mapping for dtype '{dtype_name}'. Please add to the _SHORT_NAME_TO_DTYPE dict"
         ) from e
 
 
@@ -1337,6 +1357,26 @@ _maybe_dtype(
 )
 
 _DTYPE_TO_NAME: dict[torch.dtype, str] = {v: k for k, v in _NAME_TO_DTYPE.items()}
+
+_SHORT_NAME_TO_DTYPE: dict[str, torch.dtype] = {
+    "f32": torch.float32,
+    "f64": torch.float64,
+    "c64": torch.complex64,
+    "c128": torch.complex128,
+    "f16": torch.float16,
+    "bf16": torch.bfloat16,
+    "ui8": torch.uint8,
+    "i8": torch.int8,
+    "i16": torch.int16,
+    "i32": torch.int32,
+    "i64": torch.int64,
+    "b": torch.bool,
+    "f8_e4m3fnuz": torch.float8_e4m3fnuz,
+}
+
+_DTYPE_TO_SHORT_NAME: dict[torch.dtype, str] = {
+    v: k for k, v in _SHORT_NAME_TO_DTYPE.items()
+}
 
 AnyTensor = Union[torch.Tensor, InferenceTensor]
 

--- a/sharktank/sharktank/utils/testing.py
+++ b/sharktank/sharktank/utils/testing.py
@@ -4,6 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from typing import Optional
 import contextlib
 from pathlib import Path
 import os
@@ -20,7 +21,7 @@ from ..types import *
 
 # Range of torch.rand() is [0,1)
 # Range of torch.rand() * 2 - 1 is [-1, 1), includes negative values
-def make_rand_torch(shape, dtype=torch.float32):
+def make_rand_torch(shape: list[int], dtype: Optional[torch.dtype] = torch.float32):
     return torch.rand(shape, dtype=dtype) * 2 - 1
 
 

--- a/sharktank/tests/models/t5/t5_test.py
+++ b/sharktank/tests/models/t5/t5_test.py
@@ -4,6 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import functools
 from transformers.models.t5.modeling_t5 import (
     T5Attention as ReferenceT5Attention,
     T5LayerSelfAttention as ReferenceT5LayerSelfAttention,
@@ -14,13 +15,21 @@ from transformers import (
     T5EncoderModel as ReferenceT5EncoderModel,
     T5Config as ReferenceT5Config,
 )
+from typing import Optional
 import os
 from collections import OrderedDict
 import pytest
 import torch
+from torch.utils._pytree import tree_map, tree_unflatten, tree_flatten_with_path
 from unittest import TestCase
 from parameterized import parameterized
-from sharktank.types import Theta, DefaultPrimitiveTensor, unbox_tensor, Dataset
+from sharktank.types import (
+    Theta,
+    DefaultPrimitiveTensor,
+    unbox_tensor,
+    Dataset,
+    dtype_to_serialized_short_name,
+)
 from sharktank.models.t5 import (
     T5Attention,
     T5SelfAttention,
@@ -41,6 +50,8 @@ from sharktank.utils.iree import (
     flatten_for_iree_signature,
     iree_to_torch,
 )
+from sharktank.transforms.dataset import set_float_dtype
+from sharktank import ops
 import iree.compiler
 
 with_t5_data = pytest.mark.skipif("not config.getoption('with_t5_data')")
@@ -67,27 +78,17 @@ class T5EncoderEagerTest(TestCase):
         torch.random.manual_seed(12345)
         torch.no_grad()
 
-    def runTestV1_1Fp32CompareTorchEagerAgainstHuggingFace(
-        self, huggingface_repo_id: str
-    ):
-        get_dataset(
-            huggingface_repo_id,
-        ).download()
-        tokenizer = AutoTokenizer.from_pretrained(huggingface_repo_id)
-        reference_model = ReferenceT5EncoderModel.from_pretrained(huggingface_repo_id)
-        reference_model.eval()
-
-        input_ids = tokenizer(
-            test_prompts,
-            return_tensors="pt",
-            padding=True,
-        ).input_ids
-
+    @with_t5_data
+    def testXxlBf16AgainstFluxGolden(self):
+        """The ground-truth values were acquired from the Flux pipeline."""
         target_model_name = (
-            f"{huggingface_repo_id.replace('/', '__').replace('-', '_')}_fp32_model"
+            f"{'google/t5-v1_1-xxl'.replace('/', '__').replace('-', '_')}_f32_model"
         )
         target_model_path = getattr(self, target_model_name)
         dataset = Dataset.load(target_model_path)
+        dataset.root_theta = dataset.root_theta.transform(
+            functools.partial(set_float_dtype, dtype=torch.bfloat16)
+        )
         config = T5Config.from_gguf_properties(
             dataset.properties,
             feed_forward_proj="gated-gelu",
@@ -95,17 +96,192 @@ class T5EncoderEagerTest(TestCase):
         model = T5Encoder(theta=dataset.root_theta, config=config)
         model.eval()
 
+        with open(
+            "/data/t5/xxl/flux_schnell_t5_v1_1_xxl_encoder_bf16_input_ids.pt", "rb"
+        ) as f:
+            reference_input_ids = torch.load(f)
+
+        outputs = model(
+            input_ids=reference_input_ids,
+            attention_mask=None,
+            output_hidden_states=False,
+        )
+
+        with open(
+            "/data/t5/xxl/flux_schnell_t5_v1_1_xxl_encoder_bf16_output_last_hidden_state.pt",
+            "rb",
+        ) as f:
+            reference_last_hidden_state = torch.load(f)
+
+        torch.testing.assert_close(
+            outputs["last_hidden_state"], reference_last_hidden_state
+        )
+
+    def runTestV1_1CompareTorchEagerHuggingFace(
+        self,
+        huggingface_repo_id: str,
+        reference_dtype: torch.dtype,
+        target_dtype: torch.dtype,
+        atol: Optional[float] = None,
+        rtol: Optional[float] = None,
+    ):
+        get_dataset(
+            huggingface_repo_id,
+        ).download()
+        tokenizer = AutoTokenizer.from_pretrained(huggingface_repo_id)
+        reference_model = ReferenceT5EncoderModel.from_pretrained(
+            huggingface_repo_id, torch_dtype=reference_dtype
+        )
+        reference_model.eval()
+
+        model = ReferenceT5EncoderModel.from_pretrained(
+            huggingface_repo_id, torch_dtype=target_dtype
+        )
+        model.eval()
+
+        input_ids = tokenizer(
+            test_prompts,
+            return_tensors="pt",
+            padding=True,
+            pad_to_multiple_of=16,
+        ).input_ids
+
+        expected_outputs = dict(reference_model(input_ids=input_ids))
+        actual_outputs = dict(model(input_ids=input_ids))
+        actual_outputs = tree_map(
+            lambda t: ops.to(t, dtype=reference_dtype), actual_outputs
+        )
+
+        torch.testing.assert_close(
+            actual_outputs, expected_outputs, atol=atol, rtol=rtol
+        )
+
+    def runTestV1_1CompareTorchEagerAgainstHuggingFace(
+        self,
+        huggingface_repo_id: str,
+        reference_dtype: torch.dtype,
+        target_dtype: torch.dtype,
+        atol: Optional[float] = None,
+        rtol: Optional[float] = None,
+    ):
+        get_dataset(
+            huggingface_repo_id,
+        ).download()
+        tokenizer = AutoTokenizer.from_pretrained(huggingface_repo_id)
+        reference_model = ReferenceT5EncoderModel.from_pretrained(
+            huggingface_repo_id, torch_dtype=reference_dtype
+        )
+        reference_model.eval()
+
+        target_model_name = (
+            f"{huggingface_repo_id.replace('/', '__').replace('-', '_')}_f32_model"
+        )
+        target_model_path = getattr(self, target_model_name)
+        dataset = Dataset.load(target_model_path)
+        dataset.root_theta = dataset.root_theta.transform(
+            functools.partial(set_float_dtype, dtype=target_dtype)
+        )
+        config = T5Config.from_gguf_properties(
+            dataset.properties,
+            feed_forward_proj="gated-gelu",
+        )
+
+        input_ids = tokenizer(
+            test_prompts,
+            return_tensors="pt",
+            padding=True,
+            pad_to_multiple_of=config.context_length_padding_block_size,
+        ).input_ids
+
+        model = T5Encoder(theta=dataset.root_theta, config=config)
+        model.eval()
+
         expected_outputs = reference_model(input_ids=input_ids)
         actual_outputs = model(input_ids=input_ids)
-        torch.testing.assert_close(actual_outputs, expected_outputs, atol=1e-5, rtol=0)
+        actual_outputs = tree_map(
+            lambda t: ops.to(t, dtype=reference_dtype), actual_outputs
+        )
+
+        torch.testing.assert_close(
+            actual_outputs, expected_outputs, atol=atol, rtol=rtol
+        )
+
+    @pytest.mark.xfail(
+        raises=AssertionError,
+        reason=(
+            "The accuracy is bad, "
+            "but for XXL we get the same result as the Flux pipeline. "
+            "This need further investigation how Flux works at all like that."
+        ),
+    )
+    @with_t5_data
+    def testV1_1SmallCompareTorchEagerHuggingFaceBf16AgainstF32(self):
+        self.runTestV1_1CompareTorchEagerHuggingFace(
+            "google/t5-v1_1-small",
+            reference_dtype=torch.float32,
+            target_dtype=torch.bfloat16,
+            atol=1e-2,
+            rtol=1.6e-2,
+        )
 
     @with_t5_data
-    def testV1_1SmallFp32CompareTorchEagerAgainstHuggingFace(self):
-        self.runTestV1_1Fp32CompareTorchEagerAgainstHuggingFace("google/t5-v1_1-small")
+    def testV1_1SmallF32CompareTorchEagerAgainstHuggingFace(self):
+        self.runTestV1_1CompareTorchEagerAgainstHuggingFace(
+            "google/t5-v1_1-small",
+            reference_dtype=torch.float32,
+            target_dtype=torch.float32,
+        )
+
+    @pytest.mark.xfail(
+        raises=AssertionError,
+        reason=(
+            "The accuracy is bad, "
+            "but for XXL we get the same result as the Flux pipeline. "
+            "This need further investigation how Flux works at all like that."
+        ),
+    )
+    @with_t5_data
+    def testV1_1SmallBf16CompareTorchEagerAgainstHuggingFaceF32(self):
+        self.runTestV1_1CompareTorchEagerAgainstHuggingFace(
+            "google/t5-v1_1-small",
+            reference_dtype=torch.float32,
+            target_dtype=torch.bfloat16,
+            atol=1e-2,
+            rtol=1.6e-2,
+        )
 
     @with_t5_data
-    def testV1_1XxlFp32CompareTorchEagerAgainstHuggingFace(self):
-        self.runTestV1_1Fp32CompareTorchEagerAgainstHuggingFace("google/t5-v1_1-xxl")
+    def testV1_1SmallBf16CompareTorchEagerAgainstHuggingFace(self):
+        self.runTestV1_1CompareTorchEagerAgainstHuggingFace(
+            "google/t5-v1_1-small",
+            reference_dtype=torch.bfloat16,
+            target_dtype=torch.bfloat16,
+        )
+
+    @with_t5_data
+    def testV1_1XxlF32CompareTorchEagerAgainstHuggingFace(self):
+        self.runTestV1_1CompareTorchEagerAgainstHuggingFace(
+            "google/t5-v1_1-xxl",
+            reference_dtype=torch.float32,
+            target_dtype=torch.float32,
+        )
+
+    @pytest.mark.xfail(
+        raises=AssertionError,
+        reason=(
+            "The accuracy is bad, but we get the same result as the Flux pipeline. "
+            "This need further investigation how Flux works at all like that."
+        ),
+    )
+    @with_t5_data
+    def testV1_1XxlBf16CompareTorchEagerAgainstHuggingFaceF32(self):
+        self.runTestV1_1CompareTorchEagerAgainstHuggingFace(
+            "google/t5-v1_1-xxl",
+            reference_dtype=torch.float32,
+            target_dtype=torch.bfloat16,
+            atol=1e-2,
+            rtol=1.6e-2,
+        )
 
 
 @pytest.mark.usefixtures("caching", "get_model_artifacts", "path_prefix")
@@ -115,14 +291,14 @@ class T5EncoderIreeTest(TempDirTestBase):
         if self.path_prefix is None:
             self.path_prefix = f"{self._temp_dir}/"
 
-    @parameterized.expand(
-        [
-            "google/t5-v1_1-small",
-            "google/t5-v1_1-xxl",
-        ]
-    )
-    @with_t5_data
-    def testV1_1Fp32CompareIreeAgainstTorchEager(self, huggingface_repo_id: str):
+    def runTestV1_1CompareIreeAgainstTorchEager(
+        self,
+        huggingface_repo_id: str,
+        reference_dtype: torch.dtype,
+        target_dtype: torch.dtype,
+        atol: Optional[float] = None,
+        rtol: Optional[float] = None,
+    ):
         get_dataset(
             huggingface_repo_id,
         ).download()
@@ -131,12 +307,15 @@ class T5EncoderIreeTest(TempDirTestBase):
         huggingface_repo_id_as_path = (
             f"{huggingface_repo_id.replace('/', '__').replace('-', '_')}"
         )
-        source_model_name = f"{huggingface_repo_id_as_path}_fp32_model"
+        source_model_name = f"{huggingface_repo_id_as_path}_f32_model"
         source_model_path = getattr(self, source_model_name)
 
-        dataset = Dataset.load(source_model_path)
+        reference_dataset = Dataset.load(source_model_path)
+        reference_dataset.root_theta = reference_dataset.root_theta.transform(
+            functools.partial(set_float_dtype, dtype=reference_dtype)
+        )
         config = T5Config.from_gguf_properties(
-            dataset.properties,
+            reference_dataset.properties,
             feed_forward_proj="gated-gelu",
         )
 
@@ -149,36 +328,37 @@ class T5EncoderIreeTest(TempDirTestBase):
         input_args = OrderedDict([("input_ids", input_ids)])
         batch_size = input_ids.shape[0]
 
-        reference_model = T5Encoder(theta=dataset.root_theta, config=config)
-        reference_result = flatten_for_iree_signature(
-            call_torch_module_function(
-                module=reference_model,
-                function_name="forward",
-                kwargs=input_args,
-                trace_path_prefix=f"{self.path_prefix}{huggingface_repo_id_as_path}_torch_",
-            )
-        )
+        reference_dtype_name = dtype_to_serialized_short_name(reference_dtype)
+        target_dtype_name = dtype_to_serialized_short_name(target_dtype)
+        target_model_path_prefix = f"{self.path_prefix}{huggingface_repo_id_as_path}_encoder_{target_dtype_name}"
 
-        mlir_path = f"{self.path_prefix}{huggingface_repo_id_as_path}_encoder_fp32.mlir"
+        reference_model = T5Encoder(theta=reference_dataset.root_theta, config=config)
+        reference_result_dict = call_torch_module_function(
+            module=reference_model,
+            function_name="forward",
+            kwargs=input_args,
+            trace_path_prefix=f"{self.path_prefix}{huggingface_repo_id_as_path}_encoder_{reference_dtype_name}_torch_",
+        )
+        reference_result = flatten_for_iree_signature(reference_result_dict)
+
+        parameters_path = f"{target_model_path_prefix}.irpa"
+        if not self.caching or not os.path.exists(parameters_path):
+            export_encoder_iree_parameters(
+                source_model_path, parameters_path, dtype=target_dtype
+            )
+
+        mlir_path = f"{target_model_path_prefix}.mlir"
         if not self.caching or not os.path.exists(mlir_path):
             export_encoder_mlir(
-                source_model_path, batch_sizes=[batch_size], mlir_output_path=mlir_path
+                parameters_path, batch_sizes=[batch_size], mlir_output_path=mlir_path
             )
-        iree_module_path = (
-            f"{self.path_prefix}{huggingface_repo_id_as_path}_encoder_fp32.vmfb"
-        )
+        iree_module_path = f"{target_model_path_prefix}.vmfb"
         if not self.caching or not os.path.exists(iree_module_path):
             iree.compiler.compile_file(
                 mlir_path,
                 output_file=iree_module_path,
                 extra_args=["--iree-hal-target-device=hip", "--iree-hip-target=gfx942"],
             )
-
-        parameters_path = (
-            f"{self.path_prefix}{huggingface_repo_id_as_path}_encoder_fp32.irpa"
-        )
-        if not self.caching or not os.path.exists(parameters_path):
-            export_encoder_iree_parameters(source_model_path, parameters_path)
 
         iree_devices = get_iree_devices(driver="hip", device_count=1)
         iree_module, iree_vm_context, iree_vm_instance = load_iree_module(
@@ -196,12 +376,70 @@ class T5EncoderIreeTest(TempDirTestBase):
                 args=iree_args,
                 driver="hip",
                 function_name=f"forward_bs{batch_size}",
-                trace_path_prefix=f"{self.path_prefix}{huggingface_repo_id_as_path}_iree_",
+                trace_path_prefix=f"{target_model_path_prefix}_iree_",
             )
         )
+        iree_result = [
+            ops.to(iree_result[i], dtype=reference_result[i].dtype)
+            for i in range(len(reference_result))
+        ]
 
-        torch.testing.assert_close(
-            reference_result, iree_result, atol=1e-4, rtol=2.0e-3
+        torch.testing.assert_close(reference_result, iree_result, atol=atol, rtol=rtol)
+
+    @with_t5_data
+    def testV1_1CompareSmallIreeF32AgainstTorchEagerF32(self):
+        self.runTestV1_1CompareIreeAgainstTorchEager(
+            "google/t5-v1_1-small",
+            reference_dtype=torch.float32,
+            target_dtype=torch.float32,
+            atol=1e-4,
+            rtol=2.0e-3,
+        )
+
+    @pytest.mark.xfail(
+        raises=AssertionError,
+        reason=(
+            "The accuracy is bad, "
+            "but but it is no worse than the accuracy for of eager bfloat16. "
+            "This need further investigation how Flux works at all like that."
+        ),
+    )
+    @with_t5_data
+    def testV1_1CompareSmallIreeBf16AgainstTorchEagerF32(self):
+        self.runTestV1_1CompareIreeAgainstTorchEager(
+            "google/t5-v1_1-small",
+            reference_dtype=torch.float32,
+            target_dtype=torch.bfloat16,
+            atol=1e-2,
+            rtol=1.6e-2,
+        )
+
+    @with_t5_data
+    def testV1_1CompareXxlIreeF32AgainstTorchEagerF32(self):
+        self.runTestV1_1CompareIreeAgainstTorchEager(
+            "google/t5-v1_1-xxl",
+            reference_dtype=torch.float32,
+            target_dtype=torch.float32,
+            atol=1e-4,
+            rtol=2.0e-3,
+        )
+
+    @pytest.mark.xfail(
+        raises=AssertionError,
+        reason=(
+            "The accuracy is bad, "
+            "but but it is no worse than the accuracy for of eager bfloat16. "
+            "This need further investigation how Flux works at all like that."
+        ),
+    )
+    @with_t5_data
+    def testV1_1CompareXxlIreeBf16AgainstTorchEagerF32(self):
+        self.runTestV1_1CompareIreeAgainstTorchEager(
+            "google/t5-v1_1-xxl",
+            reference_dtype=torch.float32,
+            target_dtype=torch.bfloat16,
+            atol=1e-2,
+            rtol=1.6e-2,
         )
 
 
@@ -211,8 +449,21 @@ class T5AttentionTest(TestCase):
         torch.random.manual_seed(12345)
         torch.no_grad()
 
-    def testCompareAgainstTransformersFp32(self):
-        dtype = torch.float32
+    @parameterized.expand(
+        [
+            [torch.float32, torch.float32],
+            [torch.bfloat16, torch.bfloat16],
+            [torch.float32, torch.bfloat16, 1e-2, 1.6e-2],
+        ]
+    )
+    def testCompareAgainstTransformers(
+        self,
+        reference_dtype: torch.dtype,
+        target_dtype: torch.dtype,
+        atol: Optional[float] = None,
+        rtol: Optional[float] = None,
+    ):
+        torch.set_default_dtype(reference_dtype)
         batch_size = 19
         batch_seq_len = 23
         reference_config = ReferenceT5Config(
@@ -233,19 +484,21 @@ class T5AttentionTest(TestCase):
         theta = Theta(
             {
                 "attn_q.weight": DefaultPrimitiveTensor(
-                    data=reference_model.q.weight.data
+                    data=reference_model.q.weight.to(dtype=target_dtype)
                 ),
                 "attn_k.weight": DefaultPrimitiveTensor(
-                    data=reference_model.k.weight.data
+                    data=reference_model.k.weight.to(dtype=target_dtype)
                 ),
                 "attn_v.weight": DefaultPrimitiveTensor(
-                    data=reference_model.v.weight.data
+                    data=reference_model.v.weight.to(dtype=target_dtype)
                 ),
                 "attn_o.weight": DefaultPrimitiveTensor(
-                    data=reference_model.o.weight.data
+                    data=reference_model.o.weight.to(dtype=target_dtype)
                 ),
                 "attn_rel_b.weight": DefaultPrimitiveTensor(
-                    data=reference_model.relative_attention_bias.weight.data
+                    data=reference_model.relative_attention_bias.weight.to(
+                        dtype=target_dtype
+                    )
                 ),
             }
         )
@@ -257,24 +510,52 @@ class T5AttentionTest(TestCase):
             d_model=reference_config.d_model,
             d_kv=reference_config.d_kv,
             num_heads=reference_config.num_heads,
-            activation_dtype=dtype,
+            activation_dtype=target_dtype,
             has_relative_attention_bias=True,
         )
         model.eval()
 
-        hidden_states = make_rand_torch(
-            shape=[batch_size, batch_seq_len, reference_config.d_model], dtype=dtype
+        reference_hidden_states = make_rand_torch(
+            shape=[batch_size, batch_seq_len, reference_config.d_model],
+            dtype=reference_dtype,
         )
-        mask = make_random_mask(shape=[batch_size, 1, 1, batch_seq_len], dtype=dtype)
-        expected_outputs = reference_model(hidden_states=hidden_states, mask=mask)
+        reference_mask = make_random_mask(
+            shape=[batch_size, 1, 1, batch_seq_len], dtype=reference_dtype
+        )
+        expected_outputs = reference_model(
+            hidden_states=reference_hidden_states, mask=reference_mask
+        )
+
+        hidden_states = ops.to(reference_hidden_states, dtype=target_dtype)
+        mask = ops.to(reference_mask, dtype=target_dtype)
         actual_outputs = model(
             hidden_states=DefaultPrimitiveTensor(data=hidden_states),
             mask=DefaultPrimitiveTensor(data=mask),
         )
-        torch.testing.assert_close(actual_outputs, expected_outputs, atol=1e-5, rtol=0)
+        actual_outputs = tree_map(
+            lambda t: None if t is None else ops.to(t, dtype=reference_dtype),
+            actual_outputs,
+        )
 
-    def testCompareSelfAttentionAgainstTransformersFp32(self):
-        dtype = torch.float32
+        torch.testing.assert_close(
+            actual_outputs, expected_outputs, atol=atol, rtol=rtol
+        )
+
+    @parameterized.expand(
+        [
+            [torch.float32, torch.float32],
+            [torch.bfloat16, torch.bfloat16],
+            [torch.float32, torch.bfloat16, 1e-2, 1.6e-2],
+        ]
+    )
+    def testCompareSelfAttentionAgainstTransformers(
+        self,
+        reference_dtype: torch.dtype,
+        target_dtype: torch.dtype,
+        atol: Optional[float] = None,
+        rtol: Optional[float] = None,
+    ):
+        torch.set_default_dtype(reference_dtype)
         batch_size = 19
         batch_seq_len = 23
         reference_config = ReferenceT5Config(
@@ -296,22 +577,24 @@ class T5AttentionTest(TestCase):
         theta = Theta(
             {
                 "attn_q.weight": DefaultPrimitiveTensor(
-                    data=reference_model.SelfAttention.q.weight.data
+                    data=reference_model.SelfAttention.q.weight.to(dtype=target_dtype)
                 ),
                 "attn_k.weight": DefaultPrimitiveTensor(
-                    data=reference_model.SelfAttention.k.weight.data
+                    data=reference_model.SelfAttention.k.weight.to(dtype=target_dtype)
                 ),
                 "attn_v.weight": DefaultPrimitiveTensor(
-                    data=reference_model.SelfAttention.v.weight.data
+                    data=reference_model.SelfAttention.v.weight.to(dtype=target_dtype)
                 ),
                 "attn_o.weight": DefaultPrimitiveTensor(
-                    data=reference_model.SelfAttention.o.weight.data
+                    data=reference_model.SelfAttention.o.weight.to(dtype=target_dtype)
                 ),
                 "attn_rel_b.weight": DefaultPrimitiveTensor(
-                    data=reference_model.SelfAttention.relative_attention_bias.weight.data
+                    data=reference_model.SelfAttention.relative_attention_bias.weight.to(
+                        dtype=target_dtype
+                    )
                 ),
                 "attn_norm.weight": DefaultPrimitiveTensor(
-                    data=reference_model.layer_norm.weight.data
+                    data=reference_model.layer_norm.weight.to(dtype=target_dtype)
                 ),
             }
         )
@@ -323,24 +606,37 @@ class T5AttentionTest(TestCase):
             d_model=reference_config.d_model,
             d_kv=reference_config.d_kv,
             num_heads=reference_config.num_heads,
-            activation_dtype=dtype,
+            activation_dtype=torch.float32,
             layer_norm_epsilon=reference_config.layer_norm_epsilon,
             has_relative_attention_bias=True,
         )
         model.eval()
 
-        hidden_states = make_rand_torch(
-            shape=[batch_size, batch_seq_len, reference_config.d_model], dtype=dtype
+        reference_hidden_states = make_rand_torch(
+            shape=[batch_size, batch_seq_len, reference_config.d_model],
+            dtype=reference_dtype,
         )
-        mask = make_random_mask(shape=[batch_size, 1, 1, batch_seq_len], dtype=dtype)
-        position_bias = make_rand_torch(
-            shape=[batch_size, reference_config.num_heads, batch_seq_len, batch_seq_len]
+        reference_mask = make_random_mask(
+            shape=[batch_size, 1, 1, batch_seq_len], dtype=reference_dtype
+        )
+        reference_position_bias = make_rand_torch(
+            shape=[
+                batch_size,
+                reference_config.num_heads,
+                batch_seq_len,
+                batch_seq_len,
+            ],
+            dtype=reference_dtype,
         )
         expected_outputs = reference_model(
-            hidden_states=hidden_states,
-            attention_mask=mask,
-            position_bias=position_bias,
+            hidden_states=reference_hidden_states,
+            attention_mask=reference_mask,
+            position_bias=reference_position_bias,
         )
+
+        hidden_states = ops.to(reference_hidden_states, dtype=target_dtype)
+        mask = ops.to(reference_mask, dtype=target_dtype)
+        position_bias = ops.to(reference_position_bias, dtype=target_dtype)
         actual_outputs = model(
             hidden_states=DefaultPrimitiveTensor(data=hidden_states),
             attention_mask=DefaultPrimitiveTensor(data=mask),
@@ -349,7 +645,14 @@ class T5AttentionTest(TestCase):
         actual_outputs = [
             unbox_tensor(t) if t is not None else t for t in actual_outputs
         ]
-        torch.testing.assert_close(actual_outputs, expected_outputs, atol=1e-5, rtol=0)
+        actual_outputs = tree_map(
+            lambda t: None if t is None else ops.to(t, dtype=reference_dtype),
+            actual_outputs,
+        )
+
+        torch.testing.assert_close(
+            actual_outputs, expected_outputs, atol=atol, rtol=rtol
+        )
 
 
 class T5LayerFFTest(TestCase):
@@ -358,8 +661,21 @@ class T5LayerFFTest(TestCase):
         torch.random.manual_seed(12345)
         torch.no_grad()
 
-    def testCompareAgainstTransformersFp32(self):
-        dtype = torch.float32
+    @parameterized.expand(
+        [
+            [torch.float32, torch.float32],
+            [torch.bfloat16, torch.bfloat16],
+            [torch.float32, torch.bfloat16, 1e-2, 1.6e-2],
+        ]
+    )
+    def testCompareAgainstTransformers(
+        self,
+        reference_dtype: torch.dtype,
+        target_dtype: torch.dtype,
+        atol: Optional[float] = None,
+        rtol: Optional[float] = None,
+    ):
+        torch.set_default_dtype(reference_dtype)
         batch_size = 19
         batch_seq_len = 23
         reference_config = ReferenceT5Config(
@@ -376,16 +692,20 @@ class T5LayerFFTest(TestCase):
         theta = Theta(
             {
                 "ffn_gate.weight": DefaultPrimitiveTensor(
-                    data=reference_model.DenseReluDense.wi_0.weight
+                    data=reference_model.DenseReluDense.wi_0.weight.to(
+                        dtype=target_dtype
+                    )
                 ),
                 "ffn_up.weight": DefaultPrimitiveTensor(
-                    data=reference_model.DenseReluDense.wi_1.weight
+                    data=reference_model.DenseReluDense.wi_1.weight.to(
+                        dtype=target_dtype
+                    )
                 ),
                 "ffn_down.weight": DefaultPrimitiveTensor(
-                    data=reference_model.DenseReluDense.wo.weight
+                    data=reference_model.DenseReluDense.wo.weight.to(dtype=target_dtype)
                 ),
                 "ffn_norm.weight": DefaultPrimitiveTensor(
-                    data=reference_model.layer_norm.weight
+                    data=reference_model.layer_norm.weight.to(dtype=target_dtype)
                 ),
             }
         )
@@ -394,17 +714,24 @@ class T5LayerFFTest(TestCase):
             is_gated_act=reference_config.is_gated_act,
             dense_act_fn=reference_config.dense_act_fn,
             layer_norm_epsilon=reference_config.layer_norm_epsilon,
-            activation_dtype=dtype,
+            activation_dtype=torch.float32,
         )
 
-        hidden_states = make_rand_torch(
-            shape=[batch_size, batch_seq_len, reference_config.d_model], dtype=dtype
+        reference_hidden_states = make_rand_torch(
+            shape=[batch_size, batch_seq_len, reference_config.d_model],
+            dtype=reference_dtype,
         )
-
         expected_output = reference_model(
-            hidden_states=hidden_states,
+            hidden_states=reference_hidden_states,
         )
+
+        hidden_states = ops.to(reference_hidden_states, dtype=target_dtype)
         actual_output = model(
             hidden_states=DefaultPrimitiveTensor(data=hidden_states),
         )
-        torch.testing.assert_close(actual_output, expected_output, atol=1e-5, rtol=0)
+        actual_output = tree_map(
+            lambda t: None if t is None else ops.to(t, dtype=reference_dtype),
+            actual_output,
+        )
+
+        torch.testing.assert_close(actual_output, expected_output, atol=atol, rtol=rtol)


### PR DESCRIPTION
Adds various tests for verifying bfloat16 execution.

The bfloat16 eager execution matches Flux's output. One test verifies this against golden values from the Flux pipeline.

I would say that the eager numerical error is still quite high. My initial idea was to compare the numerical error in IREE bfloat16 vs eager float32. It should match the error profile as the one we get between eager bfloat16 compared against eager float32. The problem is that the bfloat16 eager has a high error that needs further investigation.
Due to this some tests are marked as xfail as we don't have a good metric to evaluate the IREE results.