### PR TITLE
Add `--durations` to some `pytest` commands in CI workflows.

### DIFF
--- a/.github/workflows/ci-libshortfin.yml
+++ b/.github/workflows/ci-libshortfin.yml
@@ -146,4 +146,4 @@ jobs:
       working-directory: ${{ env.LIBSHORTFIN_DIR }}
       run: |
         ctest --timeout 30 --output-on-failure --test-dir build
-        pytest -s
+        pytest -s --durations=10

--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Run sharktank tests
         if: ${{ !cancelled() }}
         run: |
-          pytest -n 4 sharktank/
+          pytest -n 4 sharktank/ --durations=10
 
 
   test_with_data:
@@ -128,4 +128,5 @@ jobs:
         run: |
           pytest \
             --with-t5-data \
-            sharktank/tests/models/t5/t5_test.py
+            sharktank/tests/models/t5/t5_test.py \
+            --durations=0


### PR DESCRIPTION
This will help triage slow tests.

Docs:

* https://docs.pytest.org/en/stable/example/simple.html#profiling-test-duration
* https://docs.pytest.org/en/stable/how-to/usage.html#profiling-test-execution-duration