### PR TITLE
[shortfin] Upgrade package build dockerfile to manylinux_2_28.

### DIFF
--- a/shortfin/build_tools/build_linux_package.sh
+++ b/shortfin/build_tools/build_linux_package.sh
@@ -36,11 +36,8 @@ REPO_ROOT="$(cd "$THIS_DIR"/../../ && pwd)"
 SCRIPT_NAME="$(basename $0)"
 ARCH="$(uname -m)"
 
-# TODO(#130): Update to manylinux_2_28, upstream or a fork
-#   * upstream uses a version of gcc that has build warnings/errors
-#   * https://github.com/nod-ai/base-docker-images is a bit out of date but can include a recent clang
-# MANYLINUX_DOCKER_IMAGE="${MANYLINUX_DOCKER_IMAGE:-quay.io/pypa/manylinux_2_28_${ARCH}:latest}"
-MANYLINUX_DOCKER_IMAGE="${MANYLINUX_DOCKER_IMAGE:-quay.io/pypa/manylinux2014_${ARCH}:latest}"
+# Note: we can switch to https://github.com/nod-ai/base-docker-images as needed for extra deps.
+MANYLINUX_DOCKER_IMAGE="${MANYLINUX_DOCKER_IMAGE:-quay.io/pypa/manylinux_2_28_${ARCH}:latest}"
 PYTHON_VERSIONS="${OVERRIDE_PYTHON_VERSIONS:-cp311-cp311 cp312-cp312 cp313-cp313}"
 OUTPUT_DIR="${OUTPUT_DIR:-${THIS_DIR}/wheelhouse}"
 


### PR DESCRIPTION
Progress on https://github.com/nod-ai/shark-ai/issues/130.

The manylinux2014 image includes gcc 10.2.1 by default while manylinux_2_28 includes gcc 12.2.1. At one point we had warnings/errors building on the newer gcc version, but that is no longer the case.

With the new Rust dependency coming from https://github.com/nod-ai/shark-ai/pull/610, we will likely want to revive https://github.com/nod-ai/base-docker-images/blob/main/dockerfiles/manylinux_x86_64.Dockerfile, add more dependencies there, then switch from the upstream `quay.io/...` image to that `ghcr.io/nod-ai/...` image.

Tested locally with `OUTPUT_DIR="/tmp/wheelhouse" sudo -E ./build_tools/build_linux_package.sh`. If the nightly package build fails for some reason we can easily revert this.