### PR TITLE
[tuner]: use lowering config binding

### DIFF
--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -61,8 +61,8 @@ def apply_configuration(
     expr5 = re.compile(r"\"amdgpu-waves-per-eu\" = \"([0-9])\"")
     repl0 = f"<intrinsic = {intrinsic}, subgroup_m_count = {subgroup_m_count}, subgroup_n_count = {subgroup_n_count}>"
     repl1 = f'LLVMGPUVectorDistribute workgroup_size = [{", ".join(map(str, configuration.workgroup_size))}] subgroup_size = {configuration.subgroup_size},'
-    repl2 = f'workgroup = [{", ".join(map(str, workgroup_sizes))}]'
-    repl3 = f'reduction = [{", ".join(map(str, reduction_sizes))}]'
+    repl2 = f"workgroup = {workgroup_sizes}"
+    repl3 = f"reduction = {reduction_sizes}"
     repl4 = f"gpu_pipeline_options = {configuration.gpu_pipeline_options}"
     repl5 = f'"amdgpu-waves-per-eu" = "{configuration.waves_per_eu}"'
 

--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -585,7 +585,7 @@ def tune(
         tune_logger.debug(str(problem_size))
         configs = []
         for i, config in enumerate(
-            generate_solutions(tune_logger, problem_size, num_subgroups, mma_list)
+            generate_solutions(tuner_context, problem_size, num_subgroups, mma_list)
         ):
             if i >= limit:
                 break

--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -45,9 +45,9 @@ def apply_configuration(
     workgroup_sizes: list[int],
     reduction_sizes: list[int],
 ) -> str:
-    intrinsic = configuration.intrinsic()
-    subgroup_m_count = configuration.subgroup_m_count()
-    subgroup_n_count = configuration.subgroup_n_count()
+    intrinsic = get_intrinsic(configuration)
+    subgroup_m_count = get_subgroup_m_count(configuration)
+    subgroup_n_count = get_subgroup_n_count(configuration)
     tune_logger.info(f"Applying: {configuration}")
     expr0 = re.compile(
         r"<intrinsic = #iree_gpu\.mma_layout<(.+)>, subgroup_m_count = ([0-9]+), subgroup_n_count = ([0-9]+)>"
@@ -125,9 +125,9 @@ class MmtTuner(DispatchTuner, MmtParser):
     def get_transform_function_mmt(
         self, problem_size: ProblemSize, functionName: str, configuration: Configuration
     ) -> str:
-        intrinsic = configuration.intrinsic()
-        subgroup_m_count = configuration.subgroup_m_count()
-        subgroup_n_count = configuration.subgroup_n_count()
+        intrinsic = get_intrinsic(configuration)
+        subgroup_m_count = get_subgroup_m_count(configuration)
+        subgroup_n_count = get_subgroup_n_count(configuration)
 
         wg_x, wg_y, wg_z = configuration.workgroup_size
         extra_config = get_pipeline_config(configuration)
@@ -199,9 +199,9 @@ class ConvTuner(DispatchTuner, ConvParser):
         reduction_sizes = ", ".join(
             map(str, self.get_conv_reduction_sizes(configuration))
         )
-        intrinsic = configuration.intrinsic()
-        subgroup_m_count = configuration.subgroup_m_count()
-        subgroup_n_count = configuration.subgroup_n_count()
+        intrinsic = get_intrinsic(configuration)
+        subgroup_m_count = get_subgroup_m_count(configuration)
+        subgroup_n_count = get_subgroup_n_count(configuration)
 
         wg_x, wg_y, wg_z = configuration.workgroup_size
         extra_config = get_pipeline_config(configuration)
@@ -269,9 +269,9 @@ class ContractionTuner(DispatchTuner, ContractionParser):
         reduction_sizes = ", ".join(
             map(str, get_batch_mmt_reduction_sizes(configuration))
         )
-        intrinsic = configuration.intrinsic()
-        subgroup_m_count = configuration.subgroup_m_count()
-        subgroup_n_count = configuration.subgroup_n_count()
+        intrinsic = get_intrinsic(configuration)
+        subgroup_m_count = get_subgroup_m_count(configuration)
+        subgroup_n_count = get_subgroup_n_count(configuration)
 
         wg_x, wg_y, wg_z = configuration.workgroup_size
         extra_config = get_pipeline_config(configuration)
@@ -359,9 +359,9 @@ class BatchMmtTuner(DispatchTuner, BatchMmtParser):
         functionName: str,
         configuration: Configuration,
     ) -> str:
-        intrinsic = configuration.intrinsic()
-        subgroup_m_count = configuration.subgroup_m_count()
-        subgroup_n_count = configuration.subgroup_n_count()
+        intrinsic = get_intrinsic(configuration)
+        subgroup_m_count = get_subgroup_m_count(configuration)
+        subgroup_n_count = get_subgroup_n_count(configuration)
 
         wg_x, wg_y, wg_z = configuration.workgroup_size
         extra_config = get_pipeline_config(configuration)
@@ -428,9 +428,9 @@ class BatchMatmulTuner(DispatchTuner, BatchMatmulParser):
         input1 = f"tensor<{problem_size.rhs_type}>"
         output = f"tensor<{problem_size.res_type}>"
 
-        intrinsic = configuration.intrinsic()
-        subgroup_m_count = configuration.subgroup_m_count()
-        subgroup_n_count = configuration.subgroup_n_count()
+        intrinsic = get_intrinsic(configuration)
+        subgroup_m_count = get_subgroup_m_count(configuration)
+        subgroup_n_count = get_subgroup_n_count(configuration)
 
         wg_x, wg_y, wg_z = configuration.workgroup_size
         extra_config = get_pipeline_config(configuration)

--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -38,7 +38,7 @@ from .dispatch_parser import *
 
 tune_logger = logging.getLogger("tune")
 
-
+# TODO: remove the argument 'workgroup_sizes' and 'reduction_sizes'.
 def apply_configuration(
     template: list[str],
     configuration: Configuration,

--- a/tuner/tuner/candidate_gen_test.py
+++ b/tuner/tuner/candidate_gen_test.py
@@ -48,13 +48,25 @@ def test_apply_params_mmt(tuner_ctx: common.TunerContext) -> None:
 
     mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
+    lowering_config_dict = {
+        "mma_kind": mma_attr,
+        "workgroup": ir.ArrayAttr.get(
+            [
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 8),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 8),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 8),
+            ]
+        ),
+        "reduction": ir.ArrayAttr.get([]),
+        "subgroup_m_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 16),
+        "subgroup_n_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 16),
+    }
+
+    lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
     config = common.Configuration(
         subgroup_size=16,
         workgroup_size=[16, 16, 1],
-        intrinsic=mma_attr,
-        tile_sizes=[8, 8, 8],
-        subgroup_m_count=16,
-        subgroup_n_count=16,
+        lowering_config=iree_gpu.LoweringConfigAttr.get(lowering_config_attrs),
         gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(
             prefetch_shared_memory=True
         ),
@@ -104,13 +116,24 @@ def test_apply_params_conv(tuner_ctx: common.TunerContext) -> None:
 
     mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
+    lowering_config_dict = {
+        "mma_kind": mma_attr,
+        "workgroup": ir.ArrayAttr.get(
+            [
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 464),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 320),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 16),
+            ]
+        ),
+        "reduction": ir.ArrayAttr.get([]),
+        "subgroup_m_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 1),
+        "subgroup_n_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 4),
+    }
+    lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
     config = common.Configuration(
         subgroup_size=64,
         workgroup_size=[256, 1, 1],
-        intrinsic=mma_attr,
-        tile_sizes=[464, 320, 16],
-        subgroup_m_count=1,
-        subgroup_n_count=4,
+        lowering_config=iree_gpu.LoweringConfigAttr.get(lowering_config_attrs),
         gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(
             reorder_workgroups_strategy=iree_gpu.ReorderWorkgroupsStrategyAttr.get(
                 iree_gpu.ReorderWorkgroupsStrategy.Transpose
@@ -171,13 +194,25 @@ def test_apply_params_contract(tuner_ctx: common.TunerContext) -> None:
 
     mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
+    lowering_config_dict = {
+        "mma_kind": mma_attr,
+        "workgroup": ir.ArrayAttr.get(
+            [
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 480),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 384),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 32),
+            ]
+        ),
+        "reduction": ir.ArrayAttr.get([]),
+        "subgroup_m_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 1),
+        "subgroup_n_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 4),
+    }
+
+    lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
     config = common.Configuration(
         subgroup_size=64,
         workgroup_size=[256, 1, 1],
-        intrinsic=mma_attr,
-        tile_sizes=[480, 384, 32],
-        subgroup_m_count=1,
-        subgroup_n_count=4,
+        lowering_config=iree_gpu.LoweringConfigAttr.get(lowering_config_attrs),
         gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=2,
     )
@@ -220,13 +255,26 @@ def test_apply_params_batch_matmul(tuner_ctx: common.TunerContext) -> None:
 
     mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
+    lowering_config_dict = {
+        "mma_kind": mma_attr,
+        "workgroup": ir.ArrayAttr.get(
+            [
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 416),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 320),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 128),
+            ]
+        ),
+        "reduction": ir.ArrayAttr.get([]),
+        "subgroup_m_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 2),
+        "subgroup_n_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 2),
+    }
+
+    lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
+
     config = common.Configuration(
         subgroup_size=64,
         workgroup_size=[128, 2, 1],
-        intrinsic=mma_attr,
-        tile_sizes=[416, 320, 128],
-        subgroup_m_count=2,
-        subgroup_n_count=2,
+        lowering_config=iree_gpu.LoweringConfigAttr.get(lowering_config_attrs),
         gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=2,
     )
@@ -272,13 +320,25 @@ def test_apply_params_batch_mmt_float(tuner_ctx: common.TunerContext) -> None:
 
     mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
+    lowering_config_dict = {
+        "mma_kind": mma_attr,
+        "workgroup": ir.ArrayAttr.get(
+            [
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 128),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 64),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 128),
+            ]
+        ),
+        "reduction": ir.ArrayAttr.get([]),
+        "subgroup_m_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 2),
+        "subgroup_n_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 2),
+    }
+
+    lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
     config = common.Configuration(
         subgroup_size=64,
         workgroup_size=[128, 2, 1],
-        intrinsic=mma_attr,
-        tile_sizes=[128, 64, 128],
-        subgroup_m_count=2,
-        subgroup_n_count=2,
+        lowering_config=iree_gpu.LoweringConfigAttr.get(lowering_config_attrs),
         gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=2,
     )
@@ -322,13 +382,25 @@ def test_apply_params_batch_mmt_int(tuner_ctx: common.TunerContext) -> None:
 
     mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
+    lowering_config_dict = {
+        "mma_kind": mma_attr,
+        "workgroup": ir.ArrayAttr.get(
+            [
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 128),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 64),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 128),
+            ]
+        ),
+        "reduction": ir.ArrayAttr.get([]),
+        "subgroup_m_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 2),
+        "subgroup_n_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 2),
+    }
+
+    lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
     config = common.Configuration(
         subgroup_size=64,
         workgroup_size=[128, 2, 1],
-        intrinsic=mma_attr,
-        tile_sizes=[128, 64, 128],
-        subgroup_m_count=2,
-        subgroup_n_count=2,
+        lowering_config=iree_gpu.LoweringConfigAttr.get(lowering_config_attrs),
         gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=4,
     )
@@ -395,13 +467,25 @@ def test_apply_params_broadcast_rhs_mmt(tuner_ctx: common.TunerContext) -> None:
 
     mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
+    lowering_config_dict = {
+        "mma_kind": mma_attr,
+        "workgroup": ir.ArrayAttr.get(
+            [
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 128),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 64),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 128),
+            ]
+        ),
+        "reduction": ir.ArrayAttr.get([]),
+        "subgroup_m_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 2),
+        "subgroup_n_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 2),
+    }
+
+    lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
     config = common.Configuration(
         subgroup_size=64,
         workgroup_size=[128, 2, 1],
-        intrinsic=mma_attr,
-        tile_sizes=[128, 64, 128],
-        subgroup_m_count=2,
-        subgroup_n_count=2,
+        lowering_config=iree_gpu.LoweringConfigAttr.get(lowering_config_attrs),
         gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=4,
     )

--- a/tuner/tuner/candidate_gen_test.py
+++ b/tuner/tuner/candidate_gen_test.py
@@ -39,7 +39,7 @@ def test_apply_params_mmt(tuner_ctx: common.TunerContext) -> None:
     mlir_template = [
         "<intrinsic = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>, subgroup_m_count = 16, subgroup_n_count = 16>",
         "<LLVMGPUVectorDistribute workgroup_size = [16, 16] subgroup_size = 16,",
-        "<workgroup = [[8, 8, 8]], reduction = [[8, 8, 8]]>",
+        "<workgroup = [8, 8, 8], reduction = [8, 8, 8]>",
         "gpu_pipeline_options = #iree_gpu.pipeline_options<reorder_workgroups_strategy = None>",
         '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}',
     ]
@@ -50,7 +50,7 @@ def test_apply_params_mmt(tuner_ctx: common.TunerContext) -> None:
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
     lowering_config = common.get_lowering_config(
         tuner_ctx=tuner_ctx,
-        mma_attr=mma_attr,
+        mma_kind=mma_attr,
         workgroup=[8, 8, 0],
         reduction=[0, 0, 8],
         subgroup_m_count=16,
@@ -89,8 +89,8 @@ def test_apply_params_mmt(tuner_ctx: common.TunerContext) -> None:
         "LLVMGPUVectorDistribute workgroup_size = [16, 16, 1] subgroup_size = 16"
         in modified
     )
-    assert "workgroup = [[8, 8, 0]]" in modified
-    assert "reduction = [[0, 0, 8]]" in modified
+    assert "workgroup = [8, 8, 0]" in modified
+    assert "reduction = [0, 0, 8]" in modified
     assert (
         "gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true>"
         in modified
@@ -102,7 +102,7 @@ def test_apply_params_conv(tuner_ctx: common.TunerContext) -> None:
     mlir_template = [
         "<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 16, subgroup_n_count = 16>",
         "<LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64,",
-        "<workgroup = [[1, 1, 64, 128, 1, 1, 32]], reduction = [[1, 1, 64, 128, 1, 1, 32]]>",
+        "<workgroup = [1, 1, 64, 128, 1, 1, 32], reduction = [1, 1, 64, 128, 1, 1, 32]>",
         'gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true>, {llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}',
     ]
 
@@ -112,7 +112,7 @@ def test_apply_params_conv(tuner_ctx: common.TunerContext) -> None:
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
     lowering_config = common.get_lowering_config(
         tuner_ctx=tuner_ctx,
-        mma_attr=mma_attr,
+        mma_kind=mma_attr,
         workgroup=[464, 320, 0],
         reduction=[0, 0, 16],
         subgroup_m_count=1,
@@ -155,8 +155,8 @@ def test_apply_params_conv(tuner_ctx: common.TunerContext) -> None:
         "LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64"
         in modified
     )
-    assert "workgroup = [[1, 1, 464, 320, 1, 1, 0]]" in modified
-    assert "reduction = [[0, 0, 0, 0, 0, 0, 16]]" in modified
+    assert "workgroup = [1, 1, 464, 320, 1, 1, 0]" in modified
+    assert "reduction = [0, 0, 0, 0, 0, 0, 16]" in modified
     assert (
         "gpu_pipeline_options = #iree_gpu.pipeline_options<reorder_workgroups_strategy = <Transpose>>"
         in modified
@@ -168,7 +168,7 @@ def test_apply_params_contract(tuner_ctx: common.TunerContext) -> None:
     mlir_template = [
         "<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 2, subgroup_n_count = 2>}>",
         "<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64,",
-        "<workgroup = [[1, 1, 1, 64, 64, 128]], reduction = [[1, 1, 1, 64, 64, 128]]>",
+        "<workgroup = [1, 1, 1, 64, 64, 128], reduction = [1, 1, 1, 64, 64, 128]>",
         '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}',
     ]
 
@@ -185,7 +185,7 @@ def test_apply_params_contract(tuner_ctx: common.TunerContext) -> None:
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
     lowering_config = common.get_lowering_config(
         tuner_ctx=tuner_ctx,
-        mma_attr=mma_attr,
+        mma_kind=mma_attr,
         workgroup=[480, 384, 0],
         reduction=[0, 0, 32],
         subgroup_m_count=1,
@@ -214,8 +214,8 @@ def test_apply_params_contract(tuner_ctx: common.TunerContext) -> None:
         "LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64"
         in new_mlir
     )
-    assert "workgroup = [[1, 480, 384, 0]]" in new_mlir
-    assert "reduction = [[0, 0, 0, 32]]" in new_mlir
+    assert "workgroup = [1, 480, 384, 0]" in new_mlir
+    assert "reduction = [0, 0, 0, 32]" in new_mlir
     assert '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}' in new_mlir
 
 
@@ -223,7 +223,7 @@ def test_apply_params_batch_matmul(tuner_ctx: common.TunerContext) -> None:
     mlir_template = [
         "<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 4, subgroup_n_count = 1>}>",
         "<LLVMGPUVectorDistribute workgroup_size = [64, 4, 1] subgroup_size = 64,",
-        "<workgroup = [[1, 128, 64, 64]], reduction = [[1, 128, 64, 64]]>",
+        "<workgroup = [1, 128, 64, 64], reduction = [1, 128, 64, 64]>",
         '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}',
     ]
 
@@ -240,7 +240,7 @@ def test_apply_params_batch_matmul(tuner_ctx: common.TunerContext) -> None:
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
     lowering_config = common.get_lowering_config(
         tuner_ctx=tuner_ctx,
-        mma_attr=mma_attr,
+        mma_kind=mma_attr,
         workgroup=[416, 320, 0],
         reduction=[0, 0, 128],
         subgroup_m_count=2,
@@ -273,8 +273,8 @@ def test_apply_params_batch_matmul(tuner_ctx: common.TunerContext) -> None:
         "LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64"
         in modified
     )
-    assert "workgroup = [[1, 416, 320, 0]]" in modified
-    assert "reduction = [[0, 0, 0, 128]]" in modified
+    assert "workgroup = [1, 416, 320, 0]" in modified
+    assert "reduction = [0, 0, 0, 128]" in modified
     assert '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}' in modified
 
 
@@ -282,7 +282,7 @@ def test_apply_params_batch_mmt_float(tuner_ctx: common.TunerContext) -> None:
     mlir_template = [
         "<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 4, subgroup_n_count = 1>}>",
         "<LLVMGPUVectorDistribute workgroup_size = [64, 4, 1] subgroup_size = 64,",
-        "<workgroup = [[1, 128, 128, 64]], reduction = [[1, 128, 128, 64]]>",
+        "<workgroup = [1, 128, 128, 64], reduction = [1, 128, 128, 64]>",
         '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}',
     ]
 
@@ -298,7 +298,7 @@ def test_apply_params_batch_mmt_float(tuner_ctx: common.TunerContext) -> None:
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
     lowering_config = common.get_lowering_config(
         tuner_ctx=tuner_ctx,
-        mma_attr=mma_attr,
+        mma_kind=mma_attr,
         workgroup=[128, 64, 0],
         reduction=[0, 0, 128],
         subgroup_m_count=2,
@@ -329,8 +329,8 @@ def test_apply_params_batch_mmt_float(tuner_ctx: common.TunerContext) -> None:
         "LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64"
         in modified
     )
-    assert "workgroup = [[1, 128, 64, 0]]" in modified
-    assert "reduction = [[0, 0, 0, 128]]" in modified
+    assert "workgroup = [1, 128, 64, 0]" in modified
+    assert "reduction = [0, 0, 0, 128]" in modified
     assert '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}' in modified
 
 
@@ -338,7 +338,7 @@ def test_apply_params_batch_mmt_int(tuner_ctx: common.TunerContext) -> None:
     mlir_template = [
         "<intrinsic = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>, subgroup_m_count = 4, subgroup_n_count = 1>}>",
         "<LLVMGPUVectorDistribute workgroup_size = [64, 4, 1] subgroup_size = 64,",
-        "<workgroup = [[1, 128, 128, 64]], reduction = [[1, 128, 128, 64]]>",
+        "<workgroup = [1, 128, 128, 64], reduction = [1, 128, 128, 64]>",
         '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}',
     ]
 
@@ -354,7 +354,7 @@ def test_apply_params_batch_mmt_int(tuner_ctx: common.TunerContext) -> None:
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
     lowering_config = common.get_lowering_config(
         tuner_ctx=tuner_ctx,
-        mma_attr=mma_attr,
+        mma_kind=mma_attr,
         workgroup=[128, 64, 0],
         reduction=[0, 0, 128],
         subgroup_m_count=2,
@@ -387,8 +387,8 @@ def test_apply_params_batch_mmt_int(tuner_ctx: common.TunerContext) -> None:
         "LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64"
         in modified
     )
-    assert "workgroup = [[1, 128, 64, 0]]" in modified
-    assert "reduction = [[0, 0, 0, 128]]" in modified
+    assert "workgroup = [1, 128, 64, 0]" in modified
+    assert "reduction = [0, 0, 0, 128]" in modified
     assert '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}' in modified
 
     assert embeddable
@@ -408,8 +408,8 @@ def test_apply_params_batch_mmt_int(tuner_ctx: common.TunerContext) -> None:
         "%config = transform.param.constant #iree_codegen.compilation_info<"
         in embeddable
     )
-    assert "workgroup = [[1, 128, 64, 0]]" in embeddable
-    assert "reduction = [[0, 0, 0, 128]]" in embeddable
+    assert "workgroup = [128, 64, 0]" in embeddable
+    assert "reduction = [0, 0, 128]" in embeddable
     assert 'llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}' in embeddable
     assert "workgroup_size = [128, 2, 1] subgroup_size = 64" in embeddable
 
@@ -418,7 +418,7 @@ def test_apply_params_broadcast_rhs_mmt(tuner_ctx: common.TunerContext) -> None:
     mlir_template = [
         "<intrinsic = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>, subgroup_m_count = 4, subgroup_n_count = 1>}>",
         "<LLVMGPUVectorDistribute workgroup_size = [64, 4, 1] subgroup_size = 64,",
-        "<workgroup = [[1, 128, 128, 64]], reduction = [[1, 128, 128, 64]]>",
+        "<workgroup = [1, 128, 128, 64]], reduction = [1, 128, 128, 64]>",
         '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}',
     ]
 
@@ -434,7 +434,7 @@ def test_apply_params_broadcast_rhs_mmt(tuner_ctx: common.TunerContext) -> None:
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
     lowering_config = common.get_lowering_config(
         tuner_ctx=tuner_ctx,
-        mma_attr=mma_attr,
+        mma_kind=mma_attr,
         workgroup=[128, 64, 0],
         reduction=[0, 0, 128],
         subgroup_m_count=2,
@@ -470,8 +470,8 @@ def test_apply_params_broadcast_rhs_mmt(tuner_ctx: common.TunerContext) -> None:
         "LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64"
         in modified
     )
-    assert "workgroup = [[1, 128, 64, 0]]" in modified
-    assert "reduction = [[0, 0, 0, 128]]" in modified
+    assert "workgroup = [1, 128, 64, 0]" in modified
+    assert "reduction = [0, 0, 0, 128]" in modified
     assert '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}' in modified
 
     assert embeddable
@@ -492,8 +492,8 @@ def test_apply_params_broadcast_rhs_mmt(tuner_ctx: common.TunerContext) -> None:
         "%config = transform.param.constant #iree_codegen.compilation_info<"
         in embeddable
     )
-    assert "workgroup = [[1, 128, 64, 0]]" in embeddable
-    assert "reduction = [[0, 0, 0, 128]]" in embeddable
+    assert "workgroup = [128, 64, 0]" in embeddable
+    assert "reduction = [0, 0, 128]" in embeddable
     assert 'llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}' in embeddable
     assert "workgroup_size = [128, 2, 1] subgroup_size = 64" in embeddable
 

--- a/tuner/tuner/candidate_gen_test.py
+++ b/tuner/tuner/candidate_gen_test.py
@@ -39,7 +39,7 @@ def test_apply_params_mmt(tuner_ctx: common.TunerContext) -> None:
     mlir_template = [
         "<intrinsic = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>, subgroup_m_count = 16, subgroup_n_count = 16>",
         "<LLVMGPUVectorDistribute workgroup_size = [16, 16] subgroup_size = 16,",
-        "<tile_sizes = [[8, 8, 8]]>",
+        "<workgroup = [[8, 8, 8]], reduction = [[8, 8, 8]]>",
         "gpu_pipeline_options = #iree_gpu.pipeline_options<reorder_workgroups_strategy = None>",
         '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}',
     ]
@@ -48,25 +48,18 @@ def test_apply_params_mmt(tuner_ctx: common.TunerContext) -> None:
 
     mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
-    lowering_config_dict = {
-        "mma_kind": mma_attr,
-        "workgroup": ir.ArrayAttr.get(
-            [
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 8),
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 8),
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 8),
-            ]
-        ),
-        "reduction": ir.ArrayAttr.get([]),
-        "subgroup_m_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 16),
-        "subgroup_n_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 16),
-    }
-
-    lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
+    lowering_config = common.get_lowering_config(
+        tuner_ctx=tuner_ctx,
+        mma_attr=mma_attr,
+        workgroup=[8, 8, 0],
+        reduction=[0, 0, 8],
+        subgroup_m_count=16,
+        subgroup_n_count=16,
+    )
     config = common.Configuration(
         subgroup_size=16,
         workgroup_size=[16, 16, 1],
-        lowering_config=iree_gpu.LoweringConfigAttr.get(lowering_config_attrs),
+        lowering_config=lowering_config,
         gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(
             prefetch_shared_memory=True
         ),
@@ -96,7 +89,8 @@ def test_apply_params_mmt(tuner_ctx: common.TunerContext) -> None:
         "LLVMGPUVectorDistribute workgroup_size = [16, 16, 1] subgroup_size = 16"
         in modified
     )
-    assert "tile_sizes = [[8, 8, 8]]" in modified
+    assert "workgroup = [[8, 8, 0]]" in modified
+    assert "reduction = [[0, 0, 8]]" in modified
     assert (
         "gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true>"
         in modified
@@ -108,7 +102,7 @@ def test_apply_params_conv(tuner_ctx: common.TunerContext) -> None:
     mlir_template = [
         "<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 16, subgroup_n_count = 16>",
         "<LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64,",
-        "<tile_sizes = [[1, 1, 64, 128, 1, 1, 32]]>",
+        "<workgroup = [[1, 1, 64, 128, 1, 1, 32]], reduction = [[1, 1, 64, 128, 1, 1, 32]]>",
         'gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true>, {llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}',
     ]
 
@@ -116,24 +110,18 @@ def test_apply_params_conv(tuner_ctx: common.TunerContext) -> None:
 
     mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
-    lowering_config_dict = {
-        "mma_kind": mma_attr,
-        "workgroup": ir.ArrayAttr.get(
-            [
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 464),
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 320),
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 16),
-            ]
-        ),
-        "reduction": ir.ArrayAttr.get([]),
-        "subgroup_m_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 1),
-        "subgroup_n_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 4),
-    }
-    lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
+    lowering_config = common.get_lowering_config(
+        tuner_ctx=tuner_ctx,
+        mma_attr=mma_attr,
+        workgroup=[464, 320, 0],
+        reduction=[0, 0, 16],
+        subgroup_m_count=1,
+        subgroup_n_count=4,
+    )
     config = common.Configuration(
         subgroup_size=64,
         workgroup_size=[256, 1, 1],
-        lowering_config=iree_gpu.LoweringConfigAttr.get(lowering_config_attrs),
+        lowering_config=lowering_config,
         gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(
             reorder_workgroups_strategy=iree_gpu.ReorderWorkgroupsStrategyAttr.get(
                 iree_gpu.ReorderWorkgroupsStrategy.Transpose
@@ -167,7 +155,8 @@ def test_apply_params_conv(tuner_ctx: common.TunerContext) -> None:
         "LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64"
         in modified
     )
-    assert "tile_sizes = [[1, 1, 464, 320, 1, 1, 16]]" in modified
+    assert "workgroup = [[1, 1, 464, 320, 1, 1, 0]]" in modified
+    assert "reduction = [[0, 0, 0, 0, 0, 0, 16]]" in modified
     assert (
         "gpu_pipeline_options = #iree_gpu.pipeline_options<reorder_workgroups_strategy = <Transpose>>"
         in modified
@@ -179,7 +168,7 @@ def test_apply_params_contract(tuner_ctx: common.TunerContext) -> None:
     mlir_template = [
         "<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 2, subgroup_n_count = 2>}>",
         "<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64,",
-        "<tile_sizes = [[1, 1, 1, 64, 64, 128]]>",
+        "<workgroup = [[1, 1, 1, 64, 64, 128]], reduction = [[1, 1, 1, 64, 64, 128]]>",
         '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}',
     ]
 
@@ -194,25 +183,18 @@ def test_apply_params_contract(tuner_ctx: common.TunerContext) -> None:
 
     mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
-    lowering_config_dict = {
-        "mma_kind": mma_attr,
-        "workgroup": ir.ArrayAttr.get(
-            [
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 480),
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 384),
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 32),
-            ]
-        ),
-        "reduction": ir.ArrayAttr.get([]),
-        "subgroup_m_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 1),
-        "subgroup_n_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 4),
-    }
-
-    lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
+    lowering_config = common.get_lowering_config(
+        tuner_ctx=tuner_ctx,
+        mma_attr=mma_attr,
+        workgroup=[480, 384, 0],
+        reduction=[0, 0, 32],
+        subgroup_m_count=1,
+        subgroup_n_count=4,
+    )
     config = common.Configuration(
         subgroup_size=64,
         workgroup_size=[256, 1, 1],
-        lowering_config=iree_gpu.LoweringConfigAttr.get(lowering_config_attrs),
+        lowering_config=lowering_config,
         gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=2,
     )
@@ -232,7 +214,8 @@ def test_apply_params_contract(tuner_ctx: common.TunerContext) -> None:
         "LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64"
         in new_mlir
     )
-    assert "tile_sizes = [[1, 480, 384, 32]]" in new_mlir
+    assert "workgroup = [[1, 480, 384, 0]]" in new_mlir
+    assert "reduction = [[0, 0, 0, 32]]" in new_mlir
     assert '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}' in new_mlir
 
 
@@ -240,7 +223,7 @@ def test_apply_params_batch_matmul(tuner_ctx: common.TunerContext) -> None:
     mlir_template = [
         "<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 4, subgroup_n_count = 1>}>",
         "<LLVMGPUVectorDistribute workgroup_size = [64, 4, 1] subgroup_size = 64,",
-        "<tile_sizes = [[1, 128, 64, 64]]>",
+        "<workgroup = [[1, 128, 64, 64]], reduction = [[1, 128, 64, 64]]>",
         '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}',
     ]
 
@@ -255,26 +238,18 @@ def test_apply_params_batch_matmul(tuner_ctx: common.TunerContext) -> None:
 
     mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
-    lowering_config_dict = {
-        "mma_kind": mma_attr,
-        "workgroup": ir.ArrayAttr.get(
-            [
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 416),
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 320),
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 128),
-            ]
-        ),
-        "reduction": ir.ArrayAttr.get([]),
-        "subgroup_m_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 2),
-        "subgroup_n_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 2),
-    }
-
-    lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
-
+    lowering_config = common.get_lowering_config(
+        tuner_ctx=tuner_ctx,
+        mma_attr=mma_attr,
+        workgroup=[416, 320, 0],
+        reduction=[0, 0, 128],
+        subgroup_m_count=2,
+        subgroup_n_count=2,
+    )
     config = common.Configuration(
         subgroup_size=64,
         workgroup_size=[128, 2, 1],
-        lowering_config=iree_gpu.LoweringConfigAttr.get(lowering_config_attrs),
+        lowering_config=lowering_config,
         gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=2,
     )
@@ -298,7 +273,8 @@ def test_apply_params_batch_matmul(tuner_ctx: common.TunerContext) -> None:
         "LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64"
         in modified
     )
-    assert "tile_sizes = [[1, 416, 320, 128]]" in modified
+    assert "workgroup = [[1, 416, 320, 0]]" in modified
+    assert "reduction = [[0, 0, 0, 128]]" in modified
     assert '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}' in modified
 
 
@@ -306,7 +282,7 @@ def test_apply_params_batch_mmt_float(tuner_ctx: common.TunerContext) -> None:
     mlir_template = [
         "<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 4, subgroup_n_count = 1>}>",
         "<LLVMGPUVectorDistribute workgroup_size = [64, 4, 1] subgroup_size = 64,",
-        "<tile_sizes = [[1, 128, 128, 64]]>",
+        "<workgroup = [[1, 128, 128, 64]], reduction = [[1, 128, 128, 64]]>",
         '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}',
     ]
 
@@ -320,25 +296,18 @@ def test_apply_params_batch_mmt_float(tuner_ctx: common.TunerContext) -> None:
 
     mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
-    lowering_config_dict = {
-        "mma_kind": mma_attr,
-        "workgroup": ir.ArrayAttr.get(
-            [
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 128),
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 64),
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 128),
-            ]
-        ),
-        "reduction": ir.ArrayAttr.get([]),
-        "subgroup_m_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 2),
-        "subgroup_n_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 2),
-    }
-
-    lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
+    lowering_config = common.get_lowering_config(
+        tuner_ctx=tuner_ctx,
+        mma_attr=mma_attr,
+        workgroup=[128, 64, 0],
+        reduction=[0, 0, 128],
+        subgroup_m_count=2,
+        subgroup_n_count=2,
+    )
     config = common.Configuration(
         subgroup_size=64,
         workgroup_size=[128, 2, 1],
-        lowering_config=iree_gpu.LoweringConfigAttr.get(lowering_config_attrs),
+        lowering_config=lowering_config,
         gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=2,
     )
@@ -360,7 +329,8 @@ def test_apply_params_batch_mmt_float(tuner_ctx: common.TunerContext) -> None:
         "LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64"
         in modified
     )
-    assert "tile_sizes = [[1, 128, 64, 128]]" in modified
+    assert "workgroup = [[1, 128, 64, 0]]" in modified
+    assert "reduction = [[0, 0, 0, 128]]" in modified
     assert '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}' in modified
 
 
@@ -368,7 +338,7 @@ def test_apply_params_batch_mmt_int(tuner_ctx: common.TunerContext) -> None:
     mlir_template = [
         "<intrinsic = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>, subgroup_m_count = 4, subgroup_n_count = 1>}>",
         "<LLVMGPUVectorDistribute workgroup_size = [64, 4, 1] subgroup_size = 64,",
-        "<tile_sizes = [[1, 128, 128, 64]]>",
+        "<workgroup = [[1, 128, 128, 64]], reduction = [[1, 128, 128, 64]]>",
         '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}',
     ]
 
@@ -382,25 +352,18 @@ def test_apply_params_batch_mmt_int(tuner_ctx: common.TunerContext) -> None:
 
     mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
-    lowering_config_dict = {
-        "mma_kind": mma_attr,
-        "workgroup": ir.ArrayAttr.get(
-            [
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 128),
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 64),
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 128),
-            ]
-        ),
-        "reduction": ir.ArrayAttr.get([]),
-        "subgroup_m_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 2),
-        "subgroup_n_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 2),
-    }
-
-    lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
+    lowering_config = common.get_lowering_config(
+        tuner_ctx=tuner_ctx,
+        mma_attr=mma_attr,
+        workgroup=[128, 64, 0],
+        reduction=[0, 0, 128],
+        subgroup_m_count=2,
+        subgroup_n_count=2,
+    )
     config = common.Configuration(
         subgroup_size=64,
         workgroup_size=[128, 2, 1],
-        lowering_config=iree_gpu.LoweringConfigAttr.get(lowering_config_attrs),
+        lowering_config=lowering_config,
         gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=4,
     )
@@ -424,7 +387,8 @@ def test_apply_params_batch_mmt_int(tuner_ctx: common.TunerContext) -> None:
         "LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64"
         in modified
     )
-    assert "tile_sizes = [[1, 128, 64, 128]]" in modified
+    assert "workgroup = [[1, 128, 64, 0]]" in modified
+    assert "reduction = [[0, 0, 0, 128]]" in modified
     assert '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}' in modified
 
     assert embeddable
@@ -444,7 +408,8 @@ def test_apply_params_batch_mmt_int(tuner_ctx: common.TunerContext) -> None:
         "%config = transform.param.constant #iree_codegen.compilation_info<"
         in embeddable
     )
-    assert "tile_sizes = [[1, 128, 64, 128]]" in embeddable
+    assert "workgroup = [[1, 128, 64, 0]]" in embeddable
+    assert "reduction = [[0, 0, 0, 128]]" in embeddable
     assert 'llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}' in embeddable
     assert "workgroup_size = [128, 2, 1] subgroup_size = 64" in embeddable
 
@@ -453,7 +418,7 @@ def test_apply_params_broadcast_rhs_mmt(tuner_ctx: common.TunerContext) -> None:
     mlir_template = [
         "<intrinsic = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>, subgroup_m_count = 4, subgroup_n_count = 1>}>",
         "<LLVMGPUVectorDistribute workgroup_size = [64, 4, 1] subgroup_size = 64,",
-        "<tile_sizes = [[1, 128, 128, 64]]>",
+        "<workgroup = [[1, 128, 128, 64]], reduction = [[1, 128, 128, 64]]>",
         '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}',
     ]
 
@@ -467,25 +432,18 @@ def test_apply_params_broadcast_rhs_mmt(tuner_ctx: common.TunerContext) -> None:
 
     mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
-    lowering_config_dict = {
-        "mma_kind": mma_attr,
-        "workgroup": ir.ArrayAttr.get(
-            [
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 128),
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 64),
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 128),
-            ]
-        ),
-        "reduction": ir.ArrayAttr.get([]),
-        "subgroup_m_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 2),
-        "subgroup_n_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 2),
-    }
-
-    lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
+    lowering_config = common.get_lowering_config(
+        tuner_ctx=tuner_ctx,
+        mma_attr=mma_attr,
+        workgroup=[128, 64, 0],
+        reduction=[0, 0, 128],
+        subgroup_m_count=2,
+        subgroup_n_count=2,
+    )
     config = common.Configuration(
         subgroup_size=64,
         workgroup_size=[128, 2, 1],
-        lowering_config=iree_gpu.LoweringConfigAttr.get(lowering_config_attrs),
+        lowering_config=lowering_config,
         gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=4,
     )
@@ -512,7 +470,8 @@ def test_apply_params_broadcast_rhs_mmt(tuner_ctx: common.TunerContext) -> None:
         "LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64"
         in modified
     )
-    assert "tile_sizes = [[1, 128, 64, 128]]" in modified
+    assert "workgroup = [[1, 128, 64, 0]]" in modified
+    assert "reduction = [[0, 0, 0, 128]]" in modified
     assert '{llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}' in modified
 
     assert embeddable
@@ -533,7 +492,8 @@ def test_apply_params_broadcast_rhs_mmt(tuner_ctx: common.TunerContext) -> None:
         "%config = transform.param.constant #iree_codegen.compilation_info<"
         in embeddable
     )
-    assert "tile_sizes = [[1, 128, 64, 128]]" in embeddable
+    assert "workgroup = [[1, 128, 64, 0]]" in embeddable
+    assert "reduction = [[0, 0, 0, 128]]" in embeddable
     assert 'llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}' in embeddable
     assert "workgroup_size = [128, 2, 1] subgroup_size = 64" in embeddable
 
@@ -541,7 +501,7 @@ def test_apply_params_broadcast_rhs_mmt(tuner_ctx: common.TunerContext) -> None:
 def test_detect_broadcast_rhs_mmt(tuner_ctx: common.TunerContext) -> None:
     mlir_lines = [
         r"%18 = tensor.empty() : tensor<2x1024x10240xi32>",
-        r"%19 = linalg.fill {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 64, 128, 128]]>} ins(%c0_i32 : i32) outs(%18 : tensor<2x1024x10240xi32>) -> tensor<2x1024x10240xi32>",
+        r"%19 = linalg.fill {lowering_config = #iree_codegen.lowering_config<workgroup = [[1, 64, 128, 0]], reduction = [[0, 0, 0, 128]]>} ins(%c0_i32 : i32) outs(%18 : tensor<2x1024x10240xi32>) -> tensor<2x1024x10240xi32>",
         r'%20 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%11, %12 : tensor<2x1024x1280xi8>, tensor<10240x1280xi8>) outs(%19 : tensor<2x1024x10240xi32>) attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 64, 128, 128]]>} {',
     ]
     assert candidate_gen.ContractionTuner("mk", "nk", "mnk").is_broadcast_rhs_mmt(

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -121,6 +121,7 @@ class Configuration:
     def intrinsic(self) -> Optional[iree_gpu.MMAAttr]:
         if "mma_kind" in self.lowering_config.attributes:
             return self.lowering_config.attributes["mma_kind"]
+        return None
 
     def tilesize_workgroup(self) -> list[int]:
         if "workgroup" in self.lowering_config.attributes:
@@ -151,7 +152,7 @@ def get_lowering_config(
     tuner_ctx: TunerContext,
     **kwargs: Any,
 ) -> iree_gpu.LoweringConfigAttr:
-    lowering_config_dict = {}
+    lowering_config_dict: dict[str, Any] = {}
     for key, value in kwargs.items():
         match key:
             case "workgroup" | "reduction":

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -105,25 +105,33 @@ def get_compatible_mfma_intrinsics(
     return list(filter(is_comptible, mma_intrinsics))
 
 
-class ReorderWorkgroupsStrategy(Enum):
-    NONE = 0
-    SWIZZLE = 1
-    TRANSPOSE = 2
-
-    def __str__(self) -> str:
-        return self.name.title()
-
-
 @dataclass
 class Configuration:
     subgroup_size: int
     workgroup_size: list[int]
-    intrinsic: iree_gpu.MMAAttr
-    tile_sizes: list[int]
-    subgroup_m_count: int
-    subgroup_n_count: int
+    lowering_config: iree_gpu.LoweringConfigAttr
     gpu_pipeline_options: iree_gpu.PipelineOptionsAttr
     waves_per_eu: int
+
+    @property
+    def intrinsic(self) -> iree_gpu.MMAAttr:
+        return self.lowering_config.attributes["mma_kind"]
+
+    @property
+    def tilesize_workgroup(self) -> list[int]:
+        return [attr.value for attr in self.lowering_config.attributes["workgroup"]]
+
+    @property
+    def tilesize_reduction(self) -> list[int]:
+        return [attr.value for attr in self.lowering_config.attributes["reduction"]]
+
+    @property
+    def subgroup_m_count(self) -> int:
+        return self.lowering_config.attributes["subgroup_m_count"].value
+
+    @property
+    def subgroup_n_count(self) -> int:
+        return self.lowering_config.attributes["subgroup_n_count"].value
 
 
 def get_pipeline_config(configuration: Configuration) -> str:

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -215,6 +215,6 @@ def test_get_lowering_config(tuner_ctx: common.TunerContext) -> None:
         waves_per_eu=2,
     )
 
-    assert config.intrinsic() is None
-    assert config.subgroup_m_count() == 1
-    assert config.subgroup_n_count() == 1
+    assert common.get_intrinsic(config) is None
+    assert common.get_subgroup_m_count(config) == 1
+    assert common.get_subgroup_n_count(config) == 1

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -76,24 +76,18 @@ def test_gpu_pipeline_options(tuner_ctx: common.TunerContext) -> None:
 def test_get_pipeline_config(tuner_ctx: common.TunerContext) -> None:
     mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
-    lowering_config_dict = {
-        "mma_kind": mma_attr,
-        "workgroup": ir.ArrayAttr.get(
-            [
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 4),
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 8),
-                ir.IntegerAttr.get(tuner_ctx.type.i32, 16),
-            ]
-        ),
-        "reduction": ir.ArrayAttr.get([]),
-        "subgroup_m_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 1),
-        "subgroup_n_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 1),
-    }
-    lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
+    lowering_config = common.get_lowering_config(
+        tuner_ctx=tuner_ctx,
+        mma_attr=mma_attr,
+        workgroup=[4, 8, 0],
+        reduction=[0, 0, 16],
+        subgroup_m_count=1,
+        subgroup_n_count=1,
+    )
     config = common.Configuration(
         subgroup_size=32,
         workgroup_size=[16, 16, 1],
-        lowering_config=iree_gpu.LoweringConfigAttr.get(lowering_config_attrs),
+        lowering_config=lowering_config,
         gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=2,
     )
@@ -197,3 +191,24 @@ def test_get_compatible_mfma_intrinsics(tuner_ctx: common.TunerContext) -> None:
         )
         == []
     )
+
+
+def test_get_lowering_config(tuner_ctx: common.TunerContext) -> None:
+    lowering_config = common.get_lowering_config(
+        tuner_ctx=tuner_ctx,
+        workgroup=[4, 8, 0],
+        reduction=[0, 0, 16],
+        subgroup_m_count=1,
+        subgroup_n_count=1,
+    )
+    config = common.Configuration(
+        subgroup_size=32,
+        workgroup_size=[16, 16, 1],
+        lowering_config=lowering_config,
+        gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
+        waves_per_eu=2,
+    )
+
+    assert config.intrinsic() is None
+    assert config.subgroup_m_count() == 1
+    assert config.subgroup_n_count() == 1

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -73,16 +73,27 @@ def test_gpu_pipeline_options(tuner_ctx: common.TunerContext) -> None:
     )
 
 
-def test_get_pipeline_config(mlir_ctx: ir.Context) -> None:
+def test_get_pipeline_config(tuner_ctx: common.TunerContext) -> None:
     mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
+    lowering_config_dict = {
+        "mma_kind": mma_attr,
+        "workgroup": ir.ArrayAttr.get(
+            [
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 4),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 8),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 16),
+            ]
+        ),
+        "reduction": ir.ArrayAttr.get([]),
+        "subgroup_m_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 1),
+        "subgroup_n_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 1),
+    }
+    lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
     config = common.Configuration(
         subgroup_size=32,
         workgroup_size=[16, 16, 1],
-        intrinsic=mma_attr,
-        tile_sizes=[4, 8, 16],
-        subgroup_m_count=1,
-        subgroup_n_count=1,
+        lowering_config=iree_gpu.LoweringConfigAttr.get(lowering_config_attrs),
         gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=2,
     )

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -78,7 +78,7 @@ def test_get_pipeline_config(tuner_ctx: common.TunerContext) -> None:
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
     lowering_config = common.get_lowering_config(
         tuner_ctx=tuner_ctx,
-        mma_attr=mma_attr,
+        mma_kind=mma_attr,
         workgroup=[4, 8, 0],
         reduction=[0, 0, 16],
         subgroup_m_count=1,
@@ -201,6 +201,12 @@ def test_get_lowering_config(tuner_ctx: common.TunerContext) -> None:
         subgroup_m_count=1,
         subgroup_n_count=1,
     )
+
+    assert (
+        str(lowering_config)
+        == "#iree_gpu.lowering_config<{reduction = [0, 0, 16], subgroup_m_count = 1 : i64, subgroup_n_count = 1 : i64, workgroup = [4, 8, 0]}>"
+    )
+
     config = common.Configuration(
         subgroup_size=32,
         workgroup_size=[16, 16, 1],

--- a/tuner/tuner/dispatch_constraints.py
+++ b/tuner/tuner/dispatch_constraints.py
@@ -248,7 +248,7 @@ def generate_solutions(
                     ir.IntegerAttr.get(int_type, 0),
                     ir.IntegerAttr.get(int_type, lookup(k)),
                 ]
-            ),  # placeholder now to be consistent with iree
+            ),  # Placeholder now to be consistent with iree.
             "subgroup_m_count": ir.IntegerAttr.get(int_type, lookup(sg_m_cnt)),
             "subgroup_n_count": ir.IntegerAttr.get(int_type, lookup(sg_n_cnt)),
         }

--- a/tuner/tuner/dispatch_constraints.py
+++ b/tuner/tuner/dispatch_constraints.py
@@ -174,13 +174,13 @@ def getMMAAttr(
 
 
 def generate_solutions(
-    logger: logging.Logger,
+    tuner_ctx: TunerContext,
     problem_size: ProblemSize,
     num_subgrups: int,
     mma_intrinsics: list[iree_gpu.MMAIntrinsic],
 ) -> Iterator[Configuration]:
     M, N, K = problem_size.MNK
-    logger.info(f"{M},{N},{K}")
+    tuner_ctx.logger.info(f"{M},{N},{K}")
     m, n, k = z3.Int("m"), z3.Int("n"), z3.Int("k")
     subgroup_size = z3.Int("subgroup_size")
     intrinsic_mn = z3.Int("intrinsic_mn")
@@ -218,11 +218,7 @@ def generate_solutions(
         mma_intrinsics,
     )
     solver.add(z3.simplify(z3.And(constraints)))
-    logger.debug(f"Initial constraints: {solver}")
-
-    int_type = ir.IntegerType.get_signless(64)
-
-    tuner_ctx = TunerContext(ir.Context(), logger)
+    tuner_ctx.logger.debug(f"Initial constraints: {solver}")
 
     i = 0
     while solver.check() == z3.sat:

--- a/tuner/tuner/dispatch_constraints.py
+++ b/tuner/tuner/dispatch_constraints.py
@@ -220,7 +220,7 @@ def generate_solutions(
     solver.add(z3.simplify(z3.And(constraints)))
     logger.debug(f"Initial constraints: {solver}")
 
-    int_type = ir.IntegerType.get_signless(32)
+    int_type = ir.IntegerType.get_signless(64)
 
     i = 0
     while solver.check() == z3.sat:
@@ -239,11 +239,15 @@ def generate_solutions(
                 [
                     ir.IntegerAttr.get(int_type, lookup(m)),
                     ir.IntegerAttr.get(int_type, lookup(n)),
-                    ir.IntegerAttr.get(int_type, lookup(k)),
+                    ir.IntegerAttr.get(int_type, 0),
                 ]
             ),
             "reduction": ir.ArrayAttr.get(
-                []
+                [
+                    ir.IntegerAttr.get(int_type, 0),
+                    ir.IntegerAttr.get(int_type, 0),
+                    ir.IntegerAttr.get(int_type, lookup(k)),
+                ]
             ),  # placeholder now to be consistent with iree
             "subgroup_m_count": ir.IntegerAttr.get(int_type, lookup(sg_m_cnt)),
             "subgroup_n_count": ir.IntegerAttr.get(int_type, lookup(sg_n_cnt)),
@@ -251,7 +255,6 @@ def generate_solutions(
 
         lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
         lowering_config = iree_gpu.LoweringConfigAttr.get(lowering_config_attrs)
-
         config = Configuration(
             lookup(subgroup_size),
             [lookup(wg_x), lookup(wg_y), lookup(wg_z)],

--- a/tuner/tuner/dispatch_constraints_test.py
+++ b/tuner/tuner/dispatch_constraints_test.py
@@ -39,7 +39,7 @@ def test_generate_solutions(tuner_ctx: common.TunerContext) -> None:
         matmul_size, lhs_type, rhs_type, res_type, common.DispatchKind.mmt
     )
     configs = dispatch_constraints.generate_solutions(
-        tuner_ctx.logger,
+        tuner_ctx,
         problem_size,
         4,
         [

--- a/tuner/tuner/dispatch_parser.py
+++ b/tuner/tuner/dispatch_parser.py
@@ -171,7 +171,6 @@ class ConvParser(DispatchParser):
 
         oh = 1
 
-        # oc = configuration.tilesize_workgroup()[1]
         ow, oc, _ = configuration.tilesize_workgroup()
 
         return [batch, oh, ow, oc, fh, fw, 0]

--- a/tuner/tuner/dispatch_parser.py
+++ b/tuner/tuner/dispatch_parser.py
@@ -21,17 +21,17 @@ def parse_tensor_type(tensor_type: str) -> ShapedType:
 
 
 def get_mmt_workgroup_sizes(configuration: Configuration):
-    return get_tilesize_workgroup(configuration)
+    return get_workgroup_tile_sizes(configuration)
 
 
 def get_mmt_reduction_sizes(configuration: Configuration):
-    return get_tilesize_reduction(configuration)
+    return get_reduction_tile_sizes(configuration)
 
 
 def get_contract_workgroup_sizes(
     configuration: Configuration, tile_dims: str
 ) -> list[int]:
-    m, n, _k = get_tilesize_workgroup(configuration)
+    m, n, _k = get_workgroup_tile_sizes(configuration)
 
     workgroup_size = [1] * len(tile_dims)
     for idx, dim in enumerate(tile_dims):
@@ -48,7 +48,7 @@ def get_contract_workgroup_sizes(
 def get_contract_reduction_sizes(
     configuration: Configuration, tile_dims: str
 ) -> list[int]:
-    _m, _n, k = get_tilesize_reduction(configuration)
+    _m, _n, k = get_reduction_tile_sizes(configuration)
     reduction_size = [0] * len(tile_dims)
     for idx, dim in enumerate(tile_dims):
         if dim == "k":
@@ -58,11 +58,11 @@ def get_contract_reduction_sizes(
 
 
 def get_batch_mmt_workgroup_sizes(configuration: Configuration) -> list[int]:
-    return [1] + get_tilesize_workgroup(configuration)
+    return [1] + get_workgroup_tile_sizes(configuration)
 
 
 def get_batch_mmt_reduction_sizes(configuration: Configuration) -> list[int]:
-    return [0] + get_tilesize_reduction(configuration)
+    return [0] + get_reduction_tile_sizes(configuration)
 
 
 class MlirRegex(Enum):
@@ -171,12 +171,12 @@ class ConvParser(DispatchParser):
 
         oh = 1
 
-        ow, oc, _ic = get_tilesize_workgroup(configuration)
+        ow, oc, _ic = get_workgroup_tile_sizes(configuration)
 
         return [batch, oh, ow, oc, fh, fw, 0]
 
     def get_conv_reduction_sizes(self, configuration: Configuration) -> list[int]:
-        _ow, _oc, ic = get_tilesize_reduction(configuration)
+        _ow, _oc, ic = get_reduction_tile_sizes(configuration)
 
         return [0, 0, 0, 0, 0, 0, ic]
 

--- a/tuner/tuner/dispatch_parser.py
+++ b/tuner/tuner/dispatch_parser.py
@@ -171,12 +171,12 @@ class ConvParser(DispatchParser):
 
         oh = 1
 
-        ow, oc, _ = configuration.tilesize_workgroup()
+        ow, oc, _ic = configuration.tilesize_workgroup()
 
         return [batch, oh, ow, oc, fh, fw, 0]
 
     def get_conv_reduction_sizes(self, configuration: Configuration) -> list[int]:
-        _, _, ic = configuration.tilesize_reduction()
+        _ow, _oc, ic = configuration.tilesize_reduction()
 
         return [0, 0, 0, 0, 0, 0, ic]
 

--- a/tuner/tuner/dispatch_parser.py
+++ b/tuner/tuner/dispatch_parser.py
@@ -21,17 +21,17 @@ def parse_tensor_type(tensor_type: str) -> ShapedType:
 
 
 def get_mmt_workgroup_sizes(configuration: Configuration):
-    return configuration.tilesize_workgroup()
+    return get_tilesize_workgroup(configuration)
 
 
 def get_mmt_reduction_sizes(configuration: Configuration):
-    return configuration.tilesize_reduction()
+    return get_tilesize_reduction(configuration)
 
 
 def get_contract_workgroup_sizes(
     configuration: Configuration, tile_dims: str
 ) -> list[int]:
-    m, n, _ = configuration.tilesize_workgroup()
+    m, n, _k = get_tilesize_workgroup(configuration)
 
     workgroup_size = [1] * len(tile_dims)
     for idx, dim in enumerate(tile_dims):
@@ -48,7 +48,7 @@ def get_contract_workgroup_sizes(
 def get_contract_reduction_sizes(
     configuration: Configuration, tile_dims: str
 ) -> list[int]:
-    _, _, k = configuration.tilesize_reduction()
+    _m, _n, k = get_tilesize_reduction(configuration)
     reduction_size = [0] * len(tile_dims)
     for idx, dim in enumerate(tile_dims):
         if dim == "k":
@@ -58,11 +58,11 @@ def get_contract_reduction_sizes(
 
 
 def get_batch_mmt_workgroup_sizes(configuration: Configuration) -> list[int]:
-    return [1] + configuration.tilesize_workgroup()
+    return [1] + get_tilesize_workgroup(configuration)
 
 
 def get_batch_mmt_reduction_sizes(configuration: Configuration) -> list[int]:
-    return [0] + configuration.tilesize_reduction()
+    return [0] + get_tilesize_reduction(configuration)
 
 
 class MlirRegex(Enum):
@@ -171,12 +171,12 @@ class ConvParser(DispatchParser):
 
         oh = 1
 
-        ow, oc, _ic = configuration.tilesize_workgroup()
+        ow, oc, _ic = get_tilesize_workgroup(configuration)
 
         return [batch, oh, ow, oc, fh, fw, 0]
 
     def get_conv_reduction_sizes(self, configuration: Configuration) -> list[int]:
-        _ow, _oc, ic = configuration.tilesize_reduction()
+        _ow, _oc, ic = get_tilesize_reduction(configuration)
 
         return [0, 0, 0, 0, 0, 0, ic]
 

--- a/tuner/tuner/dispatch_parser.py
+++ b/tuner/tuner/dispatch_parser.py
@@ -21,11 +21,11 @@ def parse_tensor_type(tensor_type: str) -> ShapedType:
 
 
 def get_mmt_tile_sizes(configuration: Configuration):
-    return configuration.tile_sizes
+    return configuration.tilesize_workgroup
 
 
 def get_contract_tile_sizes(configuration: Configuration, tile_dims: str) -> list[int]:
-    m, n, k = configuration.tile_sizes
+    m, n, k = configuration.tilesize_workgroup
     tile_size = [1] * len(tile_dims)
     for idx, dim in enumerate(tile_dims):
         if dim == "m":
@@ -38,7 +38,7 @@ def get_contract_tile_sizes(configuration: Configuration, tile_dims: str) -> lis
 
 
 def get_batch_mmt_tile_sizes(configuration: Configuration) -> list[int]:
-    return [1] + configuration.tile_sizes
+    return [1] + configuration.tilesize_workgroup
 
 
 class MlirRegex(Enum):
@@ -141,7 +141,7 @@ class ConvParser(DispatchParser):
         return "conv_2d_nhwc_hwcf" in op_name
 
     def get_conv_tile_sizes(self, configuration: Configuration) -> list[int]:
-        m, n, k = configuration.tile_sizes
+        m, n, k = configuration.tilesize_workgroup
         batch = 1
         fh = 1
         fw = 1

--- a/tuner/tuner/dispatch_parser_test.py
+++ b/tuner/tuner/dispatch_parser_test.py
@@ -44,7 +44,7 @@ def test_get_mmt_tile_sizes(tuner_ctx: common.TunerContext) -> None:
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
     lowering_config = common.get_lowering_config(
         tuner_ctx=tuner_ctx,
-        mma_attr=mma_attr,
+        mma_kind=mma_attr,
         workgroup=[128, 320, 0],
         reduction=[0, 0, 32],
         subgroup_m_count=1,
@@ -66,7 +66,7 @@ def test_get_conv_tile_sizes(tuner_ctx: common.TunerContext) -> None:
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
     lowering_config = common.get_lowering_config(
         tuner_ctx=tuner_ctx,
-        mma_attr=mma_attr,
+        mma_kind=mma_attr,
         workgroup=[464, 320, 0],
         reduction=[0, 0, 16],
         subgroup_m_count=1,
@@ -104,7 +104,7 @@ def test_get_contract_tile_sizes(tuner_ctx: common.TunerContext) -> None:
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
     lowering_config = common.get_lowering_config(
         tuner_ctx=tuner_ctx,
-        mma_attr=mma_attr,
+        mma_kind=mma_attr,
         workgroup=[4, 8, 0],
         reduction=[0, 0, 16],
         subgroup_m_count=1,
@@ -123,16 +123,8 @@ def test_get_contract_tile_sizes(tuner_ctx: common.TunerContext) -> None:
     assert dispatch_parser.get_contract_reduction_sizes(config, "nmk") == [0, 0, 16]
     assert dispatch_parser.get_contract_workgroup_sizes(config, "knm") == [0, 8, 4]
     assert dispatch_parser.get_contract_reduction_sizes(config, "knm") == [16, 0, 0]
-    assert dispatch_parser.get_contract_workgroup_sizes(config, "kkk") == [
-        0,
-        0,
-        0,
-    ]
-    assert dispatch_parser.get_contract_reduction_sizes(config, "kkk") == [
-        16,
-        16,
-        16,
-    ]
+    assert dispatch_parser.get_contract_workgroup_sizes(config, "kkk") == [0, 0, 0]
+    assert dispatch_parser.get_contract_reduction_sizes(config, "kkk") == [16, 16, 16]
 
 
 def test_get_shapes_mmt(tuner_ctx: common.TunerContext) -> None:

--- a/tuner/tuner/dispatch_parser_test.py
+++ b/tuner/tuner/dispatch_parser_test.py
@@ -42,13 +42,24 @@ def test_parse_tensor_type(tuner_ctx: common.TunerContext) -> None:
 def test_get_mmt_tile_sizes(tuner_ctx: common.TunerContext) -> None:
     mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
+    lowering_config_dict = {
+        "mma_kind": mma_attr,
+        "workgroup": ir.ArrayAttr.get(
+            [
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 128),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 320),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 32),
+            ]
+        ),
+        "reduction": ir.ArrayAttr.get([]),
+        "subgroup_m_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 0),
+        "subgroup_n_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 0),
+    }
+    lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
     config = dispatch_parser.Configuration(
         subgroup_size=0,
         workgroup_size=[],
-        intrinsic=mma_attr,
-        tile_sizes=[128, 320, 32],
-        subgroup_m_count=0,
-        subgroup_n_count=0,
+        lowering_config=iree_gpu.LoweringConfigAttr.get(lowering_config_attrs),
         gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=0,
     )
@@ -58,13 +69,24 @@ def test_get_mmt_tile_sizes(tuner_ctx: common.TunerContext) -> None:
 def test_get_conv_tile_sizes(tuner_ctx: common.TunerContext) -> None:
     mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
+    lowering_config_dict = {
+        "mma_kind": mma_attr,
+        "workgroup": ir.ArrayAttr.get(
+            [
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 464),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 320),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 16),
+            ]
+        ),
+        "reduction": ir.ArrayAttr.get([]),
+        "subgroup_m_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 1),
+        "subgroup_n_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 4),
+    }
+    lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
     config = dispatch_parser.Configuration(
         subgroup_size=64,
         workgroup_size=[256, 1, 1],
-        intrinsic=mma_attr,
-        tile_sizes=[464, 320, 16],
-        subgroup_m_count=1,
-        subgroup_n_count=4,
+        lowering_config=iree_gpu.LoweringConfigAttr.get(lowering_config_attrs),
         gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=1,
     )
@@ -82,13 +104,24 @@ def test_get_conv_tile_sizes(tuner_ctx: common.TunerContext) -> None:
 def test_get_contract_tile_sizes(tuner_ctx: common.TunerContext) -> None:
     mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16
     mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
+    lowering_config_dict = {
+        "mma_kind": mma_attr,
+        "workgroup": ir.ArrayAttr.get(
+            [
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 4),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 8),
+                ir.IntegerAttr.get(tuner_ctx.type.i32, 16),
+            ]
+        ),
+        "reduction": ir.ArrayAttr.get([]),
+        "subgroup_m_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 1),
+        "subgroup_n_count": ir.IntegerAttr.get(tuner_ctx.type.i32, 1),
+    }
+    lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
     config = dispatch_parser.Configuration(
         subgroup_size=32,
         workgroup_size=[16, 16, 1],
-        intrinsic=mma_attr,
-        tile_sizes=[4, 8, 16],
-        subgroup_m_count=1,
-        subgroup_n_count=1,
+        lowering_config=iree_gpu.LoweringConfigAttr.get(lowering_config_attrs),
         gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=2,
     )


### PR DESCRIPTION
This PR is relevant to the task in https://github.com/nod-ai/shark-ai/issues/453 : use IREE bindings for compilation info (incl., lowering_config and translation_info).  

Remove data class `ReorderWorkgroupsStrategy`, and use lowering_config binding. 