### PR TITLE
[sharktank] Fix flaxy quantizer test 

### DIFF
--- a/sharktank/tests/types/quantizers_test.py
+++ b/sharktank/tests/types/quantizers_test.py
@@ -72,7 +72,9 @@ class StaticScaledQuantizerTest(TempDirTestBase):
         )
         ssq = self._roundtrip(ssq, "_ssq")
         self.assertEqual(ssq.axis, 1)
-        torch.testing.assert_close(ssq.scale, torch.tensor([0.2, 0.4, 0.8]))
+        torch.testing.assert_close(
+            ssq.scale, torch.tensor([0.2, 0.4, 0.8], dtype=torch.float32)
+        )
         torch.testing.assert_close(ssq.reciprocal_scale, torch.tensor([5.0, 2.5, 1.25]))
         self.assertIs(ssq.dtype, torch.float16)
 


### PR DESCRIPTION
Forcibly assigns type to avoid test flake when it selects bfloat16 for unknown reasons.