### PR TITLE
TriePagedAttentionCache

### DIFF
--- a/app_tests/integration_tests/llm/shortfin/conftest.py
+++ b/app_tests/integration_tests/llm/shortfin/conftest.py
@@ -87,7 +87,7 @@ def model_test_dir(request, tmp_path_factory):
             "paged_kv_cache": {
                 "block_seq_stride": 16,
                 "device_block_count": 256,
-                "prefix_sharing_algorithm": "none",
+                "prefix_sharing_algorithm": prefix_sharing_algorithm,
             },
         }
         logger.info(f"Saving edited config to: {edited_config_path}\n")

--- a/app_tests/integration_tests/llm/shortfin/conftest.py
+++ b/app_tests/integration_tests/llm/shortfin/conftest.py
@@ -51,6 +51,7 @@ def model_test_dir(request, tmp_path_factory):
     tokenizer_id = request.param["tokenizer_id"]
     settings = request.param["settings"]
     batch_sizes = request.param["batch_sizes"]
+    prefix_sharing_algorithm = request.param["prefix_sharing_algorithm"]
 
     tmp_dir = tmp_path_factory.mktemp("cpu_llm_server_test")
     hf_home = os.environ.get("HF_HOME", None)

--- a/app_tests/integration_tests/llm/shortfin/conftest.py
+++ b/app_tests/integration_tests/llm/shortfin/conftest.py
@@ -83,7 +83,11 @@ def model_test_dir(request, tmp_path_factory):
             "prefill_batch_sizes": batch_sizes,
             "decode_batch_sizes": batch_sizes,
             "transformer_block_count": 26,
-            "paged_kv_cache": {"block_seq_stride": 16, "device_block_count": 256},
+            "paged_kv_cache": {
+                "block_seq_stride": 16,
+                "device_block_count": 256,
+                "prefix_sharing_algorithm": "none",
+            },
         }
         logger.info(f"Saving edited config to: {edited_config_path}\n")
         logger.info(f"Config: {json.dumps(config, indent=2)}")

--- a/app_tests/integration_tests/llm/shortfin/cpu_llm_server_test.py
+++ b/app_tests/integration_tests/llm/shortfin/cpu_llm_server_test.py
@@ -65,17 +65,6 @@ def do_generate(prompt, port):
 @pytest.mark.parametrize(
     "model_test_dir,llm_server",
     [
-        (
-            {
-                "repo_id": "SlyEcho/open_llama_3b_v2_gguf",
-                "model_file": "open-llama-3b-v2-f16.gguf",
-                "tokenizer_id": "openlm-research/open_llama_3b_v2",
-                "settings": CPU_SETTINGS,
-                "batch_sizes": [1, 4],
-                "prefix_sharing_algorithm": "none",
-            },
-            {"model_file": "open-llama-3b-v2-f16.gguf", "settings": CPU_SETTINGS},
-        ),
         pytest.param(
             {
                 "repo_id": "SlyEcho/open_llama_3b_v2_gguf",
@@ -89,6 +78,17 @@ def do_generate(prompt, port):
             marks=pytest.mark.xfail(
                 reason="Trie-based prefix sharing not yet supported"
             ),
+        ),
+        pytest.param(
+            {
+                "repo_id": "SlyEcho/open_llama_3b_v2_gguf",
+                "model_file": "open-llama-3b-v2-f16.gguf",
+                "tokenizer_id": "openlm-research/open_llama_3b_v2",
+                "settings": CPU_SETTINGS,
+                "batch_sizes": [1, 4],
+                "prefix_sharing_algorithm": "none",
+            },
+            {"model_file": "open-llama-3b-v2-f16.gguf", "settings": CPU_SETTINGS},
         ),
     ],
     indirect=True,

--- a/app_tests/integration_tests/llm/shortfin/cpu_llm_server_test.py
+++ b/app_tests/integration_tests/llm/shortfin/cpu_llm_server_test.py
@@ -72,9 +72,24 @@ def do_generate(prompt, port):
                 "tokenizer_id": "openlm-research/open_llama_3b_v2",
                 "settings": CPU_SETTINGS,
                 "batch_sizes": [1, 4],
+                "prefix_sharing_algorithm": "none",
             },
             {"model_file": "open-llama-3b-v2-f16.gguf", "settings": CPU_SETTINGS},
-        )
+        ),
+        pytest.param(
+            {
+                "repo_id": "SlyEcho/open_llama_3b_v2_gguf",
+                "model_file": "open-llama-3b-v2-f16.gguf",
+                "tokenizer_id": "openlm-research/open_llama_3b_v2",
+                "settings": CPU_SETTINGS,
+                "batch_sizes": [1, 4],
+                "prefix_sharing_algorithm": "trie",
+            },
+            {"model_file": "open-llama-3b-v2-f16.gguf", "settings": CPU_SETTINGS},
+            marks=pytest.mark.xfail(
+                reason="Trie-based prefix sharing not yet supported"
+            ),
+        ),
     ],
     indirect=True,
 )

--- a/app_tests/integration_tests/llm/shortfin/cpu_llm_server_test.py
+++ b/app_tests/integration_tests/llm/shortfin/cpu_llm_server_test.py
@@ -75,9 +75,6 @@ def do_generate(prompt, port):
                 "prefix_sharing_algorithm": "trie",
             },
             {"model_file": "open-llama-3b-v2-f16.gguf", "settings": CPU_SETTINGS},
-            marks=pytest.mark.xfail(
-                reason="Trie-based prefix sharing not yet supported"
-            ),
         ),
         pytest.param(
             {

--- a/shortfin/python/shortfin_apps/llm/components/config_struct.py
+++ b/shortfin/python/shortfin_apps/llm/components/config_struct.py
@@ -86,7 +86,7 @@ class PagedKVCacheParams:
     # Size of the cache on each device.
     device_block_count: int
 
-    cache_type: str = "trie"  # currently supporting base and trie
+    cache_type: str = "base"  # currently supporting base and trie
 
 
 @dataclass_json(undefined=Undefined.RAISE)

--- a/shortfin/python/shortfin_apps/llm/components/config_struct.py
+++ b/shortfin/python/shortfin_apps/llm/components/config_struct.py
@@ -86,6 +86,8 @@ class PagedKVCacheParams:
     # Size of the cache on each device.
     device_block_count: int
 
+    cache_type: str = "trie"  # currently supporting base and trie
+
 
 @dataclass_json(undefined=Undefined.RAISE)
 @dataclass

--- a/shortfin/python/shortfin_apps/llm/components/config_struct.py
+++ b/shortfin/python/shortfin_apps/llm/components/config_struct.py
@@ -86,7 +86,7 @@ class PagedKVCacheParams:
     # Size of the cache on each device.
     device_block_count: int
 
-    cache_type: str = "base"  # currently supporting base and trie
+    prefix_sharing_algorithm: str = "none"  # currently supporting none and trie
 
 
 @dataclass_json(undefined=Undefined.RAISE)

--- a/shortfin/python/shortfin_apps/llm/components/kvcache/base_attention_cache.py
+++ b/shortfin/python/shortfin_apps/llm/components/kvcache/base_attention_cache.py
@@ -63,7 +63,7 @@ class BasePageAttentionCacheAllocation(PageAllocation):
         if self._is_released:
             logger.warning("Releasing already-released allocation")
             return
-        self._cache.page_pool.release_pages(self._pages)
+        self._cache.page_pool.free_pages(self._pages)
         self._is_released = True
 
     def __rerp__(self) -> str:

--- a/shortfin/python/shortfin_apps/llm/components/kvcache/base_attention_cache.py
+++ b/shortfin/python/shortfin_apps/llm/components/kvcache/base_attention_cache.py
@@ -34,8 +34,10 @@ class PageAllocation(ABC):
         pass
 
     @abstractmethod
-    def publish_pages(self, tokens, publish_incomplete_pages=False) -> None:
-        """Makes pages[0:up_to_page_index] available to other requests."""
+    def publish_pages_for_tokens(self, tokens, publish_incomplete_pages=False) -> None:
+        """
+        Makes pages available to other requests. For details, reference the derived class in trie_attention_cache.py.
+        """
         pass
 
     @abstractmethod
@@ -56,7 +58,7 @@ class BasePageAttentionCacheAllocation(PageAllocation):
     def pages(self) -> List[PageInfo]:
         return list(self._pages)
 
-    def publish_pages(self, tokens, publish_incomplete_pages=False) -> None:
+    def publish_pages_for_tokens(self, tokens, publish_incomplete_pages=False) -> None:
         pass
 
     def release_pages(self) -> None:

--- a/shortfin/python/shortfin_apps/llm/components/kvcache/base_attention_cache.py
+++ b/shortfin/python/shortfin_apps/llm/components/kvcache/base_attention_cache.py
@@ -34,7 +34,7 @@ class PageAllocation(ABC):
         pass
 
     @abstractmethod
-    def publish_pages(self, up_to_page_index) -> None:
+    def publish_pages(self, tokens, publish_incomplete_pages=False) -> None:
         """Makes pages[0:up_to_page_index] available to other requests."""
         pass
 
@@ -56,7 +56,7 @@ class BasePageAttentionCacheAllocation(PageAllocation):
     def pages(self) -> List[PageInfo]:
         return list(self._pages)
 
-    def publish_pages(self, up_to_page_index) -> None:
+    def publish_pages(self, tokens, publish_incomplete_pages=False) -> None:
         pass
 
     def release_pages(self) -> None:

--- a/shortfin/python/shortfin_apps/llm/components/kvcache/base_attention_cache.py
+++ b/shortfin/python/shortfin_apps/llm/components/kvcache/base_attention_cache.py
@@ -34,7 +34,7 @@ class PageAllocation(ABC):
         pass
 
     @abstractmethod
-    def publish_pages_for_tokens(self, tokens, publish_incomplete_pages=False) -> None:
+    def publish_pages_for_tokens(self, tokens, publish_incomplete_page=False) -> None:
         """
         Makes pages available to other requests. For details, reference the derived class in trie_attention_cache.py.
         """
@@ -58,7 +58,7 @@ class BasePageAttentionCacheAllocation(PageAllocation):
     def pages(self) -> List[PageInfo]:
         return list(self._pages)
 
-    def publish_pages_for_tokens(self, tokens, publish_incomplete_pages=False) -> None:
+    def publish_pages_for_tokens(self, tokens, publish_incomplete_page=False) -> None:
         pass
 
     def release_pages(self) -> None:

--- a/shortfin/python/shortfin_apps/llm/components/kvcache/base_attention_cache.py
+++ b/shortfin/python/shortfin_apps/llm/components/kvcache/base_attention_cache.py
@@ -34,7 +34,9 @@ class PageAllocation(ABC):
         pass
 
     @abstractmethod
-    def publish_pages_for_tokens(self, tokens, publish_incomplete_page=False) -> None:
+    def publish_pages_for_tokens(
+        self, tokens, *, publish_incomplete_page=False
+    ) -> None:
         """
         Makes pages available to other requests. For details, reference the derived class in trie_attention_cache.py.
         """
@@ -46,14 +48,14 @@ class PageAllocation(ABC):
         pass
 
     @abstractmethod
-    def extend_allocation(self, tokens, extra_token_slots=0) -> None:
+    def extend_allocation(self, tokens, *, extra_token_slots=0) -> None:
         """
         Extends the allocation to include additional tokens. For details, reference the derived class in trie_attention_cache.py.
         """
         pass
 
 
-class BasePageAttentionCacheAllocation(PageAllocation):
+class BasePagedAttentionCacheAllocation(PageAllocation):
     """Represents a page allocation in the cache."""
 
     def __init__(self, pages: Iterable[PageInfo], cache: "BasePagedAttentionCache"):
@@ -65,7 +67,9 @@ class BasePageAttentionCacheAllocation(PageAllocation):
     def pages(self) -> List[PageInfo]:
         return list(self._pages)
 
-    def publish_pages_for_tokens(self, tokens, publish_incomplete_page=False) -> None:
+    def publish_pages_for_tokens(
+        self, tokens, *, publish_incomplete_page=False
+    ) -> None:
         pass
 
     def release_pages(self) -> None:
@@ -75,7 +79,7 @@ class BasePageAttentionCacheAllocation(PageAllocation):
         self._cache.page_pool.free_pages(self._pages)
         self._is_released = True
 
-    def extend_allocation(self, tokens, extra_token_slots=0) -> None:
+    def extend_allocation(self, tokens, *, extra_token_slots=0) -> None:
         # assert old tokens are a prefix of incoming tokens
         # if we don't have enough pages to hold the tokens, we need to allocate more pages
         token_count = len(tokens) + extra_token_slots
@@ -89,7 +93,7 @@ class BasePageAttentionCacheAllocation(PageAllocation):
             self._pages += tuple(new_pages)
 
     def __rerp__(self) -> str:
-        return f"BasePageAttentionCacheAllocation(pages={self._pages}, cache={self._cache})"
+        return f"BasePagedAttentionCacheAllocation(pages={self._pages}, cache={self._cache})"
 
 
 class BasePagedAttentionCache:
@@ -139,4 +143,4 @@ class BasePagedAttentionCache:
         if pages is None:
             raise CacheAllocationFailure()
 
-        return BasePageAttentionCacheAllocation(pages, cache=self)
+        return BasePagedAttentionCacheAllocation(pages, cache=self)

--- a/shortfin/python/shortfin_apps/llm/components/kvcache/trie_attention_cache.py
+++ b/shortfin/python/shortfin_apps/llm/components/kvcache/trie_attention_cache.py
@@ -122,7 +122,7 @@ class TriePageAttentionCacheAllocation(PageAllocation):
         publish_token_count = min(len(self.tokens), up_to_page_index * tokens_per_page)
 
         cur_node = self.last_cached_node
-        first_uncached_page_index = self.start_index // tokens_per_page
+        first_uncached_page_index = len(self.cached_pages)
 
         uncached_tokens = [
             tuple(self.tokens[i : i + tokens_per_page])
@@ -138,6 +138,9 @@ class TriePageAttentionCacheAllocation(PageAllocation):
         for token_block, page in zip(uncached_tokens, uncached_pages):
             new_node = cur_node.create_child(token_block, page)
             cur_node = new_node
+
+        self.cached_pages.extend(uncached_pages)
+        self.newly_acquired_pages = self.newly_acquired_pages[len(uncached_pages) :]
 
         if cur_node is not self.cache.root:
             self.cache.leaves.add(cur_node)

--- a/shortfin/python/shortfin_apps/llm/components/kvcache/trie_attention_cache.py
+++ b/shortfin/python/shortfin_apps/llm/components/kvcache/trie_attention_cache.py
@@ -103,7 +103,7 @@ class TriePagedAttentionCacheAllocation(PageAllocation):
     def pages(self) -> List[PageInfo]:
         return self._pages
 
-    def publish_pages(self, tokens, publish_incomplete_page=False) -> None:
+    def publish_pages_for_tokens(self, tokens, publish_incomplete_page=False) -> None:
         """Make pages available in the cache for the specified tokens.
 
         Args:

--- a/shortfin/python/shortfin_apps/llm/components/kvcache/trie_attention_cache.py
+++ b/shortfin/python/shortfin_apps/llm/components/kvcache/trie_attention_cache.py
@@ -70,7 +70,7 @@ class TrieNode:
         return self is other
 
 
-class TriePageAttentionCacheAllocation(PageAllocation):
+class TriePagedAttentionCacheAllocation(PageAllocation):
     """Represents a page allocation in the trie-based cache.
 
     Tracks sequence of pages and which ones are already published to the cache,
@@ -255,7 +255,7 @@ class TriePagedAttentionCache(BasePagedAttentionCache):
         new_pages = self.page_pool.acquire_free_pages(n_empty_pages)
 
         if new_pages is not None:
-            return TriePageAttentionCacheAllocation(
+            return TriePagedAttentionCacheAllocation(
                 cache=self,
                 tokens=tokens,
                 last_cached_node=cur_node,
@@ -272,7 +272,7 @@ class TriePagedAttentionCache(BasePagedAttentionCache):
                 "Failed to acquire pages even after attempting eviction from LRU leaves"
             )
 
-        return TriePageAttentionCacheAllocation(
+        return TriePagedAttentionCacheAllocation(
             cache=self,
             tokens=tokens,
             last_cached_node=cur_node,

--- a/shortfin/python/shortfin_apps/llm/components/kvcache/trie_attention_cache.py
+++ b/shortfin/python/shortfin_apps/llm/components/kvcache/trie_attention_cache.py
@@ -103,7 +103,9 @@ class TriePagedAttentionCacheAllocation(PageAllocation):
     def pages(self) -> List[PageInfo]:
         return self._pages
 
-    def publish_pages_for_tokens(self, tokens, publish_incomplete_page=False) -> None:
+    def publish_pages_for_tokens(
+        self, tokens, *, publish_incomplete_page=False
+    ) -> None:
         """Make pages available in the cache for the specified tokens.
 
         Args:
@@ -181,7 +183,7 @@ class TriePagedAttentionCacheAllocation(PageAllocation):
         self.last_cached_node.ref_count -= 1
         self._is_released = True
 
-    def extend_allocation(self, tokens: List[int], extra_token_slots=0) -> None:
+    def extend_allocation(self, tokens: List[int], *, extra_token_slots=0) -> None:
         """Extend the current allocation to accommodate additional tokens.
 
         Args:

--- a/shortfin/python/shortfin_apps/llm/components/kvcache/trie_attention_cache.py
+++ b/shortfin/python/shortfin_apps/llm/components/kvcache/trie_attention_cache.py
@@ -154,11 +154,12 @@ class TriePagedAttentionCacheAllocation(PageAllocation):
 
         tokens_per_page = self.cache.tokens_per_page
 
-        number_of_pages_to_publish = len(tokens) / tokens_per_page
         if publish_incomplete_page:
-            number_of_pages_to_publish = math.ceil(number_of_pages_to_publish)
+            number_of_pages_to_publish = -(
+                len(tokens) // -tokens_per_page
+            )  # ceil division
         else:
-            number_of_pages_to_publish = math.floor(number_of_pages_to_publish)
+            number_of_pages_to_publish = len(tokens) // tokens_per_page
 
         # Create token blocks for unpublished pages
         start_token_index = self.number_of_published_pages * tokens_per_page

--- a/shortfin/python/shortfin_apps/llm/components/kvcache/trie_attention_cache.py
+++ b/shortfin/python/shortfin_apps/llm/components/kvcache/trie_attention_cache.py
@@ -1,0 +1,325 @@
+from typing import Dict, Set, List, Tuple, Optional
+from dataclasses import dataclass
+import time
+import math
+import heapq
+from .page_pool import PagePool, PageInfo
+from .base_attention_cache import (
+    BasePagedAttentionCache,
+    PageAllocation,
+    CacheAllocationFailure,
+)
+
+
+@dataclass
+class TrieNode:
+    """Node of the block trie for paged attention cache.
+
+    Each node represents a page of tokens in the cache, with edges representing
+    token sequences that can follow. This allows prefix sharing between sequences
+    that have common prefixes.
+
+    Attributes:
+        tokens: Tuple of tokens stored in this node's page
+        page: PageInfo object containing the actual cache page
+        children: Dict mapping token sequences to child nodes
+        parent: Parent node in the trie (None for root)
+        ref_count: Number of active references to this node
+        access_time: Last access timestamp for LRU eviction
+    """
+
+    tokens: Tuple[int, ...]
+    page: PageInfo
+    children: Optional[Dict[Tuple[int, ...], "TrieNode"]] = None
+    parent: Optional["TrieNode"] = None
+    ref_count: int = 0
+    access_time: float = 0.0
+
+    def __post_init__(self) -> None:
+        """Initialize children dict and access time if not provided."""
+        if self.children is None:
+            self.children = {}
+        self.access_time = time.monotonic()
+
+    def create_child(self, tokens: Tuple[int, ...], page: PageInfo) -> "TrieNode":
+        """Create a new child node with the given tokens and page.
+
+        Args:
+            tokens: Sequence of tokens for the new node
+            page: PageInfo for the new node's cache page
+
+        Returns:
+            The newly created child node
+        """
+        new_node = TrieNode(tokens=tokens, page=page, parent=self)
+        self.children[tokens] = new_node
+        return new_node
+
+    def unlink(self) -> None:
+        """Remove this node from its parent's children."""
+        if self.parent is not None:
+            del self.parent.children[self.tokens]
+            self.parent = None
+
+    def __hash__(self) -> int:
+        """Nodes are uniquely identified by their memory address."""
+        return id(self)
+
+    def __eq__(self, other: object) -> bool:
+        """Nodes are equal only if they are the same object."""
+        return self is other
+
+
+class TriePageAttentionCacheAllocation(PageAllocation):
+    """Represents a page allocation in the trie-based cache.
+
+    Tracks both previously cached pages and newly allocated pages,
+    implementing the PageAllocation protocol for the trie cache.
+
+    Attributes:
+        cache: The parent cache this allocation belongs to
+        tokens: Complete sequence of tokens this allocation represents
+        last_cached_node: Last matched node in the trie
+        cached_pages: List of pages already in cache
+        newly_acquired_pages: List of newly allocated pages
+        start_index: Index where cached tokens end and new tokens begin
+    """
+
+    def __init__(
+        self,
+        cache: "TriePagedAttentionCache",
+        tokens: List[int],
+        last_cached_node: TrieNode,
+        cached_pages: List[PageInfo],
+        newly_acquired_pages: List[PageInfo],
+        start_index: int,
+    ):
+        self.cache = cache
+        self.tokens = tokens
+        self.last_cached_node = last_cached_node
+        self.cached_pages = cached_pages
+        self.newly_acquired_pages = newly_acquired_pages
+        self.start_index = start_index
+        self._is_released = False
+
+    @property
+    def pages(self) -> List[PageInfo]:
+        """List all pages in this allocation, both cached and new.
+
+        Returns:
+            Combined list of cached and newly acquired pages
+        """
+        return self.cached_pages + self.newly_acquired_pages
+
+    def publish_pages(self, up_to_page_index: int) -> None:
+        """Make pages available in the cache up to the specified index.
+
+        Args:
+            up_to_page_index: Number of pages to publish, starting from the beginning
+        """
+        tokens_per_page = self.cache.tokens_per_page
+
+        publish_token_count = min(len(self.tokens), up_to_page_index * tokens_per_page)
+
+        cur_node = self.last_cached_node
+        first_uncached_page_index = self.start_index // tokens_per_page
+
+        uncached_tokens = [
+            tuple(self.tokens[i : i + tokens_per_page])
+            for i in range(
+                first_uncached_page_index * tokens_per_page,
+                publish_token_count,
+                tokens_per_page,
+            )
+        ]
+
+        uncached_pages = self.newly_acquired_pages[: len(uncached_tokens)]
+
+        for token_block, page in zip(uncached_tokens, uncached_pages):
+            new_node = cur_node.create_child(token_block, page)
+            cur_node = new_node
+
+        if cur_node is not self.cache.root:
+            self.cache.leaves.add(cur_node)
+
+        cur_node.ref_count += 1
+        self.last_cached_node.ref_count -= 1
+        self.last_cached_node = cur_node
+
+    def release_pages(self) -> None:
+        """Release the allocation's reference to its pages.
+
+        Decrements reference count of the last cached node. When count
+        reaches zero, the node becomes eligible for eviction.
+        """
+        if self._is_released:
+            return
+
+        self.last_cached_node.ref_count -= 1
+        self._is_released = True
+
+
+class TriePagedAttentionCache(BasePagedAttentionCache):
+    """Trie-based paged attention cache implementation.
+
+    Implements prefix sharing through a trie structure where each node
+    represents a page of tokens. Common prefixes between sequences share
+    the same nodes/pages, reducing memory usage.
+
+    Attributes:
+        root: Root node of the trie
+        leaves: Set of leaf nodes for efficient eviction
+        page_pool: Pool providing page allocations
+        tokens_per_page: Number of tokens that fit in each page
+    """
+
+    def __init__(self, page_pool: PagePool, tokens_per_page: int):
+        """Initialize the trie cache.
+
+        Args:
+            page_pool: Pool to allocate pages from
+            tokens_per_page: Number of tokens per page
+
+        Raises:
+            ValueError: If tokens_per_page <= 0
+        """
+        if tokens_per_page <= 0:
+            raise ValueError("tokens_per_page must be positive")
+
+        super().__init__(page_pool, tokens_per_page)
+
+        # Create root node with dummy page
+        dummy_page = PageInfo(
+            index=0,  # Root uses reserved index 0
+            pool=self.page_pool,
+            token_offset=0,
+            token_count=0,
+        )
+        self.root = TrieNode(tokens=tuple(), page=dummy_page)
+        self.leaves: Set[TrieNode] = set()
+
+    def _match(self, tokens: List[int]) -> Tuple[TrieNode, List[PageInfo]]:
+        """
+        Find the longest prefix match in the trie.
+
+        Walks the trie following the token sequence as far as possible,
+        collecting matched pages along the way.
+
+        Args:
+            tokens: Sequence of tokens to match
+
+        Returns:
+            Tuple of (last matched node, list of matched pages)
+        """
+        tokens = tuple(tokens)
+        matched_pages = []
+        cur = self.root
+
+        for i in range(0, len(tokens), self.tokens_per_page):
+            token_block = tokens[i : i + self.tokens_per_page]
+
+            if token_block not in cur.children:
+                break
+            cur = cur.children[token_block]
+            cur.access_time = time.monotonic()
+            matched_pages.append(cur.page)
+
+        return cur, matched_pages
+
+    def acquire_pages_for_tokens(
+        self,
+        tokens: List[int],
+        extra_token_slots: int = 0,
+    ) -> PageAllocation:
+        """Acquire pages for a sequence of tokens.
+
+        Attempts to reuse existing cached pages where possible through
+        prefix matching, allocating new pages only for the uncached suffix.
+
+        Args:
+            tokens: Sequence of tokens needing pages
+            extra_token_slots: Additional token slots to allocate beyond tokens
+
+        Returns:
+            PageAllocation containing both cached and newly allocated pages
+
+        Raises:
+            CacheAllocationFailure: If unable to allocate required pages
+        """
+        tokens = tuple(tokens)
+
+        cur_node, matched_pages = self._match(tokens)
+        cur_node.ref_count += 1
+
+        n_cached_tokens = len(matched_pages) * self.tokens_per_page
+        remaining_length = len(tokens) - n_cached_tokens + extra_token_slots
+        n_empty_pages = math.ceil(remaining_length / self.tokens_per_page)
+
+        new_pages = self.page_pool.acquire_free_pages(n_empty_pages)
+
+        if new_pages is not None:
+            return TriePageAttentionCacheAllocation(
+                cache=self,
+                tokens=tokens,
+                last_cached_node=cur_node,
+                cached_pages=matched_pages,
+                newly_acquired_pages=new_pages,
+                start_index=n_cached_tokens,
+            )
+
+        # Try eviction
+        self._evict_pages(n_empty_pages - len(self.page_pool.available_pages))
+        new_pages = self.page_pool.acquire_free_pages(n_empty_pages)
+
+        if new_pages is None:
+            raise CacheAllocationFailure(
+                "Failed to acquire pages even after attempting eviction from LRU leaves"
+            )
+
+        return TriePageAttentionCacheAllocation(
+            cache=self,
+            tokens=tokens,
+            last_cached_node=cur_node,
+            cached_pages=matched_pages,
+            newly_acquired_pages=new_pages,
+            start_index=n_cached_tokens,
+        )
+
+    def _evict_pages(self, max_pages: int) -> int:
+        """Evict up to max_pages pages using LRU strategy.
+
+        Evicts from unreferenced leaf nodes first, working up the trie
+        as nodes become childless.
+
+        Args:
+            max_pages: Maximum number of pages to evict
+
+        Returns:
+            Number of pages actually evicted
+        """
+        pages_to_evict = []
+
+        # Initialize heap with unreferenced leaves
+        unused_leaf_heap = [
+            (leaf.access_time, leaf) for leaf in self.leaves if leaf.ref_count == 0
+        ]
+        heapq.heapify(unused_leaf_heap)
+
+        # Evict least recently used nodes
+        while unused_leaf_heap and len(pages_to_evict) < max_pages:
+            _, leaf = heapq.heappop(unused_leaf_heap)
+            pages_to_evict.append(leaf.page)
+            parent = leaf.parent
+            leaf.unlink()
+            self.leaves.remove(leaf)
+
+            # If parent becomes childless, it becomes a leaf
+            if parent is not self.root and not parent.children:
+                self.leaves.add(parent)
+                if parent.ref_count == 0:
+                    heapq.heappush(unused_leaf_heap, (parent.access_time, parent))
+
+        if pages_to_evict:
+            self.page_pool.free_pages(pages_to_evict)
+
+        return len(pages_to_evict)

--- a/shortfin/python/shortfin_apps/llm/components/kvcache/trie_attention_cache.py
+++ b/shortfin/python/shortfin_apps/llm/components/kvcache/trie_attention_cache.py
@@ -52,7 +52,7 @@ class TrieNode:
     page: PageInfo
     children: Optional[Dict[Tuple[int, ...], "TrieNode"]] = None
     parent: Optional["TrieNode"] = None
-    ref_count: RefCount
+    ref_count: RefCount = None
     access_time: float = 0.0
 
     def __post_init__(self) -> None:

--- a/shortfin/python/shortfin_apps/llm/components/messages.py
+++ b/shortfin/python/shortfin_apps/llm/components/messages.py
@@ -63,7 +63,7 @@ class InferenceExecRequest(sf.Message):
 
     def publish_allocated_pages(self, up_to_page_index: int):
         assert self.allocation
-        self.allocation.publish_pages(
+        self.allocation.publish_pages_for_tokens(
             self.input_token_ids, publish_incomplete_pages=False
         )
 

--- a/shortfin/python/shortfin_apps/llm/components/messages.py
+++ b/shortfin/python/shortfin_apps/llm/components/messages.py
@@ -58,7 +58,7 @@ class InferenceExecRequest(sf.Message):
     def cache_page_indices(self, max_len: int) -> list[int]:
         if not self.allocation:
             return []
-        indices = [p.index for p in self.allocation.pages[:max_len]]
+        indices = [p.index for p in self.allocation._pages[:max_len]]
         return indices
 
     def publish_allocated_pages(self, up_to_page_index: int):

--- a/shortfin/python/shortfin_apps/llm/components/messages.py
+++ b/shortfin/python/shortfin_apps/llm/components/messages.py
@@ -63,7 +63,9 @@ class InferenceExecRequest(sf.Message):
 
     def publish_allocated_pages(self, up_to_page_index: int):
         assert self.allocation
-        self.allocation.publish_pages(up_to_page_index)
+        self.allocation.publish_pages(
+            self.input_token_ids, publish_incomplete_pages=False
+        )
 
     def free_cache_pages(self):
         if self.allocation:

--- a/shortfin/python/shortfin_apps/llm/components/messages.py
+++ b/shortfin/python/shortfin_apps/llm/components/messages.py
@@ -58,7 +58,7 @@ class InferenceExecRequest(sf.Message):
     def cache_page_indices(self, max_len: int) -> list[int]:
         if not self.allocation:
             return []
-        indices = [p.index for p in self.allocation._pages[:max_len]]
+        indices = [p.index for p in self.allocation.pages[:max_len]]
         return indices
 
     def publish_allocated_pages(self, up_to_page_index: int):

--- a/shortfin/python/shortfin_apps/llm/components/messages.py
+++ b/shortfin/python/shortfin_apps/llm/components/messages.py
@@ -64,7 +64,7 @@ class InferenceExecRequest(sf.Message):
     def publish_allocated_pages(self, up_to_page_index: int):
         assert self.allocation
         self.allocation.publish_pages_for_tokens(
-            self.input_token_ids, publish_incomplete_pages=False
+            self.input_token_ids, publish_incomplete_page=False
         )
 
     def free_cache_pages(self):

--- a/shortfin/python/shortfin_apps/llm/components/messages.py
+++ b/shortfin/python/shortfin_apps/llm/components/messages.py
@@ -52,8 +52,6 @@ class InferenceExecRequest(sf.Message):
         self.return_all_logits = False
         self.return_host_array = True
         self.result_logits = None
-        self.allocation.release_pages()
-        self.allocation = None
 
     def cache_page_indices(self, max_len: int) -> list[int]:
         if not self.allocation:
@@ -70,6 +68,7 @@ class InferenceExecRequest(sf.Message):
     def free_cache_pages(self):
         if self.allocation:
             self.allocation.release_pages()
+            self.allocation = None
 
 
 class StrobeMessage(sf.Message):

--- a/shortfin/python/shortfin_apps/llm/components/service.py
+++ b/shortfin/python/shortfin_apps/llm/components/service.py
@@ -16,6 +16,7 @@ from .kvcache.base_attention_cache import (
     CacheAllocationFailure,
     PageAllocation,
 )
+from .kvcache.trie_attention_cache import TriePagedAttentionCache
 from .kvcache.page_pool import PagePoolConfig, PagePool, PageInfo
 from .config_struct import ModelParams
 from .manager import SystemManager
@@ -67,10 +68,16 @@ class GenerateService:
         page_pool = PagePool(
             devices=self.main_fiber.devices_dict.values(), config=page_pool_config
         )
-        self.page_cache = BasePagedAttentionCache(
-            page_pool=page_pool,
-            tokens_per_page=model_params.paged_kv_cache.block_seq_stride,
-        )
+        if model_params.paged_kv_cache.cache_type == "trie":
+            self.page_cache = TriePagedAttentionCache(
+                page_pool=page_pool,
+                tokens_per_page=model_params.paged_kv_cache.block_seq_stride,
+            )
+        elif model_params.paged_kv_cache.cache_type == "base":
+            self.page_cache = BasePagedAttentionCache(
+                page_pool=page_pool,
+                tokens_per_page=model_params.paged_kv_cache.block_seq_stride,
+            )
 
         self.program_isolation = PROG_ISOLATIONS[program_isolation]
 

--- a/shortfin/python/shortfin_apps/llm/components/service.py
+++ b/shortfin/python/shortfin_apps/llm/components/service.py
@@ -78,6 +78,10 @@ class GenerateService:
                 page_pool=page_pool,
                 tokens_per_page=model_params.paged_kv_cache.block_seq_stride,
             )
+        else:
+            raise ValueError(
+                f"Unknown model_params.paged_kv_cache.cache_type {model_params.paged_kv_cache.cache_type}. Currently only supporting 'trie' and 'base'."
+            )
 
         self.program_isolation = PROG_ISOLATIONS[program_isolation]
 

--- a/shortfin/python/shortfin_apps/llm/components/service.py
+++ b/shortfin/python/shortfin_apps/llm/components/service.py
@@ -68,19 +68,19 @@ class GenerateService:
         page_pool = PagePool(
             devices=self.main_fiber.devices_dict.values(), config=page_pool_config
         )
-        if model_params.paged_kv_cache.cache_type == "trie":
+        if model_params.paged_kv_cache.prefix_sharing_algorithm == "trie":
             self.page_cache = TriePagedAttentionCache(
                 page_pool=page_pool,
                 tokens_per_page=model_params.paged_kv_cache.block_seq_stride,
             )
-        elif model_params.paged_kv_cache.cache_type == "base":
+        elif model_params.paged_kv_cache.prefix_sharing_algorithm == "none":
             self.page_cache = BasePagedAttentionCache(
                 page_pool=page_pool,
                 tokens_per_page=model_params.paged_kv_cache.block_seq_stride,
             )
         else:
             raise ValueError(
-                f"Unknown model_params.paged_kv_cache.cache_type {model_params.paged_kv_cache.cache_type}. Currently only supporting 'trie' and 'base'."
+                f"Unknown model_params.paged_kv_cache.prefix_sharing_algorithm {model_params.paged_kv_cache.prefix_sharing_algorithm}. Currently only supporting 'trie' and 'none'."
             )
 
         self.program_isolation = PROG_ISOLATIONS[program_isolation]

--- a/shortfin/tests/apps/llm/components/kvcache/base_attention_cache_test.py
+++ b/shortfin/tests/apps/llm/components/kvcache/base_attention_cache_test.py
@@ -32,7 +32,7 @@ class MockPagePool(PagePool):
         except queue.Empty:
             return None
 
-    def release_pages(self, pages):
+    def free_pages(self, pages):
         for page in pages:
             self._queue.put(page)
 

--- a/shortfin/tests/apps/llm/components/kvcache/base_attention_cache_test.py
+++ b/shortfin/tests/apps/llm/components/kvcache/base_attention_cache_test.py
@@ -10,7 +10,7 @@ from typing import List, Optional, Set
 
 from shortfin_apps.llm.components.kvcache.base_attention_cache import (
     BasePagedAttentionCache,
-    BasePageAttentionCacheAllocation,
+    BasePagedAttentionCacheAllocation,
     CacheAllocationFailure,
 )
 from shortfin_apps.llm.components.kvcache.page_pool import PagePool, PageInfo

--- a/shortfin/tests/apps/llm/components/kvcache/trie_attention_cache_test.py
+++ b/shortfin/tests/apps/llm/components/kvcache/trie_attention_cache_test.py
@@ -1,0 +1,395 @@
+import pytest
+from typing import List, Tuple
+import shortfin as sf
+import shortfin.array as sfnp
+from unittest.mock import Mock, MagicMock
+import threading
+import time
+from dataclasses import dataclass
+
+from shortfin_apps.llm.components.kvcache.trie_attention_cache import (
+    TriePagedAttentionCache,
+)
+from shortfin_apps.llm.components.kvcache.base_attention_cache import (
+    CacheAllocationFailure,
+)
+from shortfin_apps.llm.components.kvcache.page_pool import (
+    PagePool,
+    PageInfo,
+    PagePoolConfig,
+)
+
+
+# Test constants
+TEST_PAGE_SIZE = 16  # Tokens per page
+TEST_POOL_CAPACITY = 10
+
+
+@dataclass
+class TokenSequence:
+    """Helper class for test parameterization"""
+
+    tokens: List[int]
+    description: str
+    expected_pages: int
+    expected_cached: int = 0
+
+    def __str__(self):
+        return self.description
+
+
+class MockScopedDevice:
+    """A proper mock for ScopedDevice that implements required interface"""
+
+    def __init__(self):
+        self._mock = Mock(spec=sf.ScopedDevice)
+        # Add any necessary attributes/methods the real ScopedDevice has
+        self._mock.device_id = 0
+        self._mock.device_type = "CPU"
+
+    def __repr__(self):
+        return f"MockScopedDevice(device_id={self._mock.device_id})"
+
+
+@pytest.fixture
+def mock_device_array():
+    """Create mock device array with proper interface implementation"""
+
+    class MockDeviceArray:
+        def __init__(self):
+            self.shape = None
+            self.dtype = None
+
+        def view(self, *args):
+            return Mock()
+
+        def copy_from(self, src):
+            pass
+
+    return MockDeviceArray()
+
+
+@pytest.fixture
+def mock_device():
+    """Create properly structured mock device"""
+    return MockScopedDevice()
+
+
+@pytest.fixture
+def page_pool(mock_device, mock_device_array):
+    """Create PagePool with properly structured mock components"""
+    # Mock the device array creation
+    original_for_device = sf.array.device_array.for_device
+
+    def mock_for_device(device, shape, dtype):
+        mock_array = mock_device_array
+        mock_array.shape = shape
+        mock_array.dtype = dtype
+        return mock_array
+
+    sf.array.device_array.for_device = mock_for_device
+
+    try:
+        config = PagePoolConfig(
+            dtype=sfnp.float16,
+            alloc_page_count=TEST_POOL_CAPACITY,
+            paged_kv_block_size_elements=128,
+        )
+
+        pool = PagePool(devices=[mock_device], config=config)
+        pool.page_tables = [mock_device_array]
+        return pool
+    finally:
+        # Restore original function
+        sf.array.device_array.for_device = original_for_device
+
+
+@pytest.fixture
+def trie_cache(page_pool):
+    """Create TriePagedAttentionCache instance"""
+    return TriePagedAttentionCache(page_pool=page_pool, tokens_per_page=TEST_PAGE_SIZE)
+
+
+@pytest.fixture
+def published_sequence(trie_cache):
+    """Helper fixture that returns a function to publish token sequences"""
+
+    def _publish_sequence(tokens: List[int]) -> None:
+        alloc = trie_cache.acquire_pages_for_tokens(tokens, extra_token_slots=0)
+        alloc.publish_pages(len(alloc.pages))
+        alloc.release_pages()
+
+    return _publish_sequence
+
+
+def print_tree_state(cache, prefix=""):
+    """Helper function to print current tree state in a readable format"""
+    if not hasattr(cache, "root"):
+        print(f"{prefix}Unable to access trie structure")
+        return
+
+    def node_info(node):
+        token_str = f"tokens={list(node.tokens) if node.tokens else 'root'}"
+        return f"{token_str}, ref_count={node.ref_count}, page_index={node.page.index}"
+
+    def print_node(node, depth=0):
+        indent = "  " * depth
+        print(f"{prefix}{indent}- {node_info(node)}")
+        if node.children:
+            for child in node.children.values():
+                print_node(child, depth + 1)
+
+    print(f"{prefix}Tree state:")
+    print_node(cache.root)
+
+
+# Test sequences for parameterization
+basic_sequences = [
+    TokenSequence(tokens=[], description="empty_sequence", expected_pages=0),
+    TokenSequence(
+        tokens=list(range(TEST_PAGE_SIZE // 2)),
+        description="partial_page",
+        expected_pages=1,
+    ),
+    TokenSequence(
+        tokens=list(range(TEST_PAGE_SIZE)), description="exact_page", expected_pages=1
+    ),
+    TokenSequence(
+        tokens=list(range(TEST_PAGE_SIZE + 1)),
+        description="overflow_page",
+        expected_pages=2,
+    ),
+    TokenSequence(
+        tokens=list(range(TEST_PAGE_SIZE * 2)),
+        description="multiple_pages",
+        expected_pages=2,
+    ),
+]
+
+reuse_sequences = [
+    (list(range(TEST_PAGE_SIZE)), list(range(TEST_PAGE_SIZE)), "exact_match", 1, 1),
+    (
+        list(range(TEST_PAGE_SIZE * 2)),
+        list(range(TEST_PAGE_SIZE * 2)),
+        "multi_page_match",
+        2,
+        2,
+    ),
+    (
+        list(range(TEST_PAGE_SIZE * 2)),
+        list(range(TEST_PAGE_SIZE)) + list(range(100, 100 + TEST_PAGE_SIZE)),
+        "prefix_match",
+        2,
+        1,
+    ),
+    (
+        list(range(TEST_PAGE_SIZE)),
+        list(range(50, 50 + TEST_PAGE_SIZE)),
+        "no_match",
+        1,
+        0,
+    ),
+]
+
+
+@pytest.mark.parametrize("seq", basic_sequences)
+def test_basic_allocation(trie_cache, seq):
+    """Test basic page allocation without reuse"""
+    allocation = trie_cache.acquire_pages_for_tokens(seq.tokens, extra_token_slots=0)
+    assert len(allocation.pages) == seq.expected_pages
+    assert len(allocation.cached_pages) == 0
+    assert len(allocation.newly_acquired_pages) == seq.expected_pages
+    allocation.release_pages()
+
+
+@pytest.mark.parametrize(
+    "initial_tokens,reuse_tokens,description,total_pages,expected_cached",
+    reuse_sequences,
+)
+def test_page_reuse(
+    trie_cache,
+    published_sequence,
+    initial_tokens,
+    reuse_tokens,
+    description,
+    total_pages,
+    expected_cached,
+):
+    """Test page reuse scenarios"""
+    # Publish initial sequence
+    published_sequence(initial_tokens)
+
+    # Try to reuse
+    allocation = trie_cache.acquire_pages_for_tokens(reuse_tokens, extra_token_slots=0)
+    assert len(allocation.pages) == total_pages
+    assert len(allocation.cached_pages) == expected_cached
+    assert len(allocation.newly_acquired_pages) == total_pages - expected_cached
+    allocation.release_pages()
+
+
+@pytest.fixture
+def filled_cache(trie_cache, published_sequence):
+    """Fixture that fills cache with numbered sequences"""
+    sequences = []
+    for i in range(TEST_POOL_CAPACITY):
+        tokens = list(range(i * 100, i * 100 + TEST_PAGE_SIZE))
+        published_sequence(tokens)
+        sequences.append(tokens)
+    return sequences
+
+
+@pytest.mark.parametrize(
+    "access_count", [1, TEST_POOL_CAPACITY // 2, TEST_POOL_CAPACITY - 1]
+)
+def test_lru_eviction(trie_cache, access_count):
+    """Test LRU eviction with different access patterns"""
+    print(f"\nStarting test_lru_eviction with access_count={access_count}")
+
+    # Create mix of published and unpublished sequences
+    keep_published = 3  # Number of sequences to keep published
+    sequences = []
+
+    # First add some sequences we'll keep published
+    print("\nPublishing sequences to keep active:")
+    for i in range(keep_published):
+        tokens = list(range(i * 100, i * 100 + TEST_PAGE_SIZE))
+        alloc = trie_cache.acquire_pages_for_tokens(tokens, extra_token_slots=0)
+        alloc.publish_pages(1)  # Don't release these - they should stay in cache
+        sequences.append(tokens)
+        print(f"Published sequence {i} (keeping active)")
+        print_tree_state(trie_cache, "  ")
+
+    # Then add sequences we'll publish but release (evictable)
+    print("\nAdding releasable sequences:")
+    for i in range(keep_published, TEST_POOL_CAPACITY):
+        tokens = list(range(i * 100, i * 100 + TEST_PAGE_SIZE))
+        alloc = trie_cache.acquire_pages_for_tokens(tokens, extra_token_slots=0)
+        alloc.publish_pages(1)
+        alloc.release_pages()  # These can be evicted
+        sequences.append(tokens)
+        print(f"Added releasable sequence {i}")
+        print_tree_state(trie_cache, "  ")
+
+    print("\nCache state before accessing sequences:")
+    print_tree_state(trie_cache, "  ")
+
+    # Access some sequences to update their LRU status
+    print(f"\nAccessing {access_count} sequences to update LRU order:")
+    for i in range(access_count):
+        print(f"\nAccessing sequence {i}:")
+        alloc = trie_cache.acquire_pages_for_tokens(sequences[i], extra_token_slots=0)
+        print_tree_state(trie_cache, "  ")
+        alloc.release_pages()
+        print(f"After releasing allocation {i}:")
+        print_tree_state(trie_cache, "  ")
+
+    print("\nCache state before attempting new allocation:")
+    print_tree_state(trie_cache, "  ")
+    print("\nAvailable pages in pool:", len(trie_cache.page_pool.available_pages))
+
+    # Try to allocate new sequence - should evict least recently used unpublished sequence
+    new_tokens = list(range(1000, 1000 + TEST_PAGE_SIZE))
+    print(f"\nAttempting to allocate new sequence: {new_tokens}")
+    new_alloc = trie_cache.acquire_pages_for_tokens(new_tokens, extra_token_slots=0)
+    print("\nNew allocation succeeded:")
+    print(f"- Allocated {len(new_alloc.pages)} new pages")
+    print(f"- Cached pages: {len(new_alloc.cached_pages)}")
+    print(f"- Newly acquired pages: {len(new_alloc.newly_acquired_pages)}")
+    print("\nCache state after new allocation:")
+    print_tree_state(trie_cache, "  ")
+    new_alloc.release_pages()
+
+    # Verify recently accessed sequences AND published sequences weren't evicted
+    print("\nVerifying preserved sequences:")
+    for i in range(max(access_count, keep_published)):
+        print(f"\nChecking sequence {i}:")
+        recheck = trie_cache.acquire_pages_for_tokens(sequences[i], extra_token_slots=0)
+        cached_pages = len(recheck.cached_pages)
+        print(f"- Cached pages found: {cached_pages}")
+        assert (
+            cached_pages == 1
+        ), f"Sequence {i} was evicted but should have been preserved"
+        recheck.release_pages()
+
+
+@pytest.mark.parametrize("publish_steps", [1, 2, 3])
+def test_progressive_publish(trie_cache, publish_steps):
+    """Test publishing pages progressively"""
+    tokens = list(range(TEST_PAGE_SIZE * 3))  # Three pages
+    alloc = trie_cache.acquire_pages_for_tokens(tokens)
+
+    for step in range(publish_steps):
+        # Publish next page
+        alloc.publish_pages(step + 1)
+
+        # Verify reuse up to published point
+        reuse_tokens = tokens[: (step + 1) * TEST_PAGE_SIZE]
+        reuse_alloc = trie_cache.acquire_pages_for_tokens(reuse_tokens)
+        assert len(reuse_alloc.cached_pages) == step + 1
+        reuse_alloc.release_pages()
+
+    alloc.release_pages()
+
+
+@pytest.mark.parametrize("ref_count", [1, 2, 5])
+def test_reference_counting(trie_cache, ref_count):
+    """Test reference counting with different counts"""
+    tokens = list(range(TEST_PAGE_SIZE))
+    allocations = []
+
+    # Create initial allocation and publish
+    first_alloc = trie_cache.acquire_pages_for_tokens(tokens, extra_token_slots=0)
+    first_alloc.publish_pages(1)
+    allocations.append(first_alloc)
+    print("\nInitial allocation created")
+    print_tree_state(trie_cache, "  ")
+
+    # Create additional references
+    for i in range(ref_count - 1):
+        alloc = trie_cache.acquire_pages_for_tokens(tokens, extra_token_slots=0)
+        allocations.append(alloc)
+        print(f"\nCreated reference {i+1}")
+        print_tree_state(trie_cache, "  ")
+
+    # Fill remaining cache
+    remaining = TEST_POOL_CAPACITY - 1
+    fill_allocations = []
+    for i in range(remaining):
+        fill_tokens = list(
+            range(100 + i * TEST_PAGE_SIZE, 100 + (i + 1) * TEST_PAGE_SIZE)
+        )
+        alloc = trie_cache.acquire_pages_for_tokens(fill_tokens, extra_token_slots=0)
+        alloc.publish_pages(1)
+        fill_allocations.append(alloc)
+        print(f"\nFilled cache slot {i+1}/{remaining}")
+        print_tree_state(trie_cache, "  ")
+
+    print("\nAttempting allocation that should fail...")
+    try:
+        new_tokens = list(range(1000, 1000 + TEST_PAGE_SIZE))
+        new_alloc = trie_cache.acquire_pages_for_tokens(new_tokens, extra_token_slots=0)
+        print("ERROR: Allocation succeeded when it should have failed!")
+        print(f"- Allocated {len(new_alloc.pages)} new pages")
+        print(f"- Cached pages: {len(new_alloc.cached_pages)}")
+        print(
+            f"- Number of newly acquired pages: {len(new_alloc.newly_acquired_pages)}"
+        )
+        print(f"- Newly acquired pages: {new_alloc.newly_acquired_pages}")
+        print("\nPost-allocation state:")
+        print_tree_state(trie_cache, "  ")
+        new_alloc.release_pages()
+        pytest.fail("Expected CacheAllocationFailure was not raised")
+    except CacheAllocationFailure:
+        print("Success: CacheAllocationFailure raised as expected")
+
+    # Cleanup
+    print("\nCleaning up allocations...")
+    for alloc in allocations + fill_allocations:
+        alloc.release_pages()
+
+
+@pytest.mark.parametrize("tokens_per_page", [0, -1, -100])
+def test_invalid_init(page_pool, tokens_per_page):
+    """Test validation in __init__"""
+    with pytest.raises(ValueError):
+        TriePagedAttentionCache(page_pool=page_pool, tokens_per_page=tokens_per_page)

--- a/shortfin/tests/apps/llm/components/kvcache/trie_attention_cache_test.py
+++ b/shortfin/tests/apps/llm/components/kvcache/trie_attention_cache_test.py
@@ -116,7 +116,7 @@ def published_sequence(trie_cache):
 
     def _publish_sequence(tokens: List[int]) -> None:
         alloc = trie_cache.acquire_pages_for_tokens(tokens, extra_token_slots=0)
-        alloc.publish_pages(alloc.tokens)
+        alloc.publish_pages_for_tokens(alloc.tokens)
         alloc.release_pages()
 
     return _publish_sequence
@@ -202,7 +202,7 @@ def test_basic_allocation(trie_cache, seq):
         len(allocation.pages) - allocation.number_of_published_pages
         == seq.expected_pages
     )
-    allocation.publish_pages(allocation.tokens)
+    allocation.publish_pages_for_tokens(allocation.tokens)
     allocation.release_pages()
 
 
@@ -231,7 +231,7 @@ def test_page_reuse(
         len(allocation.pages) - allocation.number_of_published_pages
         == total_pages - expected_cached
     )
-    allocation.publish_pages(allocation.tokens)
+    allocation.publish_pages_for_tokens(allocation.tokens)
     allocation.release_pages()
 
 
@@ -262,7 +262,7 @@ def test_lru_eviction(trie_cache, access_count):
     for i in range(keep_published):
         tokens = list(range(i * 100, i * 100 + TEST_PAGE_SIZE))
         alloc = trie_cache.acquire_pages_for_tokens(tokens, extra_token_slots=0)
-        alloc.publish_pages(alloc.tokens[:TEST_PAGE_SIZE])
+        alloc.publish_pages_for_tokens(alloc.tokens[:TEST_PAGE_SIZE])
         sequences.append(tokens)
         print(f"Published sequence {i} (keeping active)")
         print_tree_state(trie_cache, "  ")
@@ -272,7 +272,7 @@ def test_lru_eviction(trie_cache, access_count):
     for i in range(keep_published, TEST_POOL_CAPACITY):
         tokens = list(range(i * 100, i * 100 + TEST_PAGE_SIZE))
         alloc = trie_cache.acquire_pages_for_tokens(tokens, extra_token_slots=0)
-        alloc.publish_pages(alloc.tokens[:TEST_PAGE_SIZE])
+        alloc.publish_pages_for_tokens(alloc.tokens[:TEST_PAGE_SIZE])
         alloc.release_pages()  # These can be evicted
         sequences.append(tokens)
         print(f"Added releasable sequence {i}")
@@ -344,7 +344,7 @@ def test_progressive_publish(trie_cache, publish_steps):
         # Publish next page
         print(f"Publishing up to page {step}")
         # Replace publishing with tokens
-        alloc.publish_pages(alloc.tokens[: (step) * TEST_PAGE_SIZE])
+        alloc.publish_pages_for_tokens(alloc.tokens[: (step) * TEST_PAGE_SIZE])
         print("\nCache state after publish:")
         print_tree_state(trie_cache)
 
@@ -387,7 +387,7 @@ def test_reference_counting(trie_cache, ref_count):
     # Create initial allocation and publish
     first_alloc = trie_cache.acquire_pages_for_tokens(tokens, extra_token_slots=0)
     # Replace publishing with tokens
-    first_alloc.publish_pages(first_alloc.tokens)
+    first_alloc.publish_pages_for_tokens(first_alloc.tokens)
     allocations.append(first_alloc)
     print("\nInitial allocation created")
     print_tree_state(trie_cache, "  ")
@@ -407,7 +407,7 @@ def test_reference_counting(trie_cache, ref_count):
             range(100 + i * TEST_PAGE_SIZE, 100 + (i + 1) * TEST_PAGE_SIZE)
         )
         alloc = trie_cache.acquire_pages_for_tokens(fill_tokens, extra_token_slots=0)
-        alloc.publish_pages(alloc.tokens[:TEST_PAGE_SIZE])
+        alloc.publish_pages_for_tokens(alloc.tokens[:TEST_PAGE_SIZE])
         fill_allocations.append(alloc)
         print(f"\nFilled cache slot {i+1}/{remaining}")
         print_tree_state(trie_cache, "  ")

--- a/shortfin/tests/apps/llm/components/kvcache/trie_attention_cache_test.py
+++ b/shortfin/tests/apps/llm/components/kvcache/trie_attention_cache_test.py
@@ -428,10 +428,3 @@ def test_reference_counting(trie_cache, ref_count):
     print("\nCleaning up allocations...")
     for alloc in allocations + fill_allocations:
         alloc.release_pages()
-
-
-@pytest.mark.parametrize("tokens_per_page", [0, -1, -100])
-def test_invalid_init(page_pool, tokens_per_page):
-    """Test validation in __init__"""
-    with pytest.raises(ValueError):
-        TriePagedAttentionCache(page_pool=page_pool, tokens_per_page=tokens_per_page)


### PR DESCRIPTION
feat: Add TriePagedAttentionCache with initial implementation

Added TriePagedAttentionCache as an optional prefix sharing algorithm, selectable via:
`config["paged_kv_cache"]["prefix_sharing_algorithm"] = "trie"`

Current Status:
- Basic implementation and unit tests complete
- Integration test cases for both Base and Trie implementations, with trie implementation xfailed due to pending cache allocation improvements
- BasePagedAttentionCache remains the default

Next Steps:
To achieve full functionality, we need to support cache re-allocations to extend the associated tokens & pages.