### PR TITLE
Unset `_SHORTFIN_USING_DYLIB` when building static.

### DIFF
--- a/shortfin/build_tools/cmake/shortfin_library.cmake
+++ b/shortfin/build_tools/cmake/shortfin_library.cmake
@@ -51,7 +51,6 @@ function(shortfin_public_library)
     shortfin_components_to_static_libs(_STATIC_COMPONENTS ${_RULE_COMPONENTS})
     add_library("${_RULE_NAME}-static" STATIC ${_RULE_SRCS})
     target_compile_definitions("${_RULE_NAME}-static" INTERFACE
-      _SHORTFIN_USING_DYLIB
       ${_usage_compile_definitions}
     )
     target_include_directories("${_RULE_NAME}-static" INTERFACE ${_usage_include_directories})


### PR DESCRIPTION
This doesn't look intentional (added in https://github.com/nod-ai/shark-ai/pull/434) and it contributes to https://github.com/nod-ai/shark-ai/issues/534:

```
[main] Building folder: d:/dev/projects/shark-ai/shortfin/build 
[build] Starting build
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.EXE" --build d:/dev/projects/shark-ai/shortfin/build --config RelWithDebInfo --target shortfin_array_test --
[build] [1/2   0% :: 0.041] Re-checking globbed directories...
[build] [1/1 100% :: 0.240] Linking CXX executable src\shortfin\array\shortfin_array_test.exe
[build] FAILED: src/shortfin/array/shortfin_array_test.exe src/shortfin/array/shortfin_array_test[1]_tests.cmake D:/dev/projects/shark-ai/shortfin/build/src/shortfin/array/shortfin_array_test[1]_tests.cmake 
[build] C:\WINDOWS\system32\cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_exe --intdir=src\shortfin\array\CMakeFiles\shortfin_array_test.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\mt.exe --manifests  -- C:\PROGRA~2\MICROS~1\2022\BUILDT~1\VC\Tools\MSVC\1441~1.341\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\shortfin_array_test.rsp  /out:src\shortfin\array\shortfin_array_test.exe /implib:src\shortfin\array\shortfin_array_test.lib /pdb:src\shortfin\array\shortfin_array_test.pdb /version:0.0 /machine:x64 /debug /INCREMENTAL /subsystem:console  -natvis:D:/dev/projects/iree/runtime/iree.natvis /INCREMENTAL:NO /LTCG && C:\WINDOWS\system32\cmd.exe /C "cd /D D:\dev\projects\shark-ai\shortfin\build\src\shortfin\array && "C:\Program Files\CMake\bin\cmake.exe" -D TEST_TARGET=shortfin_array_test -D TEST_EXECUTABLE=D:/dev/projects/shark-ai/shortfin/build/src/shortfin/array/shortfin_array_test.exe -D TEST_EXECUTOR= -D TEST_WORKING_DIR=D:/dev/projects/shark-ai/shortfin/build -D TEST_EXTRA_ARGS= -D TEST_PROPERTIES= -D TEST_PREFIX= -D TEST_SUFFIX= -D TEST_FILTER= -D NO_PRETTY_TYPES=FALSE -D NO_PRETTY_VALUES=FALSE -D TEST_LIST=shortfin_array_test_TESTS -D CTEST_FILE=D:/dev/projects/shark-ai/shortfin/build/src/shortfin/array/shortfin_array_test[1]_tests.cmake -D TEST_DISCOVERY_TIMEOUT=5 -D TEST_XML_OUTPUT_DIR= -P "C:/Program Files/CMake/share/cmake-3.30/Modules/GoogleTestAddTests.cmake"""
[build] LINK: command "C:\PROGRA~2\MICROS~1\2022\BUILDT~1\VC\Tools\MSVC\1441~1.341\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\shortfin_array_test.rsp /out:src\shortfin\array\shortfin_array_test.exe /implib:src\shortfin\array\shortfin_array_test.lib /pdb:src\shortfin\array\shortfin_array_test.pdb /version:0.0 /machine:x64 /debug /INCREMENTAL /subsystem:console -natvis:D:/dev/projects/iree/runtime/iree.natvis /INCREMENTAL:NO /LTCG /MANIFEST:EMBED,ID=1" failed (exit code 1120) with the following output:
[build] array_test.cc.obj : error LNK2001: unresolved external symbol "__declspec(dllimport) public: class shortfin::local::Worker & __cdecl shortfin::local::System::init_worker(void)" (__imp_?init_worker@System@local@shortfin@@QEAAAEAVWorker@23@XZ)
[build] array_test.cc.obj : error LNK2001: unresolved external symbol "__declspec(dllimport) public: class std::shared_ptr<class shortfin::local::Fiber> __cdecl shortfin::local::System::CreateFiber(class shortfin::local::Worker &,class std::span<class shortfin::local::Device * const,-1>)" (__imp_?CreateFiber@System@local@shortfin@@QEAA?AV?$shared_ptr@VFiber@local@shortfin@@@std@@AEAVWorker@23@V?$span@QEAVDevice@local@shortfin@@$0?0@5@@Z)
...
[build] src\shortfin\array\shortfin_array_test.exe : fatal error LNK1120: 50 unresolved externals
[build] ninja: build stopped: subcommand failed.
[proc] The command: "C:\Program Files\CMake\bin\cmake.EXE" --build d:/dev/projects/shark-ai/shortfin/build --config RelWithDebInfo --target shortfin_array_test -- exited with code: 1
[driver] Build completed: 00:00:00.301
[build] Build finished with exit code 1
```