### PR TITLE
[shortfin] Bump IREE dep to iree-3.1.0rc20241204.

### DIFF
--- a/.github/workflows/ci-libshortfin.yml
+++ b/.github/workflows/ci-libshortfin.yml
@@ -97,7 +97,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_REPO_DIR }}
         submodules: false
-        ref: iree-3.0.0rc20241118
+        ref: iree-3.1.0rc20241203
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_REPO_DIR }}

--- a/.github/workflows/ci-libshortfin.yml
+++ b/.github/workflows/ci-libshortfin.yml
@@ -97,7 +97,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_REPO_DIR }}
         submodules: false
-        ref: iree-3.1.0rc20241203
+        ref: iree-3.1.0rc20241204
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_REPO_DIR }}

--- a/.github/workflows/ci-sdxl.yaml
+++ b/.github/workflows/ci-sdxl.yaml
@@ -64,7 +64,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_REPO_DIR }}
         submodules: false
-        ref: iree-3.1.0rc20241203
+        ref: iree-3.1.0rc20241204
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_REPO_DIR }}

--- a/.github/workflows/ci-sdxl.yaml
+++ b/.github/workflows/ci-sdxl.yaml
@@ -64,7 +64,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_REPO_DIR }}
         submodules: false
-        ref: iree-3.0.0rc20241118
+        ref: iree-3.1.0rc20241203
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_REPO_DIR }}

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -70,8 +70,8 @@ jobs:
           # We could also pin to a known working or stable version.
           # This should eventually stabilize. Do the best we can for now.
           pip install -f https://iree.dev/pip-release-links.html --upgrade \
-            iree-base-compiler==3.1.0rc20241203 \
-            iree-base-runtime==3.1.0rc20241203 \
+            iree-base-compiler==3.1.0rc20241204 \
+            iree-base-runtime==3.1.0rc20241204 \
             "numpy<2.0"
 
       - name: Install SGLang

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -70,8 +70,8 @@ jobs:
           # We could also pin to a known working or stable version.
           # This should eventually stabilize. Do the best we can for now.
           pip install -f https://iree.dev/pip-release-links.html --upgrade \
-            iree-base-compiler==3.0.0rc20241118 \
-            iree-base-runtime==3.0.0rc20241118 \
+            iree-base-compiler==3.1.0rc20241203 \
+            iree-base-runtime==3.1.0rc20241203 \
             "numpy<2.0"
 
       - name: Install SGLang

--- a/.github/workflows/ci_linux_x64_asan-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_asan-libshortfin.yml
@@ -109,7 +109,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_SOURCE_DIR }}
         submodules: false
-        ref: iree-3.1.0rc20241203
+        ref: iree-3.1.0rc20241204
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_SOURCE_DIR }}

--- a/.github/workflows/ci_linux_x64_asan-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_asan-libshortfin.yml
@@ -109,7 +109,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_SOURCE_DIR }}
         submodules: false
-        ref: iree-3.0.0rc20241118
+        ref: iree-3.1.0rc20241203
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_SOURCE_DIR }}

--- a/.github/workflows/ci_linux_x64_nogil-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_nogil-libshortfin.yml
@@ -57,7 +57,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_REPO_DIR }}
         submodules: false
-        ref: iree-3.1.0rc20241203
+        ref: iree-3.1.0rc20241204
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_REPO_DIR }}

--- a/.github/workflows/ci_linux_x64_nogil-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_nogil-libshortfin.yml
@@ -57,7 +57,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_REPO_DIR }}
         submodules: false
-        ref: iree-3.0.0rc20241118
+        ref: iree-3.1.0rc20241203
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_REPO_DIR }}

--- a/shortfin/CMakeLists.txt
+++ b/shortfin/CMakeLists.txt
@@ -40,7 +40,7 @@ if(NOT WIN32)
 endif()
 
 # Pins
-set(SHORTFIN_IREE_GIT_TAG "iree-3.0.0rc20241118")
+set(SHORTFIN_IREE_GIT_TAG "iree-3.1.0rc20241203")
 
 # build options
 option(SHORTFIN_BUILD_PYTHON_BINDINGS "Builds Python Bindings" OFF)

--- a/shortfin/CMakeLists.txt
+++ b/shortfin/CMakeLists.txt
@@ -40,7 +40,7 @@ if(NOT WIN32)
 endif()
 
 # Pins
-set(SHORTFIN_IREE_GIT_TAG "iree-3.1.0rc20241203")
+set(SHORTFIN_IREE_GIT_TAG "iree-3.1.0rc20241204")
 
 # build options
 option(SHORTFIN_BUILD_PYTHON_BINDINGS "Builds Python Bindings" OFF)

--- a/shortfin/requirements-iree-compiler.txt
+++ b/shortfin/requirements-iree-compiler.txt
@@ -1,4 +1,4 @@
 # Keep in sync with "ref: iree-" in .github/workflows/* and GIT_TAG in CMakeLists.txt
 -f https://iree.dev/pip-release-links.html
-iree-base-compiler==3.1.0rc20241203
-iree-base-runtime==3.1.0rc20241203
+iree-base-compiler==3.1.0rc20241204
+iree-base-runtime==3.1.0rc20241204

--- a/shortfin/requirements-iree-compiler.txt
+++ b/shortfin/requirements-iree-compiler.txt
@@ -1,4 +1,4 @@
 # Keep in sync with "ref: iree-" in .github/workflows/* and GIT_TAG in CMakeLists.txt
 -f https://iree.dev/pip-release-links.html
-iree-base-compiler==3.0.0rc20241118
-iree-base-runtime==3.0.0rc20241118
+iree-base-compiler==3.1.0rc20241203
+iree-base-runtime==3.1.0rc20241203


### PR DESCRIPTION
Diff: https://github.com/iree-org/iree/compare/iree-3.0.0rc20241118...iree-3.1.0rc20241204

Notable changes that could affect shortfin:

* https://github.com/iree-org/iree/commit/cd4aa72a15cf9467a33a36bca87fbd45e29974b1 "[runtime][python] Fix device array deepcopy when not mappable"
* https://github.com/iree-org/iree/commit/ef4ecf3b7111cead7bf29f630965c36395e515e9 "[iree.build] Wire up out of process concurrency."
* https://github.com/iree-org/iree/commit/516ff10aae2abd37529f673b27ce20648ce59fc9 "[python] Overhaul iree.build console output and error handling."
* https://github.com/iree-org/iree/commit/978943859418d160ac3c7b32f6917e13fc240a97 "[iree.build] Make the fetch_http action more robust."
* https://github.com/iree-org/iree/commit/006c5d8dcb638b0abfc704fb8c89cb6dc43377f5 "Avoid compound literal struct init for better C/C++ compat."

This update (particularly the last commit there) fixes https://github.com/nod-ai/shark-ai/issues/534 (the Windows build was broken).