### PR TITLE
[shortfin] Disable C++ tests in package builds.

### DIFF
--- a/shortfin/setup.py
+++ b/shortfin/setup.py
@@ -212,6 +212,7 @@ def build_cmake_configuration(CMAKE_BUILD_DIR: Path, extra_cmake_args=[]):
         "-DSHORTFIN_BUNDLE_DEPS=ON",
         f"-DCMAKE_BUILD_TYPE={cfg}",
         "-DSHORTFIN_BUILD_PYTHON_BINDINGS=ON",
+        "-DSHORTFIN_BUILD_TESTS=OFF",
         f"-DPython3_EXECUTABLE={sys.executable}",
     ] + extra_cmake_args
 


### PR DESCRIPTION
Progress on https://github.com/nod-ai/shark-ai/issues/584.

This is expected to save around 10-20 seconds when building packages on standard GitHub-hosted runners:

```
Tue, 03 Dec 2024 11:07:18 GMT   [372/380] Linking CXX shared library src/libshortfin.so.3.1.0
Tue, 03 Dec 2024 11:07:18 GMT   [373/380] Creating library symlink src/libshortfin.so.1 src/libshortfin.so
Tue, 03 Dec 2024 11:07:23 GMT   [374/380] Linking CXX executable src/shortfin/support/shortfin_support_test
Tue, 03 Dec 2024 11:07:23 GMT   [375/380] Linking CXX executable src/shortfin/array/shortfin_array_test
Tue, 03 Dec 2024 11:07:36 GMT   [376/380] Building CXX object python/CMakeFiles/shortfin_python_extension.dir/array_host_ops.cc.o
Tue, 03 Dec 2024 11:07:45 GMT   [377/380] Linking CXX shared module python/_shortfin_default/lib.cpython-311-x86_64-linux-gnu.so
```
(from these logs: https://github.com/nod-ai/shark-ai/actions/runs/12138320160/job/33843543941#step:6:738)

IREE also disables its tests when building packages:
* https://github.com/iree-org/iree/blob/cbb11f220c69e0106dbfd1533a00237c3a74e7e3/compiler/setup.py#L260
* https://github.com/iree-org/iree/blob/cbb11f220c69e0106dbfd1533a00237c3a74e7e3/runtime/setup.py#L278