### PR TITLE
Switch ci-sdxl github runner and refactor workflow.

### DIFF
--- a/.github/workflows/ci-sdxl.yaml
+++ b/.github/workflows/ci-sdxl.yaml
@@ -37,7 +37,7 @@ env:
 jobs:
   build-and-test:
     name: Build and test
-    runs-on: mi300-sdxl-kernel
+    runs-on: mi300x-4
 
     steps:
     - name: Install dependencies

--- a/.github/workflows/ci-sdxl.yaml
+++ b/.github/workflows/ci-sdxl.yaml
@@ -35,8 +35,8 @@ env:
   LIBSHORTFIN_DIR: ${{ github.workspace }}/shortfin/
 
 jobs:
-  build-and-test:
-    name: Build and test
+  install-and-test:
+    name: Install and test
     runs-on: mi300x-4
 
     steps:
@@ -55,53 +55,27 @@ jobs:
           sudo apt install ninja -y
         fi
 
-    - name: Checkout IREE repo
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        repository: iree-org/iree
-        path: ${{ env.IREE_REPO_DIR }}
-        submodules: false
-        ref: iree-3.1.0rc20241204
-
-    - name: Initalize IREE submodules
-      working-directory: ${{ env.IREE_REPO_DIR }}
-      run : |
-        git submodule update --init --depth 1 -- third_party/benchmark
-        git submodule update --init --depth 1 -- third_party/cpuinfo/
-        git submodule update --init --depth 1 -- third_party/flatcc
-        git submodule update --init --depth 1 -- third_party/googletest
-        git submodule update --init --depth 1 -- third_party/hip-build-deps/
-
     - name: Setup Python
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: "3.12"
         cache: "pip"
-    - name: Install Python packages
-      # TODO: Switch to `pip install -r requirements.txt -e shortfin/`.
+
+    - name: Install requirements
       working-directory: ${{ env.LIBSHORTFIN_DIR }}
       run: |
         pip install -r requirements-tests.txt
         pip install -r requirements-iree-compiler.txt
         pip freeze
 
-    - name: Build shortfin (full)
+    - name: Install shortfin
       working-directory: ${{ env.LIBSHORTFIN_DIR }}
       run: |
-        mkdir build
-        cmake -GNinja \
-          -S. \
-          -Bbuild \
-          -DCMAKE_C_COMPILER=clang-18 \
-          -DCMAKE_CXX_COMPILER=clang++-18 \
-          -DSHORTFIN_BUNDLE_DEPS=ON \
-          -DSHORTFIN_IREE_SOURCE_DIR="${{ env.IREE_REPO_DIR }}" \
-          -DSHORTFIN_BUILD_PYTHON_BINDINGS=ON
-        cmake --build build --target all
-        pip install -v -e build/
+        pip install --no-compile -e .
 
-    - name: Test shortfin (full)
+    - name: Test apps/sd/e2e_test
       working-directory: ${{ env.LIBSHORTFIN_DIR }}
+      env:
+        HIP_VISIBLE_DEVICES: 0
       run: |
-        ctest --timeout 30 --output-on-failure --test-dir build
-        HIP_VISIBLE_DEVICES=0 pytest tests/apps/sd/e2e_test.py -v -s --system=amdgpu
+        pytest tests/apps/sd/e2e_test.py -v -s --system=amdgpu


### PR DESCRIPTION
The `mi300-sdxl-kernel` runner has been offline for a few weeks, so runs of this workflow have been queued: https://github.com/nod-ai/shark-ai/actions/workflows/ci-sdxl.yaml. This `mi300x-4` runner is probably fit to run this workflow.

Also refactored the workflow to not use explicit build steps, which loosens the requirements on installed software and helps make progress on https://github.com/nod-ai/shark-ai/issues/584.