### PR TITLE
Switch workflows to use new nightly iree-turbine packages.

### DIFF
--- a/.github/workflows/ci-llama-large-tests.yaml
+++ b/.github/workflows/ci-llama-large-tests.yaml
@@ -61,7 +61,7 @@ jobs:
 
           # Install nightly IREE packages.
           # We could also pin to a known working or stable version.
-          pip install -f https://iree.dev/pip-release-links.html --pre \
+          pip install -f https://iree.dev/pip-release-links.html --pre --upgrade \
             iree-base-compiler \
             iree-base-runtime \
             iree-turbine

--- a/.github/workflows/ci-llama-large-tests.yaml
+++ b/.github/workflows/ci-llama-large-tests.yaml
@@ -59,14 +59,12 @@ jobs:
           pip install --no-compile -r pytorch-cpu-requirements.txt
           pip install --no-compile -r requirements.txt -r sharktank/requirements-tests.txt -e sharktank/
 
-          # Install latest iree-turbine.
-          pip install --no-compile -f https://iree.dev/pip-release-links.html --src deps \
-            -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
-
-          # Test with nightly releases, not what iree-turbine uses.
-          pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
+          # Install nightly IREE packages.
+          # We could also pin to a known working or stable version.
+          pip install -f https://iree.dev/pip-release-links.html --pre \
             iree-base-compiler \
-            iree-base-runtime
+            iree-base-runtime \
+            iree-turbine
 
           pip freeze
 

--- a/.github/workflows/ci-llama-quick-tests.yaml
+++ b/.github/workflows/ci-llama-quick-tests.yaml
@@ -61,7 +61,7 @@ jobs:
 
           # Install nightly IREE packages.
           # We could also pin to a known working or stable version.
-          pip install -f https://iree.dev/pip-release-links.html --pre \
+          pip install -f https://iree.dev/pip-release-links.html --pre --upgrade \
             iree-base-compiler \
             iree-base-runtime \
             iree-turbine

--- a/.github/workflows/ci-llama-quick-tests.yaml
+++ b/.github/workflows/ci-llama-quick-tests.yaml
@@ -59,14 +59,12 @@ jobs:
           pip install --no-compile -r pytorch-cpu-requirements.txt
           pip install --no-compile -r requirements.txt -r sharktank/requirements-tests.txt -e sharktank/
 
-          # Install latest iree-turbine.
-          pip install --no-compile -f https://iree.dev/pip-release-links.html --src deps \
-            -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
-
-          # Test with nightly releases, not what iree-turbine uses.
-          pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
+          # Install nightly IREE packages.
+          # We could also pin to a known working or stable version.
+          pip install -f https://iree.dev/pip-release-links.html --pre \
             iree-base-compiler \
-            iree-base-runtime
+            iree-base-runtime \
+            iree-turbine
 
           pip freeze
 

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -65,13 +65,10 @@ jobs:
           # from non default locations first. Installing the PyTorch CPU
           # wheels saves multiple minutes and a lot of bandwidth on runner setup.
           pip install --no-compile -r pytorch-cpu-requirements.txt
-          pip install --no-compile -f https://iree.dev/pip-release-links.html --src deps \
-            -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
+          pip install -f https://iree.dev/pip-release-links.html --pre iree-turbine
           pip install --no-compile -r requirements.txt -e sharktank/ shortfin/
 
-          # Try with the latest nightly releases, not what iree-turbine pins.
-          # We could also pin to a known working or stable version.
-          # This should eventually stabilize. Do the best we can for now.
+          # Pin to known-working versions.
           pip install -f https://iree.dev/pip-release-links.html --upgrade \
             iree-base-compiler==3.1.0rc20241204 \
             iree-base-runtime==3.1.0rc20241204 \

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -69,7 +69,7 @@ jobs:
           pip install --no-compile -r requirements.txt -e sharktank/ shortfin/
 
           # Pin to known-working versions.
-          pip install -f https://iree.dev/pip-release-links.html --upgrade \
+          pip install -f https://iree.dev/pip-release-links.html --pre --upgrade \
             iree-base-compiler==3.1.0rc20241204 \
             iree-base-runtime==3.1.0rc20241204 \
             "numpy<2.0"

--- a/.github/workflows/ci-sglang-integration-tests.yml
+++ b/.github/workflows/ci-sglang-integration-tests.yml
@@ -54,8 +54,6 @@ jobs:
           # from non default locations first. Installing the PyTorch CPU
           # wheels saves multiple minutes and a lot of bandwidth on runner setup.
           pip install --no-compile -r pytorch-cpu-requirements.txt
-          pip install --no-compile -f https://iree.dev/pip-release-links.html --src deps \
-            -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
           pip install --no-compile -r requirements.txt -e sharktank/ shortfin/
 
           # Use newest possible releases to be able to track commits that may
@@ -63,6 +61,7 @@ jobs:
           pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
             iree-base-compiler \
             iree-base-runtime \
+            iree-turbine \
             "numpy<2.0"
 
           # Install SGLang and sentence_transformers

--- a/.github/workflows/ci-sglang-integration-tests.yml
+++ b/.github/workflows/ci-sglang-integration-tests.yml
@@ -58,7 +58,7 @@ jobs:
 
           # Use newest possible releases to be able to track commits that may
           # cause errors.
-          pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
+          pip install -f https://iree.dev/pip-release-links.html --pre --upgrade \
             iree-base-compiler \
             iree-base-runtime \
             iree-turbine \

--- a/.github/workflows/ci-shark-ai.yml
+++ b/.github/workflows/ci-shark-ai.yml
@@ -55,16 +55,12 @@ jobs:
           pip install --no-compile -r pytorch-cpu-requirements.txt
           pip install --no-compile -r requirements.txt -e sharktank/ shortfin/
 
-          # Install latest iree-tubrine.
-          pip install --no-compile -f https://iree.dev/pip-release-links.html --src deps \
-            -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
-
-          # Try with the latest IREE nightly releases, not what iree-turbine pins.
+          # Install nightly IREE packages.
           # We could also pin to a known working or stable version.
-          # This should eventually stabilize. Do the best we can for now.
-          pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
+          pip install -f https://iree.dev/pip-release-links.html --pre \
             iree-base-compiler \
-            iree-base-runtime
+            iree-base-runtime \
+            iree-turbine
 
           pip freeze
 

--- a/.github/workflows/ci-shark-ai.yml
+++ b/.github/workflows/ci-shark-ai.yml
@@ -57,7 +57,7 @@ jobs:
 
           # Install nightly IREE packages.
           # We could also pin to a known working or stable version.
-          pip install -f https://iree.dev/pip-release-links.html --pre \
+          pip install -f https://iree.dev/pip-release-links.html --pre --upgrade \
             iree-base-compiler \
             iree-base-runtime \
             iree-turbine

--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -85,7 +85,7 @@ jobs:
       run:
         shell: bash
     env:
-      PIP_CACHE_DIR: "${{ github.workspace }}/.pip-cache"
+      VENV_DIR: ${{ github.workspace }}/.venv
       HF_HOME: "/data/huggingface"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -96,15 +96,12 @@ jobs:
         with:
           python-version: ${{matrix.version}}
 
-      - name: Cache Pip Packages
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
-        id: cache-pip
-        with:
-          path: ${{ env.PIP_CACHE_DIR }}
-          key: pip-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('*requirements*.txt','sharktank/requirements*.txt') }}
+      - name: Create Python venv
+        run: python -m venv ${VENV_DIR}
 
       - name: Install sharktank deps
         run: |
+          source ${VENV_DIR}/bin/activate
           python -m pip install --no-compile --upgrade pip
           # Note: We install in three steps in order to satisfy requirements
           # from non default locations first. Installing the PyTorch CPU
@@ -121,6 +118,7 @@ jobs:
 
       - name: Run tests
         run: |
+          source ${VENV_DIR}/bin/activate
           pytest \
             --with-t5-data \
             sharktank/tests/models/t5/t5_test.py \

--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -60,10 +60,12 @@ jobs:
           pip install --no-compile -r pytorch-cpu-requirements.txt
           pip install --no-compile -r requirements.txt -r sharktank/requirements-tests.txt -e sharktank/
 
-          # Update to the latest iree packages.
-          pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
-            iree-base-compiler iree-base-runtime --src deps \
-            -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
+          # Install nightly IREE packages.
+          # We could also pin to a known working or stable version.
+          pip install -f https://iree.dev/pip-release-links.html --pre \
+            iree-base-compiler \
+            iree-base-runtime \
+            iree-turbine
 
       - name: Run sharktank tests
         if: ${{ !cancelled() }}
@@ -110,16 +112,12 @@ jobs:
           pip install --no-compile -r pytorch-cpu-requirements.txt
           pip install --no-compile -r requirements.txt -r sharktank/requirements-tests.txt -e sharktank/
 
-          # Install latest iree-tubrine.
-          pip install --no-compile -f https://iree.dev/pip-release-links.html --src deps \
-            -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
-
-          # Try with the latest IREE nightly releases, not what iree-turbine pins.
+          # Install nightly IREE packages.
           # We could also pin to a known working or stable version.
-          # This should eventually stabilize. Do the best we can for now.
-          pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
+          pip install -f https://iree.dev/pip-release-links.html --pre \
             iree-base-compiler \
-            iree-base-runtime
+            iree-base-runtime \
+            iree-turbine
 
       - name: Run tests
         run: |
@@ -158,10 +156,13 @@ jobs:
           # wheels saves multiple minutes and a lot of bandwidth on runner setup.
           pip install --no-compile -r pytorch-cpu-requirements.txt
           pip install --no-compile -r requirements.txt -r sharktank/requirements-tests.txt -e sharktank/
-          # Update to the latest iree packages.
-          pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
-            iree-base-compiler iree-base-runtime --src deps \
-            -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
+
+          # Install nightly IREE packages.
+          # We could also pin to a known working or stable version.
+          pip install -f https://iree.dev/pip-release-links.html --pre \
+            iree-base-compiler \
+            iree-base-runtime \
+            iree-turbine
       - name: Run punet tests
         run: |
           pytest -v sharktank/ -m punet_quick \

--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -114,7 +114,7 @@ jobs:
 
           # Install nightly IREE packages.
           # We could also pin to a known working or stable version.
-          pip install -f https://iree.dev/pip-release-links.html --pre \
+          pip install -f https://iree.dev/pip-release-links.html --pre --upgrade \
             iree-base-compiler \
             iree-base-runtime \
             iree-turbine
@@ -159,7 +159,7 @@ jobs:
 
           # Install nightly IREE packages.
           # We could also pin to a known working or stable version.
-          pip install -f https://iree.dev/pip-release-links.html --pre \
+          pip install -f https://iree.dev/pip-release-links.html --pre --upgrade \
             iree-base-compiler \
             iree-base-runtime \
             iree-turbine

--- a/.github/workflows/ci_eval.yaml
+++ b/.github/workflows/ci_eval.yaml
@@ -57,16 +57,12 @@ jobs:
           pip install --no-compile -r pytorch-cpu-requirements.txt
           pip install --no-compile -r requirements.txt -r sharktank/requirements-tests.txt -e sharktank/
 
-          # Install latest iree-tubrine.
-          pip install --no-compile -f https://iree.dev/pip-release-links.html --src deps \
-            -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
-
-          # Try with the latest IREE nightly releases, not what iree-turbine pins.
+          # Install nightly IREE packages.
           # We could also pin to a known working or stable version.
-          # This should eventually stabilize. Do the best we can for now.
-          pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
+          pip install -f https://iree.dev/pip-release-links.html --pre \
             iree-base-compiler \
-            iree-base-runtime
+            iree-base-runtime \
+            iree-turbine
 
           pip freeze
 
@@ -119,9 +115,10 @@ jobs:
           pip install --no-compile -r pytorch-cpu-requirements.txt
           pip install --no-compile -r requirements.txt -r sharktank/requirements-tests.txt -e sharktank/
 
-          # Install latest iree-tubrine.
-          pip install --no-compile -f https://iree.dev/pip-release-links.html --src deps \
-            -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
+          # Install nightly iree-turbine.
+          # We could also pin to a known working or stable version.
+          pip install -f https://iree.dev/pip-release-links.html --pre \
+            iree-turbine
 
       - name: Run perplexity test with Torch
         run: |

--- a/.github/workflows/ci_eval.yaml
+++ b/.github/workflows/ci_eval.yaml
@@ -117,7 +117,7 @@ jobs:
 
           # Install nightly iree-turbine.
           # We could also pin to a known working or stable version.
-          pip install -f https://iree.dev/pip-release-links.html --pre \
+          pip install -f https://iree.dev/pip-release-links.html --pre --upgrade \
             iree-turbine
 
       - name: Run perplexity test with Torch

--- a/.github/workflows/ci_eval_short.yaml
+++ b/.github/workflows/ci_eval_short.yaml
@@ -56,16 +56,12 @@ jobs:
           pip install --no-compile -r pytorch-cpu-requirements.txt
           pip install --no-compile -r requirements.txt -r sharktank/requirements-tests.txt -e sharktank/
 
-          # Install latest iree-tubrine.
-          pip install --no-compile -f https://iree.dev/pip-release-links.html --src deps \
-            -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
-
-          # Try with the latest IREE nightly releases, not what iree-turbine pins.
+          # Install nightly IREE packages.
           # We could also pin to a known working or stable version.
-          # This should eventually stabilize. Do the best we can for now.
-          pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
+          pip install -f https://iree.dev/pip-release-links.html --pre \
             iree-base-compiler \
-            iree-base-runtime
+            iree-base-runtime \
+            iree-turbine
 
           pip freeze
 

--- a/.github/workflows/ci_eval_short.yaml
+++ b/.github/workflows/ci_eval_short.yaml
@@ -58,7 +58,7 @@ jobs:
 
           # Install nightly IREE packages.
           # We could also pin to a known working or stable version.
-          pip install -f https://iree.dev/pip-release-links.html --pre \
+          pip install -f https://iree.dev/pip-release-links.html --pre --upgrade \
             iree-base-compiler \
             iree-base-runtime \
             iree-turbine

--- a/docs/nightly_releases.md
+++ b/docs/nightly_releases.md
@@ -86,26 +86,19 @@ deactivate
 
 ## Installing newer versions of dependencies
 
-To install the `iree-turbine` package from the latest source:
+To install all IREE packages from nightly releases:
+
+```bash
+pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
+  iree-base-compiler \
+  iree-base-runtime \
+  iree-turbine
+```
+
+To install an editable `iree-turbine` package from the latest source:
 
 ```bash
 pip install --src deps \
-  -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
-```
-
-To install the `iree-base-compiler` and `iree-base-runtime` packages from
-nightly releases:
-
-```bash
-pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
-  iree-base-compiler iree-base-runtime
-```
-
-To install all three packages together:
-
-```bash
-pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
-  iree-base-compiler iree-base-runtime --src deps \
   -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
 ```
 


### PR DESCRIPTION
This simplification will help with https://github.com/nod-ai/shark-ai/issues/584.

Nightly releases of iree-turbine are now being built thanks to https://github.com/iree-org/iree-turbine/pull/314 and published at the same index as the other IREE packages thanks to https://github.com/iree-org/iree/pull/19391.