### PR TITLE
Use Trie and Base Caching in SGL Benchmark

### DIFF
--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -19,6 +19,8 @@
 name: SGLang Llama Benchmarking Tests
 
 on:
+  # TODO: Remove after validation
+  pull_request:
   workflow_dispatch:
   schedule:
     # Weekdays at 4:00 AM UTC = 9:00 PM PST.

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -19,8 +19,6 @@
 name: SGLang Llama Benchmarking Tests
 
 on:
-  # TODO: Remove after validation
-  pull_request:
   workflow_dispatch:
   schedule:
     # Weekdays at 4:00 AM UTC = 9:00 PM PST.

--- a/app_tests/benchmark_tests/llm/sglang_benchmarks/sglang_benchmark_test.py
+++ b/app_tests/benchmark_tests/llm/sglang_benchmarks/sglang_benchmark_test.py
@@ -65,3 +65,4 @@ def test_sglang_benchmark(request_rate, tokenizer_id, sglang_args, tmp_path_fact
         log_jsonl_result(benchmark_args.output_file)
     except Exception as e:
         logger.error(e)
+        raise e

--- a/app_tests/benchmark_tests/llm/sglang_benchmarks/utils.py
+++ b/app_tests/benchmark_tests/llm/sglang_benchmarks/utils.py
@@ -48,6 +48,7 @@ class SGLangBenchmarkArgs:
             disable_tqdm=False,
             disable_stream=False,
             disable_ignore_eos=False,
+            lora_name=None,
         )
 
     def __repr__(self):

--- a/app_tests/benchmark_tests/llm/sglang_benchmarks/utils.py
+++ b/app_tests/benchmark_tests/llm/sglang_benchmarks/utils.py
@@ -49,6 +49,7 @@ class SGLangBenchmarkArgs:
             disable_stream=False,
             disable_ignore_eos=False,
             lora_name=None,
+            profile=False,
         )
 
     def __repr__(self):


### PR DESCRIPTION
# Description

Previously we were only benchmarking against the `base` caching algorithm when we run our SGLang benchmark tests. This PR allows us to benchmark against both the `base` and `trie` caching algorithms.

Along with that, it adds the same trick from #655 to be able to reuse model artifacts instead of generating new ones each time, which drastically decreases the overall time required to run the benchmark test.

It also includes a patch to run the benchmark script after syncing SGLang repo today, and ensures that an error is raised when one occurs