### PR TITLE
Delete unused requirements file

### DIFF
--- a/sharktank/requirements-dev-turbine.txt
+++ b/sharktank/requirements-dev-turbine.txt
@@ -1,1 +1,0 @@
--e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"


### PR DESCRIPTION
This requirements file pointing to iree-turbine is not used in any workflow or referred to in the documentation. If needed, we can re-add one pointing to the new package entry later again.