### PR TITLE
Relax restrictions on explicit versions

### DIFF
--- a/sharktank/requirements.txt
+++ b/sharktank/requirements.txt
@@ -17,5 +17,5 @@ datasets
 torch>=2.3.0
 
 # Serving deps.
-fastapi==0.112.2
-uvicorn==0.30.6
+fastapi>=0.112.2
+uvicorn>=0.30.6


### PR DESCRIPTION
Instead of pinning specific versions for `fastapi` and `uvicorn`, only a minimum version is set now instead.