### PR TITLE
Fix version_suffix for nighly shark-ai packages in build_packages.yml.

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -23,26 +23,25 @@ jobs:
     if: ${{ github.repository_owner == 'nod-ai' || github.event_name != 'schedule' }}
     runs-on: ubuntu-24.04
     outputs:
-      shark_package_version: ${{ steps.version.outputs.shark_package_version }}
+      version_suffix: ${{ steps.version_rc.outputs.version_suffix }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: 3.12
-          cache: "pip"
+
       - name: Install Python packages
-        run: |
-          pip install packaging
-          pip freeze
+        run: pip install packaging
+
       - name: Generate release candidate versions
         id: version_rc
         run: |
           version_suffix="$(printf 'rc%(%Y%m%d)T')"
-          echo "version_suffix=${version_suffix}" >> $GITHUB_ENV
-          sharktank_package_version=$(python3 build_tools/python_deploy/compute_local_version.py --version-suffix=${version_suffix} sharktank)
-          shortfin_package_version=$(python3 build_tools/python_deploy/compute_local_version.py --version-suffix=${version_suffix} shortfin)
-          sharkai_package_version=$(python3 build_tools/python_deploy/compute_common_version.py -rc --version-suffix=${version_suffix} --write-json)
+          echo "version_suffix=${version_suffix}" >> $GITHUB_OUTPUT
+          python3 build_tools/python_deploy/compute_local_version.py --version-suffix=${version_suffix} sharktank
+          python3 build_tools/python_deploy/compute_local_version.py --version-suffix=${version_suffix} shortfin
+          python3 build_tools/python_deploy/compute_common_version.py -rc --version-suffix=${version_suffix} --write-json
       - name: Upload version_local.json
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
@@ -115,7 +114,7 @@ jobs:
         OUTPUT_DIR: "${{ github.workspace }}/bindist"
       run: |
         [ -e ./bindist/* ] && rm ./bindist/*
-        ./c/build_tools/python_deploy/write_requirements.py --version-suffix=${version_suffix}
+        ./c/build_tools/python_deploy/write_requirements.py --version-suffix=${{ needs.setup_metadata.outputs.version_suffix }}
         ./c/shark-ai/build_tools/build_linux_package.sh
 
     - name: Build sharktank (Linux x86_64)


### PR DESCRIPTION
Tested here: https://github.com/ScottTodd/shark-ai/actions/runs/12244417956 and confirmed that the `METADATA` embedded within `shark_ai.*.whl` has `Requires-Dist: shortfin==3.1.0rc20241209` as expected, compared to the baseline of `Requires-Dist: shortfin==3.1.0`.

I then also ran
```bash
pip install --pre --find-links https://github.com/ScottTodd/shark-ai/releases/expanded_assets/dev-wheels shark-ai
# Looking in links: https://github.com/ScottTodd/shark-ai/releases/expanded_assets/dev-wheels
# Collecting shark-ai
#   Downloading https://github.com/ScottTodd/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241209-py3-none-any.whl (1.4 kB)
# Collecting iree-base-compiler (from shark-ai)
#   Using cached iree_base_compiler-3.0.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl.metadata (1.0 kB)
# Collecting iree-base-runtime (from shark-ai)
#   Using cached iree_base_runtime-3.0.0-cp311-cp311-manylinux_2_28_x86_64.whl.metadata (1.0 kB)
# Collecting iree-turbine (from shark-ai)
#   Using cached iree_turbine-3.0.0-py3-none-any.whl.metadata (5.8 kB)
# Collecting shortfin==3.1.0rc20241209 (from shark-ai)
#   Downloading https://github.com/ScottTodd/shark-ai/releases/download/dev-wheels/shortfin-3.1.0rc20241209-cp311-cp311-manylinux_2_28_x86_64.whl (2.7 MB)

pip freeze | grep sh
# shark-ai==3.1.0rc20241209
# shortfin==3.1.0rc20241209
```

Compared to the baseline of
```bash
pip install --pre --find-links https://github.com/nod-ai/shark-ai/releases/expanded_assets/dev-wheels shark-ai
# Looking in links: https://github.com/nod-ai/shark-ai/releases/expanded_assets/dev-wheels
# Collecting shark-ai
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241209-py3-none-any.whl (1.4 kB)
# Collecting iree-base-compiler (from shark-ai)
#   Using cached iree_base_compiler-3.0.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl.metadata (1.0 kB)
# Collecting iree-base-runtime (from shark-ai)
#   Using cached iree_base_runtime-3.0.0-cp311-cp311-manylinux_2_28_x86_64.whl.metadata (1.0 kB)
# Collecting iree-turbine (from shark-ai)
#   Using cached iree_turbine-3.0.0-py3-none-any.whl.metadata (5.8 kB)
# INFO: pip is looking at multiple versions of shark-ai to determine which version is compatible with other requirements. This could take a while.
# Collecting shark-ai
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241208-py3-none-any.whl (1.4 kB)
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241207-py3-none-any.whl (1.4 kB)
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241206-py3-none-any.whl (1.4 kB)
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241205-py3-none-any.whl (1.4 kB)
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241204-py3-none-any.whl (1.4 kB)
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241203-py3-none-any.whl (1.4 kB)
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241202-py3-none-any.whl (1.4 kB)
# INFO: pip is still looking at multiple versions of shark-ai to determine which version is compatible with other requirements. This could take a while.
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241201-py3-none-any.whl (1.4 kB)
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241130-py3-none-any.whl (1.4 kB)
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241129-py3-none-any.whl (1.4 kB)
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241128-py3-none-any.whl (1.4 kB)
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241127-py3-none-any.whl (1.4 kB)
# INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. See https://pip.pypa.io/warnings/backtracking for guidance. If you want to abort this run, press Ctrl + C.
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241126-py3-none-any.whl (1.4 kB)
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241125-py3-none-any.whl (1.4 kB)
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241124-py3-none-any.whl (1.4 kB)
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241123-py3-none-any.whl (1.4 kB)
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241122-py3-none-any.whl (1.4 kB)
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241121-py3-none-any.whl (1.4 kB)
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241120-py3-none-any.whl (1.4 kB)
#   Downloading https://github.com/nod-ai/shark-ai/releases/download/dev-wheels/shark_ai-3.1.0rc20241119-py3-none-any.whl (1.4 kB)
#   Using cached shark_ai-3.0.0-py3-none-any.whl.metadata (764 bytes)
# Collecting shortfin==3.0.0 (from shark-ai)
#   Using cached shortfin-3.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl.metadata (8.2 kB)

pip freeze | grep sh
# shark-ai==3.0.0
# shortfin==3.0.0
```