### PR TITLE
[tuner]: use translation_info binding

### DIFF
--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -52,7 +52,10 @@ def apply_configuration(
     workgroup_sizes = lowering_config.workgroup_tile_sizes
     reduction_sizes = lowering_config.reduction_tile_sizes
     gpu_pipeline_options = configuration.translation_info.configuration[
-        GPU_PIPELINE_OPTIONS
+        GPU_PIPELINE_OPTIONS_KEY
+    ]
+    waves_per_eu = configuration.translation_info.configuration[LLVM_FUNC_ATTRS_KEY][
+        WAVES_PER_EU_KEY
     ]
     tune_logger.info(f"Applying: {configuration}")
     expr0 = re.compile(
@@ -70,7 +73,7 @@ def apply_configuration(
     repl2 = f"workgroup = {workgroup_sizes}"
     repl3 = f"reduction = {reduction_sizes}"
     repl4 = f"gpu_pipeline_options = {gpu_pipeline_options}"
-    repl5 = f'"amdgpu-waves-per-eu" = "{configuration.waves_per_eu}"'
+    repl5 = f'"amdgpu-waves-per-eu" = {waves_per_eu}'
 
     new_mlir = ""
     for line in template:
@@ -131,15 +134,6 @@ class MmtTuner(DispatchTuner, MmtParser):
     def get_transform_function_mmt(
         self, problem_size: ProblemSize, functionName: str, configuration: Configuration
     ) -> str:
-        lowering_config = configuration.lowering_config
-        intrinsic = lowering_config.mma_kind
-        (
-            subgroup_m_count,
-            subgroup_n_count,
-        ) = lowering_config.subgroup_count_mn
-
-        wg_x, wg_y, wg_z = configuration.translation_info.workgroup_size
-        extra_config = get_pipeline_config(configuration)
         return f"""
     transform.named_sequence @{functionName}(%matmul: !transform.any_op {{transform.readonly}}) -> (!transform.any_op, !transform.any_param) {{
     %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
@@ -148,13 +142,8 @@ class MmtTuner(DispatchTuner, MmtParser):
     transform.iree.match.cast_compatible_type %lhs = tensor<{problem_size.lhs_type}> : !transform.any_value
     transform.iree.match.cast_compatible_type %rhs = tensor<{problem_size.rhs_type}> : !transform.any_value
     %config = transform.param.constant #iree_codegen.compilation_info<
-        lowering_config = {configuration.lowering_config}>,
-        translation_info = #iree_codegen.translation_info<LLVMGPUVectorDistribute
-        workgroup_size = [{wg_x}, {wg_y}, {wg_z}] subgroup_size = {configuration.translation_info.subgroup_size},
-        {{mma_schedule = #iree_gpu.mma_schedule<
-            intrinsic = {intrinsic},
-            subgroup_m_count = {subgroup_m_count}, subgroup_n_count = {subgroup_n_count}>
-        {extra_config}}}>
+        lowering_config = {configuration.lowering_config},
+        translation_info = {configuration.translation_info}
         > -> !transform.any_param
     transform.yield %matmul, %config : !transform.any_op, !transform.any_param
     }}
@@ -200,16 +189,6 @@ class ConvTuner(DispatchTuner, ConvParser):
         filter = f"tensor<{problem_size.rhs_type}>"
         output = f"tensor<{dynamic_batch_output_ty}>"
 
-        lowering_config = configuration.lowering_config
-        intrinsic = lowering_config.mma_kind
-        (
-            subgroup_m_count,
-            subgroup_n_count,
-        ) = lowering_config.subgroup_count_mn
-
-        wg_x, wg_y, wg_z = configuration.translation_info.workgroup_size
-        extra_config = get_pipeline_config(configuration)
-
         return f"""
     transform.named_sequence @{functionName}(%conv: !transform.any_op {{transform.readonly}})
     -> (!transform.any_op, !transform.any_param) {{
@@ -220,13 +199,8 @@ class ConvTuner(DispatchTuner, ConvParser):
         outs(%out : {output}) -> {output}
     }} : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
         %config = transform.param.constant #iree_codegen.compilation_info<
-        lowering_config = {configuration.lowering_config}>,
-        translation_info = #iree_codegen.translation_info<LLVMGPUVectorDistribute
-        workgroup_size = [{wg_x}, {wg_y}, {wg_z}] subgroup_size = {configuration.translation_info.subgroup_size},
-            {{mma_schedule = #iree_gpu.mma_schedule<
-                intrinsic = {intrinsic},
-                subgroup_m_count = {subgroup_m_count}, subgroup_n_count = {subgroup_n_count}>
-            {extra_config}}}>
+        lowering_config = {configuration.lowering_config},
+        translation_info = {configuration.translation_info}
         > -> !transform.any_param
     transform.yield %conv, %config : !transform.any_op, !transform.any_param
     }}
@@ -265,16 +239,6 @@ class ContractionTuner(DispatchTuner, ContractionParser):
         functionName: str,
         configuration: Configuration,
     ) -> str:
-        lowering_config = configuration.lowering_config
-        intrinsic = lowering_config.mma_kind
-        (
-            subgroup_m_count,
-            subgroup_n_count,
-        ) = lowering_config.subgroup_count_mn
-
-        wg_x, wg_y, wg_z = configuration.translation_info.workgroup_size
-        extra_config = get_pipeline_config(configuration)
-
         lhs_dynamic_batch = problem_size.lhs_type
         lhs_dynamic_batch.shape = lhs_dynamic_batch.shape.copy()
         lhs_dynamic_batch.shape[0] = -1
@@ -287,13 +251,8 @@ transform.named_sequence @{functionName}(%generic: !transform.any_op {{transform
 transform.iree.match.cast_compatible_type %lhs = tensor<{lhs_dynamic_batch}> : !transform.any_value
 transform.iree.match.cast_compatible_type %rhs = tensor<{problem_size.rhs_type}> : !transform.any_value
 %config = transform.param.constant #iree_codegen.compilation_info<
-    lowering_config = {configuration.lowering_config}>,
-    translation_info = #iree_codegen.translation_info<LLVMGPUVectorDistribute
-    workgroup_size = [{wg_x}, {wg_y}, {wg_z}] subgroup_size = {configuration.translation_info.subgroup_size},
-    {{mma_schedule = #iree_gpu.mma_schedule<
-        intrinsic = {intrinsic},
-        subgroup_m_count = {subgroup_m_count}, subgroup_n_count = {subgroup_n_count}>
-    {extra_config}}}>
+    lowering_config = {configuration.lowering_config},
+    translation_info = {configuration.translation_info}
     > -> !transform.any_param
 transform.yield %generic, %config : !transform.any_op, !transform.any_param
 }}
@@ -354,16 +313,6 @@ class BatchMmtTuner(DispatchTuner, BatchMmtParser):
         functionName: str,
         configuration: Configuration,
     ) -> str:
-        lowering_config = configuration.lowering_config
-        intrinsic = lowering_config.mma_kind
-        (
-            subgroup_m_count,
-            subgroup_n_count,
-        ) = lowering_config.subgroup_count_mn
-
-        wg_x, wg_y, wg_z = configuration.translation_info.workgroup_size
-        extra_config = get_pipeline_config(configuration)
-
         return f"""
 transform.named_sequence @{functionName}(%generic: !transform.any_op {{transform.readonly}}) -> (!transform.any_op, !transform.any_param) {{
 %mmt = transform.include @match_batch_mmt_i8_i8_i32 failures(propagate) (%generic) : (!transform.any_op) -> !transform.any_op
@@ -372,13 +321,8 @@ transform.named_sequence @{functionName}(%generic: !transform.any_op {{transform
 transform.iree.match.cast_compatible_type %lhs = tensor<{problem_size.lhs_type}> : !transform.any_value
 transform.iree.match.cast_compatible_type %rhs = tensor<{problem_size.rhs_type}> : !transform.any_value
 %config = transform.param.constant #iree_codegen.compilation_info<
-    lowering_config = {configuration.lowering_config}>,
-    translation_info = #iree_codegen.translation_info<LLVMGPUVectorDistribute
-    workgroup_size = [{wg_x}, {wg_y}, {wg_z}] subgroup_size = {configuration.translation_info.subgroup_size},
-    {{mma_schedule = #iree_gpu.mma_schedule<
-        intrinsic = {intrinsic},
-        subgroup_m_count = {subgroup_m_count}, subgroup_n_count = {subgroup_n_count}>
-    {extra_config}}}>
+    lowering_config = {configuration.lowering_config},
+    translation_info ={configuration.translation_info}
     > -> !transform.any_param
 transform.yield %generic, %config : !transform.any_op, !transform.any_param
 }}
@@ -424,16 +368,6 @@ class BatchMatmulTuner(DispatchTuner, BatchMatmulParser):
         input1 = f"tensor<{problem_size.rhs_type}>"
         output = f"tensor<{problem_size.res_type}>"
 
-        lowering_config = configuration.lowering_config
-        intrinsic = lowering_config.mma_kind
-        (
-            subgroup_m_count,
-            subgroup_n_count,
-        ) = lowering_config.subgroup_count_mn
-
-        wg_x, wg_y, wg_z = configuration.translation_info.workgroup_size
-        extra_config = get_pipeline_config(configuration)
-
         return f"""
     transform.named_sequence @{functionName}(%batch_matmul: !transform.any_op {{transform.readonly}})
     -> (!transform.any_op, !transform.any_param) {{
@@ -444,13 +378,8 @@ class BatchMatmulTuner(DispatchTuner, BatchMatmulParser):
         outs(%out : {output}) -> {output}
     }} : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
         %config = transform.param.constant #iree_codegen.compilation_info<
-        lowering_config = {configuration.lowering_config}>,
-        translation_info = #iree_codegen.translation_info<LLVMGPUPadAndVectorDistribute
-        workgroup_size = [{wg_x}, {wg_y}, {wg_z}] subgroup_size = {configuration.translation_info.subgroup_size},
-            {{mma_schedule = #iree_gpu.mma_schedule<
-                intrinsic = {intrinsic},
-                subgroup_m_count = {subgroup_m_count}, subgroup_n_count = {subgroup_n_count}>
-            {extra_config}}}>
+        lowering_config = {configuration.lowering_config},
+        translation_info = {configuration.translation_info}
         > -> !transform.any_param
     transform.yield %batch_matmul, %config : !transform.any_op, !transform.any_param
     }}

--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -322,7 +322,7 @@ transform.iree.match.cast_compatible_type %lhs = tensor<{problem_size.lhs_type}>
 transform.iree.match.cast_compatible_type %rhs = tensor<{problem_size.rhs_type}> : !transform.any_value
 %config = transform.param.constant #iree_codegen.compilation_info<
     lowering_config = {configuration.lowering_config},
-    translation_info ={configuration.translation_info}
+    translation_info = {configuration.translation_info}
     > -> !transform.any_param
 transform.yield %generic, %config : !transform.any_op, !transform.any_param
 }}

--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -52,7 +52,7 @@ def apply_configuration(
     workgroup_sizes = lowering_config.workgroup_tile_sizes
     reduction_sizes = lowering_config.reduction_tile_sizes
     gpu_pipeline_options = configuration.translation_info.configuration[
-        "gpu_pipeline_options"
+        GPU_PIPELINE_OPTIONS
     ]
     tune_logger.info(f"Applying: {configuration}")
     expr0 = re.compile(

--- a/tuner/tuner/candidate_gen_test.py
+++ b/tuner/tuner/candidate_gen_test.py
@@ -58,10 +58,12 @@ def test_apply_params_mmt(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=16,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.None_
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
     )
     pipeline_option = iree_gpu.PipelineOptionsAttr.get(prefetch_shared_memory=True)
-    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    pipeline_option_dict = ir.DictAttr.get(
+        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    )
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [16, 16, 1], 16, pipeline_option_dict
     )
@@ -124,14 +126,16 @@ def test_apply_params_conv(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=4,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.None_
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
     )
     pipeline_option = iree_gpu.PipelineOptionsAttr.get(
         reorder_workgroups_strategy=iree_gpu.ReorderWorkgroupsStrategyAttr.get(
             iree_gpu.ReorderWorkgroupsStrategy.Transpose
         )
     )
-    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    pipeline_option_dict = ir.DictAttr.get(
+        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    )
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [256, 1, 1], 64, pipeline_option_dict
     )
@@ -203,10 +207,12 @@ def test_apply_params_contract(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=4,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.None_
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
     )
     pipeline_option = iree_gpu.PipelineOptionsAttr.get()
-    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    pipeline_option_dict = ir.DictAttr.get(
+        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    )
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [256, 1, 1], 64, pipeline_option_dict
     )
@@ -264,10 +270,12 @@ def test_apply_params_batch_matmul(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=2,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.None_
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
     )
     pipeline_option = iree_gpu.PipelineOptionsAttr.get()
-    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    pipeline_option_dict = ir.DictAttr.get(
+        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    )
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [128, 2, 1], 64, pipeline_option_dict
     )
@@ -328,10 +336,12 @@ def test_apply_params_batch_mmt_float(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=2,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.None_
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
     )
     pipeline_option = iree_gpu.PipelineOptionsAttr.get()
-    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    pipeline_option_dict = ir.DictAttr.get(
+        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    )
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [128, 2, 1], 64, pipeline_option_dict
     )
@@ -390,10 +400,12 @@ def test_apply_params_batch_mmt_int(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=2,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.None_
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
     )
     pipeline_option = iree_gpu.PipelineOptionsAttr.get()
-    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    pipeline_option_dict = ir.DictAttr.get(
+        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    )
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [128, 2, 1], 64, pipeline_option_dict
     )
@@ -476,10 +488,12 @@ def test_apply_params_broadcast_rhs_mmt(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=2,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.None_
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
     )
     pipeline_option = iree_gpu.PipelineOptionsAttr.get()
-    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    pipeline_option_dict = ir.DictAttr.get(
+        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    )
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [128, 2, 1], 64, pipeline_option_dict
     )

--- a/tuner/tuner/candidate_gen_test.py
+++ b/tuner/tuner/candidate_gen_test.py
@@ -14,6 +14,7 @@ from typing import Generator
 
 from iree.compiler import ir  # type: ignore
 from iree.compiler.dialects import iree_gpu  # type: ignore
+from iree.compiler.dialects import iree_codegen  # type: ignore
 
 from . import candidate_gen
 from . import common
@@ -56,13 +57,17 @@ def test_apply_params_mmt(tuner_ctx: common.TunerContext) -> None:
         subgroup_m_count=16,
         subgroup_n_count=16,
     )
+    pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
+        iree_codegen.DispatchLoweringPassPipeline.None_
+    )
+    pipeline_option = iree_gpu.PipelineOptionsAttr.get(prefetch_shared_memory=True)
+    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    translation_info = iree_codegen.TranslationInfoAttr.get(
+        pipeline_attr, None, [16, 16, 1], 16, pipeline_option_dict
+    )
     config = common.Configuration(
-        subgroup_size=16,
-        workgroup_size=[16, 16, 1],
+        translation_info=translation_info,
         lowering_config=lowering_config,
-        gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(
-            prefetch_shared_memory=True
-        ),
         waves_per_eu=8,
     )
 
@@ -118,15 +123,21 @@ def test_apply_params_conv(tuner_ctx: common.TunerContext) -> None:
         subgroup_m_count=1,
         subgroup_n_count=4,
     )
+    pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
+        iree_codegen.DispatchLoweringPassPipeline.None_
+    )
+    pipeline_option = iree_gpu.PipelineOptionsAttr.get(
+        reorder_workgroups_strategy=iree_gpu.ReorderWorkgroupsStrategyAttr.get(
+            iree_gpu.ReorderWorkgroupsStrategy.Transpose
+        )
+    )
+    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    translation_info = iree_codegen.TranslationInfoAttr.get(
+        pipeline_attr, None, [256, 1, 1], 64, pipeline_option_dict
+    )
     config = common.Configuration(
-        subgroup_size=64,
-        workgroup_size=[256, 1, 1],
+        translation_info=translation_info,
         lowering_config=lowering_config,
-        gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(
-            reorder_workgroups_strategy=iree_gpu.ReorderWorkgroupsStrategyAttr.get(
-                iree_gpu.ReorderWorkgroupsStrategy.Transpose
-            )
-        ),
         waves_per_eu=2,
     )
 
@@ -191,11 +202,17 @@ def test_apply_params_contract(tuner_ctx: common.TunerContext) -> None:
         subgroup_m_count=1,
         subgroup_n_count=4,
     )
+    pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
+        iree_codegen.DispatchLoweringPassPipeline.None_
+    )
+    pipeline_option = iree_gpu.PipelineOptionsAttr.get()
+    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    translation_info = iree_codegen.TranslationInfoAttr.get(
+        pipeline_attr, None, [256, 1, 1], 64, pipeline_option_dict
+    )
     config = common.Configuration(
-        subgroup_size=64,
-        workgroup_size=[256, 1, 1],
+        translation_info=translation_info,
         lowering_config=lowering_config,
-        gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=2,
     )
 
@@ -246,11 +263,17 @@ def test_apply_params_batch_matmul(tuner_ctx: common.TunerContext) -> None:
         subgroup_m_count=2,
         subgroup_n_count=2,
     )
+    pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
+        iree_codegen.DispatchLoweringPassPipeline.None_
+    )
+    pipeline_option = iree_gpu.PipelineOptionsAttr.get()
+    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    translation_info = iree_codegen.TranslationInfoAttr.get(
+        pipeline_attr, None, [128, 2, 1], 64, pipeline_option_dict
+    )
     config = common.Configuration(
-        subgroup_size=64,
-        workgroup_size=[128, 2, 1],
+        translation_info=translation_info,
         lowering_config=lowering_config,
-        gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=2,
     )
 
@@ -304,11 +327,17 @@ def test_apply_params_batch_mmt_float(tuner_ctx: common.TunerContext) -> None:
         subgroup_m_count=2,
         subgroup_n_count=2,
     )
+    pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
+        iree_codegen.DispatchLoweringPassPipeline.None_
+    )
+    pipeline_option = iree_gpu.PipelineOptionsAttr.get()
+    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    translation_info = iree_codegen.TranslationInfoAttr.get(
+        pipeline_attr, None, [128, 2, 1], 64, pipeline_option_dict
+    )
     config = common.Configuration(
-        subgroup_size=64,
-        workgroup_size=[128, 2, 1],
+        translation_info=translation_info,
         lowering_config=lowering_config,
-        gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=2,
     )
 
@@ -360,11 +389,17 @@ def test_apply_params_batch_mmt_int(tuner_ctx: common.TunerContext) -> None:
         subgroup_m_count=2,
         subgroup_n_count=2,
     )
+    pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
+        iree_codegen.DispatchLoweringPassPipeline.None_
+    )
+    pipeline_option = iree_gpu.PipelineOptionsAttr.get()
+    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    translation_info = iree_codegen.TranslationInfoAttr.get(
+        pipeline_attr, None, [128, 2, 1], 64, pipeline_option_dict
+    )
     config = common.Configuration(
-        subgroup_size=64,
-        workgroup_size=[128, 2, 1],
+        translation_info=translation_info,
         lowering_config=lowering_config,
-        gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=4,
     )
 
@@ -440,11 +475,17 @@ def test_apply_params_broadcast_rhs_mmt(tuner_ctx: common.TunerContext) -> None:
         subgroup_m_count=2,
         subgroup_n_count=2,
     )
+    pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
+        iree_codegen.DispatchLoweringPassPipeline.None_
+    )
+    pipeline_option = iree_gpu.PipelineOptionsAttr.get()
+    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    translation_info = iree_codegen.TranslationInfoAttr.get(
+        pipeline_attr, None, [128, 2, 1], 64, pipeline_option_dict
+    )
     config = common.Configuration(
-        subgroup_size=64,
-        workgroup_size=[128, 2, 1],
+        translation_info=translation_info,
         lowering_config=lowering_config,
-        gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=4,
     )
 

--- a/tuner/tuner/candidate_gen_test.py
+++ b/tuner/tuner/candidate_gen_test.py
@@ -58,19 +58,22 @@ def test_apply_params_mmt(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=16,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
-    pipeline_option = iree_gpu.PipelineOptionsAttr.get(prefetch_shared_memory=True)
-    pipeline_option_dict = ir.DictAttr.get(
-        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    pipeline_options = iree_gpu.PipelineOptionsAttr.get(prefetch_shared_memory=True)
+    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("8")})
+    config_dict = ir.DictAttr.get(
+        {
+            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
+            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
+        }
     )
     translation_info = iree_codegen.TranslationInfoAttr.get(
-        pipeline_attr, None, [16, 16, 1], 16, pipeline_option_dict
+        pipeline_attr, None, [16, 16, 1], 16, config_dict
     )
     config = common.Configuration(
         translation_info=translation_info,
         lowering_config=lowering_config,
-        waves_per_eu=8,
     )
 
     problem_size = common.ProblemSize(
@@ -126,23 +129,26 @@ def test_apply_params_conv(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=4,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
-    pipeline_option = iree_gpu.PipelineOptionsAttr.get(
+    pipeline_options = iree_gpu.PipelineOptionsAttr.get(
         reorder_workgroups_strategy=iree_gpu.ReorderWorkgroupsStrategyAttr.get(
             iree_gpu.ReorderWorkgroupsStrategy.Transpose
         )
     )
-    pipeline_option_dict = ir.DictAttr.get(
-        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("2")})
+    config_dict = ir.DictAttr.get(
+        {
+            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
+            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
+        }
     )
     translation_info = iree_codegen.TranslationInfoAttr.get(
-        pipeline_attr, None, [256, 1, 1], 64, pipeline_option_dict
+        pipeline_attr, None, [256, 1, 1], 64, config_dict
     )
     config = common.Configuration(
         translation_info=translation_info,
         lowering_config=lowering_config,
-        waves_per_eu=2,
     )
 
     problem_size = common.ProblemSize(
@@ -207,19 +213,22 @@ def test_apply_params_contract(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=4,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
-    pipeline_option = iree_gpu.PipelineOptionsAttr.get()
-    pipeline_option_dict = ir.DictAttr.get(
-        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    pipeline_options = iree_gpu.PipelineOptionsAttr.get()
+    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("2")})
+    config_dict = ir.DictAttr.get(
+        {
+            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
+            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
+        }
     )
     translation_info = iree_codegen.TranslationInfoAttr.get(
-        pipeline_attr, None, [256, 1, 1], 64, pipeline_option_dict
+        pipeline_attr, None, [256, 1, 1], 64, config_dict
     )
     config = common.Configuration(
         translation_info=translation_info,
         lowering_config=lowering_config,
-        waves_per_eu=2,
     )
 
     tf_mlir = candidate_gen.ContractionTuner("mk", "nk", tile_dims).apply_params(
@@ -270,19 +279,22 @@ def test_apply_params_batch_matmul(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=2,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
-    pipeline_option = iree_gpu.PipelineOptionsAttr.get()
-    pipeline_option_dict = ir.DictAttr.get(
-        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    pipeline_options = iree_gpu.PipelineOptionsAttr.get()
+    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("2")})
+    config_dict = ir.DictAttr.get(
+        {
+            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
+            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
+        }
     )
     translation_info = iree_codegen.TranslationInfoAttr.get(
-        pipeline_attr, None, [128, 2, 1], 64, pipeline_option_dict
+        pipeline_attr, None, [128, 2, 1], 64, config_dict
     )
     config = common.Configuration(
         translation_info=translation_info,
         lowering_config=lowering_config,
-        waves_per_eu=2,
     )
 
     tf_mlir = candidate_gen.BatchMatmulTuner("mk", "nk", tile_dims).apply_params(
@@ -336,19 +348,22 @@ def test_apply_params_batch_mmt_float(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=2,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
-    pipeline_option = iree_gpu.PipelineOptionsAttr.get()
-    pipeline_option_dict = ir.DictAttr.get(
-        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    pipeline_options = iree_gpu.PipelineOptionsAttr.get()
+    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("2")})
+    config_dict = ir.DictAttr.get(
+        {
+            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
+            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
+        }
     )
     translation_info = iree_codegen.TranslationInfoAttr.get(
-        pipeline_attr, None, [128, 2, 1], 64, pipeline_option_dict
+        pipeline_attr, None, [128, 2, 1], 64, config_dict
     )
     config = common.Configuration(
         translation_info=translation_info,
         lowering_config=lowering_config,
-        waves_per_eu=2,
     )
 
     tf_mlir = candidate_gen.BatchMmtTuner().apply_params(
@@ -400,19 +415,22 @@ def test_apply_params_batch_mmt_int(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=2,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
-    pipeline_option = iree_gpu.PipelineOptionsAttr.get()
-    pipeline_option_dict = ir.DictAttr.get(
-        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    pipeline_options = iree_gpu.PipelineOptionsAttr.get()
+    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("4")})
+    config_dict = ir.DictAttr.get(
+        {
+            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
+            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
+        }
     )
     translation_info = iree_codegen.TranslationInfoAttr.get(
-        pipeline_attr, None, [128, 2, 1], 64, pipeline_option_dict
+        pipeline_attr, None, [128, 2, 1], 64, config_dict
     )
     config = common.Configuration(
         translation_info=translation_info,
         lowering_config=lowering_config,
-        waves_per_eu=4,
     )
 
     tf_mlir = candidate_gen.BatchMmtTuner().apply_params(
@@ -488,19 +506,22 @@ def test_apply_params_broadcast_rhs_mmt(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=2,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
-    pipeline_option = iree_gpu.PipelineOptionsAttr.get()
-    pipeline_option_dict = ir.DictAttr.get(
-        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    pipeline_options = iree_gpu.PipelineOptionsAttr.get()
+    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("4")})
+    config_dict = ir.DictAttr.get(
+        {
+            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
+            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
+        }
     )
     translation_info = iree_codegen.TranslationInfoAttr.get(
-        pipeline_attr, None, [128, 2, 1], 64, pipeline_option_dict
+        pipeline_attr, None, [128, 2, 1], 64, config_dict
     )
     config = common.Configuration(
         translation_info=translation_info,
         lowering_config=lowering_config,
-        waves_per_eu=4,
     )
 
     tf_mlir = candidate_gen.ContractionTuner(

--- a/tuner/tuner/candidate_gen_test.py
+++ b/tuner/tuner/candidate_gen_test.py
@@ -61,13 +61,7 @@ def test_apply_params_mmt(tuner_ctx: common.TunerContext) -> None:
         iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
     pipeline_options = iree_gpu.PipelineOptionsAttr.get(prefetch_shared_memory=True)
-    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("8")})
-    config_dict = ir.DictAttr.get(
-        {
-            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
-            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
-        }
-    )
+    config_dict = common.get_translation_info_config(pipeline_options, 8)
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [16, 16, 1], 16, config_dict
     )
@@ -136,13 +130,7 @@ def test_apply_params_conv(tuner_ctx: common.TunerContext) -> None:
             iree_gpu.ReorderWorkgroupsStrategy.Transpose
         )
     )
-    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("2")})
-    config_dict = ir.DictAttr.get(
-        {
-            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
-            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
-        }
-    )
+    config_dict = common.get_translation_info_config(pipeline_options, 2)
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [256, 1, 1], 64, config_dict
     )
@@ -216,13 +204,7 @@ def test_apply_params_contract(tuner_ctx: common.TunerContext) -> None:
         iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
     pipeline_options = iree_gpu.PipelineOptionsAttr.get()
-    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("2")})
-    config_dict = ir.DictAttr.get(
-        {
-            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
-            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
-        }
-    )
+    config_dict = common.get_translation_info_config(pipeline_options, 2)
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [256, 1, 1], 64, config_dict
     )
@@ -282,13 +264,7 @@ def test_apply_params_batch_matmul(tuner_ctx: common.TunerContext) -> None:
         iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
     pipeline_options = iree_gpu.PipelineOptionsAttr.get()
-    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("2")})
-    config_dict = ir.DictAttr.get(
-        {
-            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
-            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
-        }
-    )
+    config_dict = common.get_translation_info_config(pipeline_options, 2)
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [128, 2, 1], 64, config_dict
     )
@@ -351,13 +327,7 @@ def test_apply_params_batch_mmt_float(tuner_ctx: common.TunerContext) -> None:
         iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
     pipeline_options = iree_gpu.PipelineOptionsAttr.get()
-    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("2")})
-    config_dict = ir.DictAttr.get(
-        {
-            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
-            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
-        }
-    )
+    config_dict = common.get_translation_info_config(pipeline_options, 2)
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [128, 2, 1], 64, config_dict
     )
@@ -418,13 +388,7 @@ def test_apply_params_batch_mmt_int(tuner_ctx: common.TunerContext) -> None:
         iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
     pipeline_options = iree_gpu.PipelineOptionsAttr.get()
-    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("4")})
-    config_dict = ir.DictAttr.get(
-        {
-            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
-            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
-        }
-    )
+    config_dict = common.get_translation_info_config(pipeline_options, 4)
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [128, 2, 1], 64, config_dict
     )
@@ -509,13 +473,7 @@ def test_apply_params_broadcast_rhs_mmt(tuner_ctx: common.TunerContext) -> None:
         iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
     pipeline_options = iree_gpu.PipelineOptionsAttr.get()
-    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("4")})
-    config_dict = ir.DictAttr.get(
-        {
-            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
-            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
-        }
-    )
+    config_dict = common.get_translation_info_config(pipeline_options, 4)
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [128, 2, 1], 64, config_dict
     )

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -14,6 +14,7 @@ from typing import Any
 from iree.compiler import ir  # type: ignore
 
 from iree.compiler.dialects import iree_gpu  # type: ignore
+from iree.compiler.dialects import iree_codegen  # type: ignore
 
 
 class CommonTypes:
@@ -112,10 +113,8 @@ def get_compatible_mfma_intrinsics(
 
 @dataclass
 class Configuration:
-    subgroup_size: int
-    workgroup_size: list[int]
+    translation_info: iree_codegen.TranslationInfoAttr
     lowering_config: iree_gpu.LoweringConfigAttr
-    gpu_pipeline_options: iree_gpu.PipelineOptionsAttr
     waves_per_eu: int
 
 
@@ -159,7 +158,9 @@ def get_lowering_config(
 
 def get_pipeline_config(configuration: Configuration) -> str:
     extra_config = ""
-    pipeline_options = configuration.gpu_pipeline_options
+    pipeline_options = configuration.translation_info.configuration[
+        "gpu_pipeline_options"
+    ]
     if pipeline_options != iree_gpu.PipelineOptionsAttr.get():
         extra_config += f", gpu_pipeline_options = {pipeline_options}"
 

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -163,6 +163,31 @@ def get_lowering_config(
     return iree_gpu.LoweringConfigAttr.get(lowering_config_attrs)
 
 
+def get_translation_info_config(
+    pipeline_options: iree_gpu.PipelineOptionsAttr, waves_per_eu: int | str
+) -> ir.DictAttr:
+    if isinstance(waves_per_eu, int):
+        waves_per_eu = str(waves_per_eu)
+    elif not isinstance(waves_per_eu, str):
+        assert (
+            False
+        ), f"waves_per_eu must be an int or str, but got {type(waves_per_eu).__name__}"
+
+    # Create the waves_per_eu dictionary attribute.
+    waves_per_eu_dict = ir.DictAttr.get(
+        {WAVES_PER_EU_KEY: ir.StringAttr.get(waves_per_eu)}
+    )
+
+    config_dict = ir.DictAttr.get(
+        {
+            GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
+            LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
+        }
+    )
+
+    return config_dict
+
+
 def read_input_mlir(filename: str) -> list[str]:
     with open(filename, "r") as f:
         return f.readlines()

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -163,30 +163,19 @@ def get_lowering_config(
     return iree_gpu.LoweringConfigAttr.get(lowering_config_attrs)
 
 
-# Generate a config dictionary in translation info
+# Generate a config dictionary used in translation_info attribute.
 def get_translation_info_config(
     pipeline_options: iree_gpu.PipelineOptionsAttr, waves_per_eu: int
 ) -> ir.DictAttr:
     """
     Example IR
     translation_info = #iree_codegen.translation_info<
-                    pipeline = LLVMGPUVectorDistribute
-                    workgroup_size = [512, 1, 1]
-                    subgroup_size = 64,
-                    {gpu_pipeline_options = #iree_gpu.pipeline_options<>
+                    pipeline = LLVMGPUVectorDistribute workgroup_size = [512, 1, 1] subgroup_size = 64,
+                    {gpu_pipeline_options = #iree_gpu.pipeline_options<...>,
                      llvm_func_attrs = {"amdgpu-waves-per-eu" = "3"}
                     }
                 >
-    Example Usage:
-            pipeline_options = iree_gpu.PipelineOptionsAttr.get(...)
-            waves_per_eu = 3
-
-            config_dict = get_translation_info_config(
-                pipeline_options=pipeline_options,
-                waves_per_eu=waves_per_eu
-            )
-
-    this 'config_dict' is subsequently used afterward to generate the 'translation_info' in the above example IR."""
+    """
     waves_per_eu_str = str(waves_per_eu)
 
     # Create the waves_per_eu dictionary attribute.

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -115,11 +115,14 @@ def get_compatible_mfma_intrinsics(
 class Configuration:
     translation_info: iree_codegen.TranslationInfoAttr
     lowering_config: iree_gpu.LoweringConfigAttr
-    waves_per_eu: int
 
 
 # The key name for GPUPipelineOptionsAttr in the translation info config dictionary.
-GPU_PIPELINE_OPTIONS = "gpu_pipeline_options"
+GPU_PIPELINE_OPTIONS_KEY = "gpu_pipeline_options"
+# The key name for llvm_func_attrs attribute in the translation info config dictionary.
+LLVM_FUNC_ATTRS_KEY = "llvm_func_attrs"
+# The Key name for the 'amdgpu-waves-per-eu' within the llvm_func_attrs attribute.
+WAVES_PER_EU_KEY = "amdgpu-waves-per-eu"
 
 
 def get_lowering_config(
@@ -158,19 +161,6 @@ def get_lowering_config(
         lowering_config_dict[key] = promoted_value
     lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
     return iree_gpu.LoweringConfigAttr.get(lowering_config_attrs)
-
-
-def get_pipeline_config(configuration: Configuration) -> str:
-    extra_config = ""
-    pipeline_options = configuration.translation_info.configuration[
-        GPU_PIPELINE_OPTIONS
-    ]
-    if pipeline_options != iree_gpu.PipelineOptionsAttr.get():
-        extra_config += f", gpu_pipeline_options = {pipeline_options}"
-
-    if configuration.waves_per_eu != 2:
-        extra_config += f', llvm_func_attrs = {{"amdgpu-waves-per-eu" = "{configuration.waves_per_eu}"}}'
-    return extra_config
 
 
 def read_input_mlir(filename: str) -> list[str]:

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -163,19 +163,35 @@ def get_lowering_config(
     return iree_gpu.LoweringConfigAttr.get(lowering_config_attrs)
 
 
+# Generate a config dictionary in translation info
 def get_translation_info_config(
-    pipeline_options: iree_gpu.PipelineOptionsAttr, waves_per_eu: int | str
+    pipeline_options: iree_gpu.PipelineOptionsAttr, waves_per_eu: int
 ) -> ir.DictAttr:
-    if isinstance(waves_per_eu, int):
-        waves_per_eu = str(waves_per_eu)
-    elif not isinstance(waves_per_eu, str):
-        assert (
-            False
-        ), f"waves_per_eu must be an int or str, but got {type(waves_per_eu).__name__}"
+    """
+    Example IR
+    translation_info = #iree_codegen.translation_info<
+                    pipeline = LLVMGPUVectorDistribute
+                    workgroup_size = [512, 1, 1]
+                    subgroup_size = 64,
+                    {gpu_pipeline_options = #iree_gpu.pipeline_options<>
+                     llvm_func_attrs = {"amdgpu-waves-per-eu" = "3"}
+                    }
+                >
+    Example Usage:
+            pipeline_options = iree_gpu.PipelineOptionsAttr.get(...)
+            waves_per_eu = 3
+
+            config_dict = get_translation_info_config(
+                pipeline_options=pipeline_options,
+                waves_per_eu=waves_per_eu
+            )
+
+    this 'config_dict' is subsequently used afterward to generate the 'translation_info' in the above example IR."""
+    waves_per_eu_str = str(waves_per_eu)
 
     # Create the waves_per_eu dictionary attribute.
     waves_per_eu_dict = ir.DictAttr.get(
-        {WAVES_PER_EU_KEY: ir.StringAttr.get(waves_per_eu)}
+        {WAVES_PER_EU_KEY: ir.StringAttr.get(waves_per_eu_str)}
     )
 
     config_dict = ir.DictAttr.get(

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -118,6 +118,10 @@ class Configuration:
     waves_per_eu: int
 
 
+# The key name for GPUPipelineOptionsAttr in the translation info config dictionary.
+GPU_PIPELINE_OPTIONS = "gpu_pipeline_options"
+
+
 def get_lowering_config(
     tuner_ctx: TunerContext,
     **kwargs: Any,
@@ -159,7 +163,7 @@ def get_lowering_config(
 def get_pipeline_config(configuration: Configuration) -> str:
     extra_config = ""
     pipeline_options = configuration.translation_info.configuration[
-        "gpu_pipeline_options"
+        GPU_PIPELINE_OPTIONS
     ]
     if pipeline_options != iree_gpu.PipelineOptionsAttr.get():
         extra_config += f", gpu_pipeline_options = {pipeline_options}"

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -86,10 +86,12 @@ def test_get_pipeline_config(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=1,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.None_
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
     )
     pipeline_option = iree_gpu.PipelineOptionsAttr.get()
-    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    pipeline_option_dict = ir.DictAttr.get(
+        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    )
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [16, 16, 1], 32, pipeline_option_dict
     )
@@ -106,7 +108,9 @@ def test_get_pipeline_config(tuner_ctx: common.TunerContext) -> None:
     assert config2_str == ', llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}'
 
     pipeline_option = iree_gpu.PipelineOptionsAttr.get(prefetch_shared_memory=True)
-    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    pipeline_option_dict = ir.DictAttr.get(
+        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    )
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [16, 16, 1], 32, pipeline_option_dict
     )
@@ -222,10 +226,12 @@ def test_get_lowering_config(tuner_ctx: common.TunerContext) -> None:
     )
 
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.None_
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
     )
     pipeline_option = iree_gpu.PipelineOptionsAttr.get()
-    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    pipeline_option_dict = ir.DictAttr.get(
+        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    )
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [16, 16, 1], 32, pipeline_option_dict
     )

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -89,13 +89,7 @@ def test_get_pipeline_config(tuner_ctx: common.TunerContext) -> None:
         iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
     pipeline_options = iree_gpu.PipelineOptionsAttr.get()
-    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("2")})
-    config_dict = ir.DictAttr.get(
-        {
-            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
-            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
-        }
-    )
+    config_dict = common.get_translation_info_config(pipeline_options, 2)
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [16, 16, 1], 32, config_dict
     )
@@ -103,17 +97,13 @@ def test_get_pipeline_config(tuner_ctx: common.TunerContext) -> None:
         translation_info=translation_info,
         lowering_config=lowering_config,
     )
-    config1_str: str = str(config.translation_info.configuration["llvm_func_attrs"])
+    config1_str: str = str(
+        config.translation_info.configuration[common.LLVM_FUNC_ATTRS_KEY]
+    )
     assert config1_str == '{"amdgpu-waves-per-eu" = "2"}'
 
     pipeline_options = iree_gpu.PipelineOptionsAttr.get(prefetch_shared_memory=True)
-    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("4")})
-    config_dict = ir.DictAttr.get(
-        {
-            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
-            "llvm_func_attrs": waves_per_eu_dict,
-        }
-    )
+    config_dict = common.get_translation_info_config(pipeline_options, 4)
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [16, 16, 1], 32, config_dict
     )
@@ -231,13 +221,7 @@ def test_get_lowering_config(tuner_ctx: common.TunerContext) -> None:
         iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
     pipeline_options = iree_gpu.PipelineOptionsAttr.get()
-    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("2")})
-    config_dict = ir.DictAttr.get(
-        {
-            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
-            "llvm_func_attrs": waves_per_eu_dict,
-        }
-    )
+    config_dict = common.get_translation_info_config(pipeline_options, 2)
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [16, 16, 1], 32, config_dict
     )

--- a/tuner/tuner/dispatch_constraints.py
+++ b/tuner/tuner/dispatch_constraints.py
@@ -248,16 +248,9 @@ def generate_solutions(
             iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
         )
         pipeline_options = iree_gpu.PipelineOptionsAttr.get()
-        waves_per_eu_dict = ir.DictAttr.get(
-            {WAVES_PER_EU_KEY: ir.StringAttr.get(str(lookup(waves_per_eu)))}
+        config_dict = get_translation_info_config(
+            pipeline_options, lookup(waves_per_eu)
         )
-        config_dict = ir.DictAttr.get(
-            {
-                GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
-                LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
-            }
-        )
-
         translation_info = iree_codegen.TranslationInfoAttr.get(
             pipeline_attr,
             None,

--- a/tuner/tuner/dispatch_constraints.py
+++ b/tuner/tuner/dispatch_constraints.py
@@ -247,17 +247,25 @@ def generate_solutions(
         pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
             iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
         )
-        pipeline_option = iree_gpu.PipelineOptionsAttr.get()
-        pipeline_option_dict = ir.DictAttr.get({GPU_PIPELINE_OPTIONS: pipeline_option})
+        pipeline_options = iree_gpu.PipelineOptionsAttr.get()
+        waves_per_eu_dict = ir.DictAttr.get(
+            {WAVES_PER_EU_KEY: ir.StringAttr.get(str(lookup(waves_per_eu)))}
+        )
+        config_dict = ir.DictAttr.get(
+            {
+                GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
+                LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
+            }
+        )
 
         translation_info = iree_codegen.TranslationInfoAttr.get(
             pipeline_attr,
             None,
             [lookup(wg_x), lookup(wg_y), lookup(wg_z)],
             lookup(subgroup_size),
-            pipeline_option_dict,
+            config_dict,
         )
-        config = Configuration(translation_info, lowering_config, lookup(waves_per_eu))
+        config = Configuration(translation_info, lowering_config)
         solver.add(z3.simplify(z3.Not(z3.And(list(x == model[x] for x in all_vars)))))
         i += 1
         yield config

--- a/tuner/tuner/dispatch_constraints.py
+++ b/tuner/tuner/dispatch_constraints.py
@@ -248,11 +248,8 @@ def generate_solutions(
             iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
         )
         pipeline_option = iree_gpu.PipelineOptionsAttr.get()
-        # TODO: expose the function getDictKeyName() from GPUPipelineOptionsAttr to
-        # get the key name 'gpu_pipeline_options'in the translation info config dictionary
-        pipeline_option_dict = ir.DictAttr.get(
-            {"gpu_pipeline_options": pipeline_option}
-        )
+        pipeline_option_dict = ir.DictAttr.get({GPU_PIPELINE_OPTIONS: pipeline_option})
+
         translation_info = iree_codegen.TranslationInfoAttr.get(
             pipeline_attr,
             None,

--- a/tuner/tuner/dispatch_parser_test.py
+++ b/tuner/tuner/dispatch_parser_test.py
@@ -52,10 +52,12 @@ def test_get_mmt_tile_sizes(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=4,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.None_
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
     )
     pipeline_option = iree_gpu.PipelineOptionsAttr.get()
-    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    pipeline_option_dict = ir.DictAttr.get(
+        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    )
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [], 0, pipeline_option_dict
     )
@@ -81,10 +83,12 @@ def test_get_conv_tile_sizes(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=4,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.None_
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
     )
     pipeline_option = iree_gpu.PipelineOptionsAttr.get()
-    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    pipeline_option_dict = ir.DictAttr.get(
+        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    )
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [256, 1, 1], 64, pipeline_option_dict
     )
@@ -109,10 +113,12 @@ def test_get_contract_tile_sizes(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=1,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.None_
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
     )
     pipeline_option = iree_gpu.PipelineOptionsAttr.get()
-    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    pipeline_option_dict = ir.DictAttr.get(
+        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    )
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [16, 16, 1], 32, pipeline_option_dict
     )

--- a/tuner/tuner/dispatch_parser_test.py
+++ b/tuner/tuner/dispatch_parser_test.py
@@ -55,13 +55,7 @@ def test_get_mmt_tile_sizes(tuner_ctx: common.TunerContext) -> None:
         iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
     pipeline_options = iree_gpu.PipelineOptionsAttr.get()
-    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("0")})
-    config_dict = ir.DictAttr.get(
-        {
-            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
-            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
-        }
-    )
+    config_dict = common.get_translation_info_config(pipeline_options, 0)
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [], 0, config_dict
     )
@@ -89,13 +83,7 @@ def test_get_conv_tile_sizes(tuner_ctx: common.TunerContext) -> None:
         iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
     pipeline_options = iree_gpu.PipelineOptionsAttr.get()
-    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("1")})
-    config_dict = ir.DictAttr.get(
-        {
-            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
-            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
-        }
-    )
+    config_dict = common.get_translation_info_config(pipeline_options, 1)
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [256, 1, 1], 64, config_dict
     )
@@ -122,13 +110,7 @@ def test_get_contract_tile_sizes(tuner_ctx: common.TunerContext) -> None:
         iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
     pipeline_options = iree_gpu.PipelineOptionsAttr.get()
-    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("2")})
-    config_dict = ir.DictAttr.get(
-        {
-            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
-            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
-        }
-    )
+    config_dict = common.get_translation_info_config(pipeline_options, 2)
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [16, 16, 1], 32, config_dict
     )

--- a/tuner/tuner/dispatch_parser_test.py
+++ b/tuner/tuner/dispatch_parser_test.py
@@ -52,19 +52,22 @@ def test_get_mmt_tile_sizes(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=4,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
-    pipeline_option = iree_gpu.PipelineOptionsAttr.get()
-    pipeline_option_dict = ir.DictAttr.get(
-        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    pipeline_options = iree_gpu.PipelineOptionsAttr.get()
+    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("0")})
+    config_dict = ir.DictAttr.get(
+        {
+            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
+            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
+        }
     )
     translation_info = iree_codegen.TranslationInfoAttr.get(
-        pipeline_attr, None, [], 0, pipeline_option_dict
+        pipeline_attr, None, [], 0, config_dict
     )
     config = common.Configuration(
         translation_info=translation_info,
         lowering_config=lowering_config,
-        waves_per_eu=0,
     )
     lowering_config = config.lowering_config
     assert lowering_config.workgroup_tile_sizes == [128, 320, 0]
@@ -83,19 +86,22 @@ def test_get_conv_tile_sizes(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=4,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
-    pipeline_option = iree_gpu.PipelineOptionsAttr.get()
-    pipeline_option_dict = ir.DictAttr.get(
-        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    pipeline_options = iree_gpu.PipelineOptionsAttr.get()
+    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("1")})
+    config_dict = ir.DictAttr.get(
+        {
+            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
+            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
+        }
     )
     translation_info = iree_codegen.TranslationInfoAttr.get(
-        pipeline_attr, None, [256, 1, 1], 64, pipeline_option_dict
+        pipeline_attr, None, [256, 1, 1], 64, config_dict
     )
     config = common.Configuration(
         translation_info=translation_info,
         lowering_config=lowering_config,
-        waves_per_eu=1,
     )
     assert config.lowering_config.workgroup_tile_sizes == [1, 1, 464, 320, 1, 1, 0]
     assert config.lowering_config.reduction_tile_sizes == [0, 0, 0, 0, 0, 0, 16]
@@ -113,19 +119,22 @@ def test_get_contract_tile_sizes(tuner_ctx: common.TunerContext) -> None:
         subgroup_n_count=1,
     )
     pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorize
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
-    pipeline_option = iree_gpu.PipelineOptionsAttr.get()
-    pipeline_option_dict = ir.DictAttr.get(
-        {common.GPU_PIPELINE_OPTIONS: pipeline_option}
+    pipeline_options = iree_gpu.PipelineOptionsAttr.get()
+    waves_per_eu_dict = ir.DictAttr.get({"amdgpu-waves-per-eu": ir.StringAttr.get("2")})
+    config_dict = ir.DictAttr.get(
+        {
+            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
+            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
+        }
     )
     translation_info = iree_codegen.TranslationInfoAttr.get(
-        pipeline_attr, None, [16, 16, 1], 32, pipeline_option_dict
+        pipeline_attr, None, [16, 16, 1], 32, config_dict
     )
     config = common.Configuration(
         translation_info=translation_info,
         lowering_config=lowering_config,
-        waves_per_eu=2,
     )
     assert dispatch_parser.get_contract_workgroup_sizes(config, "mnk") == [4, 8, 0]
     assert dispatch_parser.get_contract_reduction_sizes(config, "mnk") == [0, 0, 16]

--- a/tuner/tuner/dispatch_parser_test.py
+++ b/tuner/tuner/dispatch_parser_test.py
@@ -15,6 +15,7 @@ from typing import Generator
 from iree.compiler import ir  # type: ignore
 from iree.compiler.dialects import func  # type: ignore
 from iree.compiler.dialects import iree_gpu  # type: ignore
+from iree.compiler.dialects import iree_codegen  # type: ignore
 
 from . import common
 from . import dispatch_parser
@@ -50,11 +51,17 @@ def test_get_mmt_tile_sizes(tuner_ctx: common.TunerContext) -> None:
         subgroup_m_count=1,
         subgroup_n_count=4,
     )
-    config = dispatch_parser.Configuration(
-        subgroup_size=0,
-        workgroup_size=[],
+    pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
+        iree_codegen.DispatchLoweringPassPipeline.None_
+    )
+    pipeline_option = iree_gpu.PipelineOptionsAttr.get()
+    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    translation_info = iree_codegen.TranslationInfoAttr.get(
+        pipeline_attr, None, [], 0, pipeline_option_dict
+    )
+    config = common.Configuration(
+        translation_info=translation_info,
         lowering_config=lowering_config,
-        gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=0,
     )
     lowering_config = config.lowering_config
@@ -73,11 +80,17 @@ def test_get_conv_tile_sizes(tuner_ctx: common.TunerContext) -> None:
         subgroup_m_count=1,
         subgroup_n_count=4,
     )
-    config = dispatch_parser.Configuration(
-        subgroup_size=64,
-        workgroup_size=[256, 1, 1],
+    pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
+        iree_codegen.DispatchLoweringPassPipeline.None_
+    )
+    pipeline_option = iree_gpu.PipelineOptionsAttr.get()
+    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    translation_info = iree_codegen.TranslationInfoAttr.get(
+        pipeline_attr, None, [256, 1, 1], 64, pipeline_option_dict
+    )
+    config = common.Configuration(
+        translation_info=translation_info,
         lowering_config=lowering_config,
-        gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=1,
     )
     assert config.lowering_config.workgroup_tile_sizes == [1, 1, 464, 320, 1, 1, 0]
@@ -95,11 +108,17 @@ def test_get_contract_tile_sizes(tuner_ctx: common.TunerContext) -> None:
         subgroup_m_count=1,
         subgroup_n_count=1,
     )
-    config = dispatch_parser.Configuration(
-        subgroup_size=32,
-        workgroup_size=[16, 16, 1],
+    pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
+        iree_codegen.DispatchLoweringPassPipeline.None_
+    )
+    pipeline_option = iree_gpu.PipelineOptionsAttr.get()
+    pipeline_option_dict = ir.DictAttr.get({"gpu_pipeline_options": pipeline_option})
+    translation_info = iree_codegen.TranslationInfoAttr.get(
+        pipeline_attr, None, [16, 16, 1], 32, pipeline_option_dict
+    )
+    config = common.Configuration(
+        translation_info=translation_info,
         lowering_config=lowering_config,
-        gpu_pipeline_options=iree_gpu.PipelineOptionsAttr.get(),
         waves_per_eu=2,
     )
     assert dispatch_parser.get_contract_workgroup_sizes(config, "mnk") == [4, 8, 0]


### PR DESCRIPTION
This PR is relevant to the task in https://github.com/nod-ai/shark-ai/issues/453 : use IREE bindings for compilation info (incl., lowering_config and translation_info).

Use translation_info from IREE  python binding. 