### PR TITLE
[enums] monkey patch `register_attribute_builder`

### DIFF
--- a/tuner/tuner/__init__.py
+++ b/tuner/tuner/__init__.py
@@ -9,7 +9,7 @@ from iree.compiler import ir
 # substitute replace=True so that colliding registration don't error
 def register_attribute_builder(kind, replace=True):
     def decorator_builder(func):
-        AttrBuilder.insert(kind, func, replace=replace)
+        ir.AttrBuilder.insert(kind, func, replace=replace)
         return func
 
     return decorator_builder

--- a/tuner/tuner/__init__.py
+++ b/tuner/tuner/__init__.py
@@ -7,8 +7,8 @@
 from iree.compiler import ir  # type: ignore
 
 
-# substitute replace=True so that colliding registration don't error
-# TODO(makslevental): remove after https://github.com/llvm/llvm-project/pull/117918 is resolved
+# Substitute `replace=True` so that colliding registration don't error.
+# TODO(makslevental): remove after https://github.com/llvm/llvm-project/pull/117918 is resolved.
 def register_attribute_builder(kind, replace=True):
     def decorator_builder(func):
         ir.AttrBuilder.insert(kind, func, replace=replace)

--- a/tuner/tuner/__init__.py
+++ b/tuner/tuner/__init__.py
@@ -8,6 +8,7 @@ from iree.compiler import ir  # type: ignore
 
 
 # substitute replace=True so that colliding registration don't error
+# TODO(makslevental): remove after https://github.com/llvm/llvm-project/pull/117918 is resolved
 def register_attribute_builder(kind, replace=True):
     def decorator_builder(func):
         ir.AttrBuilder.insert(kind, func, replace=replace)

--- a/tuner/tuner/__init__.py
+++ b/tuner/tuner/__init__.py
@@ -4,7 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from iree.compiler import ir
+from iree.compiler import ir  # type: ignore
+
 
 # substitute replace=True so that colliding registration don't error
 def register_attribute_builder(kind, replace=True):
@@ -13,5 +14,6 @@ def register_attribute_builder(kind, replace=True):
         return func
 
     return decorator_builder
+
 
 ir.register_attribute_builder = register_attribute_builder

--- a/tuner/tuner/__init__.py
+++ b/tuner/tuner/__init__.py
@@ -3,3 +3,15 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from iree.compiler import ir
+
+# substitute replace=True so that colliding registration don't error
+def register_attribute_builder(kind, replace=True):
+    def decorator_builder(func):
+        AttrBuilder.insert(kind, func, replace=replace)
+        return func
+
+    return decorator_builder
+
+ir.register_attribute_builder = register_attribute_builder

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -217,3 +217,10 @@ def test_get_lowering_config(tuner_ctx: common.TunerContext) -> None:
 
     assert config.lowering_config.mma_kind is None
     assert config.lowering_config.subgroup_count_mn == (1, 1)
+
+
+def test_enum_collision():
+    from iree.compiler.dialects import linalg, vector
+
+    linalg_iter_type_e = linalg._iteratortype(0, None)
+    vector_iter_type_e = vector._vector_iteratortype(0, None)

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -217,10 +217,3 @@ def test_get_lowering_config(tuner_ctx: common.TunerContext) -> None:
 
     assert config.lowering_config.mma_kind is None
     assert config.lowering_config.subgroup_count_mn == (1, 1)
-
-
-def test_enum_collision():
-    from iree.compiler.dialects import linalg, vector
-
-    linalg_iter_type_e = linalg._iteratortype(0, None)
-    vector_iter_type_e = vector._vector_iteratortype(0, None)

--- a/tuner/tuner/libtuner_test.py
+++ b/tuner/tuner/libtuner_test.py
@@ -499,3 +499,7 @@ def test_validate_devices_with_invalid_device() -> None:
                     exit_program=True,
                 )
                 assert expected_call in mock_handle_error.call_args_list
+
+
+def test_enum_collision():
+    from iree.compiler.dialects import linalg, vector  # type: ignore

--- a/tuner/tuner/libtuner_test.py
+++ b/tuner/tuner/libtuner_test.py
@@ -502,4 +502,4 @@ def test_validate_devices_with_invalid_device() -> None:
 
 
 def test_enum_collision():
-    from iree.compiler.dialects import linalg, vector  # type: ignore
+    from iree.compiler.dialects import linalg, vector, iree_gpu, iree_codegen, iree_input  # type: ignore


### PR DESCRIPTION
Hack/patch to workaround overlapping `AttrBuilder` registrations. Needed until https://github.com/iree-org/iree/pull/19324 and https://github.com/llvm/llvm-project/pull/117918 get resolved.