### PR TITLE
Harmonize scripts to compute versions

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -67,9 +67,9 @@ jobs:
         id: version_local
         run: |
           echo "version_suffix=${version_suffix}" >> $GITHUB_OUTPUT
-          python3 build_tools/python_deploy/compute_local_version.py --version-suffix=${version_suffix} sharktank
-          python3 build_tools/python_deploy/compute_local_version.py --version-suffix=${version_suffix} shortfin
-          python3 build_tools/python_deploy/compute_common_version.py -rc --version-suffix=${version_suffix} --write-json
+          python3 build_tools/python_deploy/compute_local_version.py --version-suffix=${version_suffix} --write-json sharktank
+          python3 build_tools/python_deploy/compute_local_version.py --version-suffix=${version_suffix} --write-json shortfin
+          python3 build_tools/python_deploy/compute_common_version.py --version-suffix=${version_suffix} --write-json
 
       - name: Upload version_local.json files
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/build_tools/python_deploy/compute_local_version.py
+++ b/build_tools/python_deploy/compute_local_version.py
@@ -6,50 +6,61 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # This scripts grabs the X.Y.Z[.dev]` version identifier from a
-# `version.json` and writes the corresponding
+# `version.json` and writes a version identifier for a stable,
+# nightly or development release, or a release with an arbitrary
 # `X.Y.ZrcYYYYMMDD` version identifier to `version_local.json`.
 
 import argparse
 from pathlib import Path
 import json
 from datetime import datetime
+import subprocess
 
 from packaging.version import Version
 
 
 parser = argparse.ArgumentParser()
 parser.add_argument("path", type=Path)
-parser.add_argument("--version-suffix", action="store", type=str)
+parser.add_argument("--write-json", action="store_true")
+
+release_type = parser.add_mutually_exclusive_group(required=True)
+release_type.add_argument("-stable", "--stable-release", action="store_true")
+release_type.add_argument("-rc", "--nightly-release", action="store_true")
+release_type.add_argument("-dev", "--development-release", action="store_true")
+release_type.add_argument("--version-suffix", action="store", type=str)
+
 args = parser.parse_args()
 
-VERSION_FILE = args.path / "version.json"
-VERSION_FILE_LOCAL = args.path / "version_local.json"
+VERSION_FILE_PATH = args.path / "version.json"
+VERSION_FILE_LOCAL_PATH = args.path / "version_local.json"
 
 
-def load_version_info():
-    with open(VERSION_FILE, "rt") as f:
+def load_version_info(version_file):
+    with open(version_file, "rt") as f:
         return json.load(f)
 
 
-def write_version_info():
-    with open(VERSION_FILE_LOCAL, "w") as f:
-        json.dump(version_local, f, indent=2)
+def write_version_info(version_file, version):
+    with open(version_file, "w") as f:
+        json.dump({"package-version": version}, f, indent=2)
         f.write("\n")
 
 
-version_info = load_version_info()
+version_info = load_version_info(VERSION_FILE_PATH)
+package_version = version_info.get("package-version")
+current_version = Version(package_version).base_version
 
-if args.version_suffix:
-    VERSION_SUFFIX = args.version_suffix
-else:
-    VERSION_SUFFIX = "rc" + datetime.today().strftime("%Y%m%d")
+if args.nightly_release:
+    current_version += "rc" + datetime.today().strftime("%Y%m%d")
+elif args.development_release:
+    current_version += (
+        ".dev0+"
+        + subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ascii").strip()
+    )
+elif args.version_suffix:
+    current_version += args.version_suffix
 
-PACKAGE_VERSION = version_info.get("package-version")
-PACKAGE_BASE_VERSION = Version(PACKAGE_VERSION).base_version
-PACKAGE_LOCAL_VERSION = PACKAGE_BASE_VERSION + VERSION_SUFFIX
+if args.write_json:
+    write_version_info(VERSION_FILE_LOCAL_PATH, current_version)
 
-version_local = {"package-version": PACKAGE_LOCAL_VERSION}
-
-write_version_info()
-
-print(PACKAGE_LOCAL_VERSION)
+print(current_version)


### PR DESCRIPTION
Harmonizes the scripts to compute the versions. JSON files are only written if `--write-json` is passed. Furthermore, `--version-suffix` can no longer be combined with other release types and gives full control over defining a suffix to the user. Similar changes are applied to the scripts used in IREE.