### PR TITLE
Update user docs for running `llm server` + upgrade `gguf` to `0.11.0`

### DIFF
--- a/docs/shortfin/llm/user/e2e_llama8b_mi300x.md
+++ b/docs/shortfin/llm/user/e2e_llama8b_mi300x.md
@@ -22,38 +22,27 @@ python -m venv --prompt shark-ai .venv
 source .venv/bin/activate
 ```
 
-### Install `shortfin`
+## Install stable shark-ai packages
 
-You can install either the `latest stable` version of shortfin by installing
-`shark-ai` or the `nightly` version directly:
-
-#### Stable
+<!-- TODO: Add `sharktank` to `shark-ai` meta package -->
 
 ```bash
-pip install shark-ai[apps]
+pip install shark-ai[apps] sharktank
 ```
 
-#### Nightly
+### Nightly packages
+
+To install nightly packages:
+
+<!-- TODO: Add `sharktank` to `shark-ai` meta package -->
 
 ```bash
-pip install shortfin[apps] --pre -f https://github.com/nod-ai/shark-ai/releases/expanded_assets/dev-wheels
+pip install shark-ai[apps] sharktank \
+    --pre --find-links https://github.com/nod-ai/shark-ai/releases/expanded_assets/dev-wheels
 ```
 
-<!-- TODO: Remove when sharktank added to `shark-ai[apps]` -->
-### Install `sharktank`
-
-Install the `nightly` version of sharktank:
-
-```bash
-pip install sharktank --pre -f https://github.com/nod-ai/shark-ai/releases/expanded_assets/dev-wheels
-```
-
-<!-- TODO: Remove once `sentencepiece` added to nightly `sharktank` -->
-### Install `sentencepiece`
-
-```bash
-pip install sentencepiece
-```
+See also the
+[instructions here](https://github.com/nod-ai/shark-ai/blob/main/docs/nightly_releases.md).
 
 ### Define a directory for export files
 

--- a/sharktank/requirements.txt
+++ b/sharktank/requirements.txt
@@ -1,7 +1,7 @@
 iree-turbine
 
 # Runtime deps.
-gguf==0.11.0
+gguf>=0.11.0
 numpy<2.0
 
 # Model deps.

--- a/sharktank/requirements.txt
+++ b/sharktank/requirements.txt
@@ -5,7 +5,7 @@ gguf==0.10.0
 numpy<2.0
 
 # Needed for newer gguf versions (TODO: remove when gguf package includes this)
-# sentencepiece>=0.1.98,<=0.2.0
+sentencepiece>=0.1.98,<=0.2.0
 
 # Model deps.
 huggingface-hub==0.22.2

--- a/sharktank/requirements.txt
+++ b/sharktank/requirements.txt
@@ -1,11 +1,8 @@
 iree-turbine
 
 # Runtime deps.
-gguf==0.10.0
+gguf==0.11.0
 numpy<2.0
-
-# Needed for newer gguf versions (TODO: remove when gguf package includes this)
-sentencepiece>=0.1.98,<=0.2.0
 
 # Model deps.
 huggingface-hub==0.22.2


### PR DESCRIPTION
# Description

Did a pass through and made updates + fixes to the user docs for `e2e_llama8b_mi300x.md`.

1. Update install instructions for `shark-ai`
2. Update nightly install instructions for `shortfin` and `sharktank`
3. Update paths for model artifacts to ensure they work with `llama3.1-8b-fp16-instruct`
4. Remove steps to `write edited config`. No longer needed after #487 

Added back `sentencepiece` as a requirement for `sharktank`. Not having it caused `export_paged_llm_v1` to break when installing nightly:

```text
ModuleNotFoundError: No module named 'sentencepiece'
```

This was obfuscated when building from source, because `shortfin` includes `sentencepiece` in `requirements-tests.txt`.
