### PR TITLE
Expanded sharded support for alternative sharding mechanisms

### DIFF
--- a/sharktank/sharktank/layers/kv_cache.py
+++ b/sharktank/sharktank/layers/kv_cache.py
@@ -292,7 +292,9 @@ class PagedKVCache(BaseKVCache):
             shards = [
                 shard.unflatten(1, self.sub_page_dims) for shard in page_slab.shards
             ]
-            return SplitPrimitiveTensor(ts=shards, shard_dim=4)
+            return SplitPrimitiveTensor(
+                ts=shards, shard_dim=4, devices=page_slab.devices
+            )
 
     def shard_state(
         self, state: List[torch.Tensor]

--- a/sharktank/sharktank/models/llama/llama.py
+++ b/sharktank/sharktank/models/llama/llama.py
@@ -9,6 +9,8 @@ from typing import Optional
 from dataclasses import dataclass
 from typing import Union
 
+from iree.turbine.aot import DeviceAffinity
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -62,7 +64,7 @@ class PagedLlamaModelV1(BaseCausalLMModel):
     unsharded result or chain it with other tensor-parallel operations.
     """
 
-    def __init__(self, theta: Theta, config: LlamaModelConfig, devices: list):
+    def __init__(self, theta: Theta, config: LlamaModelConfig, devices: list = None):
         hp = config.hp
         super().__init__(
             theta,
@@ -79,6 +81,9 @@ class PagedLlamaModelV1(BaseCausalLMModel):
         self.activation_dtype = config.activation_dtype
         self.use_hf = config.use_hf
         self.attention_kernel = config.attention_kernel
+
+        if devices is None:
+            devices = [DeviceAffinity(i) for i in range(config.tensor_parallelism_size)]
 
         self.add_module(
             "token_embedding",

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -796,7 +796,7 @@ def _repeat_trampoline(
 
 
 @overridable
-def replicate(input: AnyTensor, count: int) -> ShardedTensor:
+def replicate(input: AnyTensor, devices: list) -> ShardedTensor:
     """Replicate across devices.
 
     Possibly reshards if required."""
@@ -805,11 +805,11 @@ def replicate(input: AnyTensor, count: int) -> ShardedTensor:
 
 @replicate.trampoline
 def _replicate_trampoline(
-    d: SignatureDispatcher, input: AnyTensor, count: int
+    d: SignatureDispatcher, input: AnyTensor, devices: list
 ) -> ShardedTensor:
     tensors = (input,)
     for override in d.find_overrides(tensors):
-        result = override(input, count=count)
+        result = override(input, devices=devices)
         if result is not NotImplemented:
             return override, result
     else:

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -796,7 +796,9 @@ def _repeat_trampoline(
 
 
 @overridable
-def replicate(input: AnyTensor, devices: list) -> ShardedTensor:
+def replicate(
+    input: AnyTensor, devices: list = None, count: int = None
+) -> ShardedTensor:
     """Replicate across devices.
 
     Possibly reshards if required."""
@@ -805,11 +807,11 @@ def replicate(input: AnyTensor, devices: list) -> ShardedTensor:
 
 @replicate.trampoline
 def _replicate_trampoline(
-    d: SignatureDispatcher, input: AnyTensor, devices: list
+    d: SignatureDispatcher, input: AnyTensor, devices: list = None, count: int = None
 ) -> ShardedTensor:
     tensors = (input,)
     for override in d.find_overrides(tensors):
-        result = override(input, devices=devices)
+        result = override(input, devices=devices, count=count)
         if result is not NotImplemented:
             return override, result
     else:

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -28,8 +28,10 @@ import torch
 from torch import Tensor
 from torch.utils._pytree import register_pytree_node, SequenceKey
 import torch.utils._pytree
+
 from ..utils.math import ceildiv
 from iree.turbine.aot import (
+    DeviceAffinity,
     DeviceTensorTrait,
     ExternalTensorTrait,
 )
@@ -791,6 +793,7 @@ class ShardedTensorBase(ShardedTensor):
         ts: list[torch.Tensor],
         name: str = UnnamedTensorName,
         shape: Optional[list[int]],
+        devices: Optional[list],
     ):
         assert len(ts) > 0
         assert shard_dim is None or (shard_dim >= 0 and len(ts[0].shape) > shard_dim)
@@ -805,6 +808,22 @@ class ShardedTensorBase(ShardedTensor):
             for i, t in enumerate(ts)
         )
 
+        if devices is None:
+            devices = [DeviceAffinity(i) for i in range(len(self._shards))]
+
+        self._devices: tuple[DeviceAffinity] = tuple(devices)
+
+        for i, t in enumerate(ts):
+            DeviceTensorTrait(i).set(t)
+
+    def assign_affinities(self, affinities):
+        assert len(affinities) == len(self._devices)
+        self._devices = tuple(affinities)
+        for s, d in zip(self._shards, self._devices):
+            if isinstance(s, DefaultPrimitiveTensor):
+                s = s.as_torch()
+            DeviceTensorTrait(d.ordinal, d.queues).set(s)
+
     @property
     def shard_count(self) -> int:
         return len(self._shards)
@@ -812,6 +831,10 @@ class ShardedTensorBase(ShardedTensor):
     @property
     def shards(self) -> tuple[InferenceTensor]:
         return self._shards
+
+    @property
+    def devices(self) -> tuple[DeviceAffinity]:
+        return self._devices
 
     @property
     def is_replicated(self) -> bool:
@@ -871,8 +894,6 @@ class ShardedTensorBase(ShardedTensor):
             try:
                 t = raw_tensors[t_name]
                 ts.append(t)
-                # TODO: this should be changed to tracked device affinity
-                DeviceTensorTrait(i).set(t)
             except KeyError as e:
                 raise IOError(
                     f"Missing component tensor '{t_name}' in {raw_tensors.keys()}"
@@ -965,6 +986,7 @@ class SplitPrimitiveTensor(ShardedTensorBase):
         shard_count: None | int = None,
         name: str = UnnamedTensorName,
         shape: Optional[list[int]] = None,
+        devices: list | None = None,
     ):
         """
         If `ts` is a list of tensors, it is interpreted as the shards.
@@ -973,16 +995,25 @@ class SplitPrimitiveTensor(ShardedTensorBase):
         will be split along dimension `shard_dim` into `shard_count`
         number of pieces.
         """
-        if isinstance(ts, torch.Tensor):
-            from ..ops import transfer_to_logical_device
 
+        assert shard_count is None or not isinstance(ts, torch.Tensor)
+        shard_count = shard_count if shard_count is not None else len(ts)
+
+        if devices is None:
+            devices = [DeviceAffinity(i) for i in range(shard_count)]
+
+        assert len(devices) == shard_count
+
+        if isinstance(ts, torch.Tensor):
             assert shard_count is not None
             ts = ts.split(ceildiv(ts.shape[shard_dim], shard_count), dim=shard_dim)
-            ts = [transfer_to_logical_device(t, i) for i, t in enumerate(ts)]
+
+            from ..ops import transfer_to_logical_device
+
+            ts = [transfer_to_logical_device(t, d.ordinal) for t, d in zip(ts, devices)]
             assert len(ts) == shard_count
             shard_count = None
 
-        assert shard_count is None
         assert len(ts) > 0
         first_shape = ts[0].shape
         assert len(first_shape) > shard_dim
@@ -1004,7 +1035,9 @@ class SplitPrimitiveTensor(ShardedTensorBase):
                 s == t for i, (s, t) in enumerate(zip(shape, t_shape)) if i != shard_dim
             ), f"Shape mismatch for non-split dimension for tensor shard {i} with shape {t.shape}"
 
-        super().__init__(name=name, ts=ts, shape=shape, shard_dim=shard_dim)
+        super().__init__(
+            name=name, ts=ts, shape=shape, shard_dim=shard_dim, devices=devices
+        )
 
     def _is_slicing_split_dim(self, key):
         if isinstance(
@@ -1072,7 +1105,9 @@ class SplitPrimitiveTensor(ShardedTensorBase):
                 # Rank reduction dimension before the split dim.
                 shard_dim -= 1
 
-        return SplitPrimitiveTensor(ts=shards, shard_dim=shard_dim)
+        return SplitPrimitiveTensor(
+            ts=shards, shard_dim=shard_dim, devices=self.devices
+        )
 
     def __setitem__(self, key, value):
         assert isinstance(value, SplitPrimitiveTensor)
@@ -1098,7 +1133,8 @@ class ReplicatedTensor(ShardedTensor):
     def __init__(
         self,
         *,
-        ts: list[torch.Tensor] | torch.Tensor,
+        ts: list[torch.Tensor],
+        devices: None | list[DeviceAffinity] = None,
         shard_count: None | int = None,
         name: str = UnnamedTensorName,
     ):
@@ -1108,13 +1144,7 @@ class ReplicatedTensor(ShardedTensor):
         If `ts` is a tensor then `shard_count` must be provided and it,
         will be replicated that many times.
         """
-        if isinstance(ts, torch.Tensor):
-            assert shard_count is not None
-            from ..ops import transfer_to_logical_device
-
-            ts = [transfer_to_logical_device(ts, i) for i in range(shard_count)]
-            shard_count = None
-
+        assert not isinstance(ts, torch.Tensor)
         assert shard_count is None
         assert len(ts) > 0
         first_shape = ts[0].shape
@@ -1134,6 +1164,22 @@ class ReplicatedTensor(ShardedTensor):
             for i, t in enumerate(ts)
         )
 
+        if devices is None:
+            devices = tuple([DeviceAffinity(i) for i in range(len(ts))])
+
+        self._devices: tuple[DeviceAffinity] = tuple(devices)
+
+        for d, t in zip(devices, ts):
+            DeviceTensorTrait(d.ordinal, d.queues).set(t)
+
+    def assign_affinities(self, affinities):
+        assert len(affinities) == len(self._devices)
+        self._devices = tuple(affinities)
+        for s, d in zip(self._shards, self._devices):
+            if isinstance(s, DefaultPrimitiveTensor):
+                s = s.as_torch()
+            DeviceTensorTrait(d.ordinal, d.queues).set(s)
+
     @property
     def shard_count(self) -> int:
         return len(self._shards)
@@ -1141,6 +1187,10 @@ class ReplicatedTensor(ShardedTensor):
     @property
     def shards(self) -> tuple[InferenceTensor]:
         return self._shards
+
+    @property
+    def devices(self) -> tuple[DeviceAffinity]:
+        return self._devices
 
     @property
     def is_replicated(self) -> bool:
@@ -1188,10 +1238,6 @@ class ReplicatedTensor(ShardedTensor):
                 nt = deepcopy(t)
                 ts.append(nt)
 
-            # TODO This should be changed to assigned affinities
-            for i in range(shard_count):
-                DeviceTensorTrait(i).set(ts[i])
-
         except KeyError as e:
             raise IOError(f"Missing component tensor '' in {raw_tensors.keys()}") from e
         return cls(name=name, ts=ts)
@@ -1210,12 +1256,13 @@ class ReplicatedTensor(ShardedTensor):
                 else:
                     shard_keys.append(k)
             shards.append(shard[*shard_keys])
-        return ReplicatedTensor(ts=shards)
+        return ReplicatedTensor(ts=shards, devices=self.devices)
 
     def __repr__(self):
         return (
             f"ReplicatedTensor({self.name}, {self.shape}, "
             f"shard_count={len(self._shards)} "
+            f"devices={self.devices} "
             f"of {self.shards[0].shape})"
         )
 
@@ -1243,13 +1290,14 @@ class UnreducedTensor(ShardedTensorBase):
         self,
         *,
         ts: list[torch.Tensor],
+        devices: Optional[list] = None,
         name: str = UnnamedTensorName,
         shape: Optional[list[int]] = None,
     ):
         assert len(ts) > 0
         shape = list(ts[0].shape if shape is None else shape)
         assert all(shape == list(t.shape) for t in ts)
-        super().__init__(name=name, ts=ts, shape=shape, shard_dim=None)
+        super().__init__(name=name, ts=ts, shape=shape, shard_dim=None, devices=devices)
 
 
 def flatten_tensor_tree(

--- a/sharktank/sharktank/types/theta.py
+++ b/sharktank/sharktank/types/theta.py
@@ -25,8 +25,6 @@ from ..utils.io import ShardedArchiveBuilder
 
 from .tensors import (
     InferenceTensor,
-    PrimitiveTensor,
-    QuantizedTensor,
     InferenceTensorMetadata,
     DefaultPrimitiveTensor,
     REGISTERED_INFERENCE_TENSOR_CLASSES,

--- a/sharktank/sharktank/utils/cli.py
+++ b/sharktank/sharktank/utils/cli.py
@@ -70,8 +70,13 @@ def add_model_options(parser: argparse.ArgumentParser):
         choices=["decomposed", "torch"],
     )
     parser.add_argument(
+        "--skip-prefill",
+        help="Skips exporting prefill",
+        action="store_true",
+    )
+    parser.add_argument(
         "--skip-decode",
-        help="Enables prefill only, skips decode",
+        help="Skips exporting decode",
         action="store_true",
     )
 

--- a/sharktank/tests/layers/sharded_rotary_embedding_test.py
+++ b/sharktank/tests/layers/sharded_rotary_embedding_test.py
@@ -7,6 +7,8 @@
 
 import torch
 
+from iree.turbine.aot import DeviceAffinity
+
 from sharktank.layers import RotaryEmbeddingLayer
 from sharktank import ops
 from sharktank.types import (
@@ -27,6 +29,8 @@ def test_sharded_rotary_table():
     max_seqlen = 128
     rope_freq_base = None
 
+    devices = [DeviceAffinity(i) for i in range(4)]
+
     # First we setup and get the default rotary embedding layer
     xq = torch.rand((bs, max_seqlen, heads, rope_dims), dtype=torch.float)
     xk = torch.rand((bs, max_seqlen, heads, rope_dims), dtype=torch.float)
@@ -45,7 +49,7 @@ def test_sharded_rotary_table():
         rope_dimension_count=rope_dims,
         max_seqlen=max_seqlen,
         rope_freq_base=rope_freq_base,
-        tensor_parallelism_size=4,
+        devices=devices,
     )
     sq = shard_layer(xt=xq, start_index=0)
     sk = shard_layer(xt=xk, start_index=0)

--- a/sharktank/tests/models/llama/sharded_llama_test.py
+++ b/sharktank/tests/models/llama/sharded_llama_test.py
@@ -6,7 +6,7 @@
 
 import unittest
 import pytest
-from typing import Any, List, Tuple, OrderedDict
+from typing import Any, Tuple, OrderedDict
 from sharktank.models.llama.llama import LlamaModelConfig, PagedLlamaModelV1
 import sharktank.ops as ops
 from sharktank.types import unbox_tensor, Dataset, UnreducedTensor, SplitPrimitiveTensor

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -630,7 +630,7 @@ class AttentionTest(unittest.TestCase):
         q_s = SplitPrimitiveTensor(shard_dim=0, ts=q.split(1, dim=0))
         k_s = SplitPrimitiveTensor(shard_dim=0, ts=k.split(1, dim=0))
         v_s = SplitPrimitiveTensor(shard_dim=0, ts=v.split(1, dim=0))
-        a_s = ReplicatedTensor(ts=a, shard_count=4)
+        a_s = ReplicatedTensor(ts=[a] * 4)
 
         expected_result = ops.scaled_dot_product_attention(
             q, k, v, a=a, is_causal=False
@@ -754,7 +754,7 @@ class MatmulTest(unittest.TestCase):
         expected_result = torch.matmul(a, b)
         shard_count = 3
         a_sharded = SplitPrimitiveTensor(ts=a, shard_dim=1, shard_count=shard_count)
-        b_sharded = ReplicatedTensor(ts=b, shard_count=shard_count)
+        b_sharded = ReplicatedTensor(ts=[b] * shard_count)
         res_sharded = ops.matmul(a_sharded, b_sharded)
         assert isinstance(res_sharded, SplitPrimitiveTensor)
         assert res_sharded.shard_dim == 1
@@ -837,7 +837,7 @@ class ReplicateTest(unittest.TestCase):
         tensor = torch.rand(4, 5, dtype=torch.float32)
         shard_count = 3
         actual_result = ops.replicate(tensor, count=shard_count)
-        expected_result = ReplicatedTensor(ts=tensor, shard_count=shard_count)
+        expected_result = ReplicatedTensor(ts=[tensor] * shard_count)
         assert expected_result.is_deep_equal(actual_result)
 
         # Test that is a copy.

--- a/sharktank/tests/types/tensors_test.py
+++ b/sharktank/tests/types/tensors_test.py
@@ -106,7 +106,7 @@ class ShardedTensorTest(unittest.TestCase):
 
     def testReplicatedTensorExtractSlice(self):
         tensor = torch.rand([2, 3, 4], dtype=torch.float32)
-        replicated_tensor = ReplicatedTensor(ts=tensor, shard_count=3)
+        replicated_tensor = ReplicatedTensor(ts=[tensor] * 3)
         s = [slice(1, 2), slice(0, 3, 2), None]
         expected_result = tensor[s]
         replicated_sliced_tensor = replicated_tensor[s]
@@ -116,7 +116,7 @@ class ShardedTensorTest(unittest.TestCase):
 
     def testReplicatedTensorExtractElement(self):
         tensor = torch.rand([2, 3, 4], dtype=torch.float32)
-        replicated_tensor = ReplicatedTensor(ts=tensor, shard_count=3)
+        replicated_tensor = ReplicatedTensor(ts=[tensor] * 3)
         idx = (
             1,
             2,


### PR DESCRIPTION
Single-logical-multi-physical sharding allows tensor access between
different devices and tighter synchronization on execution. This means
that sharding needs to support more than differing device ordinals but
also configre multiple queues for the same device. Sharded tensor types
are reworked to support tracking both the supported device AND the queue
it is enqueued on.

To support this each sharded tensor now tracks the DeviceAffinity it is
associated with, along with reassigning affinities post construction.
This allows pre-sharded models to have their affinities updated with an
alternative transfer mechanism.

If device affinity is not specified the default arrangement assumes
separate device ordinals for each shard.