### PR TITLE
[sharktank] Use reshape instead of view

### DIFF
--- a/sharktank/sharktank/layers/mmdit.py
+++ b/sharktank/sharktank/layers/mmdit.py
@@ -41,7 +41,7 @@ def attention(q, k, v, pe):
         q=q, k=k, v=v, a=None, is_causal=True, scale=None
     )
     x = ops.permute(x, (0, 2, 1, 3))
-    x = x.view(x.shape[0], x.shape[1], -1)
+    x = x.reshape(x.shape[0], x.shape[1], -1)
 
     return x
 


### PR DESCRIPTION
Fixes `RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.` by using `reshape` which occurs when running `tests/layers/mmdit_test.py` with Python 3.11.10 and `torch==2.5.1+cpu`.