### PR TITLE
[sharktank] Depend on `sentencepiece`

### DIFF
--- a/sharktank/requirements.txt
+++ b/sharktank/requirements.txt
@@ -5,7 +5,7 @@ gguf==0.10.0
 numpy<2.0
 
 # Needed for newer gguf versions (TODO: remove when gguf package includes this)
-# sentencepiece>=0.1.98,<=0.2.0
+sentencepiece>=0.1.98,<=0.2.0
 
 # Model deps.
 huggingface-hub==0.22.2


### PR DESCRIPTION
While `gguf`'s `pyproject.toml` lists `sentencepiece` as a dependency (https://github.com/ggerganov/llama.cpp/blob/a07c32ea54850c989f0ef6989da5b955b77b7172/pyproject.toml#L20), the package does not get pulled in when installing gguf via `uv pip` or `pip`. However, without the package the sanity test `python -c "from sharktank import ops; print('Sanity check passed')"`, documented in https://github.com/nod-ai/shark-ai/blob/main/docs/nightly_releases.md#quickstart---sharktank, fails.