### PR TITLE
[sharktank] Unpin NumPy

### DIFF
--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -60,6 +60,10 @@ jobs:
           path: ${{ env.PIP_CACHE_DIR }}
           key: pip-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('*requirements*.txt','sharktank/requirements*.txt') }}
 
+      - name: Install numpy
+        if: ${{ matrix.os == 'windows-2022' && matrix.torch-version == '2.3.0' }}
+        run: pip install "numpy<2.0"
+
       - name: Install pip deps
         run: |
           python -m pip install --no-compile --upgrade pip

--- a/sharktank/requirements.txt
+++ b/sharktank/requirements.txt
@@ -2,7 +2,7 @@ iree-turbine
 
 # Runtime deps.
 gguf>=0.11.0
-numpy<2.0
+numpy
 
 # Model deps.
 huggingface-hub==0.22.2


### PR DESCRIPTION
`numpy<2.0` is required for Windows with `torch<2.4`. Expanding testing on Windows with Python 3.12 and torch 2.4.1.