### PR TITLE
[tuner] Add unified compilation step for models and dispatches

### DIFF
--- a/tuner/examples/dispatch/dispatch_tuner.py
+++ b/tuner/examples/dispatch/dispatch_tuner.py
@@ -79,6 +79,9 @@ class DispatchTuner(libtuner.TuningClient):
     ) -> list[str]:
         return []
 
+    def get_iree_compile_flags(self) -> list[str]:
+        return []
+
 
 def main():
     args = libtuner.parse_arguments()

--- a/tuner/examples/punet/punet_autotune.py
+++ b/tuner/examples/punet/punet_autotune.py
@@ -113,6 +113,9 @@ class PunetClient(libtuner.TuningClient):
         ]
         return command
 
+    def get_iree_compile_flags(self) -> list[str]:
+        return []
+
 
 def main():
     args = libtuner.parse_arguments()

--- a/tuner/examples/test/tuner_test.py
+++ b/tuner/examples/test/tuner_test.py
@@ -7,6 +7,52 @@
 from tuner import libtuner
 
 
+class TestTuner(libtuner.TuningClient):
+    def __init__(self):
+        self.compile_flags = [
+            "--iree-hip-target=gfx942",
+            "--compile-from=executable-sources",
+        ]
+
+    def get_iree_compile_flags(self) -> list[str]:
+        return self.compile_flags
+
+    # TODO(Max191): Remove the following unused abstract functions once they
+    # are removed from the TuningClient definition.
+    def get_dispatch_benchmark_timeout_s(self) -> int:
+        return 0
+
+    def get_dispatch_compile_timeout_s(self) -> int:
+        return 0
+
+    def get_dispatch_compile_command(
+        self, candidate_tracker: libtuner.CandidateTracker
+    ) -> list[str]:
+        return []
+
+    def get_dispatch_benchmark_command(
+        self,
+        candidate_tracker: libtuner.CandidateTracker,
+    ) -> list[str]:
+        return []
+
+    def get_model_compile_timeout_s(self) -> int:
+        return 0
+
+    def get_model_compile_command(
+        self, candidate_tracker: libtuner.CandidateTracker
+    ) -> list[str]:
+        return []
+
+    def get_model_benchmark_timeout_s(self) -> int:
+        return 0
+
+    def get_model_benchmark_command(
+        self, candidate_tracker: libtuner.CandidateTracker
+    ) -> list[str]:
+        return []
+
+
 def main():
     args = libtuner.parse_arguments()
 
@@ -32,6 +78,12 @@ def main():
     print(f"Stored candidate specs in {path_config.specs_dir}\n")
     if stop_after_phase == libtuner.ExecutionPhases.generate_candidates:
         return
+
+    test_tuner = TestTuner()
+    print("Compiling candidates...")
+    candidates = libtuner.compile(
+        args, path_config, candidates, candidate_trackers, test_tuner
+    )
 
     print("Check the detailed execution logs in:")
     print(path_config.run_log.resolve())


### PR DESCRIPTION
This PR adds a new `compile()` function for compiling both models and dispatches during tuning. This will eventually replace the old path, which has a separate function for model compilation and dispatch compilation. The new compilation flow is now simpler:

1. Populate each CandidateTracker with the input and output filepaths. The input filepaths can be overridden by an optional function argument to the compile() function. This argument can be used for model tuning, passing the model filepath as the new input file.
2. For each candidate, strip the compilation info using iree-opt, and compile to a vmfb with the iree compiler python bindings. Set the candidate's TD spec file (generated during candidate generation), and add any additional iree-compile flags that came from the TuningClient. The extra flags are taken from a new abstract TuningClient function called `get_iree_compile_flags`.
3. For all successful compilations, save the vmfbs to the designated output path, and skip any failed compilation. For any failed compilation, a failure dump is saved instead of the vmfb.
4. Remove duplicate vmfbs, and return the ids of all unique candidates.