### PR TITLE
[tuner] Add unified benchmarking and compilation for models + dispatches

### DIFF
--- a/tuner/examples/dispatch/dispatch_tuner.py
+++ b/tuner/examples/dispatch/dispatch_tuner.py
@@ -79,6 +79,9 @@ class DispatchTuner(libtuner.TuningClient):
     ) -> list[str]:
         return []
 
+    def get_iree_compile_flags(self) -> list[str]:
+        return []
+
 
 def main():
     args = libtuner.parse_arguments()

--- a/tuner/examples/dispatch/dispatch_tuner.py
+++ b/tuner/examples/dispatch/dispatch_tuner.py
@@ -82,6 +82,12 @@ class DispatchTuner(libtuner.TuningClient):
     def get_iree_compile_flags(self) -> list[str]:
         return []
 
+    def get_iree_benchmark_module_flags(self) -> list[str]:
+        return []
+
+    def get_benchmark_timeout_s(self) -> int:
+        return 0
+
 
 def main():
     args = libtuner.parse_arguments()

--- a/tuner/examples/punet/punet_autotune.py
+++ b/tuner/examples/punet/punet_autotune.py
@@ -116,6 +116,12 @@ class PunetClient(libtuner.TuningClient):
     def get_iree_compile_flags(self) -> list[str]:
         return []
 
+    def get_iree_benchmark_module_flags(self) -> list[str]:
+        return []
+
+    def get_benchmark_timeout_s(self) -> int:
+        return 0
+
 
 def main():
     args = libtuner.parse_arguments()

--- a/tuner/examples/punet/punet_autotune.py
+++ b/tuner/examples/punet/punet_autotune.py
@@ -113,6 +113,9 @@ class PunetClient(libtuner.TuningClient):
         ]
         return command
 
+    def get_iree_compile_flags(self) -> list[str]:
+        return []
+
 
 def main():
     args = libtuner.parse_arguments()

--- a/tuner/examples/test/README.md
+++ b/tuner/examples/test/README.md
@@ -35,5 +35,5 @@ python -m examples.test double_mmt.mlir mmt_benchmark.mlir \
 python -m examples.test <model_file_path> <benchmark_file_path> \
     --test_num_dispatch_candidates=<num_dispatch_candidates> \
     --test_num_model_candidates=<num_model_candidates> \
-    --num-candidates=<num_generated_candidates>
+    --test_hip_target=<hip_target> \ --num-candidates=<num_generated_candidates>
 ```

--- a/tuner/examples/test/README.md
+++ b/tuner/examples/test/README.md
@@ -1,0 +1,32 @@
+# Example Tuner Test
+
+Example of tuning a dispatch and full model.
+
+## Environments
+Follow instructions in [`/tuner/README.md`](../README.md)
+
+## Running the Tuner
+
+### Choose a model to tune
+This example uses the simple `double_mmt.mlir` file.
+
+### Generate a benchmark file
+Use the usual `iree-compile` command for your model and add
+`--iree-hal-dump-executable-files-to=dump --iree-config-add-tuner-attributes`. For example:
+```shell
+iree-compile double_mmt.mlir --iree-hal-target-backends=rocm --iree-hip-target=gfx942 --iree-hal-dump-executable-files-to=dump --iree-config-add-tuner-attributes -o /dev/null
+```
+
+Next, copy the `*_benchmark.mlir` file from the `dump` directory to some temporary directory of choice.
+This will be the input to the dispatch tuner along with the original `double_mmt.mlir` model file.
+
+### Recommended Trial Run
+For an initial trial to test the tuning loop, use:
+```shell
+python -m examples.test double_mmt.mlir 5 3 mmt_benchmark.mlir --num-candidates=30
+```
+
+### Basic Usage
+```shell
+python -m examples.test <model_file_path> <num_dispatch_candidates> <num_model_candidates> <benchmark_file_path>
+```

--- a/tuner/examples/test/README.md
+++ b/tuner/examples/test/README.md
@@ -11,22 +11,29 @@ Follow instructions in [`/tuner/README.md`](../README.md)
 This example uses the simple `double_mmt.mlir` file.
 
 ### Generate a benchmark file
-Use the usual `iree-compile` command for your model and add
-`--iree-hal-dump-executable-files-to=dump --iree-config-add-tuner-attributes`. For example:
+Use the usual `iree-compile` command for your model, add
+`--iree-hal-dump-executable-files-to=dump --iree-config-add-tuner-attributes`,
+and get the dispatch benchmark that you want to tune. For example:
 ```shell
-iree-compile double_mmt.mlir --iree-hal-target-backends=rocm --iree-hip-target=gfx942 --iree-hal-dump-executable-files-to=dump --iree-config-add-tuner-attributes -o /dev/null
-```
+iree-compile double_mmt.mlir --iree-hal-target-backends=rocm \
+    --iree-hip-target=gfx942 --iree-hal-dump-executable-files-to=dump \
+    --iree-config-add-tuner-attributes -o /dev/null
 
-Next, copy the `*_benchmark.mlir` file from the `dump` directory to some temporary directory of choice.
-This will be the input to the dispatch tuner along with the original `double_mmt.mlir` model file.
+cp dump/module_main_dispatch_0_rocm_hsaco_fb_benchmark.mlir mmt_benchmark.mlir
+```
 
 ### Recommended Trial Run
 For an initial trial to test the tuning loop, use:
 ```shell
-python -m examples.test double_mmt.mlir 5 3 mmt_benchmark.mlir --num-candidates=30
+python -m examples.test double_mmt.mlir mmt_benchmark.mlir \
+    --test_num_dispatch_candidates=5 --test_num_model_candidates=3 \
+    --num-candidates=30
 ```
 
 ### Basic Usage
 ```shell
-python -m examples.test <model_file_path> <num_dispatch_candidates> <num_model_candidates> <benchmark_file_path>
+python -m examples.test <model_file_path> <benchmark_file_path> \
+    --test_num_dispatch_candidates=<num_dispatch_candidates> \
+    --test_num_model_candidates=<num_model_candidates> \
+    --num-candidates=<num_generated_candidates>
 ```

--- a/tuner/examples/test/double_mmt.mlir
+++ b/tuner/examples/test/double_mmt.mlir
@@ -1,0 +1,16 @@
+!matA_0 = tensor<2048x2048xf16>
+!matB_0 = tensor<2048x2048xf16>
+!matC_0 = tensor<2048x2048xf32>
+
+!matC_1 = tensor<2048x2048xf32>
+
+func.func @main(%arg0: !matA_0, %arg1: !matB_0) -> !matC_1 {
+  %cst = arith.constant 0.000000e+00 : f32
+  %5 = tensor.empty() : !matC_0
+  %6 = linalg.fill ins(%cst : f32) outs(%5 : !matC_0) -> !matC_0
+  %7 = linalg.matmul_transpose_b ins(%arg0, %arg1 : !matA_0, !matB_0) outs(%6 : !matC_0) -> !matC_0
+  %8 = tensor.empty() : !matC_1
+  %9 = linalg.fill ins(%cst : f32) outs(%8 : !matC_1) -> !matC_1
+  %10 = linalg.matmul_transpose_b ins(%7, %7 : !matC_0, !matC_0) outs(%9 : !matC_1) -> !matC_1
+  return %10 : !matC_1
+}

--- a/tuner/examples/test/tuner_test.py
+++ b/tuner/examples/test/tuner_test.py
@@ -64,17 +64,19 @@ def main():
     parser = argparse.ArgumentParser(description="Autotune test script")
     test_args = parser.add_argument_group("Example Test Options")
     test_args.add_argument(
-        "test_model_file", type=Path, help="Path to the model file to benchmark (.mlir)"
+        "test_model_file", type=Path, help="Path to the model file to tune (.mlir)"
     )
     test_args.add_argument(
-        "test_num_dispatch_candidates",
+        "--test_num_dispatch_candidates",
         type=int,
+        default=None,
         help="Number of dispatch candidates to keep for model benchmarks.",
     )
     test_args.add_argument(
-        "test_num_model_candidates",
+        "--test_num_model_candidates",
         type=int,
-        help="Number of model candidates to keep for model benchmarks.",
+        default=None,
+        help="Number of model candidates to produce after tuning.",
     )
     # Remaining arguments come from libtuner
     args = libtuner.parse_arguments(parser)

--- a/tuner/examples/test/tuner_test.py
+++ b/tuner/examples/test/tuner_test.py
@@ -7,6 +7,52 @@
 from tuner import libtuner
 
 
+class TestTuner(libtuner.TuningClient):
+    def __init__(self):
+        self.compile_flags = [
+            "--iree-hip-target=gfx942",
+            "--compile-from=executable-sources",
+        ]
+
+    def get_iree_compile_flags(self) -> list[str]:
+        return self.compile_flags
+
+    # TODO(Max191): Remove the following unused abstract functions once they
+    # are removed from the TuningClient definition.
+    def get_dispatch_benchmark_timeout_s(self) -> int:
+        return 0
+
+    def get_dispatch_compile_timeout_s(self) -> int:
+        return 0
+
+    def get_dispatch_compile_command(
+        self, candidate_tracker: libtuner.CandidateTracker
+    ) -> list[str]:
+        return []
+
+    def get_dispatch_benchmark_command(
+        self,
+        candidate_tracker: libtuner.CandidateTracker,
+    ) -> list[str]:
+        return []
+
+    def get_model_compile_timeout_s(self) -> int:
+        return 0
+
+    def get_model_compile_command(
+        self, candidate_tracker: libtuner.CandidateTracker
+    ) -> list[str]:
+        return []
+
+    def get_model_benchmark_timeout_s(self) -> int:
+        return 0
+
+    def get_model_benchmark_command(
+        self, candidate_tracker: libtuner.CandidateTracker
+    ) -> list[str]:
+        return []
+
+
 def main():
     args = libtuner.parse_arguments()
 
@@ -32,6 +78,12 @@ def main():
     print(f"Stored candidate specs in {path_config.specs_dir}\n")
     if stop_after_phase == libtuner.ExecutionPhases.generate_candidates:
         return
+
+    test_tuner = TestTuner()
+    print("Compiling candidates...")
+    candidates = libtuner.compile(
+        args, path_config, candidates, candidate_trackers, test_tuner
+    )
 
     print("Check the detailed execution logs in:")
     print(path_config.run_log.resolve())

--- a/tuner/examples/test/tuner_test.py
+++ b/tuner/examples/test/tuner_test.py
@@ -11,6 +11,7 @@ from tuner import libtuner
 
 class TestTuner(libtuner.TuningClient):
     def __init__(self):
+        super().__init__()
         self.compile_flags = ["--compile-from=executable-sources"]
         self.benchmark_flags = ["--benchmark_repetitions=3", "--input=1"]
 
@@ -107,14 +108,14 @@ def main():
         print("Validation successful!\n")
 
     print("Generating candidates...")
+    test_tuner = TestTuner()
     candidates = libtuner.generate_candidate_specs(
-        args, path_config, candidate_trackers
+        args, path_config, candidate_trackers, test_tuner
     )
     print(f"Stored candidate specs in {path_config.specs_dir}\n")
     if stop_after_phase == libtuner.ExecutionPhases.generate_candidates:
         return
 
-    test_tuner = TestTuner()
     print("Compiling candidates...")
     compiled_candidates = libtuner.compile(
         args, path_config, candidates, candidate_trackers, test_tuner

--- a/tuner/examples/test/tuner_test.py
+++ b/tuner/examples/test/tuner_test.py
@@ -78,6 +78,12 @@ def main():
         default=None,
         help="Number of model candidates to produce after tuning.",
     )
+    test_args.add_argument(
+        "--test_hip_target",
+        type=str,
+        default="gfx942",
+        help="Hip target for tuning.",
+    )
     # Remaining arguments come from libtuner
     args = libtuner.parse_arguments(parser)
 
@@ -127,7 +133,7 @@ def main():
     print("Compiling models with top candidates...")
     test_tuner.compile_flags = [
         "--iree-hal-target-backends=rocm",
-        "--iree-hip-target=gfx942",
+        f"--iree-hip-target={args.test_hip_target}",
     ]
     compiled_model_candidates = libtuner.compile(
         args,

--- a/tuner/tuner/dispatch_parser.py
+++ b/tuner/tuner/dispatch_parser.py
@@ -110,8 +110,7 @@ class ContractionOpInterfaceParser(DispatchParser):
     # TODO(Max191): Pass the ir_module directly instead of the template str.
     def get_shapes(self, template: list[str]) -> ProblemSize:
         matcher = ContractionOpInterfaceMatcher()
-        with ir.Context() as ctx:
-            ir_module = ir.Module.parse("\n".join(template), ctx)
+        ir_module = ir.Module.parse("\n".join(template))
         contraction_op = match_root_op(ir_module, matcher)
         assert contraction_op is not None, f"contraction op not found"
         cdims = matcher.contraction_dimensions
@@ -161,8 +160,7 @@ class ConvolutionOpInterfaceParser(DispatchParser):
 
     # TODO(Max191): Pass the ir_module directly instead of the template str.
     def get_shapes(self, template: list[str]) -> ProblemSize:
-        with ir.Context() as ctx:
-            ir_module = ir.Module.parse("\n".join(template), ctx)
+        ir_module = ir.Module.parse("\n".join(template))
         conv_op = match_root_op(ir_module, NamedOpMatcher(self.supported_ops))
         assert conv_op is not None, f"convolution op not found"
         lhs_type = ir.RankedTensorType(conv_op.operands[0].type)

--- a/tuner/tuner/op_matchers.py
+++ b/tuner/tuner/op_matchers.py
@@ -39,9 +39,12 @@ def get_ops_from_module(module: ir.Module, fn):
     return ops
 
 
+ROOT_OP_ATTR_NAME = "root_op"
+
+
 def is_root_op(op: ir.Operation) -> bool:
     for attr in op.opview.attributes:
-        if attr.name == "root_op":
+        if attr.name == ROOT_OP_ATTR_NAME:
             return True
     return False
 

--- a/tuner/tuner/spec_builder.py
+++ b/tuner/tuner/spec_builder.py
@@ -13,6 +13,7 @@ from iree.compiler.dialects import iree_codegen  # type: ignore
 from .common import *
 from .dispatch_constraints import *
 from .dispatch_parser import *
+from .op_matchers import ROOT_OP_ATTR_NAME
 
 
 def get_placeholder_spec(context: ir.Context) -> ir.Module:
@@ -37,12 +38,43 @@ def build_td_spec(
     func_name: str,
 ) -> ir.Module:
     bbargs = []
+    # The `root_op` attribute will prevent matching of ops without the attr in
+    # the resulting TD spec matcher if it is not removed, so we remove it here.
+    # After removing, we must add it back, since the op is connected to the
+    # input module, which gets used for all candidates.
+    # TODO(Max191): Find a cleaner way to do this without removing and adding
+    # back the attribute.
+    has_root_attr = ROOT_OP_ATTR_NAME in op.opview.attributes
+    if has_root_attr:
+        assert isinstance(
+            op.opview.attributes[ROOT_OP_ATTR_NAME], ir.UnitAttr
+        ), f"expected '{ROOT_OP_ATTR_NAME}' attr to be a unit attr"
+    if has_root_attr:
+        del op.opview.attributes[ROOT_OP_ATTR_NAME]
+    # Get the root op string for formatting the final spec.
+    root_operation = str(op)
+    if has_root_attr:
+        op.opview.attributes[ROOT_OP_ATTR_NAME] = ir.UnitAttr.get(op.context)
+
+    # Get the names ssa names of operands to make sure they match in the
+    # template after string formatting.
+    captured_values: set[ir.Value] = set()
     for operand in op.operands:
+        if operand in captured_values:
+            # TODO(Max191): Remove this warning when the transform for the
+            # `cast_compatible_dag_from_root` op fixes a bug in the matching
+            # logic that causes failure to match when the same operand is
+            # repeated. For now, still avoid adding duplicate SSA values to
+            # prevent parsing failure.
+            logging.warning(
+                f"Root op has repeated operand. This can cause failure to match in the resulting TD spec at compile time."
+            )
+            continue
         ssa_name = operand.get_name()
         operand_type = operand.type
         bbargs.append(f"{ssa_name}: {operand_type}")
+        captured_values.add(operand)
     bbargs_str = ", ".join(bbargs)
-    root_operation = str(op)
     spec_text = f"""
         module attributes {{ transform.with_named_sequence }} {{
             // Annotation Transform


### PR DESCRIPTION
This PR adds `benchmark()` and `compile()` functions to the tuner that can be used for both model and dispatch tuning. The new functions will replace the split benchmark/compile_models and benchmark/compile_dispatches functions. The new benchmarking and compilation functions now use the iree_runtime/iree_compiler python bindings which makes much of the code simpler. Particularly, benchmark results are now mostly parsed by the bindings, and the parse_*_benchmark_results functions are no longer needed. The new compilation and benchmarking flows are described below.

### Compilation ###

1. Populate each CandidateTracker with the input and output filepaths. The input filepaths can be overridden by an optional function argument to the compile() function. This argument can be used for model tuning, passing the model filepath as the new input file.
2. For each candidate, strip the compilation info using iree-opt, and compile to a vmfb with the iree compiler python bindings. Set the candidate's TD spec file (generated during candidate generation), and add any additional iree-compile flags that came from the TuningClient. The extra flags are taken from a new abstract TuningClient function called get_iree_compile_flags.
3. For all successful compilations, save the vmfbs to the designated output path, and skip any failed compilation. For any failed compilation, a failure dump is saved instead of the vmfb.
4. Remove duplicate vmfbs, and return the ids of all unique candidates.

### Benchmarking ###

1. Create benchmark task structs for each candidate with its CandidateTracker and the TuningClient
2. Run the candidate benchmarks on the available devices. Each benchmark task will benchmark the vmfb from the CandidateTracker using the iree_runtime python bindings, and return a benchmark result containing the candidate_id, benchmark time, and device_id.
3. Then the same benchmarking is done on the untuned baseline configuration once for each available device.
4. The results from the candidate benchmarks are compared with the baseline benchmarks from the same device, and the fastest candidates are logged and returned. The number of candidates returned is determined by an optional argument to the benchmark function, and all candidates will be returned by default.