### PR TITLE
[sharktank] Remove 'torch' from deps and warn instead

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -34,13 +34,17 @@ Setup your Python environment with the following commands:
 # Set up a virtual environment to isolate packages from other envs.
 python3.11 -m venv 3.11.venv
 source 3.11.venv/bin/activate
-
-# Optional: faster installation of torch with just CPU support.
-# See other options at https://pytorch.org/get-started/locally/
-pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
 ```
 
 ## Install SHARK and its dependencies
+
+Before installing `shark-ai` install a torch version that fulfills your needs.
+
+```bash
+# Fast installation of torch with just CPU support.
+# See other options at https://pytorch.org/get-started/locally/
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+```
 
 ```bash
 pip install shark-ai[apps]

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -38,7 +38,7 @@ source 3.11.venv/bin/activate
 
 ## Install SHARK and its dependencies
 
-Before installing `shark-ai` install a torch version that fulfills your needs.
+First install a torch version that fulfills your needs:
 
 ```bash
 # Fast installation of torch with just CPU support.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -42,9 +42,10 @@ First install a torch version that fulfills your needs:
 
 ```bash
 # Fast installation of torch with just CPU support.
-# See other options at https://pytorch.org/get-started/locally/
 pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
 ```
+
+For other options, see https://pytorch.org/get-started/locally/.
 
 Next install shark-ai:
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -46,6 +46,8 @@ Before installing `shark-ai` install a torch version that fulfills your needs.
 pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
 ```
 
+Next install shark-ai:
+
 ```bash
 pip install shark-ai[apps]
 ```

--- a/sharktank/requirements.txt
+++ b/sharktank/requirements.txt
@@ -9,10 +9,6 @@ huggingface-hub==0.22.2
 transformers==4.40.0
 datasets
 
-# It is expected that you have installed a PyTorch version/variant specific
-# to your needs, so we only include a minimum version spec.
-torch>=2.3.0
-
 # Serving deps.
 fastapi>=0.112.2
 uvicorn>=0.30.6

--- a/sharktank/sharktank/__init__.py
+++ b/sharktank/sharktank/__init__.py
@@ -3,3 +3,13 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import importlib.util
+
+msg = """No module named 'torch'. Follow https://pytorch.org/get-started/locally/#start-locally to install 'torch'.
+For example, on Linux to install with CPU support run:
+  pip3 install torch --index-url https://download.pytorch.org/whl/cpu
+"""
+
+if spec := importlib.util.find_spec("torch") is None:
+    raise ModuleNotFoundError(msg)


### PR DESCRIPTION
Instead of enforcing the installation for 'torch' as a dependency, error if 'torch' cannot be imported and point the user to how to install.