### PR TITLE
[shortfin] Bump fmt and spdlog and test with gcc 14

### DIFF
--- a/.github/workflows/ci-libshortfin.yml
+++ b/.github/workflows/ci-libshortfin.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["Ubuntu (Clang)(full)", "Ubuntu (Clang)(host-only)", "Ubuntu (GCC)", "Windows (MSVC)"]
+        name: ["Ubuntu (Clang)(full)", "Ubuntu (Clang)(host-only)", "Windows (MSVC)"]
         python-version: ["3.10", "3.11", "3.12"]
         include:
           - name: Ubuntu (Clang)(full)
@@ -53,16 +53,21 @@ jobs:
             cmake-options:
               -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_LINKER_TYPE=LLD -DSHORTFIN_HAVE_AMDGPU=OFF -DSHORTFIN_BUILD_STATIC=ON -DSHORTFIN_BUILD_DYNAMIC=ON
             additional-packages: clang lld
-          - name: Ubuntu (GCC)
+          - name: Ubuntu (GCC 13)
             runs-on: ubuntu-24.04
+            # Only test with GCC 13 and Python 3.12
+            python-version: "3.12"
+            cmake-options:
+              -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13
+          - name: Ubuntu (GCC 14)
+            runs-on: ubuntu-24.04
+            # Only test with GCC 14 and Python 3.12
+            python-version: "3.12"
+            cmake-options:
+              -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14
           - name: Windows (MSVC)
             runs-on: windows-2022
         exclude:
-          # Only test Python 3.12 with GCC
-          - name: Ubuntu (GCC)
-            python-version: "3.10"
-          - name: Ubuntu (GCC)
-            python-version: "3.11"
           # TODO: Include additional Python versions for Windows after build got fixed
           - name: Windows (MSVC)
             python-version: "3.10"

--- a/shortfin/CMakeLists.txt
+++ b/shortfin/CMakeLists.txt
@@ -39,6 +39,10 @@ if(NOT WIN32)
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
 
+# For unicode support Windows libfmt requires compiling with /utf-8.
+add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+
 # Pins
 set(SHORTFIN_IREE_GIT_TAG "iree-3.1.0rc20241204")
 
@@ -140,7 +144,7 @@ if(SHORTFIN_BUNDLE_DEPS)
   FetchContent_Declare(
     fmt
     GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-    GIT_TAG        e69e5f977d458f2650bb346dadf2ad30c5320281 # 10.2.1 (sync with spdlog)
+    GIT_TAG        0c9fce2ffefecfdce794e1859584e25877b7b592 # 11.0.2 (sync with spdlog)
   )
 
   ## spdlog
@@ -149,7 +153,7 @@ if(SHORTFIN_BUNDLE_DEPS)
   FetchContent_Declare(
     spdlog
     GIT_REPOSITORY https://github.com/gabime/spdlog.git
-    GIT_TAG        2d4acf8cc321d7783d8f2e22e17a794c6d0e9450 # v1.14.1
+    GIT_TAG        8e5613379f5140fefb0b60412fbf1f5406e7c7f8 # v1.15.0
   )
 
   ## xtl: required for xtensor

--- a/shortfin/src/shortfin/array/array.cc
+++ b/shortfin/src/shortfin/array/array.cc
@@ -10,6 +10,7 @@
 
 #include "fmt/core.h"
 #include "fmt/ranges.h"
+#include "fmt/xchar.h"
 #include "shortfin/array/xtensor_bridge.h"
 #include "shortfin/support/logging.h"
 

--- a/shortfin/src/shortfin/local/device.cc
+++ b/shortfin/src/shortfin/local/device.cc
@@ -8,6 +8,7 @@
 
 #include <fmt/core.h>
 #include <fmt/ranges.h>
+#include <fmt/xchar.h>
 
 namespace shortfin::local {
 

--- a/shortfin/src/shortfin/local/fiber.cc
+++ b/shortfin/src/shortfin/local/fiber.cc
@@ -8,6 +8,7 @@
 
 #include <fmt/core.h>
 #include <fmt/ranges.h>
+#include <fmt/xchar.h>
 
 #include "shortfin/local/system.h"
 #include "shortfin/support/logging.h"

--- a/shortfin/src/shortfin/local/program.cc
+++ b/shortfin/src/shortfin/local/program.cc
@@ -8,6 +8,7 @@
 
 #include "fmt/core.h"
 #include "fmt/std.h"
+#include "fmt/xchar.h"
 #include "iree/io/formats/parser_registry.h"
 #include "iree/modules/hal/module.h"
 #include "iree/modules/io/parameters/module.h"

--- a/shortfin/src/shortfin/local/system.cc
+++ b/shortfin/src/shortfin/local/system.cc
@@ -7,6 +7,7 @@
 #include "shortfin/local/system.h"
 
 #include <fmt/core.h>
+#include <fmt/xchar.h>
 
 #include "iree/hal/utils/allocators.h"
 #include "shortfin/local/fiber.h"

--- a/shortfin/src/shortfin/local/systems/amdgpu.cc
+++ b/shortfin/src/shortfin/local/systems/amdgpu.cc
@@ -6,6 +6,8 @@
 
 #include "shortfin/local/systems/amdgpu.h"
 
+#include <fmt/xchar.h>
+
 #include "shortfin/support/logging.h"
 #include "shortfin/support/sysconfig.h"
 

--- a/shortfin/src/shortfin/local/systems/factory.cc
+++ b/shortfin/src/shortfin/local/systems/factory.cc
@@ -4,6 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <fmt/xchar.h>
+
 #include "shortfin/local/system.h"
 #include "shortfin/support/logging.h"
 

--- a/shortfin/src/shortfin/support/config.cc
+++ b/shortfin/src/shortfin/support/config.cc
@@ -12,6 +12,7 @@
 #include <cstdlib>
 
 #include "fmt/format.h"
+#include "fmt/xchar.h"
 #include "shortfin/support/logging.h"
 
 namespace shortfin {


### PR DESCRIPTION
Bumps libftm to 11.0.2 to mitigate a build error with occurring with
gcc 14. Bumping spdlog to 1.15.0 (which bundles libfmt 11.0.2)
accordingly to keep the libs in sync. Furthermore expands testing
with gcc 14.