### PR TITLE
[sharktank] Avoid torch pre-releases

### DIFF
--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -74,7 +74,7 @@ jobs:
           # Note: We install in three steps in order to satisfy requirements
           # from non default locations first. Installing the PyTorch CPU
           # wheels saves multiple minutes and a lot of bandwidth on runner setup.
-          pip install --no-compile --pre --index-url https://download.pytorch.org/whl/test/cpu torch==${{matrix.torch-version}}+cpu
+          pip install --no-compile --index-url https://download.pytorch.org/whl/cpu torch==${{matrix.torch-version}}+cpu
 
           # Install nightly IREE packages.
           # We could also pin to a known working or stable version.


### PR DESCRIPTION
Drops passing `--pre` to avoid that pre-releases of torch get installed and switch to stable channel.