### PR TITLE
Fixed mixed precision contraction semantics for mmt_block_scaled_offset_q4_unsigned

### DIFF
--- a/sharktank/sharktank/kernels/templates/mmt_block_scaled_offset_q4_unsigned.mlir
+++ b/sharktank/sharktank/kernels/templates/mmt_block_scaled_offset_q4_unsigned.mlir
@@ -98,13 +98,14 @@ util.func private @sharktank_mmt_block_scaled_offset_q4_unsigned_3d_{{n}}_{{k}}_
       ins(%aexp, %b_grouped_dequant : !aexp_tensor_type,  !b_grouped_tensor_type)
       outs(%result_fill : !accum_tensor_type) {
   ^bb0(%a_element: !a_type, %b_element: !a_type, %out: !accum_type):
-      %bmm_mul = arith.mulf %a_element, %b_element : !a_type
     {% if accum_type == a_type %}
-      %bmm_accum = arith.addf %bmm_mul, %out : !a_type
+      %bmm_mul = arith.mulf %a_element, %b_element : !accum_type
     {% else %}
-      %bmm_mul_ext = arith.extf %bmm_mul : !a_type to !accum_type
-      %bmm_accum = arith.addf %bmm_mul_ext, %out : !accum_type
+      %ext_a = arith.extf %a_element : !a_type to !accum_type
+      %ext_b = arith.extf %b_element : !a_type to !accum_type
+      %bmm_mul = arith.mulf %ext_a, %ext_b : !accum_type
     {% endif %}
+      %bmm_accum = arith.addf %bmm_mul, %out : !accum_type
       linalg.yield %bmm_accum : !accum_type
   } -> !accum_tensor_type
 


### PR DESCRIPTION
Mixed precision contraction requires upcast before multiplication. This pr fixes this for the kernel.