### PR TITLE
Add xfail tests for single layer Flux transformer that verify IREE results against Torch

### DIFF
--- a/sharktank/sharktank/models/flux/testing.py
+++ b/sharktank/sharktank/models/flux/testing.py
@@ -216,17 +216,8 @@ def make_random_theta(config: FluxParams, dtype: torch.dtype):
     return Theta(tensor_dict)
 
 
-def export_dev_random_single_layer(
-    dtype: torch.dtype,
-    mlir_output_path: PathLike,
-    parameters_output_path: PathLike,
-    batch_sizes: list[int] = flux_transformer_default_batch_sizes,
-):
-    rng_state = torch.get_rng_state()
-    torch.random.manual_seed(12345)
-
-    dtype = torch.bfloat16
-    params = FluxParams(
+def make_dev_single_layer_config():
+    return FluxParams(
         in_channels=64,
         out_channels=64,
         vec_in_dim=768,
@@ -241,6 +232,19 @@ def export_dev_random_single_layer(
         qkv_bias=True,
         guidance_embed=True,
     )
+
+
+def export_dev_random_single_layer(
+    dtype: torch.dtype,
+    mlir_output_path: PathLike,
+    parameters_output_path: PathLike,
+    batch_sizes: list[int] = flux_transformer_default_batch_sizes,
+):
+    rng_state = torch.get_rng_state()
+    torch.random.manual_seed(12345)
+
+    dtype = torch.bfloat16
+    params = make_dev_single_layer_config()
     theta = make_random_theta(params, dtype)
     flux = FluxModelV1(
         theta=theta,

--- a/sharktank/tests/models/flux/flux_test.py
+++ b/sharktank/tests/models/flux/flux_test.py
@@ -170,6 +170,7 @@ class FluxTest(TempDirTestBase):
         raises=AssertionError,
         reason="Accuracy is not good enough. The observed absolute error is 8976.53.",
     )
+    @with_flux_data
     def testCompareDevRandomSingleLayerIreeBf16AgainstTorchEagerF32(self):
         self.runCompareDevRandomSingleLayerIreeAgainstTorchEager(
             reference_dtype=torch.float32, target_dtype=torch.bfloat16
@@ -179,6 +180,7 @@ class FluxTest(TempDirTestBase):
         raises=AssertionError,
         reason="Accuracy is probably not good enough. The observed absolute error is 73.25.",
     )
+    @with_flux_data
     def testCompareDevRandomSingleLayerIreeF32AgainstTorchEagerF32(self):
         self.runCompareDevRandomSingleLayerIreeAgainstTorchEager(
             reference_dtype=torch.float32, target_dtype=torch.float32

--- a/sharktank/tests/models/flux/flux_test.py
+++ b/sharktank/tests/models/flux/flux_test.py
@@ -5,216 +5,63 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import logging
+import functools
 import unittest
 import torch
 import pytest
-from sharktank.models.flux.flux import (
-    FluxModelV1,
-    FluxParams,
-)
+import iree.compiler
+from collections import OrderedDict
 from sharktank.models.flux.export import (
     export_flux_transformer_from_hugging_face,
+    export_flux_transformer,
 )
-from sharktank.models.flux.testing import export_dev_random_single_layer
-import sharktank.ops as ops
-from sharktank.layers.testing import (
-    make_rand_torch,
+from sharktank.models.flux.testing import (
+    export_dev_random_single_layer,
+    make_dev_single_layer_config,
+    make_random_theta,
 )
-from sharktank.types.tensors import DefaultPrimitiveTensor
-from sharktank.types.theta import Dataset, Theta
+from sharktank.models.flux.flux import FluxModelV1
 from sharktank.utils.testing import TempDirTestBase
-from sharktank.utils.hf_datasets import get_dataset
+from sharktank.utils.iree import (
+    get_iree_devices,
+    load_iree_module,
+    run_iree_module_function,
+    prepare_iree_module_function_args,
+    call_torch_module_function,
+    flatten_for_iree_signature,
+    iree_to_torch,
+)
+from sharktank import ops
+from sharktank.transforms.dataset import set_float_dtype
 
 logging.basicConfig(level=logging.DEBUG)
 with_flux_data = pytest.mark.skipif("not config.getoption('with_flux_data')")
 
-
-# TODO: Refactor this to a function that generates random toy weights, possibly
-# to another file
-in_channels = 64
-in_channels2 = 128
-hidden_size = 3072
-mlp_ratio = 4.0
-mlp_hidden_size = int((mlp_ratio - 1) * hidden_size)
-mlp_hidden_size2 = int(mlp_ratio * hidden_size)
-mlp_hidden_size3 = int(2 * (mlp_ratio - 1) * hidden_size)
-mlp_hidden_size4 = int((mlp_ratio + 1) * hidden_size)
-mlp_hidden_size5 = int((2 * mlp_ratio - 1) * hidden_size)
-context_in_dim = 4096
-time_dim = 256
-vec_dim = 768
-patch_size = 1
-out_channels = 64
-
-
-def make_random_theta(dtype: torch.dtype):
-    return Theta(
-        {
-            "img_in.weight": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((hidden_size, in_channels), dtype=dtype)
-            ),
-            "img_in.bias": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((hidden_size,), dtype=dtype)
-            ),
-            "txt_in.weight": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((hidden_size, context_in_dim), dtype=dtype)
-            ),
-            "txt_in.bias": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((hidden_size,), dtype=dtype)
-            ),
-            "time_in.in_layer.weight": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((hidden_size, time_dim), dtype=dtype)
-            ),
-            "time_in.in_layer.bias": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((hidden_size,), dtype=dtype)
-            ),
-            "time_in.out_layer.weight": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((hidden_size, hidden_size), dtype=dtype)
-            ),
-            "time_in.out_layer.bias": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((hidden_size,), dtype=dtype)
-            ),
-            "vector_in.in_layer.weight": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((hidden_size, vec_dim), dtype=dtype)
-            ),
-            "vector_in.in_layer.bias": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((hidden_size,), dtype=dtype)
-            ),
-            "vector_in.out_layer.weight": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((hidden_size, hidden_size), dtype=dtype)
-            ),
-            "vector_in.out_layer.bias": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((hidden_size,), dtype=dtype)
-            ),
-            "double_blocks.0.img_attn.norm.key_norm.scale": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((in_channels2,), dtype=dtype)
-            ),
-            "double_blocks.0.img_attn.norm.query_norm.scale": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((in_channels2,), dtype=dtype)
-            ),
-            "double_blocks.0.img_attn.proj.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((hidden_size,), dtype=dtype)
-            ),
-            "double_blocks.0.img_attn.proj.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((hidden_size, hidden_size), dtype=dtype)
-            ),
-            "double_blocks.0.img_attn.qkv.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size,), dtype=dtype)
-            ),
-            "double_blocks.0.img_attn.qkv.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size, hidden_size), dtype=dtype)
-            ),
-            "double_blocks.0.img_mlp.0.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size2), dtype=dtype)
-            ),
-            "double_blocks.0.img_mlp.0.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size2, hidden_size), dtype=dtype)
-            ),
-            "double_blocks.0.img_mlp.2.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((hidden_size), dtype=dtype)
-            ),
-            "double_blocks.0.img_mlp.2.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((hidden_size, mlp_hidden_size2), dtype=dtype)
-            ),
-            "double_blocks.0.img_mod.lin.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size3,), dtype=dtype)
-            ),
-            "double_blocks.0.img_mod.lin.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size3, hidden_size), dtype=dtype)
-            ),
-            "double_blocks.0.txt_attn.norm.key_norm.scale": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((in_channels2,), dtype=dtype)
-            ),
-            "double_blocks.0.txt_attn.norm.query_norm.scale": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((in_channels2,), dtype=dtype)
-            ),
-            "double_blocks.0.txt_attn.proj.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((hidden_size,), dtype=dtype)
-            ),
-            "double_blocks.0.txt_attn.proj.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((hidden_size, hidden_size), dtype=dtype)
-            ),
-            "double_blocks.0.txt_attn.qkv.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size,), dtype=dtype)
-            ),
-            "double_blocks.0.txt_attn.qkv.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size, hidden_size), dtype=dtype)
-            ),
-            "double_blocks.0.txt_mlp.0.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size2), dtype=dtype)
-            ),
-            "double_blocks.0.txt_mlp.0.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size2, hidden_size), dtype=dtype)
-            ),
-            "double_blocks.0.txt_mlp.2.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((hidden_size), dtype=dtype)
-            ),
-            "double_blocks.0.txt_mlp.2.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((hidden_size, mlp_hidden_size2), dtype=dtype)
-            ),
-            "double_blocks.0.txt_mod.lin.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size3,), dtype=dtype)
-            ),
-            "double_blocks.0.txt_mod.lin.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size3, hidden_size), dtype=dtype)
-            ),
-            "single_blocks.0.norm.key_norm.scale": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((in_channels2,), dtype=dtype)
-            ),
-            "single_blocks.0.norm.query_norm.scale": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((in_channels2,), dtype=dtype)
-            ),
-            "single_blocks.0.attn.proj.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((hidden_size,), dtype=dtype)
-            ),
-            "single_blocks.0.attn.proj.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((hidden_size, hidden_size), dtype=dtype)
-            ),
-            "single_blocks.0.linear1.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size5,), dtype=dtype)
-            ),
-            "single_blocks.0.linear1.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size5, hidden_size), dtype=dtype)
-            ),
-            "single_blocks.0.linear2.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((hidden_size), dtype=dtype)
-            ),
-            "single_blocks.0.linear2.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((hidden_size, mlp_hidden_size4), dtype=dtype)
-            ),
-            "single_blocks.0.modulation.lin.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size,), dtype=dtype)
-            ),
-            "single_blocks.0.modulation.lin.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size, hidden_size), dtype=dtype)
-            ),
-            "final_layer.linear.weight": DefaultPrimitiveTensor(  #
-                data=make_rand_torch(
-                    (patch_size * patch_size * out_channels, hidden_size), dtype=dtype
-                )
-            ),
-            "final_layer.linear.bias": DefaultPrimitiveTensor(  #
-                data=make_rand_torch(
-                    (patch_size * patch_size * out_channels,), dtype=dtype
-                )
-            ),
-            "final_layer.adaLN_modulation.1.weight": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((hidden_size * 2, hidden_size), dtype=dtype)
-            ),
-            "final_layer.adaLN_modulation.1.bias": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((hidden_size * 2,), dtype=dtype)
-            ),
-        }
-    )
+iree_compile_flags = [
+    "--iree-hal-target-device=hip",
+    "--iree-hip-target=gfx942",
+    "--iree-opt-const-eval=false",
+    "--iree-opt-strip-assertions=true",
+    "--iree-global-opt-propagate-transposes=true",
+    "--iree-dispatch-creation-enable-fuse-horizontal-contractions=true",
+    "--iree-dispatch-creation-enable-aggressive-fusion=true",
+    "--iree-opt-aggressively-propagate-transposes=true",
+    "--iree-opt-outer-dim-concat=true",
+    "--iree-vm-target-truncate-unsupported-floats",
+    "--iree-llvmgpu-enable-prefetch=true",
+    "--iree-opt-data-tiling=false",
+    "--iree-codegen-gpu-native-math-precision=true",
+    "--iree-codegen-llvmgpu-use-vector-distribution",
+    "--iree-hip-waves-per-eu=2",
+    "--iree-execution-model=async-external",
+    "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics)",
+]
 
 
 class FluxTest(TempDirTestBase):
     def setUp(self):
         super().setUp()
         torch.manual_seed(12345)
-        self.hidden_size = 3072
-        self.num_heads = 24
-        self.batch_size = 5
 
     def testExportDevRandomSingleLayerBf16(self):
         export_dev_random_single_layer(
@@ -222,6 +69,119 @@ class FluxTest(TempDirTestBase):
             batch_sizes=[1],
             mlir_output_path=self._temp_dir / "model.mlir",
             parameters_output_path=self._temp_dir / "parameters.irpa",
+        )
+
+    def runCompareIreeAgainstTorchEager(
+        self, reference_model: FluxModelV1, target_dtype: torch.dtype
+    ):
+        target_theta = reference_model.theta.transform(
+            functools.partial(set_float_dtype, dtype=target_dtype)
+        )
+        target_torch_model = FluxModelV1(
+            theta=target_theta,
+            params=reference_model.params,
+        )
+
+        mlir_path = self._temp_dir / "model.mlir"
+        parameters_path = self._temp_dir / "parameters.irpa"
+        batch_size = 1
+        batch_sizes = [batch_size]
+        export_flux_transformer(
+            target_torch_model,
+            mlir_output_path=mlir_path,
+            parameters_output_path=parameters_path,
+            batch_sizes=batch_sizes,
+        )
+
+        iree_module_path = self._temp_dir / "model.vmfb"
+        iree.compiler.compile_file(
+            mlir_path,
+            output_file=iree_module_path,
+            extra_args=iree_compile_flags,
+        )
+
+        target_input_args, target_input_kwargs = target_torch_model.sample_inputs(
+            batch_size
+        )
+
+        def covert_target_to_reference_dtype(t: torch.Tensor) -> torch.Tensor:
+            if t.dtype == target_dtype:
+                return t.to(dtype=reference_model.dtype)
+            return t
+
+        reference_input_args = [
+            covert_target_to_reference_dtype(t) for t in target_input_args
+        ]
+        reference_input_kwargs = OrderedDict(
+            (k, covert_target_to_reference_dtype(t))
+            for k, t in target_input_kwargs.items()
+        )
+
+        reference_result_dict = call_torch_module_function(
+            module=reference_model,
+            function_name="forward",
+            args=reference_input_args,
+            kwargs=reference_input_kwargs,
+        )
+        expected_outputs = flatten_for_iree_signature(reference_result_dict)
+
+        iree_devices = get_iree_devices(driver="hip", device_count=1)
+        iree_module, iree_vm_context, iree_vm_instance = load_iree_module(
+            module_path=iree_module_path,
+            devices=iree_devices,
+            parameters_path=parameters_path,
+        )
+        iree_args = prepare_iree_module_function_args(
+            args=flatten_for_iree_signature([target_input_args, target_input_kwargs]),
+            devices=iree_devices,
+        )
+
+        iree_result = iree_to_torch(
+            *run_iree_module_function(
+                module=iree_module,
+                vm_context=iree_vm_context,
+                args=iree_args,
+                driver="hip",
+                function_name=f"forward_bs{batch_size}",
+            )
+        )
+        actual_outputs = [
+            ops.to(iree_result[i], dtype=expected_outputs[i].dtype)
+            for i in range(len(expected_outputs))
+        ]
+        # TODO: figure out a good metric. Probably per pixel comparison would be good
+        # enough.
+        torch.testing.assert_close(actual_outputs, expected_outputs)
+
+    def runCompareDevRandomSingleLayerIreeAgainstTorchEager(
+        self, reference_dtype: torch.dtype, target_dtype: torch.dtype
+    ):
+        config = make_dev_single_layer_config()
+
+        reference_theta = make_random_theta(config, reference_dtype)
+        reference_theta.rename_tensors_to_paths()
+        reference_model = FluxModelV1(
+            theta=reference_theta,
+            params=config,
+        )
+        self.runCompareIreeAgainstTorchEager(reference_model, target_dtype)
+
+    @pytest.mark.xfail(
+        raises=AssertionError,
+        reason="Accuracy is not good enough. The observed absolute error is 8976.53.",
+    )
+    def testCompareDevRandomSingleLayerIreeBf16AgainstTorchEagerF32(self):
+        self.runCompareDevRandomSingleLayerIreeAgainstTorchEager(
+            reference_dtype=torch.float32, target_dtype=torch.bfloat16
+        )
+
+    @pytest.mark.xfail(
+        raises=AssertionError,
+        reason="Accuracy is probably not good enough. The observed absolute error is 73.25.",
+    )
+    def testCompareDevRandomSingleLayerIreeF32AgainstTorchEagerF32(self):
+        self.runCompareDevRandomSingleLayerIreeAgainstTorchEager(
+            reference_dtype=torch.float32, target_dtype=torch.float32
         )
 
     @with_flux_data


### PR DESCRIPTION
The test accuracy is not of sufficient quality and needs further investigation.
The tests compare IREE bf16 and f32 against Torch f32.

Refactor the sample input generation and make it produce noise images for final size of 1024x1024 instead of 512x512.

Remove unused duplicated function for random Theta generation.