### PR TITLE
[Tuner] Add support for TileAndFuse and multi-dim contractions

### DIFF
--- a/tuner/examples/test/README.md
+++ b/tuner/examples/test/README.md
@@ -35,5 +35,6 @@ python -m examples.test double_mmt.mlir mmt_benchmark.mlir \
 python -m examples.test <model_file_path> <benchmark_file_path> \
     --test_num_dispatch_candidates=<num_dispatch_candidates> \
     --test_num_model_candidates=<num_model_candidates> \
-    --test_hip_target=<hip_target> \ --num-candidates=<num_generated_candidates>
+    --test_hip_target=<hip_target> --num-candidates=<num_generated_candidates> \
+    --codegen-pipeline=<codegen_pipeline>
 ```

--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -644,6 +644,7 @@ def generate_configs_and_td_specs(
     tuner_context: TunerContext,
     limit: int = 4096,  # Max candidates to be generated
     num_subgroups: int = 4,  # GPU spec, used to determine candidate generation constraints
+    codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline = iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute,
 ) -> list[ir.Module]:
     dispatch_tuner_registry = DispatchTunerRegistry(check_translation_info=False)
     dispatch_tuner_registry.register(
@@ -671,7 +672,9 @@ def generate_configs_and_td_specs(
     variant_op = variant_op_list[0]
     mma_list = iree_codegen.query_mma_intrinsics(variant_op)
     for i, config in enumerate(
-        generate_solutions(tuner_context, problem_size, num_subgroups, mma_list)
+        generate_solutions(
+            tuner_context, problem_size, num_subgroups, mma_list, codegen_pipeline
+        )
     ):
         if i >= limit:
             break

--- a/tuner/tuner/dispatch_constraints.py
+++ b/tuner/tuner/dispatch_constraints.py
@@ -63,18 +63,22 @@ def get_dispatch_constraints(
 
 def calculate_shared_memory_usage_in_bytes(
     problem_size: ProblemSize,
-    m: int | z3.ArithRef,
-    n: int | z3.ArithRef,
-    k: int | z3.ArithRef,
+    m: list[int] | list[z3.ArithRef],
+    n: list[int] | list[z3.ArithRef],
+    k: list[int] | list[z3.ArithRef],
 ) -> int | z3.ArithRef:
-    lhs_memory = m * k * (problem_size.lhs_type.bitwidth // 8)
-    rhs_memory = k * n * (problem_size.rhs_type.bitwidth // 8)
+    lhs_memory = problem_size.lhs_type.bitwidth // 8
+    for size in m + k:
+        lhs_memory *= size
+    rhs_memory = problem_size.rhs_type.bitwidth // 8
+    for size in n + k:
+        rhs_memory *= size
     return lhs_memory + rhs_memory
 
 
-def generate_constraints(
+def generate_vector_distribute_constraints(
     problem_size: ProblemSize,
-    tile_sizes,
+    tile_sizes: list[z3.ArithRef],
     num_subgroups,
     subgroup_size,
     intrinsic_size,
@@ -136,10 +140,110 @@ def generate_constraints(
     constraints += [waves_per_eu == 2]
     # constraints += [z3.Or(waves_per_eu == 2, waves_per_eu == 3, waves_per_eu == 4)]
 
-    shared_memory = calculate_shared_memory_usage_in_bytes(problem_size, m, n, k)
+    shared_memory = calculate_shared_memory_usage_in_bytes(problem_size, [m], [n], [k])
     constraints += [shared_memory <= 65536]
 
     constraints += get_dispatch_constraints(problem_size, m, n, k)
+
+    return constraints
+
+
+def generate_tile_and_fuse_constraints(
+    problem_size: ProblemSize,
+    tile_sizes: list[list[z3.ArithRef]],
+    num_subgroups,
+    subgroup_size,
+    intrinsic_size,
+    workgroup_size,
+    subgroup_m_count,
+    subgroup_n_count,
+    waves_per_eu,
+    mma_intrinsics: list[iree_gpu.MMAIntrinsic],
+):
+    M, N, K = problem_size.MNK_lists
+    m_tiles, n_tiles, k_tiles, subgroup_m_tiles, subgroup_n_tiles = tile_sizes
+    intrinsic_mn, intrinsic_k = intrinsic_size
+    wg_x, wg_y, wg_z = workgroup_size
+    wg_threads = z3.Int("wg_threads")
+    constraints = [wg_x == wg_threads, wg_y == 1, wg_z == 1]
+    constraints += [subgroup_size == 64, wg_threads <= 1024]
+    constraints += [
+        get_mfma_intrinsic_constraints(
+            problem_size, intrinsic_mn, intrinsic_mn, intrinsic_k, mma_intrinsics
+        )
+    ]
+    subgroup_k_count = 1
+
+    def get_product_expr(vars):
+        prod_expr = 1
+        for v in vars:
+            prod_expr *= v
+        return prod_expr
+
+    constraints += [
+        m_tiles[-1] >= intrinsic_mn,
+        m_tiles[-1] % intrinsic_mn == 0,
+        n_tiles[-1] >= intrinsic_mn,
+        n_tiles[-1] % intrinsic_mn == 0,
+        k_tiles[-1] * intrinsic_k <= K[-1],
+        get_product_expr(m_tiles) <= 512,
+        get_product_expr(n_tiles) <= 512,
+        get_product_expr(k_tiles) <= 512 / intrinsic_k,
+    ]
+    constraints += [m_shape % m == 0 for m, m_shape in zip(m_tiles, M)]
+    constraints += [n_shape % n == 0 for n, n_shape in zip(n_tiles, N)]
+    constraints += [k_shape % k == 0 for k, k_shape in zip(k_tiles[:-1], K[:-1])]
+    constraints += [m >= 0 for m in m_tiles]
+    constraints += [n >= 0 for n in n_tiles]
+    constraints += [k >= 0 for k in k_tiles]
+    constraints += [K[-1] % (k_tiles[-1] * intrinsic_k) == 0]
+    constraints += [m <= m_shape for m, m_shape in zip(m_tiles, M)]
+    constraints += [n <= n_shape for n, n_shape in zip(n_tiles, N)]
+    constraints += [k <= k_shape for k, k_shape in zip(k_tiles[:-1], K[:-1])]
+    constraints += [(k_tiles[-1] * intrinsic_k) <= K[-1]]
+    for x in (subgroup_m_count, subgroup_n_count):
+        constraints += [x >= 1, x <= 32]
+
+    subgroup_m_tile_count = z3.Int("sg_m_tcnt")
+    subgroup_n_tile_count = z3.Int("sg_n_tcnt")
+    subgroup_k_tile_count = z3.Int("sg_k_tcnt")
+    for x in (subgroup_m_tile_count, subgroup_n_tile_count, subgroup_k_tile_count):
+        constraints += [x >= 1, x <= 32]
+    constraints += [get_product_expr(subgroup_m_tiles) == subgroup_m_tile_count]
+    constraints += [get_product_expr(subgroup_n_tiles) == subgroup_n_tile_count]
+    constraints += [
+        m % m_subgroup == 0 for m, m_subgroup in zip(m_tiles, subgroup_m_tiles)
+    ]
+    constraints += [
+        n % n_subgroup == 0 for n, n_subgroup in zip(n_tiles, subgroup_n_tiles)
+    ]
+    constraints += [m_subgroup > 0 for m_subgroup in subgroup_m_tiles]
+    constraints += [n_subgroup > 0 for n_subgroup in subgroup_n_tiles]
+
+    constraints += [
+        get_product_expr(m_tiles)
+        == subgroup_m_count * subgroup_m_tile_count * intrinsic_mn
+    ]
+    constraints += [
+        get_product_expr(n_tiles)
+        == subgroup_n_count * subgroup_n_tile_count * intrinsic_mn
+    ]
+    constraints += [
+        get_product_expr(k_tiles) == subgroup_k_count * subgroup_k_tile_count
+    ]
+    subgroups = subgroup_m_count * subgroup_n_count
+    if num_subgroups > 0:
+        constraints += [subgroups == num_subgroups]
+    else:
+        constraints += [subgroups >= 1, subgroups <= 10]
+    constraints += [wg_threads == subgroups * subgroup_size]
+
+    constraints += [waves_per_eu == 2]
+
+    shared_memory = calculate_shared_memory_usage_in_bytes(
+        problem_size, m_tiles, n_tiles, k_tiles
+    )
+    constraints += [shared_memory * intrinsic_k <= 65536]
 
     return constraints
 
@@ -178,10 +282,16 @@ def generate_solutions(
     problem_size: ProblemSize,
     num_subgrups: int,
     mma_intrinsics: list[iree_gpu.MMAIntrinsic],
+    codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline = iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute,
 ) -> Iterator[iree_codegen.CompilationInfoAttr]:
-    M, N, K = problem_size.MNK
+    M, N, K = problem_size.MNK_lists
     tuner_ctx.logger.info(f"{M},{N},{K}")
-    m, n, k = z3.Int("m"), z3.Int("n"), z3.Int("k")
+    m_vars = [z3.Int(f"m{i}") for i in range(len(M))]
+    n_vars = [z3.Int(f"n{i}") for i in range(len(N))]
+    k_vars = [z3.Int(f"k{i}") for i in range(len(K))]
+    subgroup_m_vars = [z3.Int(f"subgroup_m{i}") for i in range(len(M))]
+    subgroup_n_vars = [z3.Int(f"subgroup_n{i}") for i in range(len(N))]
+    # m, n, k = z3.Int("m"), z3.Int("n"), z3.Int("k")
     subgroup_size = z3.Int("subgroup_size")
     intrinsic_mn = z3.Int("intrinsic_mn")
     intrinsic_k = z3.Int("intrinsic_k")
@@ -189,34 +299,52 @@ def generate_solutions(
     sg_m_cnt = z3.Int("sg_m_cnt")
     sg_n_cnt = z3.Int("sg_n_cnt")
     waves_per_eu = z3.Int("waves_per_eu")
-    all_vars = [
-        m,
-        n,
-        k,
-        subgroup_size,
-        intrinsic_mn,
-        intrinsic_k,
-        wg_x,
-        wg_y,
-        wg_z,
-        sg_m_cnt,
-        sg_n_cnt,
-        waves_per_eu,
-    ]
+    all_vars = (
+        m_vars
+        + n_vars
+        + k_vars
+        + [
+            subgroup_size,
+            intrinsic_mn,
+            intrinsic_k,
+            wg_x,
+            wg_y,
+            wg_z,
+            sg_m_cnt,
+            sg_n_cnt,
+            waves_per_eu,
+        ]
+    )
 
     solver = z3.Solver()
-    constraints = generate_constraints(
-        problem_size,
-        [m, n, k],
-        num_subgrups,
-        subgroup_size,
-        [intrinsic_mn, intrinsic_k],
-        [wg_x, wg_y, wg_z],
-        sg_m_cnt,
-        sg_n_cnt,
-        waves_per_eu,
-        mma_intrinsics,
-    )
+    match codegen_pipeline:
+        case iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute:
+            constraints = generate_vector_distribute_constraints(
+                problem_size,
+                [m_vars[0], n_vars[0], k_vars[0]],
+                num_subgrups,
+                subgroup_size,
+                [intrinsic_mn, intrinsic_k],
+                [wg_x, wg_y, wg_z],
+                sg_m_cnt,
+                sg_n_cnt,
+                waves_per_eu,
+                mma_intrinsics,
+            )
+            constraints += [subgroup_m_vars[0] == 0, subgroup_n_vars[0] == 0]
+        case iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse:
+            constraints = generate_tile_and_fuse_constraints(
+                problem_size,
+                [m_vars, n_vars, k_vars, subgroup_m_vars, subgroup_n_vars],
+                num_subgrups,
+                subgroup_size,
+                [intrinsic_mn, intrinsic_k],
+                [wg_x, wg_y, wg_z],
+                sg_m_cnt,
+                sg_n_cnt,
+                waves_per_eu,
+                mma_intrinsics,
+            )
     solver.add(z3.simplify(z3.And(constraints)))
     tuner_ctx.logger.debug(f"Initial constraints: {solver}")
 
@@ -232,20 +360,76 @@ def generate_solutions(
             problem_size.lhs_type.element_type,
             problem_size.rhs_type.element_type,
         )
-        lowering_config = get_lowering_config(
-            tuner_ctx=tuner_ctx,
-            mma_kind=mma_attr,
-            workgroup=[lookup(m), lookup(n), 0],
-            reduction=[
-                0,
-                0,
-                lookup(k),
-            ],
-            subgroup_m_count=lookup(sg_m_cnt),
-            subgroup_n_count=lookup(sg_n_cnt),
+        if problem_size.cdims is None:
+            assert (
+                codegen_pipeline
+                == iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
+            ), "only LLVMGPUVectorDistribute problem sizes can have no contraction dimensions"
+            problem_size.cdims = ContractionDimensions(
+                batch=[],
+                m=[0],
+                n=[1],
+                k=[2],
+            )
+
+        def add_cdim_tile_sizes(tile_sizes, cdims, csizes):
+            for dim, size in zip(cdims, csizes):
+                tile_sizes[dim] = size
+
+        workgroup_tile_sizes = [0] * (
+            len(M) + len(N) + len(K) + len(problem_size.cdims.batch)
         )
+        subgroup_tile_sizes = [0] * (
+            len(M) + len(N) + len(K) + len(problem_size.cdims.batch)
+        )
+        reduction_tile_sizes = [0] * (
+            len(M) + len(N) + len(K) + len(problem_size.cdims.batch)
+        )
+        add_cdim_tile_sizes(
+            workgroup_tile_sizes, problem_size.cdims.m, [lookup(v) for v in m_vars]
+        )
+        add_cdim_tile_sizes(
+            workgroup_tile_sizes, problem_size.cdims.n, [lookup(v) for v in n_vars]
+        )
+        add_cdim_tile_sizes(
+            workgroup_tile_sizes,
+            problem_size.cdims.batch,
+            [1] * len(problem_size.cdims.batch),
+        )
+        add_cdim_tile_sizes(
+            subgroup_tile_sizes,
+            problem_size.cdims.m,
+            [lookup(v) for v in subgroup_m_vars],
+        )
+        add_cdim_tile_sizes(
+            subgroup_tile_sizes,
+            problem_size.cdims.n,
+            [lookup(v) for v in subgroup_n_vars],
+        )
+        add_cdim_tile_sizes(
+            subgroup_tile_sizes,
+            problem_size.cdims.batch,
+            [1] * len(problem_size.cdims.batch),
+        )
+        add_cdim_tile_sizes(
+            reduction_tile_sizes, problem_size.cdims.k, [lookup(v) for v in k_vars]
+        )
+        lowering_config_args = {
+            "tuner_ctx": tuner_ctx,
+            "mma_kind": mma_attr,
+            "workgroup": workgroup_tile_sizes,
+            "reduction": reduction_tile_sizes,
+            "subgroup_m_count": lookup(sg_m_cnt),
+            "subgroup_n_count": lookup(sg_n_cnt),
+        }
+        if (
+            codegen_pipeline
+            == iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse
+        ):
+            lowering_config_args["subgroup"] = subgroup_tile_sizes
+        lowering_config = get_lowering_config(**lowering_config_args)
         pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-            iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
+            codegen_pipeline
         )
         pipeline_options = iree_gpu.PipelineOptionsAttr.get()
         config_dict = get_translation_info_config(

--- a/tuner/tuner/dispatch_constraints_test.py
+++ b/tuner/tuner/dispatch_constraints_test.py
@@ -63,7 +63,7 @@ def test_calculate_shared_memory_usage_in_bytes(tuner_ctx: common.TunerContext) 
     )
     assert (
         dispatch_constraints.calculate_shared_memory_usage_in_bytes(
-            problem_size, 512, 64, 128
+            problem_size, [512], [64], [128]
         )
         == 147456
     )
@@ -74,7 +74,7 @@ def test_calculate_shared_memory_usage_in_bytes(tuner_ctx: common.TunerContext) 
     )
     assert (
         dispatch_constraints.calculate_shared_memory_usage_in_bytes(
-            problem_size, 512, 64, 128
+            problem_size, [512], [64], [128]
         )
         == 81920
     )
@@ -85,13 +85,160 @@ def test_calculate_shared_memory_usage_in_bytes(tuner_ctx: common.TunerContext) 
     )
     assert (
         dispatch_constraints.calculate_shared_memory_usage_in_bytes(
-            problem_size, 128, 64, 32
+            problem_size, [128], [64], [32]
+        )
+        == 12288
+    )
+
+    assert (
+        dispatch_constraints.calculate_shared_memory_usage_in_bytes(
+            problem_size, [2, 64], [4, 16], [8, 4]
         )
         == 12288
     )
 
 
-def test_generate_constraints_valid_input(tuner_ctx: common.TunerContext) -> None:
+def test_generate_tile_and_fuse_constraints_valid_input(
+    tuner_ctx: common.TunerContext,
+) -> None:
+    matmul_size = common.ContractionSizes(
+        B=[2, 16],
+        M=[4, 32],
+        N=[6, 64],
+        K=[8, 128],
+    )
+    cdims = common.ContractionDimensions(
+        batch=[0, 4],
+        m=[1, 5],
+        n=[2, 6],
+        k=[3, 7],
+    )
+    lhs_type = common.ShapedType([2, 4, 8, 16, 32, 128], tuner_ctx.type.f16)
+    rhs_type = common.ShapedType([2, 6, 8, 16, 64, 128], tuner_ctx.type.f16)
+    res_type = common.ShapedType([2, 4, 6, 16, 32, 64], tuner_ctx.type.f32)
+    problem_size = common.ProblemSize(
+        matmul_size, lhs_type, rhs_type, res_type, common.DispatchKind.contraction
+    )
+    # Define input parameters as z3 Ints
+    m, n, k = (
+        [z3.Int("m0"), z3.Int("m1")],
+        [z3.Int("n0"), z3.Int("n1")],
+        [z3.Int("k0"), z3.Int("k1")],
+    )
+    subgroup_m, subgroup_n = (
+        [z3.Int("subgroup_m0"), z3.Int("subgroup_m1")],
+        [z3.Int("subgroup_n0"), z3.Int("subgroup_n1")],
+    )
+    subgroup_size = z3.Int("subgroup_size")
+    intrinsic_mn = z3.Int("intrinsic_mn")
+    intrinsic_k = z3.Int("intrinsic_k")
+    wg_x, wg_y, wg_z = (
+        z3.Int("wg_x"),
+        z3.Int("wg_y"),
+        z3.Int("wg_z"),
+    )
+    sg_m_cnt = z3.Int("sg_m_cnt")
+    sg_n_cnt = z3.Int("sg_n_cnt")
+    waves_per_eu = z3.Int("waves_per_eu")
+
+    constraints = dispatch_constraints.generate_tile_and_fuse_constraints(
+        problem_size,
+        [m, n, k, subgroup_m, subgroup_n],
+        4,
+        subgroup_size,
+        [intrinsic_mn, intrinsic_k],
+        [wg_x, wg_y, wg_z],
+        sg_m_cnt,
+        sg_n_cnt,
+        waves_per_eu,
+        [
+            iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
+            iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
+            iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
+            iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
+        ],
+    )
+
+    solver = z3.Solver()
+    solver.add(constraints)
+
+    # Check if the constraints are satisfiable
+    assert solver.check() == z3.sat
+
+
+def test_generate_tile_and_fuse_constraints_invalid_input(
+    tuner_ctx: common.TunerContext,
+) -> None:
+    # Define input parameters that should lead to unsatisfiable constraints
+    matmul_size = common.ContractionSizes(
+        B=[2, 16],
+        M=[4, 32],
+        N=[6, 64],
+        K=[8, 128],
+    )
+    cdims = common.ContractionDimensions(
+        batch=[0, 4],
+        m=[1, 5],
+        n=[2, 6],
+        k=[3, 7],
+    )
+    lhs_type = common.ShapedType([2, 4, 8, 16, 32, 128], tuner_ctx.type.f16)
+    rhs_type = common.ShapedType([2, 6, 8, 16, 64, 128], tuner_ctx.type.f16)
+    res_type = common.ShapedType([2, 4, 6, 16, 32, 64], tuner_ctx.type.f32)
+    problem_size = common.ProblemSize(
+        matmul_size, lhs_type, rhs_type, res_type, common.DispatchKind.contraction
+    )
+    # Define input parameters as z3 Ints
+    m, n, k = (
+        [z3.Int("m0"), z3.Int("m1")],
+        [z3.Int("n0"), z3.Int("n1")],
+        [z3.Int("k0"), z3.Int("k1")],
+    )
+    subgroup_m, subgroup_n = (
+        [z3.Int("subgroup_m0"), z3.Int("subgroup_m1")],
+        [z3.Int("subgroup_n0"), z3.Int("subgroup_n1")],
+    )
+    subgroup_size = z3.Int("subgroup_size")
+    intrinsic_mn = z3.Int("intrinsic_mn")
+    intrinsic_k = z3.Int("intrinsic_k")
+    wg_x, wg_y, wg_z = (
+        z3.Int("wg_x"),
+        z3.Int("wg_y"),
+        z3.Int("wg_z"),
+    )
+    sg_m_cnt = z3.Int("sg_m_cnt")
+    sg_n_cnt = z3.Int("sg_n_cnt")
+    waves_per_eu = z3.Int("waves_per_eu")
+
+    constraints = dispatch_constraints.generate_tile_and_fuse_constraints(
+        problem_size,
+        [m, n, k, subgroup_m, subgroup_n],
+        4,
+        subgroup_size,
+        [intrinsic_mn, intrinsic_k],
+        [wg_x, wg_y, wg_z],
+        sg_m_cnt,
+        sg_n_cnt,
+        waves_per_eu,
+        [
+            iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
+            iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
+            iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
+            iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
+        ],
+    )
+    constraints.append(m[0] > 1000)  # Adding an additional unsatisfiable constraint
+
+    solver = z3.Solver()
+    solver.add(constraints)
+
+    # Check if the constraints are unsatisfiable
+    assert solver.check() == z3.unsat
+
+
+def test_generate_vector_distribute_constraints_valid_input(
+    tuner_ctx: common.TunerContext,
+) -> None:
     matmul_size = common.MatmulSize(1024, 1024, 1024)
     lhs_type = common.ShapedType([1024, 1024], tuner_ctx.type.f16)
     rhs_type = common.ShapedType([1024, 1024], tuner_ctx.type.f16)
@@ -117,7 +264,7 @@ def test_generate_constraints_valid_input(tuner_ctx: common.TunerContext) -> Non
     sg_n_cnt = z3.Int("sg_n_cnt")
     waves_per_eu = z3.Int("waves_per_eu")
 
-    constraints = dispatch_constraints.generate_constraints(
+    constraints = dispatch_constraints.generate_vector_distribute_constraints(
         problem_size,
         [m, n, k],
         4,
@@ -142,7 +289,9 @@ def test_generate_constraints_valid_input(tuner_ctx: common.TunerContext) -> Non
     assert solver.check() == z3.sat
 
 
-def test_generate_constraints_invalid_input(tuner_ctx: common.TunerContext) -> None:
+def test_generate_vector_distribute_constraints_invalid_input(
+    tuner_ctx: common.TunerContext,
+) -> None:
     # Define input parameters that should lead to unsatisfiable constraints
     matmul_size = common.MatmulSize(1024, 1024, 1024)
     lhs_type = common.ShapedType([1024, 1024], tuner_ctx.type.f16)
@@ -168,7 +317,7 @@ def test_generate_constraints_invalid_input(tuner_ctx: common.TunerContext) -> N
     sg_n_cnt = z3.Int("sg_n_cnt")
     waves_per_eu = z3.Int("waves_per_eu")
 
-    constraints = dispatch_constraints.generate_constraints(
+    constraints = dispatch_constraints.generate_vector_distribute_constraints(
         problem_size,
         [m, n, k],
         4,

--- a/tuner/tuner/dispatch_parser.py
+++ b/tuner/tuner/dispatch_parser.py
@@ -118,26 +118,22 @@ class ContractionOpInterfaceParser(DispatchParser):
         assert matcher.lhs_dims, "no lhs dimensions"
         assert matcher.rhs_dims, "no rhs dimensions"
         assert matcher.res_dims, "no result dimensions"
-        assert len(cdims.batch) <= 1, f"must have at most 1 batch dimension"
-        assert len(cdims.m) == 1, f"must have a single m dimension"
-        assert len(cdims.n) == 1, f"must have a single n dimension"
-        assert len(cdims.k) == 1, f"must have a single k dimension"
         lhs_type = ir.RankedTensorType(contraction_op.operands[0].type)
         rhs_type = ir.RankedTensorType(contraction_op.operands[1].type)
         res_type = ir.RankedTensorType(contraction_op.operands[2].type)
-        matmul_size = MatmulSize(
-            lhs_type.shape[matcher.lhs_dims.index(cdims.m[0])],
-            rhs_type.shape[matcher.rhs_dims.index(cdims.n[0])],
-            lhs_type.shape[matcher.lhs_dims.index(cdims.k[0])],
+        matmul_size = ContractionSizes(
+            M=[lhs_type.shape[matcher.lhs_dims.index(dim)] for dim in cdims.m],
+            N=[rhs_type.shape[matcher.rhs_dims.index(dim)] for dim in cdims.n],
+            K=[lhs_type.shape[matcher.lhs_dims.index(dim)] for dim in cdims.k],
+            B=[lhs_type.shape[matcher.lhs_dims.index(dim)] for dim in cdims.batch],
         )
-        if len(cdims.batch) == 1:
-            matmul_size.B = lhs_type.shape[matcher.lhs_dims.index(cdims.batch[0])]
         return ProblemSize(
             matmul_size,
             lhs_type=ShapedType(lhs_type.shape, lhs_type.element_type),
             rhs_type=ShapedType(rhs_type.shape, rhs_type.element_type),
             res_type=ShapedType(res_type.shape, res_type.element_type),
             dispatch_kind=DispatchKind.contraction,
+            cdims=matcher.contraction_dimensions,
         )
 
 

--- a/tuner/tuner/dispatch_parser_test.py
+++ b/tuner/tuner/dispatch_parser_test.py
@@ -87,10 +87,10 @@ def test_get_contraction_operation(tuner_ctx: common.TunerContext) -> None:
     assert mmt_op is not None
     assert isinstance(mmt_op.opview, linalg.GenericOp)
     shapes: common.ProblemSize = parser.get_shapes(transpose_b_str.splitlines())
-    assert shapes.matmul_size.B == 1
-    assert shapes.matmul_size.M == 16
-    assert shapes.matmul_size.N == 32
-    assert shapes.matmul_size.K == 64
+    assert shapes.matmul_size.B == []
+    assert shapes.matmul_size.M == [16]
+    assert shapes.matmul_size.N == [32]
+    assert shapes.matmul_size.K == [64]
     assert shapes.lhs_type.shape == [16, 64]
     assert isinstance(shapes.lhs_type.element_type, ir.F16Type)
     assert shapes.rhs_type.shape == [32, 64]
@@ -111,10 +111,32 @@ def test_get_contraction_operation(tuner_ctx: common.TunerContext) -> None:
     module = ir.Module.parse(bmm_transposed_inputs_str, context)
     mmt_op = parser.get_contraction_operation(module)
     shapes = parser.get_shapes(bmm_transposed_inputs_str.splitlines())
-    assert shapes.matmul_size.B == 5
-    assert shapes.matmul_size.M == 8
-    assert shapes.matmul_size.N == 40
-    assert shapes.matmul_size.K == 128
+    assert shapes.matmul_size.B == [5]
+    assert shapes.matmul_size.M == [8]
+    assert shapes.matmul_size.N == [40]
+    assert shapes.matmul_size.K == [128]
+
+    with ir.Location.unknown():
+        bmm_transposed_inputs_str = CONTRACTION_TEMPLATE.format(
+            lhs_type=ir.RankedTensorType.get(
+                [16, 8, 15, 16, 64, 256], ir.F16Type.get()
+            ),
+            rhs_type=ir.RankedTensorType.get(
+                [16, 9, 15, 16, 128, 256], ir.F16Type.get()
+            ),
+            res_type=ir.RankedTensorType.get([16, 8, 9, 16, 64, 128], ir.F32Type.get()),
+            lhs_map="affine_map<(b0, m0, n0, k0, b1, m1, n1, k1) -> (b0, m0, k0, b1, m1, k1)>",
+            rhs_map="affine_map<(b0, m0, n0, k0, b1, m1, n1, k1) -> (b0, n0, k0, b1, n1, k1)>",
+            res_map="affine_map<(b0, m0, n0, k0, b1, m1, n1, k1) -> (b0, m0, n0, b1, m1, n1)>",
+            iterator_types='["parallel", "parallel", "parallel", "reduction", "parallel", "parallel", "parallel", "reduction"]',
+        )
+    module = ir.Module.parse(bmm_transposed_inputs_str, context)
+    mmt_op = parser.get_contraction_operation(module)
+    shapes = parser.get_shapes(bmm_transposed_inputs_str.splitlines())
+    assert shapes.matmul_size.B == [16, 16]
+    assert shapes.matmul_size.M == [8, 64]
+    assert shapes.matmul_size.N == [9, 128]
+    assert shapes.matmul_size.K == [15, 256]
 
 
 def test_get_conv_operation(tuner_ctx: common.TunerContext) -> None:


### PR DESCRIPTION
This PR adds support for multi-dimensional (multiple M/N/K/batch) contraction ops using the TileAndFuse pipeline. The PR adds a new constraint set for the TileAndFuse pipeline, which allows for multiple M, N, or K contraction dimensions. A new flag is also added called `--codegen-pipeline`, which indicates whether to use `llvmgpu_vector_distribute` or `llvmgpu_tile_and_fuse`. Multi dim contraction ops do not currently work with the LLVMGPUVectorDistribute pipeline, but this can be extended as a followup. Also, tuning for convolution on the TileAndFuse pipeline is not yet implemented, but it should be a simple extension now that the TileAndFuse contraction tuning is in place.