### PR TITLE
Update more pins to IREE version 3.1.0rc20241220.

### DIFF
--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -70,8 +70,8 @@ jobs:
 
           # Pin to known-working versions.
           pip install -f https://iree.dev/pip-release-links.html --pre --upgrade \
-            iree-base-compiler==3.1.0rc20241204 \
-            iree-base-runtime==3.1.0rc20241204 \
+            iree-base-compiler==3.1.0rc20241220 \
+            iree-base-runtime==3.1.0rc20241220 \
             "numpy<2.0"
 
           # Install SGLang

--- a/shortfin/requirements-iree-compiler.txt
+++ b/shortfin/requirements-iree-compiler.txt
@@ -1,4 +1,4 @@
 # Keep in sync with "ref: iree-" in .github/workflows/* and GIT_TAG in CMakeLists.txt
 -f https://iree.dev/pip-release-links.html
-iree-base-compiler==3.1.0rc20241204
-iree-base-runtime==3.1.0rc20241204
+iree-base-compiler==3.1.0rc20241220
+iree-base-runtime==3.1.0rc20241220


### PR DESCRIPTION
Not sure why I overlooked these in https://github.com/nod-ai/shark-ai/pull/721.

Edit: oh, the other pins are `iree-3.1.0rc20241220` git refs. These are Python package pins.

Commit range: https://github.com/iree-org/iree/compare/iree-3.1.0rc20241204...iree-3.1.0rc20241220