### PR TITLE
Bump IREE deps to 3.1.0rc20250103.

### DIFF
--- a/.github/workflows/ci-libshortfin.yml
+++ b/.github/workflows/ci-libshortfin.yml
@@ -101,7 +101,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_REPO_DIR }}
         submodules: false
-        ref: iree-3.1.0rc20241220
+        ref: iree-3.1.0rc20250103
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_REPO_DIR }}

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -70,8 +70,8 @@ jobs:
 
           # Pin to known-working versions.
           pip install -f https://iree.dev/pip-release-links.html --pre --upgrade \
-            iree-base-compiler==3.1.0rc20241204 \
-            iree-base-runtime==3.1.0rc20241204 \
+            iree-base-compiler==3.1.0rc20241220 \
+            iree-base-runtime==3.1.0rc20241220 \
             "numpy<2.0"
 
           # Install SGLang

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -70,8 +70,8 @@ jobs:
 
           # Pin to known-working versions.
           pip install -f https://iree.dev/pip-release-links.html --pre --upgrade \
-            iree-base-compiler==3.1.0rc20241220 \
-            iree-base-runtime==3.1.0rc20241220 \
+            iree-base-compiler==3.1.0rc20250103 \
+            iree-base-runtime==3.1.0rc20250103 \
             "numpy<2.0"
 
           # Install SGLang

--- a/.github/workflows/ci_linux_x64_asan-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_asan-libshortfin.yml
@@ -106,7 +106,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_SOURCE_DIR }}
         submodules: false
-        ref: iree-3.1.0rc20241220
+        ref: iree-3.1.0rc20250103
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_SOURCE_DIR }}

--- a/.github/workflows/ci_linux_x64_nogil-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_nogil-libshortfin.yml
@@ -54,7 +54,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_REPO_DIR }}
         submodules: false
-        ref: iree-3.1.0rc20241220
+        ref: iree-3.1.0rc20250103
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_REPO_DIR }}

--- a/shortfin/CMakeLists.txt
+++ b/shortfin/CMakeLists.txt
@@ -44,7 +44,7 @@ add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
 add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 
 # Pins
-set(SHORTFIN_IREE_GIT_TAG "iree-3.1.0rc20241220")
+set(SHORTFIN_IREE_GIT_TAG "iree-3.1.0rc20250103")
 
 # build options
 option(SHORTFIN_BUILD_PYTHON_BINDINGS "Builds Python Bindings" OFF)

--- a/shortfin/requirements-iree-compiler.txt
+++ b/shortfin/requirements-iree-compiler.txt
@@ -1,4 +1,4 @@
 # Keep in sync with "ref: iree-" in .github/workflows/* and GIT_TAG in CMakeLists.txt
 -f https://iree.dev/pip-release-links.html
-iree-base-compiler==3.1.0rc20241220
-iree-base-runtime==3.1.0rc20241220
+iree-base-compiler==3.1.0rc20250103
+iree-base-runtime==3.1.0rc20250103

--- a/shortfin/requirements-iree-compiler.txt
+++ b/shortfin/requirements-iree-compiler.txt
@@ -1,4 +1,4 @@
 # Keep in sync with "ref: iree-" in .github/workflows/* and GIT_TAG in CMakeLists.txt
 -f https://iree.dev/pip-release-links.html
-iree-base-compiler==3.1.0rc20241204
-iree-base-runtime==3.1.0rc20241204
+iree-base-compiler==3.1.0rc20241220
+iree-base-runtime==3.1.0rc20241220


### PR DESCRIPTION
Similar to https://github.com/nod-ai/shark-ai/pull/721, bumping forward again.

Commit range: https://github.com/iree-org/iree/compare/iree-3.1.0rc20241220...iree-3.1.0rc20250103