### PR TITLE
Bump stable IREE version for sgl-benchmark

### DIFF
--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -23,8 +23,6 @@ on:
   schedule:
     # Weekdays at 11:00 AM UTC = 03:00 AM PST / 04:00 AM PDT
     - cron: "0 11 * * 1-5"
-  # TODO: Remove after verifying in CI
-  pull_request:
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -23,6 +23,8 @@ on:
   schedule:
     # Weekdays at 11:00 AM UTC = 03:00 AM PST / 04:00 AM PDT
     - cron: "0 11 * * 1-5"
+  # TODO: Remove after verifying in CI
+  pull_request:
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
@@ -70,8 +72,8 @@ jobs:
 
           # Pin to known-working versions.
           pip install -f https://iree.dev/pip-release-links.html --pre --upgrade \
-            iree-base-compiler==3.1.0rc20241204 \
-            iree-base-runtime==3.1.0rc20241204 \
+            iree-base-compiler==3.1.0rc20241220 \
+            iree-base-runtime==3.1.0rc20241220 \
             "numpy<2.0"
 
           # Install SGLang

--- a/app_tests/benchmark_tests/llm/sglang_benchmarks/shortfin_benchmark_test.py
+++ b/app_tests/benchmark_tests/llm/sglang_benchmarks/shortfin_benchmark_test.py
@@ -7,7 +7,6 @@
 import logging
 import multiprocessing
 import os
-from pathlib import Path
 import pytest
 import time
 from unittest.mock import patch


### PR DESCRIPTION
# Description

[SGLang Benchmark Test](https://github.com/nod-ai/shark-ai/actions/workflows/ci-sglang-benchmark.yml) has been failing at the compilation step. Bumping IREE version to the stable versions pushed in #721 fixes the issue.