### PR TITLE
Drop path filters from shortfin and SDXL CI workflows.

### DIFF
--- a/.github/workflows/ci-sdxl.yaml
+++ b/.github/workflows/ci-sdxl.yaml
@@ -9,15 +9,9 @@ name: CI - shortfin - SDXL
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - '.github/workflows/ci-sdxl.yaml'
-      - 'shortfin/**'
   push:
     branches:
       - main
-    paths:
-      - '.github/workflows/ci-sdxl.yaml'
-      - 'shortfin/**'
 
 permissions:
   contents: read

--- a/.github/workflows/ci_linux_x64_asan-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_asan-libshortfin.yml
@@ -9,15 +9,9 @@ name: CI - shortfin - ASan
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - '.github/workflows/ci_linux_x64_asan-libshortfin.yml'
-      - 'shortfin/**'
   push:
     branches:
       - main
-    paths:
-      - '.github/workflows/ci_linux_x64_asan-libshortfin.yml'
-      - 'shortfin/**'
 
 permissions:
   contents: read

--- a/.github/workflows/ci_linux_x64_nogil-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_nogil-libshortfin.yml
@@ -9,16 +9,9 @@ name: CI - shortfin - Python 3.13 Free-threaded
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - '.github/workflows/ci_linux_x64-libshortfin.yml'
-      - 'shortfin/**'
-
   push:
     branches:
       - main
-    paths:
-      - '.github/workflows/ci_linux_x64-libshortfin.yml'
-      - 'shortfin/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
We aren't particularly resource constrained and I'd rather have continuous signal for these workflows.

The only workflow that still uses path filters is [`.github/workflows/ci-tuner.yml`](https://github.com/nod-ai/shark-ai/blob/main/.github/workflows/ci-tuner.yml).