### PR TITLE
Revert "Bump IREE to iree-3.1.0rc20241220."

### DIFF
--- a/.github/workflows/ci-libshortfin.yml
+++ b/.github/workflows/ci-libshortfin.yml
@@ -101,7 +101,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_REPO_DIR }}
         submodules: false
-        ref: iree-3.1.0rc20241220
+        ref: iree-3.1.0rc20241204
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_REPO_DIR }}

--- a/.github/workflows/ci_linux_x64_asan-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_asan-libshortfin.yml
@@ -106,7 +106,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_SOURCE_DIR }}
         submodules: false
-        ref: iree-3.1.0rc20241220
+        ref: iree-3.1.0rc20241204
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_SOURCE_DIR }}

--- a/.github/workflows/ci_linux_x64_nogil-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_nogil-libshortfin.yml
@@ -54,7 +54,7 @@ jobs:
         repository: iree-org/iree
         path: ${{ env.IREE_REPO_DIR }}
         submodules: false
-        ref: iree-3.1.0rc20241220
+        ref: iree-3.1.0rc20241204
 
     - name: Initalize IREE submodules
       working-directory: ${{ env.IREE_REPO_DIR }}

--- a/shortfin/CMakeLists.txt
+++ b/shortfin/CMakeLists.txt
@@ -44,7 +44,7 @@ add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
 add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 
 # Pins
-set(SHORTFIN_IREE_GIT_TAG "iree-3.1.0rc20241220")
+set(SHORTFIN_IREE_GIT_TAG "iree-3.1.0rc20241204")
 
 # build options
 option(SHORTFIN_BUILD_PYTHON_BINDINGS "Builds Python Bindings" OFF)

--- a/shortfin/src/shortfin/array/storage.cc
+++ b/shortfin/src/shortfin/array/storage.cc
@@ -92,8 +92,7 @@ storage storage::subspan(iree_device_size_t byte_offset,
                          iree_device_size_t byte_length) {
   storage new_storage(device_, {}, timeline_resource_);
   SHORTFIN_THROW_IF_ERROR(iree_hal_buffer_subspan(
-      buffer_, byte_offset, byte_length, host_allocator(),
-      new_storage.buffer_.for_output()));
+      buffer_, byte_offset, byte_length, new_storage.buffer_.for_output()));
   return new_storage;
 }
 

--- a/shortfin/src/shortfin/local/program.cc
+++ b/shortfin/src/shortfin/local/program.cc
@@ -663,8 +663,7 @@ void StaticProgramParameters::Load(std::filesystem::path file_path,
 
   // Parse.
   SHORTFIN_THROW_IF_ERROR(iree_io_parse_file_index(
-      to_iree_string_view(options.format), file_handle.get(), index_.get(),
-      host_allocator_));
+      to_iree_string_view(options.format), file_handle.get(), index_.get()));
 }
 
 // -------------------------------------------------------------------------- //


### PR DESCRIPTION
Reverts nod-ai/shark-ai#721.

Checking if this helps with SDXL regressions, since https://github.com/nod-ai/shark-ai/pull/746 would be needed to get the runtime and compiler fully in sync here.