### PR TITLE
Remove serving deps from sharktank/requirements.txt.

### DIFF
--- a/sharktank/requirements.txt
+++ b/sharktank/requirements.txt
@@ -8,7 +8,3 @@ numpy
 huggingface-hub==0.22.2
 transformers==4.40.0
 datasets
-
-# Serving deps.
-fastapi>=0.112.2
-uvicorn>=0.30.6


### PR DESCRIPTION
These are included in shortfin now: https://github.com/nod-ai/shark-ai/blob/5f08cb2354c928476ace3cfdcda3b835dd13cd61/shortfin/pyproject.toml#L42-L43