### PR TITLE
Move requirements-iree-*.txt to top level.

### DIFF
--- a/.github/workflows/ci-libshortfin.yml
+++ b/.github/workflows/ci-libshortfin.yml
@@ -119,12 +119,12 @@ jobs:
         cache: "pip"
         cache-dependency-path: |
           'shortfin/requirements-tests.txt'
-          'shortfin/requirements-iree-compiler.txt'
+          'requirements-iree-pinned.txt'
     - name: Install Python packages
       working-directory: ${{ env.LIBSHORTFIN_DIR }}
       run: |
         pip install -r requirements-tests.txt
-        pip install -r requirements-iree-compiler.txt
+        pip install -r ../requirements-iree-pinned.txt
         pip freeze
 
     - name: Build shortfin

--- a/.github/workflows/ci-sdxl.yaml
+++ b/.github/workflows/ci-sdxl.yaml
@@ -65,7 +65,7 @@ jobs:
       working-directory: ${{ env.LIBSHORTFIN_DIR }}
       run: |
         pip install -r requirements-tests.txt
-        pip install -r requirements-iree-compiler.txt
+        pip install -r ../requirements-iree-pinned.txt
         pip freeze
 
     - name: Install shortfin

--- a/.github/workflows/ci_linux_x64_asan-libshortfin.yml
+++ b/.github/workflows/ci_linux_x64_asan-libshortfin.yml
@@ -142,7 +142,7 @@ jobs:
       run: |
         eval "$(pyenv init -)"
         pip install -r requirements-tests.txt
-        pip install -r requirements-iree-compiler.txt
+        pip install -r ../requirements-iree-pinned.txt
         pip freeze
 
     - name: Save Python dependencies cache

--- a/requirements-iree-pinned.txt
+++ b/requirements-iree-pinned.txt
@@ -1,0 +1,10 @@
+# Pinned versions of IREE dependencies.
+
+# Keep these versions synced with SHORTFIN_IREE_GIT_TAG in shortfin/CMakeLists.txt
+--pre
+--find-links https://iree.dev/pip-release-links.html
+iree-base-compiler==3.1.0rc20241204
+iree-base-runtime==3.1.0rc20241204
+
+# TODO(#760): include iree-turbine in this requirements file too?
+# iree-turbine==3.1.0rc20241205

--- a/requirements-iree-unpinned.txt
+++ b/requirements-iree-unpinned.txt
@@ -1,0 +1,9 @@
+# Unpinned versions of IREE dependencies.
+
+--pre
+--find-links https://iree.dev/pip-release-links.html
+iree-base-compiler
+iree-base-runtime
+
+# TODO(#760): include iree-turbine in this requirements file too?
+# iree-turbine

--- a/shortfin/requirements-iree-compiler.txt
+++ b/shortfin/requirements-iree-compiler.txt
@@ -1,4 +1,0 @@
-# Keep in sync with "ref: iree-" in .github/workflows/* and GIT_TAG in CMakeLists.txt
--f https://iree.dev/pip-release-links.html
-iree-base-compiler==3.1.0rc20241204
-iree-base-runtime==3.1.0rc20241204


### PR DESCRIPTION
This is prep work for https://github.com/nod-ai/shark-ai/issues/760.

I also considered putting the files under `build_tools/` or `shark-ai/`, but we already have a few requirements files in the repository root. Still not as many as https://github.com/vllm-project/vllm though 😛.