### PR TITLE
Re-raise exception after logging it in SDXL test.

### DIFF
--- a/shortfin/tests/apps/sd/e2e_test.py
+++ b/shortfin/tests/apps/sd/e2e_test.py
@@ -232,6 +232,7 @@ def send_json_file(url="http://0.0.0.0:8000", num_copies=1):
 
     except requests.exceptions.RequestException as e:
         print(f"Error sending the request: {e}")
+        raise e
 
     return imgs, response.status_code
 


### PR DESCRIPTION
It looks like these errors have been getting ignored, producing misleading test summaries: https://github.com/nod-ai/shark-ai/actions/runs/12606573635/job/35136865226#step:7:204

```
[2025-01-04 02:12:06] Application startup complete.
[2025-01-04 02:12:06] Uvicorn running on http://0.0.0.0:35601/ (Press CTRL+C to quit)
[2025-01-04 02:12:07] 127.0.0.1:41082 - "GET /health HTTP/1.1" 200
free(): double free detected in tcache 2
Error sending the request: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
FAILED

...

         except requests.exceptions.RequestException as e:
            print(f"Error sending the request: {e}")
    
>       return imgs, response.status_code
E       UnboundLocalError: cannot access local variable 'response' where it is not associated with a value

tests/apps/sd/e2e_test.py:236: UnboundLocalError
=========================== short test summary info ============================
SKIPPED [1] tests/apps/sd/e2e_test.py:144: unconditional skip
SKIPPED [1] tests/apps/sd/e2e_test.py:152: unconditional skip
FAILED tests/apps/sd/e2e_test.py::test_sd_server - UnboundLocalError: cannot access local variable 'response' where it is not associated with a value
FAILED tests/apps/sd/e2e_test.py::test_sd_server_bs4_dense - UnboundLocalError: cannot access local variable 'response' where it is not associated with a value
FAILED tests/apps/sd/e2e_test.py::test_sd_server_bs8_percall - UnboundLocalError: cannot access local variable 'response' where it is not associated with a value
FAILED tests/apps/sd/e2e_test.py::test_sd_server_bs4_dense_fpd2 - UnboundLocalError: cannot access local variable 'response' where it is not associated with a value
FAILED tests/apps/sd/e2e_test.py::test_sd_server_bs8_dense_fpd8 - UnboundLocalError: cannot access local variable 'response' where it is not associated with a value
=================== 5 failed, 1 passed, 2 skipped in 50.71s ====================
```