### PR TITLE
(sdxl) Updates server configurations to run with caching allocator by default.

### DIFF
--- a/shortfin/python/shortfin_apps/sd/components/config_artifacts.py
+++ b/shortfin/python/shortfin_apps/sd/components/config_artifacts.py
@@ -8,7 +8,7 @@ from iree.build import *
 from iree.build.executor import FileNamespace
 import os
 
-ARTIFACT_VERSION = "11182024"
+ARTIFACT_VERSION = "01062025"
 SDXL_CONFIG_BUCKET = f"https://sharkpublic.blob.core.windows.net/sharkpublic/sdxl/{ARTIFACT_VERSION}/configs/"
 
 


### PR DESCRIPTION
This is a band-aid patch.

We encountered a regression in under-load behavior (tracked by https://github.com/nod-ai/shark-ai/issues/753)
This effectively uses a different allocator that, while less efficient at multi-device inference execution, is more stable.
