### PR TITLE
Add missing requirements for sharktank t5 tests.

### DIFF
--- a/sharktank/requirements-tests.txt
+++ b/sharktank/requirements-tests.txt
@@ -1,6 +1,7 @@
 datasets==3.0.0
 diffusers
 parameterized
+protobuf
 pytest==8.0.0
 pytest-html
 pytest-xdist==3.5.0


### PR DESCRIPTION
Fixes https://github.com/nod-ai/shark-ai/issues/787. See the workflow passing now: https://github.com/nod-ai/shark-ai/actions/runs/12676783895/job/35330696315?pr=788.

We could also install another package that transitively includes `protobuf`, like `transformers[sentencepiece]` or `onnx`. I'm also not sure if this should be a test requirement or a release requirement, given how limited and indirect the usage is, so just starting simple and explicit.