### PR TITLE
[tuner] Allow tuning of pipeline options

### DIFF
--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -174,7 +174,7 @@ def get_lowering_config(
         # A local variable to hold the transformed value.
         promoted_value = value
         match key:
-            case "workgroup" | "reduction" | "subgroup":
+            case "workgroup" | "reduction" | "subgroup" | "promote_operands":
                 if isinstance(value, list):
                     promoted_value = ir.ArrayAttr.get(
                         [tuner_ctx.type.getI64(x) for x in value]

--- a/tuner/tuner/dispatch_constraints_test.py
+++ b/tuner/tuner/dispatch_constraints_test.py
@@ -166,7 +166,6 @@ def test_generate_tile_and_fuse_constraints_valid_input(
     )
     sg_m_cnt = z3.Int("sg_m_cnt")
     sg_n_cnt = z3.Int("sg_n_cnt")
-    waves_per_eu = z3.Int("waves_per_eu")
 
     constraints = dispatch_constraints.generate_tile_and_fuse_constraints(
         problem_size,
@@ -177,7 +176,6 @@ def test_generate_tile_and_fuse_constraints_valid_input(
         [wg_x, wg_y, wg_z],
         sg_m_cnt,
         sg_n_cnt,
-        waves_per_eu,
         [
             iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
             iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
@@ -240,7 +238,6 @@ def test_generate_tile_and_fuse_constraints_invalid_input(
     )
     sg_m_cnt = z3.Int("sg_m_cnt")
     sg_n_cnt = z3.Int("sg_n_cnt")
-    waves_per_eu = z3.Int("waves_per_eu")
 
     constraints = dispatch_constraints.generate_tile_and_fuse_constraints(
         problem_size,
@@ -251,7 +248,6 @@ def test_generate_tile_and_fuse_constraints_invalid_input(
         [wg_x, wg_y, wg_z],
         sg_m_cnt,
         sg_n_cnt,
-        waves_per_eu,
         [
             iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
             iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
@@ -300,7 +296,6 @@ def test_generate_vector_distribute_constraints_valid_input(
     )
     sg_m_cnt = z3.Int("sg_m_cnt")
     sg_n_cnt = z3.Int("sg_n_cnt")
-    waves_per_eu = z3.Int("waves_per_eu")
 
     constraints = dispatch_constraints.generate_vector_distribute_constraints(
         problem_size,
@@ -311,7 +306,6 @@ def test_generate_vector_distribute_constraints_valid_input(
         [wg_x, wg_y, wg_z],
         sg_m_cnt,
         sg_n_cnt,
-        waves_per_eu,
         [
             iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
             iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
@@ -359,7 +353,6 @@ def test_generate_vector_distribute_constraints_invalid_input(
     )
     sg_m_cnt = z3.Int("sg_m_cnt")
     sg_n_cnt = z3.Int("sg_n_cnt")
-    waves_per_eu = z3.Int("waves_per_eu")
 
     constraints = dispatch_constraints.generate_vector_distribute_constraints(
         problem_size,
@@ -370,7 +363,6 @@ def test_generate_vector_distribute_constraints_invalid_input(
         [wg_x, wg_y, wg_z],
         sg_m_cnt,
         sg_n_cnt,
-        waves_per_eu,
         [
             iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
             iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,


### PR DESCRIPTION
This PR adds some command line arguments to tune pipeline options. The new flags are `--prefetch-shared-memory-options`, `--no-reduce-shared-memory-bank-conflicts-options`, and `--waves-per-eu-options`. The flags take a comma separated list of values (bool or int), representing the possible values that the corresponding pipeline options can take in tuning.

This PR also adds `promote_operands = [0, 1]` to the TileAndFuse tuning configurations. This could potentially be a tuned parameter in the future, but for now it is typically good to promote the lhs and rhs operands.