### PR TITLE
Drop unneeded pip flags and switch torch channel

### DIFF
--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -69,7 +69,7 @@ jobs:
           pip install --no-compile -r requirements.txt -e sharktank/ shortfin/
 
           # Pin to known-working versions.
-          pip install -f https://iree.dev/pip-release-links.html --pre --upgrade \
+          pip install -f https://iree.dev/pip-release-links.html
             iree-base-compiler==3.1.0rc20241220 \
             iree-base-runtime==3.1.0rc20241220 \
             "numpy<2.0"

--- a/pytorch-cpu-requirements.txt
+++ b/pytorch-cpu-requirements.txt
@@ -1,3 +1,2 @@
---pre
---index-url https://download.pytorch.org/whl/test/cpu
+--index-url https://download.pytorch.org/whl/cpu/
 torch==2.3.0

--- a/requirements-iree-pinned.txt
+++ b/requirements-iree-pinned.txt
@@ -1,7 +1,6 @@
 # Pinned versions of IREE dependencies.
 
 # Keep these versions synced with SHORTFIN_IREE_GIT_TAG in shortfin/CMakeLists.txt
---pre
 --find-links https://iree.dev/pip-release-links.html
 iree-base-compiler==3.1.0rc20250107
 iree-base-runtime==3.1.0rc20250107


### PR DESCRIPTION
Drops `--pre` and `--upgrade` where dependencies are pinned to specific versions. Further switches to unstall torch cpu form the stable release channel.