### PR TITLE
Point to iree-turbine nightly releases

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -99,6 +99,14 @@ pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
   iree-base-compiler iree-base-runtime iree-turbine
 ```
 
+You can also install an editable iree-turbine dep:
+```bash
+# Optionally clone and install the latest editable iree-turbine dep in deps/.
+pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
+  iree-base-compiler iree-base-runtime --src deps \
+  -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
+```
+
 See also: [nightly_releases.md](nightly_releases.md).
 
 ### Running tests

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -93,8 +93,8 @@ different variant, run one of these commands first:
 # Install editable local projects.
 pip install -r requirements.txt -e sharktank/ shortfin/
 
-# Optionally clone and install the latest editable iree-turbine dep in deps/,
-# along with nightly versions of iree-base-compiler and iree-base-runtime.
+# Install the latest nightly release of iree-turbine, alond with
+# nightly versions of iree-base-compiler and iree-base-runtime.
 pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
   iree-base-compiler iree-base-runtime iree-turbine
 ```

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -96,8 +96,7 @@ pip install -r requirements.txt -e sharktank/ shortfin/
 # Optionally clone and install the latest editable iree-turbine dep in deps/,
 # along with nightly versions of iree-base-compiler and iree-base-runtime.
 pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
-  iree-base-compiler iree-base-runtime --src deps \
-  -e "git+https://github.com/iree-org/iree-turbine.git#egg=iree-turbine"
+  iree-base-compiler iree-base-runtime iree-turbine
 ```
 
 See also: [nightly_releases.md](nightly_releases.md).


### PR DESCRIPTION
Advise to install the latest nightly release instead of cloning and installing and editable version of iree-turbine.