### PR TITLE
Patch version computations in pypi_deploy.sh.

### DIFF
--- a/build_tools/python_deploy/pypi_deploy.sh
+++ b/build_tools/python_deploy/pypi_deploy.sh
@@ -95,8 +95,8 @@ function build_shark_ai_meta_package() {
 
   # TODO: rework `write_requirements.py` to use the versions from the downloaded whls?
   echo "Computing local versions for sharktank and shortfin..."
-  ${SCRIPT_DIR}/compute_local_version.py ${REPO_ROOT}/sharktank
-  ${SCRIPT_DIR}/compute_local_version.py ${REPO_ROOT}/shortfin
+  ${SCRIPT_DIR}/compute_local_version.py ${REPO_ROOT}/sharktank -stable --write-json
+  ${SCRIPT_DIR}/compute_local_version.py ${REPO_ROOT}/shortfin -stable --write-json
 
   echo "Computing common version for shark-ai meta package..."
   ${SCRIPT_DIR}/compute_common_version.py --stable-release --write-json


### PR DESCRIPTION
Adding `-stable` fixes
```
Computing local versions for sharktank and shortfin...
usage: compute_local_version.py [-h] [--write-json] (-stable | -rc | -dev | --version-suffix VERSION_SUFFIX) path
compute_local_version.py: error: one of the arguments -stable/--stable-release -rc/--nightly-release -dev/--development-release --version-suffix is required
```

Adding `--write-json` fixes the `write_requirements.py` step from either
* using previously written JSON files if present (resulting in old version pins in the meta package, oops!)
* failing to open files that don't exist (failing to release, but at least not using the wrong versions)

Future changes should put more logging in place and add a confirmation step. I only caught this because I ran _part_ of the script and paused to verify manually.