### PR TITLE
[tuner] Write candidate specs with local scope

### DIFF
--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -355,7 +355,7 @@ def main():
             prefetch_shared_memory=args.prefetch_shared_memory_options,
             no_reduce_shared_memory_bank_conflicts=args.no_reduce_shared_memory_bank_conflicts_options,
         )
-        specs = generate_configs_and_td_specs(
+        specs: list[ir.Module] = generate_configs_and_td_specs(
             mlir_module,
             tuner_ctx,
             args.limit,
@@ -369,7 +369,8 @@ def main():
             spec_path = spec_dir / f"{candidate_num}_spec.mlir"
             spec_dir.mkdir(parents=True, exist_ok=True)
             with open(spec_path, "w") as f:
-                f.write(str(spec))
+                local_scope_spec_str: str = spec.operation.get_asm(use_local_scope=True)
+                f.write(local_scope_spec_str)
 
 
 if __name__ == "__main__":

--- a/tuner/tuner/libtuner.py
+++ b/tuner/tuner/libtuner.py
@@ -688,7 +688,11 @@ def generate_candidate_specs(
                 candidate_num
             )
             with open(spec_path, "w") as f:
-                f.write(str(spec))
+                # Write the module with local scope so that compilation info
+                # attributes are inlined. This makes it easier to split up the
+                # TD spec and combine with other specs after tuning.
+                local_scope_spec_str: str = spec.operation.get_asm(use_local_scope=True)
+                f.write(local_scope_spec_str)
             new_candidate = CandidateTracker(
                 mlir_path=path_config.template_mlir,
                 candidate_id=candidate_num,


### PR DESCRIPTION
This PR changes the format of generated TD specs to inline the compilation info into the matcher function. This makes splitting the TD spec and combining with others after tuning much easier.