### PR TITLE
Bump IREE runtime pin used in shortfin close to latest.

### DIFF
--- a/shortfin/CMakeLists.txt
+++ b/shortfin/CMakeLists.txt
@@ -246,7 +246,7 @@ else()
     GIT_REPOSITORY https://github.com/iree-org/iree.git
     GIT_TAG "${SHORTFIN_IREE_GIT_TAG}"
     GIT_SUBMODULES ${IREE_SUBMODULES}
-    GIT_SHALLOW TRUE
+    GIT_SHALLOW FALSE  # TODO: switch back to TRUE when SHORTFIN_IREE_GIT_TAG is a tag and not a commit
     SYSTEM
     EXCLUDE_FROM_ALL
   )

--- a/shortfin/CMakeLists.txt
+++ b/shortfin/CMakeLists.txt
@@ -47,7 +47,10 @@ add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 # Prefer to keep the IREE git tag synced with the Python package version in the
 # requirements-iree-pinned.txt file. At a minimum, the compiler from those
 # packages must be compatible with the runtime at this source ref.
-set(SHORTFIN_IREE_GIT_TAG "iree-3.1.0rc20241220")
+# TODO: switch back to iree-3.2.0rcYYYYMMDD style tag matching Python package
+#       pin after future nightly releases
+set(SHORTFIN_IREE_GIT_TAG "9055c9d1f6342a061a6747ef9b385816b96a0a8f")
+
 
 # build options
 option(SHORTFIN_BUILD_PYTHON_BINDINGS "Builds Python Bindings" OFF)


### PR DESCRIPTION
This updates to https://github.com/iree-org/iree/commit/9055c9d1f6342a061a6747ef9b385816b96a0a8f. Diff: https://github.com/iree-org/iree/compare/iree-3.1.0rc20241220...9055c9d1f6342a061a6747ef9b385816b96a0a8f. Notably, this pulls in many performance improvements and bug fixes to https://github.com/iree-org/iree/tree/main/runtime/src/iree/hal/drivers/hip.

See discussion on https://github.com/nod-ai/shark-ai/pull/773 and https://github.com/nod-ai/shark-ai/pull/802 .