### PR TITLE
[tuner] reduce log file size

### DIFF
--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -237,11 +237,6 @@ def run_command(run_pack: RunPack) -> RunResult:
             text=True,
             timeout=timeout_seconds,
         )
-
-        if result.stdout:
-            logging.debug(f"stdout: {result.stdout}")
-        if result.stderr:
-            logging.debug(f"stderr: {result.stderr}")
     except subprocess.TimeoutExpired as e:
         logging.warning(
             f"Command '{command_str}' timed out after {timeout_seconds} seconds."

--- a/tuner/tuner/libtuner.py
+++ b/tuner/tuner/libtuner.py
@@ -803,7 +803,7 @@ def compile(
     compiled_candidates = [c for c in compiled_candidates if c is not None]
     success_rate = float(len(compiled_candidates)) / float(len(candidates))
     logging.info(
-        f"Successfully compiled [{len(compiled_candidates)}] candidates. Success rate: {success_rate}"
+        f"Successfully compiled [{len(compiled_candidates)}] candidates. Success rate: {success_rate:.2f}"
     )
 
     # Remove duplicate vmfbs from the candidate list.
@@ -875,7 +875,7 @@ def select_best_benchmark_results(
             speedup = f"{round(get_speedup(r) * 100, 2)}% of baseline"
         else:
             speedup = "baseline unavailable"
-        logging.info(f"Candidate {r.candidate_id} time: {r.time} ({speedup})")
+        logging.info(f"Candidate {r.candidate_id} time: {r.time:.2f} ({speedup})")
     return best_results
 
 


### PR DESCRIPTION
This PR aims to the log size detailed in: https://github.com/nod-ai/shark-ai/issues/806

- Avoid printing the stdout and stderr of running the command 
- Reduce the precision of fp constants printed
