### PR TITLE
[shortfin] Add a tracing enabled CI job.

### DIFF
--- a/.github/workflows/ci-libshortfin.yml
+++ b/.github/workflows/ci-libshortfin.yml
@@ -127,13 +127,13 @@ jobs:
         cmake --build build --target all
 
     - name: pip install shortfin
-      if: ${{ matrix.name != 'Ubuntu (Clang)(host-only)'}}
+      if: ${{ matrix.name != 'Ubuntu (Clang)(host-only)' && !contains(matrix.name, 'tracing') }}
       working-directory: ${{ env.LIBSHORTFIN_DIR }}
       run: |
         pip install -v -e build/
 
     - name: Test shortfin
-      if: ${{ matrix.name != 'Ubuntu (Clang)(host-only)'}}
+      if: ${{ matrix.name != 'Ubuntu (Clang)(host-only)' && !contains(matrix.name, 'tracing') }}
       working-directory: ${{ env.LIBSHORTFIN_DIR }}
       run: |
         ctest --timeout 30 --output-on-failure --test-dir build

--- a/.github/workflows/ci-libshortfin.yml
+++ b/.github/workflows/ci-libshortfin.yml
@@ -64,6 +64,12 @@ jobs:
             python-version: "3.12"
             cmake-options:
               -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14
+          - name: Ubuntu (GCC 14, tracing)
+            runs-on: ubuntu-24.04
+            # Only test with GCC 14 and Python 3.12
+            python-version: "3.12"
+            cmake-options:
+              -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DSHORTFIN_ENABLE_TRACING=ON
           - name: Windows (MSVC)
             runs-on: windows-2022
         exclude:

--- a/shortfin/CMakeLists.txt
+++ b/shortfin/CMakeLists.txt
@@ -49,7 +49,7 @@ add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 # packages must be compatible with the runtime at this source ref.
 # TODO: switch back to iree-3.2.0rcYYYYMMDD style tag matching Python package
 #       pin after future nightly releases
-set(SHORTFIN_IREE_GIT_TAG "9055c9d1f6342a061a6747ef9b385816b96a0a8f")
+set(SHORTFIN_IREE_GIT_TAG "039b8b4ba8e57a3c148cd8f73370a973d64df202")
 
 
 # build options


### PR DESCRIPTION
Also update the pinned IREE commit used for building shortfin now that a fix for Tracy on gcc has landed.