### PR TITLE
[tuner] add the output file

### DIFF
--- a/tuner/examples/simple/simple_tuner.py
+++ b/tuner/examples/simple/simple_tuner.py
@@ -75,6 +75,7 @@ def main():
 
     path_config = libtuner.PathConfig()
     path_config.base_dir.mkdir(parents=True, exist_ok=True)
+    path_config._set_tune_output(Path("autotune_output.txt"))
     # TODO(Max191): Make candidate_trackers internal to TuningClient.
     candidate_trackers: list[libtuner.CandidateTracker] = []
     stop_after_phase: str = args.stop_after
@@ -156,3 +157,13 @@ def main():
 
         print("Check the detailed execution logs in:")
         print(path_config.run_log.resolve())
+
+        print("Check the tuning results in:")
+        print(path_config.tune_output.resolve())
+        with open(path_config.tune_output, "w") as file:
+            file.write(f"Top dispatch candidates: {top_candidates}\n")
+            for id in top_candidates:
+                file.write(f"{candidate_trackers[id].spec_path.resolve()}\n")
+            file.write(f"Top model candidates: {top_model_candidates}\n")
+            for id in top_model_candidates:
+                file.write(f"{candidate_trackers[id].spec_path.resolve()}\n")

--- a/tuner/examples/simple/simple_tuner.py
+++ b/tuner/examples/simple/simple_tuner.py
@@ -102,7 +102,7 @@ def main():
     )
     print("Generating candidate tuning specs...")
     with TunerContext(logger=root_logger) as tuner_context:
-        tuner_context.add_logging_handler(summary_handler)
+        tuner_context.logger.addHandler(summary_handler)
         simple_tuner = SimpleTuner(tuner_context)
         candidates = libtuner.generate_candidate_specs(
             args, path_config, candidate_trackers, simple_tuner
@@ -121,11 +121,11 @@ def main():
         if stop_after_phase == libtuner.ExecutionPhases.compile_dispatches:
             return
 
-        print("Benchmarking compiled dispatch candidates...")
-        logging.info(f"Summarization about top dispatch candidates:")
+        message = "Benchmarking compiled dispatch candidates..."
+        print(message)
+        logging.info(message)
         simple_tuner.benchmark_flags = ["--input=1", "--benchmark_repetitions=3"]
         top_candidates = libtuner.benchmark(
-            tuner_context,
             args,
             path_config,
             compiled_candidates,
@@ -153,12 +153,12 @@ def main():
         if stop_after_phase == libtuner.ExecutionPhases.compile_models:
             return
 
-        print("Benchmarking compiled model candidates...")
-        logging.info(f"Summarization about top model candidates:")
+        message = "Benchmarking compiled model candidates..."
+        print(message)
+        logging.info(message)
         simple_tuner.benchmark_flags = model_benchmark_flags
         simple_tuner.benchmark_timeout = 60
         top_model_candidates = libtuner.benchmark(
-            tuner_context,
             args,
             path_config,
             compiled_model_candidates,
@@ -173,6 +173,5 @@ def main():
 
         print("Check the detailed execution logs in:")
         print(path_config.run_log.resolve())
-
-        print("Check the tuning results in:")
+        print("Check the summary in:")
         print(path_config.summary_log.resolve())

--- a/tuner/examples/simple/simple_tuner.py
+++ b/tuner/examples/simple/simple_tuner.py
@@ -80,9 +80,8 @@ def main():
     stop_after_phase: str = args.stop_after
 
     print("Setup logging")
-    libtuner.setup_logging(args, path_config)
-    print(path_config.run_log, end="\n")
-    print(path_config.summary_log, end="\n\n")
+    tune_logger = libtuner.setup_logging(args, path_config)
+    print(path_config.run_log, end="\n\n")
 
     if not args.dry_run:
         print("Validating devices")
@@ -95,9 +94,13 @@ def main():
     )
 
     print("Generating candidate tuning specs...")
-    with TunerContext() as tuner_context:
+    with TunerContext(logger=tune_logger) as tuner_context:
+        summary_log_file = path_config.base_dir / "summary.log"
+        path_config.set_summary_log(summary_log_file)
+        summary_handler = logging.FileHandler(summary_log_file)
+        summary_handler.setLevel(logging.INFO)
+        tuner_context.add_logging_handler(summary_handler)
         simple_tuner = SimpleTuner(tuner_context)
-        summary_logger = logging.getLogger("summary")
         candidates = libtuner.generate_candidate_specs(
             args, path_config, candidate_trackers, simple_tuner
         )
@@ -116,9 +119,10 @@ def main():
             return
 
         print("Benchmarking compiled dispatch candidates...")
-        summary_logger.info(f"Summarization about top dispatch candidates:")
+        tune_logger.info(f"Summarization about top dispatch candidates:")
         simple_tuner.benchmark_flags = ["--input=1", "--benchmark_repetitions=3"]
         top_candidates = libtuner.benchmark(
+            tuner_context,
             args,
             path_config,
             compiled_candidates,
@@ -126,9 +130,9 @@ def main():
             simple_tuner,
             args.simple_num_dispatch_candidates,
         )
-        summary_logger.info(f"Top dispatch candidates: {top_candidates}")
+        tune_logger.info(f"Top dispatch candidates: {top_candidates}")
         for id in top_candidates:
-            summary_logger.info(f"{candidate_trackers[id].spec_path.resolve()}")
+            tune_logger.info(f"{candidate_trackers[id].spec_path.resolve()}")
         if stop_after_phase == libtuner.ExecutionPhases.benchmark_dispatches:
             return
 
@@ -147,10 +151,11 @@ def main():
             return
 
         print("Benchmarking compiled model candidates...")
-        summary_logger.info(f"Summarization about top model candidates:")
+        tune_logger.info(f"Summarization about top model candidates:")
         simple_tuner.benchmark_flags = model_benchmark_flags
         simple_tuner.benchmark_timeout = 60
         top_model_candidates = libtuner.benchmark(
+            tuner_context,
             args,
             path_config,
             compiled_model_candidates,
@@ -158,9 +163,9 @@ def main():
             simple_tuner,
             args.simple_num_model_candidates,
         )
-        summary_logger.info(f"Top model candidates: {top_model_candidates}")
+        tune_logger.info(f"Top model candidates: {top_model_candidates}")
         for id in top_model_candidates:
-            summary_logger.info(f"{candidate_trackers[id].spec_path.resolve()}")
+            tune_logger.info(f"{candidate_trackers[id].spec_path.resolve()}")
         print(f"Top model candidates: {top_model_candidates}")
 
         print("Check the detailed execution logs in:")

--- a/tuner/examples/simple/simple_tuner.py
+++ b/tuner/examples/simple/simple_tuner.py
@@ -94,7 +94,6 @@ def main():
     )
 
     summary_log_file = path_config.base_dir / "summary.log"
-    path_config.set_summary_log(summary_log_file)
     summary_handler = logging.FileHandler(summary_log_file)
     summary_handler.setLevel(logging.INFO)
     summary_handler.setFormatter(
@@ -174,4 +173,4 @@ def main():
         print("Check the detailed execution logs in:")
         print(path_config.run_log.resolve())
         print("Check the summary in:")
-        print(path_config.summary_log.resolve())
+        print(summary_log_file.resolve())

--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -195,12 +195,12 @@ def generate_configs_and_td_specs(
     ):
         if i >= limit:
             break
-        tune_logger.info(f"Solution #{i+1}: {config}")
+        tune_logger.debug(f"Solution #{i+1}: {config}")
         td_spec_module = dispatch_tuner.get_td_spec(input_module, config)
         assert td_spec_module, "Failed to generate transform dialect spec"
         config_specs.append(td_spec_module)
 
-    tune_logger.info(f"Generated {len(config_specs)} tuning specs")
+    tune_logger.debug(f"Generated {len(config_specs)} tuning specs")
     return config_specs
 
 

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -46,9 +46,6 @@ class TunerContext:
         self.mlir_ctx.__enter__()
         return self
 
-    def add_logging_handler(self, handler: logging.Handler) -> None:
-        self.logger.addHandler(handler)
-
     def __exit__(
         self,
         exc_type: type[BaseException] | None,

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -46,6 +46,9 @@ class TunerContext:
         self.mlir_ctx.__enter__()
         return self
 
+    def add_logging_handler(self, handler: logging.Handler) -> None:
+        self.logger.addHandler(handler)
+
     def __exit__(
         self,
         exc_type: type[BaseException] | None,

--- a/tuner/tuner/dispatch_constraints.py
+++ b/tuner/tuner/dispatch_constraints.py
@@ -376,7 +376,7 @@ def generate_solutions(
         codegen_pipeline,
     )
     M, N, K = problem_size.MNK
-    tuner_ctx.logger.info(f"{M},{N},{K}")
+    tuner_ctx.logger.debug(f"{M},{N},{K}")
     m_vars = [z3.Int(f"m{i}") for i in range(len(M))]
     n_vars = [z3.Int(f"n{i}") for i in range(len(N))]
     k_vars = [z3.Int(f"k{i}") for i in range(len(K))]

--- a/tuner/tuner/dispatch_parser.py
+++ b/tuner/tuner/dispatch_parser.py
@@ -17,7 +17,7 @@ def parse_mlir(mlir_text: str, ctx: TunerContext) -> ir.Module:
     mlir_module = None
     try:
         mlir_module = ir.Module.parse(mlir_text, ctx.mlir_ctx)
-        ctx.logger.info("MLIR parsing successful!")
+        ctx.logger.debug("MLIR parsing successful!")
     except ir.MLIRError as e:
         ctx.logger.error(f"Error parsing MLIR: {e}")
         raise RuntimeError(f"Error parsing MLIR: {e}")

--- a/tuner/tuner/libtuner.py
+++ b/tuner/tuner/libtuner.py
@@ -895,7 +895,6 @@ def select_best_benchmark_results(
 
 
 def benchmark(
-    tuner_context: TunerContext,
     args: argparse.Namespace,
     path_config: PathConfig,
     compiled_candidates: list[int],

--- a/tuner/tuner/libtuner.py
+++ b/tuner/tuner/libtuner.py
@@ -79,6 +79,7 @@ class PathConfig:
 
     # To be set outside of class
     run_log: Optional[Path] = field(init=False, default=None)
+    tune_output: Optional[Path] = field(init=False, default=None)
 
     def __post_init__(self):
         object.__setattr__(self, "base_dir", self._name_base_dir())
@@ -94,6 +95,9 @@ class PathConfig:
 
     def _set_run_log(self, run_log: Path):
         object.__setattr__(self, "run_log", run_log)
+
+    def _set_tune_output(self, tune_output: Path):
+        object.__setattr__(self, "tune_output", self.base_dir / tune_output)
 
     def get_candidate_spec_filename(self, candidate_id: int) -> str:
         return f"{candidate_id}_spec.mlir"
@@ -801,7 +805,7 @@ def compile(
         num_worker=num_worker, task_list=task_list, function=run_iree_compile_command
     )
     compiled_candidates = [c for c in compiled_candidates if c is not None]
-    success_rate = float(len(compiled_candidates)) / float(len(candidates))
+    success_rate = float(len(compiled_candidates)) / float(len(task_list))
     logging.info(
         f"Successfully compiled [{len(compiled_candidates)}] candidates. Success rate: {success_rate:.2f}"
     )

--- a/tuner/tuner/libtuner.py
+++ b/tuner/tuner/libtuner.py
@@ -79,7 +79,6 @@ class PathConfig:
 
     # To be set outside of class
     run_log: Optional[Path] = field(init=False, default=None)
-    summary_log: Optional[Path] = field(init=False, default=None)
 
     def __post_init__(self):
         object.__setattr__(self, "base_dir", self._name_base_dir())
@@ -95,9 +94,6 @@ class PathConfig:
 
     def set_run_log(self, run_log: Path):
         object.__setattr__(self, "run_log", run_log)
-
-    def set_summary_log(self, summary_log: Path):
-        object.__setattr__(self, "summary_log", summary_log)
 
     def get_candidate_spec_filename(self, candidate_id: int) -> str:
         return f"{candidate_id}_spec.mlir"

--- a/tuner/tuner/libtuner_test.py
+++ b/tuner/tuner/libtuner_test.py
@@ -19,16 +19,6 @@ Usage: python -m pytest libtuner_test.py
 """
 
 
-@pytest.fixture
-def tuner_ctx() -> Generator[common.TunerContext, None, None]:
-    from logging import Logger
-    from unittest.mock import MagicMock
-
-    mock_logger = MagicMock(spec=Logger)
-    with common.TunerContext(logger=mock_logger) as ctx:
-        yield ctx
-
-
 def test_find_collisions() -> None:
     input = [(1, "abc"), (2, "def"), (3, "abc")]
     assert libtuner.find_collisions(input) == (True, [("abc", [1, 3]), ("def", [2])])
@@ -198,8 +188,11 @@ def test_get_compilation_success_rate():
     compiled_candidates = [None, None, None]
     assert libtuner.get_compilation_success_rate(compiled_candidates) == 0.0
 
+    compiled_candidates = []
+    assert libtuner.get_compilation_success_rate(compiled_candidates) == 0.0
 
-def test_select_best_benchmark_results(tuner_ctx: common.TunerContext) -> None:
+
+def test_select_best_benchmark_results() -> None:
     candidate_results = [
         libtuner.BenchmarkResult(1, 0.5, "hip://0"),
         libtuner.BenchmarkResult(2, 0.3, "hip://1"),
@@ -215,7 +208,6 @@ def test_select_best_benchmark_results(tuner_ctx: common.TunerContext) -> None:
     best_results: list[
         libtuner.BenchmarkResult
     ] = libtuner.select_best_benchmark_results(
-        tuner_context=tuner_ctx,
         candidate_results=candidate_results,
         baseline_results=baseline_results,
         num_candidates=3,
@@ -231,7 +223,6 @@ def test_select_best_benchmark_results(tuner_ctx: common.TunerContext) -> None:
         libtuner.BenchmarkResult(0, 0.1, "hip://3"),
     ]
     best_results = libtuner.select_best_benchmark_results(
-        tuner_context=tuner_ctx,
         candidate_results=candidate_results,
         baseline_results=baseline_results,
         num_candidates=3,
@@ -247,7 +238,6 @@ def test_select_best_benchmark_results(tuner_ctx: common.TunerContext) -> None:
         libtuner.BenchmarkResult(0, math.inf, "hip://3"),
     ]
     best_results = libtuner.select_best_benchmark_results(
-        tuner_context=tuner_ctx,
         candidate_results=candidate_results,
         baseline_results=baseline_results,
         num_candidates=3,

--- a/tuner/tuner/libtuner_test.py
+++ b/tuner/tuner/libtuner_test.py
@@ -176,6 +176,17 @@ def test_validate_devices_with_invalid_device() -> None:
                 assert expected_call in mock_handle_error.call_args_list
 
 
+def test_get_compilation_success_rate():
+    compiled_candidates = [0, None, 2, None, 4]
+    assert libtuner.get_compilation_success_rate(compiled_candidates) == 3.0 / 5.0
+
+    compiled_candidates = [0, 1, 2, 3, 4]
+    assert libtuner.get_compilation_success_rate(compiled_candidates) == 1.0
+
+    compiled_candidates = [None, None, None]
+    assert libtuner.get_compilation_success_rate(compiled_candidates) == 0.0
+
+
 def test_select_best_benchmark_results() -> None:
     candidate_results = [
         libtuner.BenchmarkResult(1, 0.5, "hip://0"),

--- a/tuner/tuner/libtuner_test.py
+++ b/tuner/tuner/libtuner_test.py
@@ -6,13 +6,9 @@
 
 import argparse
 import math
-import pytest
-import json
 from subprocess import CompletedProcess
 from unittest.mock import call, patch, MagicMock
-from typing import Generator
 from . import libtuner
-from . import common
 
 """
 Usage: python -m pytest libtuner_test.py

--- a/tuner/tuner/libtuner_test.py
+++ b/tuner/tuner/libtuner_test.py
@@ -10,11 +10,23 @@ import pytest
 import json
 from subprocess import CompletedProcess
 from unittest.mock import call, patch, MagicMock
+from typing import Generator
 from . import libtuner
+from . import common
 
 """
 Usage: python -m pytest libtuner_test.py
 """
+
+
+@pytest.fixture
+def tuner_ctx() -> Generator[common.TunerContext, None, None]:
+    from logging import Logger
+    from unittest.mock import MagicMock
+
+    mock_logger = MagicMock(spec=Logger)
+    with common.TunerContext(logger=mock_logger) as ctx:
+        yield ctx
 
 
 def test_find_collisions() -> None:
@@ -187,7 +199,7 @@ def test_get_compilation_success_rate():
     assert libtuner.get_compilation_success_rate(compiled_candidates) == 0.0
 
 
-def test_select_best_benchmark_results() -> None:
+def test_select_best_benchmark_results(tuner_ctx: common.TunerContext) -> None:
     candidate_results = [
         libtuner.BenchmarkResult(1, 0.5, "hip://0"),
         libtuner.BenchmarkResult(2, 0.3, "hip://1"),
@@ -203,6 +215,7 @@ def test_select_best_benchmark_results() -> None:
     best_results: list[
         libtuner.BenchmarkResult
     ] = libtuner.select_best_benchmark_results(
+        tuner_context=tuner_ctx,
         candidate_results=candidate_results,
         baseline_results=baseline_results,
         num_candidates=3,
@@ -218,6 +231,7 @@ def test_select_best_benchmark_results() -> None:
         libtuner.BenchmarkResult(0, 0.1, "hip://3"),
     ]
     best_results = libtuner.select_best_benchmark_results(
+        tuner_context=tuner_ctx,
         candidate_results=candidate_results,
         baseline_results=baseline_results,
         num_candidates=3,
@@ -233,6 +247,7 @@ def test_select_best_benchmark_results() -> None:
         libtuner.BenchmarkResult(0, math.inf, "hip://3"),
     ]
     best_results = libtuner.select_best_benchmark_results(
+        tuner_context=tuner_ctx,
         candidate_results=candidate_results,
         baseline_results=baseline_results,
         num_candidates=3,


### PR DESCRIPTION
This PR addresses the task described in https://github.com/nod-ai/shark-ai/issues/806.

It adds a separate output file to the tuner to summarize the most important information, such as the top candidates (dispatch and model) and paths to their specifications.

Also, it fixes the issue with incorrect reporting of the compilation success rate in the log.

