### PR TITLE
Revert "Mark sharktank vae iree test as xfail"

### DIFF
--- a/sharktank/tests/models/vae/vae_test.py
+++ b/sharktank/tests/models/vae/vae_test.py
@@ -104,9 +104,6 @@ class VaeSDXLDecoderTest(TempDirTestBase):
 
         torch.testing.assert_close(ref_results, results)
 
-    @pytest.mark.xfail(
-        reason="Waiting on fix for https://github.com/iree-org/iree/issues/19623"
-    )
     def testVaeIreeVsHuggingFace(self):
         dtype = getattr(torch, "float32")
         inputs = get_random_inputs(dtype=dtype, device="cpu", bs=1)


### PR DESCRIPTION
Reverts nod-ai/shark-ai#775: failing tests fixed by changing CI system to stable rocm version