### PR TITLE
Generate token for create-pull-request action using an app.

### DIFF
--- a/.github/workflows/update_iree_requirement_pins.yml
+++ b/.github/workflows/update_iree_requirement_pins.yml
@@ -22,6 +22,12 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
+      - uses: actions/create-github-app-token@c1a285145b9d317df6ced56c09f525b5c2b6f755 # v1.11.1
+        id: generate-token
+        with:
+          app-id: ${{ secrets.CREATE_PULL_REQUEST_TOKEN_APP_ID }}
+          private-key: ${{ secrets.CREATE_PULL_REQUEST_TOKEN_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: "Setting up Python"
@@ -41,6 +47,7 @@ jobs:
           ${{ env.CURRENT_SHORTFIN_IREE_GIT_TAG }} != ${{ env.LATEST_SHORTFIN_IREE_GIT_TAG }}
         uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # v7.0.6
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           base: main
           branch: integrates/iree
           delete-branch: true


### PR DESCRIPTION
This allows the created pull requests to run checks based on the `pull_request` trigger. See the documentation here:

* https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
* https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens

Tested here:
* https://github.com/nod-ai/shark-ai/actions/runs/12819231996/job/35746461928
* https://github.com/nod-ai/shark-ai/pull/835