### PR TITLE
[shortfin][python] Skip tokenization in sd.server if request holds `input_ids`

### DIFF
--- a/shortfin/python/shortfin_apps/sd/components/messages.py
+++ b/shortfin/python/shortfin_apps/sd/components/messages.py
@@ -114,6 +114,7 @@ class InferenceExecRequest(sf.Message):
             "steps",
             "guidance_scale",
             "seed",
+            "input_ids",
         ]
         rec_inputs = {}
         for item in gen_inputs:

--- a/shortfin/python/shortfin_apps/sd/components/service.py
+++ b/shortfin/python/shortfin_apps/sd/components/service.py
@@ -393,12 +393,15 @@ class InferenceExecutorProcess(sf.Process):
             # Tokenize prompts and negative prompts. We tokenize in bs1 for now and join later.
             input_ids_list = []
             neg_ids_list = []
-            for tokenizer in self.service.tokenizers:
-                input_ids = tokenizer.encode(request.prompt)
-                input_ids_list.append(input_ids)
-                neg_ids = tokenizer.encode(request.neg_prompt)
-                neg_ids_list.append(neg_ids)
-            ids_list = [*input_ids_list, *neg_ids_list]
+            ids_list = request.input_ids
+            # Tokenize the prompts if the request does not hold input_ids.
+            if ids_list is None:
+                for tokenizer in self.service.tokenizers:
+                    input_ids = tokenizer.encode(request.prompt)
+                    input_ids_list.append(input_ids)
+                    neg_ids = tokenizer.encode(request.neg_prompt)
+                    neg_ids_list.append(neg_ids)
+                ids_list = [*input_ids_list, *neg_ids_list]
 
             request.input_ids = ids_list
 


### PR DESCRIPTION
`sd.server` currently performs tokenization irrespective of whether the request has `input_ids` attached to it.

This patch adds a check to skip tokenization if the request has tokenized inputs attached to it, and adds `input_ids` to `gen_inputs` so that such requests can be created from `InferenceExecRequests.from_batch()`.