### PR TITLE
Add trace_tensor op and refactor tensor tracing

### DIFF
--- a/docs/debug_flags.md
+++ b/docs/debug_flags.md
@@ -16,8 +16,8 @@ false.
   to emit information. When disabled, it is a no-op.
 * `enable_nan_checks`: Enables certain expensive nan checks that may be
   included in the model.
-* `save_goldens_path`: When set to a path, any tensor traced via
-  `trace_tensor(golden=True)` will be added to a safetensors file and output
+* `trace_path`: When set to a path, any tensor traced via
+  `trace_tensor()` will be added to a safetensors file and output
   in a deterministic way to the path.
 * `use_custom_int_conv_kernel`: Uses custom kernels for integer convolution
   arithmetic. This produces the most optimal compiled results but can impede

--- a/sharktank/requirements-tests.txt
+++ b/sharktank/requirements-tests.txt
@@ -11,3 +11,4 @@ protobuf
 pytest==8.0.0
 pytest-html
 pytest-xdist==3.5.0
+safetensors>=0.4.5

--- a/sharktank/sharktank/layers/paged_llama_attention_block.py
+++ b/sharktank/sharktank/layers/paged_llama_attention_block.py
@@ -199,7 +199,7 @@ class PagedLlamaAttentionBlock(ThetaLayer):
             self.assert_not_nan(attn_weights)
 
             # Apply attention mask.
-            self.trace_tensor("attn_weights", attn_weights, values=False)
+            self.trace_tensor("attn_weights", attn_weights)
             if attention_mask is not None:
                 # self.trace_tensor("attn_mask", attention_mask)
                 attn_weights = attn_weights + attention_mask

--- a/sharktank/sharktank/models/flux/flux.py
+++ b/sharktank/sharktank/models/flux/flux.py
@@ -342,7 +342,7 @@ class MLPEmbedder(ThetaLayer):
         return self.out_layer(x)
 
 
-class EmbedND(torch.nn.Module):
+class EmbedND(BaseLayer):
     def __init__(self, dim: int, theta: int, axes_dim: list[int]):
         super().__init__()
         self.dim = dim

--- a/sharktank/sharktank/models/flux/testing.py
+++ b/sharktank/sharktank/models/flux/testing.py
@@ -47,11 +47,6 @@ def make_random_theta(config: FluxParams, dtype: torch.dtype):
     in_channels2 = 128
     hidden_size = config.hidden_size
     mlp_ratio = config.mlp_ratio
-    mlp_hidden_size = int((mlp_ratio - 1) * hidden_size)
-    mlp_hidden_size2 = int(mlp_ratio * hidden_size)
-    mlp_hidden_size3 = int(2 * (mlp_ratio - 1) * hidden_size)
-    mlp_hidden_size4 = int((mlp_ratio + 1) * hidden_size)
-    mlp_hidden_size5 = int((2 * mlp_ratio - 1) * hidden_size)
     context_in_dim = config.context_in_dim
     time_dim = 256
     vec_dim = config.vec_in_dim

--- a/sharktank/sharktank/models/punet/model.py
+++ b/sharktank/sharktank/models/punet/model.py
@@ -123,7 +123,7 @@ class Unet2DConditionModel(ThetaLayer):
         # TODO: Verify on the fly upsampling is not needed (num_upsamplers != 0).
         act_dtype = sample.dtype
         bs, *_ = sample.shape
-        self.trace_goldens(
+        self.trace_tensor(
             "inputs",
             {
                 "sample": sample,
@@ -150,11 +150,11 @@ class Unet2DConditionModel(ThetaLayer):
         add_embeds = torch.concat([text_embeds, time_embeds], dim=-1).to(emb.dtype)
         aug_embed = self.add_embedding(add_embeds)
         emb = emb + aug_embed
-        self.trace_golden("emb", emb)
+        self.trace_tensor("emb", emb)
 
         # 2. Pre-process.
         sample = self.conv_in(sample)
-        self.trace_golden("preprocess", sample)
+        self.trace_tensor("preprocess", sample)
 
         # 3. Down.
         down_block_res_samples = (sample,)
@@ -167,7 +167,7 @@ class Unet2DConditionModel(ThetaLayer):
                 encoder_attention_mask=None,
             )
             down_block_res_samples += res_samples
-            self.trace_golden(f"down_block_{i}", sample)
+            self.trace_tensor(f"down_block_{i}", sample)
 
         # 4. Mid.
         sample, _ = self.mid_block(
@@ -177,7 +177,7 @@ class Unet2DConditionModel(ThetaLayer):
             attention_mask=None,
             encoder_attention_mask=None,
         )
-        self.trace_golden("mid_block", sample)
+        self.trace_tensor("mid_block", sample)
 
         # 5. Up.
         for i, up_block in enumerate(self.up_blocks):
@@ -193,14 +193,14 @@ class Unet2DConditionModel(ThetaLayer):
                 attention_mask=None,
                 encoder_attention_mask=None,
             )
-            self.trace_golden(f"up_block_{i}", sample)
+            self.trace_tensor(f"up_block_{i}", sample)
 
         # 6. Post-process.
         if self.conv_norm_out:
             sample = self.conv_norm_out(sample)
             sample = ops.elementwise(self.conv_act, sample)
         sample = self.conv_out(sample)
-        self.trace_golden(f"output", sample)
+        self.trace_tensor(f"output", sample)
         return sample
 
     def _create_down_block(

--- a/sharktank/sharktank/models/vae/model.py
+++ b/sharktank/sharktank/models/vae/model.py
@@ -67,7 +67,7 @@ class VaeDecoderModel(ThetaLayer):
             sample ('torch.Tensor') input latents of shape (batch_size, num_channels, height, width)
 
         """
-        self.trace_goldens(
+        self.trace_tensor(
             "inputs",
             {
                 "sample": sample,
@@ -89,10 +89,10 @@ class VaeDecoderModel(ThetaLayer):
             sample = self.post_quant_conv(sample)
 
         sample = self.conv_in(sample)
-        self.trace_golden("conv_in", sample)
+        self.trace_tensor("conv_in", sample)
         # TODO add training and gradient checkpointing support
         sample = self.mid_block(sample, latent_embeds)
-        self.trace_golden("mid_block", sample)
+        self.trace_tensor("mid_block", sample)
 
         sample = sample.to(self.upscale_dtype)
         for up_block in self.up_blocks:

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -437,6 +437,13 @@ def to_default(tensor: Tensor, *args, **kwargs):
     return unbox_tensor(tensor).to(*args, **kwargs)
 
 
+@trace_tensor.override(AllOfExprsVariadic(IsOfType(Tensor, InferenceTensor)))
+def trace_tensor(key: str, *tensors: tuple[AnyTensor]):
+    if len(tensors) != 1:
+        raise ValueError("Tracing more than one tensor at a time is not supported.")
+    iree.turbine.ops.iree.trace_tensor(key, unshard(tensors[0]))
+
+
 @transfer_to_logical_device.override(Tensor)
 def transfer_to_logical_device_default(tensor: Tensor, ordinal: int):
     return iree.turbine.ops.iree.transfer_to_logical_device(

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -58,6 +58,7 @@ __all__ = [
     "softmax",
     "squeeze",
     "to",
+    "trace_tensor",
     "transfer_to_logical_device",
     "transpose",
     "unflatten",
@@ -1024,6 +1025,23 @@ def _to_trampoline(d: SignatureDispatcher, tensor: AnyTensor, *args, **kwargs):
             return override, result
     else:
         d.fail(dispatch_args)
+
+
+@overridable
+def trace_tensor(key: str, *tensors: tuple[AnyTensor]):
+    ...
+
+
+@trace_tensor.trampoline
+def _transfer_to_logical_device_trampoline(
+    d: SignatureDispatcher, key: str, *tensors: tuple[AnyTensor]
+):
+    for override in d.find_overrides(tensors):
+        result = override(key, *tensors)
+        if result is not NotImplemented:
+            return override, result
+    else:
+        d.fail(tensors)
 
 
 @overridable

--- a/sharktank/sharktank/utils/testing.py
+++ b/sharktank/sharktank/utils/testing.py
@@ -7,6 +7,7 @@
 from typing import Optional
 import contextlib
 from pathlib import Path
+from os import PathLike
 import os
 import shutil
 import tempfile
@@ -136,12 +137,56 @@ def assert_equal(
     assert equal(a, b), f"{a} and {b} are not equal"
 
 
-def assert_golden_safetensors(actual_path, ref_path):
-    """Asserts that actual and reference safetensors files are within tolerances."""
+def assert_close_safetensors(
+    actual_path: PathLike,
+    ref_path: PathLike,
+    rtol: Optional[float] = None,
+    atol: Optional[float] = None,
+    fail_fast: bool = True,
+):
+    """Asserts that actual and reference safetensors files are within tolerances.
+
+    actual_path and ref_path can be directories. In that case files with matching
+    sub-paths will be compared."""
     from safetensors import safe_open
     import torch
 
-    print(f"Asserting goldens: actual={actual_path}, ref={ref_path}")
+    print(f"Asserting tensors close: actual={actual_path}, ref={ref_path}")
+
+    not_close_list: list[tuple[str, str]] = []
+
+    if os.path.isdir(ref_path):
+        assert os.path.isdir(actual_path)
+        actual_path = os.path.abspath(actual_path)
+        ref_path = os.path.abspath(ref_path)
+        ref_paths = [
+            Path(root) / file
+            for root, dirs, files in os.walk(ref_path)
+            for file in files
+        ]
+        for ref_file_path in ref_paths:
+            actual_file_path = Path(
+                f"{actual_path}{str(ref_file_path).removeprefix(ref_path)}"
+            )
+            try:
+                assert os.path.isfile(actual_file_path)
+                assert_close_safetensors(
+                    actual_file_path,
+                    ref_file_path,
+                    rtol=rtol,
+                    atol=atol,
+                    fail_fast=fail_fast,
+                )
+            except Exception as ex:
+                if fail_fast:
+                    raise
+                not_close_list.append((actual_file_path, ref_file_path))
+                print(ex)
+        if len(not_close_list) > 0:
+            print("Not close:")
+            for actual, ref in not_close_list:
+                print(f"{actual} != {ref}")
+            assert False, "Tensors are not close."
 
     def print_stats(label, t):
         t = t.to(dtype=torch.float32)
@@ -156,6 +201,7 @@ def assert_golden_safetensors(actual_path, ref_path):
     with safe_open(actual_path, framework="pt") as actual_f, safe_open(
         ref_path, framework="pt"
     ) as ref_f:
+        is_close = True
         # Print all first.
         for name in ref_f.keys():
             actual = actual_f.get_tensor(name)
@@ -169,7 +215,15 @@ def assert_golden_safetensors(actual_path, ref_path):
         for name in ref_f.keys():
             actual = actual_f.get_tensor(name)
             ref = ref_f.get_tensor(name)
-            torch.testing.assert_close(actual, ref, msg=name)
+            try:
+                torch.testing.assert_close(actual, ref, rtol=rtol, atol=atol)
+            except Exception as ex:
+                if fail_fast:
+                    raise
+                is_close = False
+                print(ex)
+
+        assert is_close, "Tensors are not close."
 
 
 def assert_iterables_equal(


### PR DESCRIPTION
We don't have an op that dispatches to the underlying iree.turbine.ops.iree.trace_tensor.

With this change we can trace into safetensors files when executing both in eager and with IREE.
Routes all tracing through the new tracing op. The user can set a desired sink.

Added some functionality to prefix trace keys based on the module structure.

Something that I could not preserve is the tensor trace counter. It is a global variable and when exporting we pass multiple times through the traced function, which makes the counter inconsistent. The only way to distinguish traced tensors is through the trace keys.

The distinction between tensor tracing and goldens tracing has been remove at the point of issuing a trace. If the user needs different treatment they can customize the trace sink.