### PR TITLE
[Llama] Remove inplace read for KVCache

### DIFF
--- a/sharktank/sharktank/models/grok/grok.py
+++ b/sharktank/sharktank/models/grok/grok.py
@@ -170,36 +170,12 @@ class PagedGrokModelV1(BaseCausalLMModel):
         self._assert_device(attention_mask, dtype=self.activation_dtype)
         self._assert_device(start_positions)
         self._assert_device(*cache_state, dtype=self.activation_dtype)
-        bs, _ = tokens.shape
         # Precompute a position based mask for computing rope embeddings
         # as it is the same for all blocks.
         embedding_batch_mask = self.attention_embedding.compute_batch_mask(
             start_positions, batch_seq_len=1
         )
         self.trace_tensor("grok.embedding_batch_mask", embedding_batch_mask)
-
-        # Allocate per-block temporary K/V tensors. These temporaries hold
-        # one block's K/V state for the maximum context length.
-        xk_temp = torch.empty(
-            [
-                bs,
-                self.context_length,
-                self.hp.attention_head_count_kv,
-                self.hp.attn_head_dim,
-            ],
-            dtype=self.config.activation_dtype,
-            device=self.device,
-        )
-        xv_temp = torch.empty(
-            [
-                bs,
-                self.context_length,
-                self.hp.attention_head_count_kv,
-                self.hp.attn_head_dim,
-            ],
-            dtype=self.config.activation_dtype,
-            device=self.device,
-        )
 
         h = self.token_embedding(tokens)
         h *= math.sqrt(h.shape[-1])
@@ -220,8 +196,6 @@ class PagedGrokModelV1(BaseCausalLMModel):
                 attention_mask=attention_mask,
                 cache_state=cache_state,
                 seq_block_ids=seq_block_ids,
-                xk_temp=xk_temp,
-                xv_temp=xv_temp,
             )
             self.trace_tensor(f"grok.attn_block.{block_idx}.output", h)
 

--- a/sharktank/sharktank/models/llama/llama.py
+++ b/sharktank/sharktank/models/llama/llama.py
@@ -186,58 +186,12 @@ class PagedLlamaModelV1(BaseCausalLMModel):
         self._assert_device(start_positions)
         self._assert_device(*cache_state, dtype=self.activation_dtype)
 
-        bs, _ = tokens.shape
         # Precompute a position based mask for computing rope embeddings
         # as it is the same for all blocks.
         embedding_batch_mask = self.attention_embedding.compute_batch_mask(
             start_positions, batch_seq_len=1
         )
         self.trace_tensor("llama.embedding_batch_mask", embedding_batch_mask)
-
-        # Allocate per-block temporary K/V tensors. These temporaries hold
-        # one block's K/V state for the maximum context length.
-        if self.config.tensor_parallelism_size == 1:
-            xk_temp = torch.empty(
-                [
-                    bs,
-                    self.context_length,
-                    self.hp.attention_head_count_kv,
-                    self.hp.attn_head_dim,
-                ],
-                dtype=self.config.activation_dtype,
-                device=self.device,
-            )
-            xv_temp = torch.empty(
-                [
-                    bs,
-                    self.context_length,
-                    self.hp.attention_head_count_kv,
-                    self.hp.attn_head_dim,
-                ],
-                dtype=self.config.activation_dtype,
-                device=self.device,
-            )
-        else:
-            shard_size = [
-                bs,
-                self.context_length,
-                self.hp.attention_head_count_kv // self.config.tensor_parallelism_size,
-                self.hp.attn_head_dim,
-            ]
-            xk_temp_shard = [
-                torch.empty(
-                    shard_size, dtype=self.config.activation_dtype, device=self.device
-                )
-                for _ in range(self.config.tensor_parallelism_size)
-            ]
-            xv_temp_shard = [
-                torch.empty(
-                    shard_size, dtype=self.config.activation_dtype, device=self.device
-                )
-                for _ in range(self.config.tensor_parallelism_size)
-            ]
-            xk_temp = SplitPrimitiveTensor(ts=xk_temp_shard, shard_dim=2)
-            xv_temp = SplitPrimitiveTensor(ts=xv_temp_shard, shard_dim=2)
 
         h = self.token_embedding(tokens)
         self.trace_tensor("llama.token_embedding", h)
@@ -254,8 +208,6 @@ class PagedLlamaModelV1(BaseCausalLMModel):
                 attention_mask=attention_mask,
                 cache_state=cache_state,
                 seq_block_ids=seq_block_ids,
-                xk_temp=xk_temp,
-                xv_temp=xv_temp,
             )
             self.trace_tensor(f"llama.attn_block.{block_idx}.output", h)
 
@@ -323,8 +275,6 @@ class AttentionFFNBlock(ThetaLayer):
         attention_mask: Optional[torch.Tensor] = None,
         embedding_batch_mask: Optional[torch.Tensor] = None,
         cache_state: list[torch.Tensor] = None,
-        xk_temp: Optional[torch.Tensor] = None,
-        xv_temp: Optional[torch.Tensor] = None,
     ):
         h = self.attn(
             h,
@@ -335,8 +285,6 @@ class AttentionFFNBlock(ThetaLayer):
             attention_mask=attention_mask,
             embedding_batch_mask=embedding_batch_mask,
             cache_state=cache_state,
-            xk_temp=xk_temp,
-            xv_temp=xv_temp,
         )
 
         # Feed forward network.

--- a/sharktank/sharktank/models/mixtral/mixtral.py
+++ b/sharktank/sharktank/models/mixtral/mixtral.py
@@ -177,29 +177,6 @@ class PagedMixtralModelV1(BaseCausalLMModel):
         )
         self.trace_tensor("mixtral.embedding_batch_mask", embedding_batch_mask)
 
-        # Allocate per-block temporary K/V tensors. These temporaries hold
-        # one block's K/V state for the maximum context length.
-        xk_temp = torch.empty(
-            [
-                bs,
-                self.context_length,
-                self.hp.attention_head_count_kv,
-                self.hp.attn_head_dim,
-            ],
-            dtype=self.config.activation_dtype,
-            device=self.device,
-        )
-        xv_temp = torch.empty(
-            [
-                bs,
-                self.context_length,
-                self.hp.attention_head_count_kv,
-                self.hp.attn_head_dim,
-            ],
-            dtype=self.config.activation_dtype,
-            device=self.device,
-        )
-
         h = self.token_embedding(tokens)
         self.trace_tensor("mixtral.token_embedding", h)
 
@@ -218,8 +195,6 @@ class PagedMixtralModelV1(BaseCausalLMModel):
                 attention_mask=attention_mask,
                 cache_state=cache_state,
                 seq_block_ids=seq_block_ids,
-                xk_temp=xk_temp,
-                xv_temp=xv_temp,
             )
             self.trace_tensor(f"mixtral.attn_block.{block_idx}.output", h)
 

--- a/sharktank/tests/layers/kv_cache_test.py
+++ b/sharktank/tests/layers/kv_cache_test.py
@@ -53,18 +53,8 @@ def test_paged():
         page_ids=write_page_ids,
     )
 
-    # Check the written values have updated:
-    read_empty = [
-        torch.empty(
-            (bs, write_seq_length, attn_head_count, attn_head_dim), dtype=torch.float32
-        ),
-        torch.empty(
-            (bs, write_seq_length, attn_head_count, attn_head_dim), dtype=torch.float32
-        ),
-    ]
     read_back = cache.read(
         allocation,
-        read_into_partitions=read_empty,
         transformer_block_index=1,
         seq_len=write_seq_length,
         page_ids=write_page_ids,
@@ -76,19 +66,8 @@ def test_paged():
     for i in range(transformer_block_count):
         if i == 1:
             continue
-        read_ones = [
-            torch.zeros(
-                (bs, write_seq_length, attn_head_count, attn_head_dim),
-                dtype=torch.float32,
-            ),
-            torch.zeros(
-                (bs, write_seq_length, attn_head_count, attn_head_dim),
-                dtype=torch.float32,
-            ),
-        ]
         read_ones = cache.read(
             allocation,
-            read_into_partitions=read_ones,
             transformer_block_index=i,
             seq_len=write_seq_length,
             page_ids=write_page_ids,
@@ -112,19 +91,8 @@ def test_paged():
         page_ids=page_ids,
     )
 
-    read_empty = [
-        torch.zeros(
-            (bs, write_seq_length + block_seq_stride, attn_head_count, attn_head_dim),
-            dtype=torch.float32,
-        ),
-        torch.zeros(
-            (bs, write_seq_length + block_seq_stride, attn_head_count, attn_head_dim),
-            dtype=torch.float32,
-        ),
-    ]
     read_back = cache.read(
         allocation,
-        read_into_partitions=read_empty,
         transformer_block_index=1,
         seq_len=write_seq_length + 1,
         page_ids=page_ids,
@@ -191,28 +159,8 @@ def test_sharded_paged():
         page_ids=write_page_ids,
     )
 
-    # Check the written values have updated:
-    empty_k = reshard_split(
-        torch.empty(
-            (bs, write_seq_length, attn_head_count, attn_head_dim), dtype=torch.float32
-        ),
-        dim=2,
-        count=shard_count,
-    )
-
-    empty_v = reshard_split(
-        torch.empty(
-            (bs, write_seq_length, attn_head_count, attn_head_dim), dtype=torch.float32
-        ),
-        dim=2,
-        count=shard_count,
-    )
-
-    read_empty = [empty_k, empty_v]
-
     read_back = cache.read(
         allocation,
-        read_into_partitions=read_empty,
         transformer_block_index=1,
         seq_len=write_seq_length,
         page_ids=write_page_ids,
@@ -245,27 +193,8 @@ def test_sharded_paged():
         page_ids=page_ids,
     )
 
-    empty_k = reshard_split(
-        torch.zeros(
-            (bs, write_seq_length + block_seq_stride, attn_head_count, attn_head_dim),
-            dtype=torch.float32,
-        ),
-        dim=2,
-        count=shard_count,
-    )
-
-    empty_v = reshard_split(
-        torch.zeros(
-            (bs, write_seq_length + block_seq_stride, attn_head_count, attn_head_dim),
-            dtype=torch.float32,
-        ),
-        dim=2,
-        count=shard_count,
-    )
-
     read_back = cache.read(
         allocation,
-        read_into_partitions=[empty_k, empty_v],
         transformer_block_index=1,
         seq_len=write_seq_length + 1,
         page_ids=page_ids,


### PR DESCRIPTION
The in-place read for KVCache doesn't seem to be used and is just used to tell the KVCache number of partitions to read from. The number of partitions for KVCache is in reality fixed (as from the name, K/V cache) and we are adding overhead by passing this parameter.