### PR TITLE
[Sharktank][Llama][FP8] Minimal changes for numerically correct fp8

### DIFF
--- a/sharktank/sharktank/examples/paged_llm_v1.py
+++ b/sharktank/sharktank/examples/paged_llm_v1.py
@@ -39,12 +39,14 @@ class TorchGenerator:
         page_cache_size: int = 128,
         # Need to look at the model more for this.
         end_token: int = 2,
+        dump_bins: bool = False,
     ):
         self.model = model
         self.tokenizer = tokenizer
         self.shared_cache_state = model.cache.allocate(page_cache_size)
         self.free_pages = list(range(1, page_cache_size))
         self.end_token = end_token
+        self.dump_bins = dump_bins
 
     @property
     def block_seq_stride(self) -> int:
@@ -61,7 +63,7 @@ class TorchGenerator:
             cache_state = self.shared_cache_state
         else:
             cache_state = self.model.cache.allocate(bs=len(prompts))
-        return Batch(self, token_ids, seq_lens, cache_state)
+        return Batch(self, token_ids, seq_lens, cache_state, dump_bins=self.dump_bins)
 
     def alloc_page(self) -> int:
         return self.free_pages.pop()
@@ -79,6 +81,7 @@ class Batch:
         token_ids: torch.Tensor,
         seq_lens: torch.Tensor,
         cache_state: list[torch.Tensor],
+        dump_bins: bool = False,
     ):
         self.bs = token_ids.shape[0]
         assert seq_lens.shape[0] == self.bs
@@ -88,6 +91,7 @@ class Batch:
         self.cache_state = cache_state
         self.results: list[list[int]] = [[] for _ in range(self.bs)]
         self.done_result_indices: set[int] = set()
+        self.dump_bins = dump_bins
 
         # Assemble the batch.
         seq_stride = self.parent.block_seq_stride
@@ -153,6 +157,23 @@ class Batch:
             attention_mask = replicate(attention_mask, tp)
             seq_block_ids_tensor = replicate(seq_block_ids_tensor, tp)
 
+        if self.dump_bins:
+            torch.save(
+                token_ids,
+                f"prefill_token_ids_{'_'.join([str(x) for x in token_ids.shape])}.bin",
+            )
+            torch.save(
+                torch.tensor(token_ids.shape[0]).to(torch.int64),
+                f"prefill_seq_lens_1.bin",
+            )
+            torch.save(
+                seq_block_ids_tensor,
+                f"prefill_seq_block_ids_{'_'.join([str(x) for x in seq_block_ids_tensor.shape])}.bin",
+            )
+            torch.save(
+                self.cache_state[0].to(torch.float8_e4m3fnuz),
+                f"prefill_cache_state_{'_'.join([str(x) for x in self.cache_state[0].shape])}.bin",
+            )
         logits = model.prefill(
             token_ids,
             attention_mask=attention_mask,
@@ -197,6 +218,27 @@ class Batch:
             seq_block_ids_tensor = replicate(seq_block_ids_tensor, tp)
             decode_attention_mask = replicate(decode_attention_mask, tp)
 
+        if self.dump_bins:
+            torch.save(
+                self.next_tokens,
+                f"decode_next_tokens_{'_'.join([str(x)for x in self.next_tokens.shape])}.bin",
+            )
+            torch.save(
+                start_positions,
+                f"decode_start_positions_{'_'.join([str(x)for x in start_positions.shape])}.bin",
+            )
+            torch.save(
+                seq_block_ids_tensor,
+                f"decode_seq_block_ids_tensor_{'_'.join([str(x)for x in seq_block_ids_tensor.shape])}.bin",
+            )
+            torch.save(
+                torch.tensor(self.next_tokens.shape[0]).to(torch.int64),
+                f"decode_seq_lens_1.bin",
+            )
+            torch.save(
+                self.cache_state[0].to(torch.float8_e4m3fnuz),
+                f"decode_cache_state_{'_'.join([str(x) for x in self.cache_state[0].shape])}.bin",
+            )
         logits = model.decode(
             self.next_tokens,
             attention_mask=decode_attention_mask,
@@ -230,6 +272,11 @@ def main():
     parser.add_argument(
         "--save_intermediates_path",
         help="save module forward outputs to safetensors, ex: run_0 will save to run_0_prefill.savetensors",
+    )
+    parser.add_argument(
+        "--dump-bins",
+        help="dump input tensors to bin files",
+        action="store_true",
     )
     cli.add_input_dataset_options(parser)
     cli.add_tokenizer_options(parser)
@@ -267,7 +314,7 @@ def main():
 
         intermediates_saver = SaveModuleResultTensorsPatch()
         intermediates_saver.patch_child_modules(model)
-    generator = TorchGenerator(model, tokenizer)
+    generator = TorchGenerator(model, tokenizer, dump_bins=args.dump_bins)
 
     print(f":: Prompting:")
     for prompt in prompts:

--- a/sharktank/sharktank/examples/paged_llm_v1.py
+++ b/sharktank/sharktank/examples/paged_llm_v1.py
@@ -42,11 +42,8 @@ class TorchGenerator:
     ):
         self.model = model
         self.tokenizer = tokenizer
-        if self.model.config.kv_cache_type == "paged":
-            self.shared_cache_state = model.cache.allocate(page_cache_size)
-            self.free_pages = list(range(1, page_cache_size))
-        else:
-            self.shared_cache_state = None
+        self.shared_cache_state = model.cache.allocate(page_cache_size)
+        self.free_pages = list(range(1, page_cache_size))
         self.end_token = end_token
 
     @property
@@ -67,10 +64,6 @@ class TorchGenerator:
         return Batch(self, token_ids, seq_lens, cache_state)
 
     def alloc_page(self) -> int:
-        if self.model.config.kv_cache_type == "direct":
-            # We don't allocate block ids for the direct cache.
-            return 0
-
         return self.free_pages.pop()
 
     def release_page(self, index: int):

--- a/sharktank/sharktank/kernels/bitcast.py
+++ b/sharktank/sharktank/kernels/bitcast.py
@@ -31,6 +31,7 @@ __all__ = [
 ]
 
 _ftype_to_ctype_table = {
+    torch.bfloat16: torch.complex32,
     torch.float16: torch.complex32,
     torch.float32: torch.complex64,
 }

--- a/sharktank/sharktank/layers/configs/llm_configs.py
+++ b/sharktank/sharktank/layers/configs/llm_configs.py
@@ -49,7 +49,7 @@ class LlamaHParams:
         name_prefix = p.get("general.architecture", "llama")
         default_expert_count = 0
         default_expert_used_count = 0
-        default_rope_freq_base = 10000.0
+        default_rope_freq_base = 500000.0
         default_rope_dimension_count = 128
         attention_head_count = _int_prop(p, f"{name_prefix}.attention.head_count")
         rope_dimension_count = _optional_int_prop(

--- a/sharktank/sharktank/layers/ffn_block.py
+++ b/sharktank/sharktank/layers/ffn_block.py
@@ -25,15 +25,20 @@ class FFN(ThetaLayer):
         theta: Theta,
         is_gated: bool = True,
         activation_fn: Callable[[AnyTensor], AnyTensor] = F.silu,
+        fake_quant: bool = False,
     ):
         super().__init__(theta)
 
         self.is_gated = is_gated
         self.activation_fn = activation_fn
         if self.is_gated:
-            self.add_module("ffn_gate", LinearLayer(theta("ffn_gate")))
-        self.add_module("ffn_up", LinearLayer(theta("ffn_up")))
-        self.add_module("ffn_down", LinearLayer(theta("ffn_down")))
+            self.add_module(
+                "ffn_gate", LinearLayer(theta("ffn_gate"), fake_quant=fake_quant)
+            )
+        self.add_module("ffn_up", LinearLayer(theta("ffn_up"), fake_quant=fake_quant))
+        self.add_module(
+            "ffn_down", LinearLayer(theta("ffn_down"), fake_quant=fake_quant)
+        )
 
     def forward(
         self,

--- a/sharktank/sharktank/layers/linear.py
+++ b/sharktank/sharktank/layers/linear.py
@@ -78,7 +78,6 @@ class LinearLayer(ThetaLayer):
             x = qdq_input.quantize(x).unpack().dequant()
 
         y = ops.linear(x, weight, bias)
-
         # Unconditionally dequantize.
         if isinstance(y, QuantizedTensor):
             y = y.unpack().dequant()
@@ -88,7 +87,7 @@ class LinearLayer(ThetaLayer):
         # level to do this, but for now its here.
         if not isinstance(y, QuantizedTensor):
             if y.dtype == torch.float8_e4m3fnuz:
-                y = ops.to(y, torch.float16)
+                y = ops.to(y, torch.bfloat16)
                 return y
         if qdq_output is not None:
             y = qdq_output.quantize(y).unpack().dequant()

--- a/sharktank/sharktank/layers/norm.py
+++ b/sharktank/sharktank/layers/norm.py
@@ -34,7 +34,7 @@ class RMSNormLayer(ThetaLayer):
     def forward(self, x: torch.Tensor):
         orig_dtype = x.dtype
         x = ops.to(x, self.dtype)
-        norm = ops.rms_norm(x, self.weight, epsilon=self.epsilon)
+        norm = ops.rms_norm(x, self.weight, epsilon=self.epsilon, orig_dtype=orig_dtype)
         # Will automatically upcast to the dtype of the weight, which is
         # often in higher precision. Downcast back to expected.
         norm = ops.to(norm, orig_dtype)

--- a/sharktank/sharktank/models/llama/llama.py
+++ b/sharktank/sharktank/models/llama/llama.py
@@ -86,9 +86,8 @@ class PagedLlamaModelV1(BaseCausalLMModel):
 
         self.add_module(
             "token_embedding",
-            TokenEmbeddingLayer(theta("token_embd"), dtype=torch.bfloat16),
+            TokenEmbeddingLayer(theta("token_embd"), dtype=self.activation_dtype),
         )
-        # self.attention_embedding = LlamaRotaryEmbedding(config=self.hf_config)
         self.add_module(
             "attention_embedding",
             RotaryEmbeddingLayer(

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -400,11 +400,14 @@ def reshape_default(input: Union[PrimitiveTensor, Tensor], shape: List[int]) -> 
 
 # RMS norm
 @rms_norm.override(AllOfType(Tensor, InferenceTensor))
-def rms_norm_default(x, weight, *, epsilon: float) -> Tensor:
+def rms_norm_default(
+    x, weight, *, epsilon: float, orig_dtype: Union[None, torch.dtype]
+) -> Tensor:
+    if orig_dtype is None:
+        orig_dtype = x.dtype
     variance = x.pow(2).mean(-1, keepdim=True)
     output = x * elementwise(torch.rsqrt, variance + epsilon)
-    # The cast here is to match the hf implementation, affects numerics
-    output = elementwise(torch.mul, weight, to(output, weight.dtype))
+    output = elementwise(torch.mul, weight, output.to(orig_dtype))
     return output
 
 

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -407,7 +407,7 @@ def rms_norm_default(
         orig_dtype = x.dtype
     variance = x.pow(2).mean(-1, keepdim=True)
     output = x * elementwise(torch.rsqrt, variance + epsilon)
-    output = elementwise(torch.mul, weight, output.to(orig_dtype))
+    output = elementwise(torch.mul, weight, to(output, orig_dtype))
     return output
 
 

--- a/sharktank/sharktank/ops/qlinear_impls.py
+++ b/sharktank/sharktank/ops/qlinear_impls.py
@@ -52,9 +52,7 @@ def qlinear_tensor_scaled(
     if x_layout.qs.dtype.is_floating_point or weight_layout.qs.dtype.is_floating_point:
         if x_layout.qs.dtype == torch.float8_e4m3fnuz:
             # assume quark
-            return matmul(x_layout.qs, weight_layout.qs, transpose_rhs=True).to(
-                torch.float16
-            )
+            return matmul(x_layout.qs, weight_layout.qs, transpose_rhs=True)
         else:
             return NotImplemented
 

--- a/sharktank/sharktank/ops/qlinear_impls.py
+++ b/sharktank/sharktank/ops/qlinear_impls.py
@@ -53,7 +53,7 @@ def qlinear_tensor_scaled(
         if x_layout.qs.dtype == torch.float8_e4m3fnuz:
             # assume quark
             return matmul(x_layout.qs, weight_layout.qs, transpose_rhs=True).to(
-                torch.float16
+                torch.bfloat16
             )
         else:
             return NotImplemented

--- a/sharktank/sharktank/ops/qlinear_impls.py
+++ b/sharktank/sharktank/ops/qlinear_impls.py
@@ -53,7 +53,7 @@ def qlinear_tensor_scaled(
         if x_layout.qs.dtype == torch.float8_e4m3fnuz:
             # assume quark
             return matmul(x_layout.qs, weight_layout.qs, transpose_rhs=True).to(
-                torch.bfloat16
+                torch.float16
             )
         else:
             return NotImplemented

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -769,18 +769,25 @@ def _module_register_buffer_trampoline(
 
 
 @overridable
-def rms_norm(x: AnyTensor, weight: AnyTensor, *, epsilon: float) -> AnyTensor:
+def rms_norm(
+    x: AnyTensor, weight: AnyTensor, *, epsilon: float, orig_dtype: torch.dtype
+) -> AnyTensor:
     """Computes the full, unbiased RMS normalization of an input."""
     raise NotImplementedError
 
 
 @rms_norm.trampoline
 def _rms_norm_trampoline(
-    d: SignatureDispatcher, x: AnyTensor, weight: AnyTensor, *, epsilon: float
+    d: SignatureDispatcher,
+    x: AnyTensor,
+    weight: AnyTensor,
+    *,
+    epsilon: float,
+    orig_dtype: torch.dtype,
 ):
     tensors = (x, weight)
     for override in d.find_overrides(tensors):
-        result = override(x, weight, epsilon=epsilon)
+        result = override(x, weight, epsilon=epsilon, orig_dtype=orig_dtype)
         if result is not NotImplemented:
             return override, result
     else:

--- a/sharktank/sharktank/utils/export_artifacts.py
+++ b/sharktank/sharktank/utils/export_artifacts.py
@@ -94,7 +94,7 @@ class ExportArtifacts:
         block_seq_stride: int,
         iree_hal_target_device: str,
         use_attention_mask: bool = False,
-        activation_dype: str = "float16",
+        activation_dtype: str = "float16",
         attention_dtype: str = "float16",
     ):
         self.sharktank_dir = str(
@@ -108,7 +108,7 @@ class ExportArtifacts:
         self.tensor_parallelism_size = tensor_parallelism_size
         self.block_seq_stride = block_seq_stride
         self.use_attention_mask = use_attention_mask
-        self.activation_dtype = activation_dype
+        self.activation_dtype = activation_dtype
         self.attention_dtype = attention_dtype
 
     def timeit(func):

--- a/sharktank/sharktank/utils/export_artifacts.py
+++ b/sharktank/sharktank/utils/export_artifacts.py
@@ -3,7 +3,6 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-import torch
 import os
 import sys
 import subprocess

--- a/sharktank/sharktank/utils/export_artifacts.py
+++ b/sharktank/sharktank/utils/export_artifacts.py
@@ -3,7 +3,7 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-
+import torch
 import os
 import sys
 import subprocess
@@ -94,6 +94,8 @@ class ExportArtifacts:
         block_seq_stride: int,
         iree_hal_target_device: str,
         use_attention_mask: bool = False,
+        activation_dype: str,
+        attention_dtype: str,
     ):
         self.sharktank_dir = str(
             Path(os.path.dirname(os.path.abspath(__file__))).parent.parent.parent
@@ -106,6 +108,8 @@ class ExportArtifacts:
         self.tensor_parallelism_size = tensor_parallelism_size
         self.block_seq_stride = block_seq_stride
         self.use_attention_mask = use_attention_mask
+        self.activation_dtype = activation_dype
+        self.attention_dtype = attention_dtype
 
     def timeit(func):
         def wrapper(*args, **kwargs):
@@ -183,6 +187,8 @@ class ExportArtifacts:
             f"--output-config={json_path}",
             f"--bs={str(self.batch_size)}",
             f"--block-seq-stride={self.block_seq_stride}",
+            f"--attention-dtype={self.attention_dtype}",
+            f"--activation-dtype={self.activation_dtype}",
         ]
         if skip_decode:
             export_args.append("--skip-decode")

--- a/sharktank/sharktank/utils/export_artifacts.py
+++ b/sharktank/sharktank/utils/export_artifacts.py
@@ -94,8 +94,8 @@ class ExportArtifacts:
         block_seq_stride: int,
         iree_hal_target_device: str,
         use_attention_mask: bool = False,
-        activation_dype: str,
-        attention_dtype: str,
+        activation_dype: str = "float16",
+        attention_dtype: str = "float16",
     ):
         self.sharktank_dir = str(
             Path(os.path.dirname(os.path.abspath(__file__))).parent.parent.parent

--- a/sharktank/sharktank/utils/patching.py
+++ b/sharktank/sharktank/utils/patching.py
@@ -25,6 +25,7 @@ class Patch:
             orig_forward = m.forward
 
             def wrapper(*args, **kwargs):
+                self.before_forward(name, m, *args, **kwargs)
                 results = orig_forward(*args, **kwargs)
                 self.after_forward(name, m, results)
                 return results
@@ -33,6 +34,12 @@ class Patch:
 
         for name, m in module.named_modules():
             _patch(name, m)
+
+    def before_forward(
+        self, module_name: str, module: torch.nn.Module, *args, **kwargs
+    ):
+        """Called before every patched forward() function with results."""
+        ...
 
     def after_forward(self, module_name: str, module: torch.nn.Module, results):
         """Called after every patched forward() function with results."""
@@ -55,11 +62,30 @@ class SaveModuleResultTensorsPatch(Patch):
         # Map of module_name to last used index for duplicated tensors.
         self.duplicate_tensors = {}
 
+    def before_forward(self, module_name, module, *args, **kwargs):
+        for idx, arg in enumerate(args):
+            if not isinstance(arg, torch.Tensor):
+                continue
+            result_tensor = torch.detach(arg).contiguous().to(device="cpu").clone()
+            name_base = f"{module_name}_input_{idx}"
+            if name_base in self.tensors:
+                orig_dup = self.tensors[name_base]
+                del self.tensors[name_base]
+                self.duplicate_tensors[name_base] = 0
+                self.tensors[f"{name_base}#0"] = orig_dup
+            elif name_base in self.duplicate_tensors:
+                index = self.duplicate_tensors[name_base] + 1
+                self.duplicate_tensors[name_base] = index
+                self.tensors[f"{name_base}#{index}"] = result_tensor
+            else:
+                self.tensors[name_base] = result_tensor
+
     def after_forward(self, module_name: str, module: torch.nn.Module, results):
         if not isinstance(results, torch.Tensor):
             return
 
         result_tensor = torch.detach(results).contiguous().to(device="cpu").clone()
+
         if module_name in self.tensors:
             orig_dup = self.tensors[module_name]
             del self.tensors[module_name]

--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -282,7 +282,9 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
         )
 
     @pytest.mark.xfail(
-        reason="Compile Error", strict=False, raises=IreeCompileException
+        reason="Benchmark inputs not configured yet.",
+        strict=False,
+        raises=IreeBenchmarkException,
     )
     def testBenchmark8B_fp8_Non_Decomposed(self):
         output_file_name = self.dir_path_8b / "fp8_torch"

--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -100,6 +100,8 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
             attention_kernel="torch",
             tensor_parallelism_size=self.tensor_parallelism_size,
             block_seq_stride=32,
+            activation_dtype="bfloat16",
+            attention_dtype="float8_e4m3fnuz",
         )
         self.prefill_args_bs4_128_stride_32_f16 = (
             self.artifacts_dir / "prefill_args_bs4_128_stride_32"

--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -309,7 +309,7 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
             hip_device_id=self.iree_device,
             vmfb_name=output_vmfb,
             irpa_path=self.irpa_path_fp8,
-            args=self.iree_run_prefill_args,
+            args=self.iree_run_prefill_args_fp8,
             cwd=self.repo_root,
         )
         # benchmark decode
@@ -317,7 +317,7 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
             hip_device_id=self.iree_device,
             vmfb_name=output_vmfb,
             irpa_path=self.irpa_path_fp8,
-            args=self.iree_run_decode_args,
+            args=self.iree_run_decode_args_fp8,
             cwd=self.repo_root,
         )
 

--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -281,7 +281,9 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
             cwd=self.repo_root,
         )
 
-    @pytest.mark.xfail(reason="Compile Error", strict=True, raises=IreeCompileException)
+    @pytest.mark.xfail(
+        reason="Compile Error", strict=False, raises=IreeCompileException
+    )
     def testBenchmark8B_fp8_Non_Decomposed(self):
         output_file_name = self.dir_path_8b / "fp8_torch"
         output_mlir = self.llama8b_fp8_torch_sdpa_artifacts.create_file(

--- a/sharktank/tests/models/llama/quark_parity_test.py
+++ b/sharktank/tests/models/llama/quark_parity_test.py
@@ -10,9 +10,7 @@ import torch
 import unittest
 import pytest
 
-# is_mi300x = pytest.mark.skipif("config.getoption('iree_hip_target') != 'gfx942'")
 
-# @is_mi300x
 @pytest.mark.skip(reason="need to generate values to compare against")
 class QuarkParityTest(unittest.TestCase):
     def test_compare_against_quark(self):

--- a/sharktank/tests/models/llama/quark_parity_test.py
+++ b/sharktank/tests/models/llama/quark_parity_test.py
@@ -13,6 +13,7 @@ import pytest
 # is_mi300x = pytest.mark.skipif("config.getoption('iree_hip_target') != 'gfx942'")
 
 # @is_mi300x
+@pytest.mark.skip(reason="need to generate values to compare against")
 class QuarkParityTest(unittest.TestCase):
     def test_compare_against_quark(self):
         def both(key, index=None):

--- a/sharktank/tests/models/llama/quark_parity_test.py
+++ b/sharktank/tests/models/llama/quark_parity_test.py
@@ -1,0 +1,65 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+from safetensors import safe_open
+import torch
+import unittest
+import pytest
+
+# is_mi300x = pytest.mark.skipif("config.getoption('iree_hip_target') != 'gfx942'")
+
+# @is_mi300x
+class QuarkParityTest(unittest.TestCase):
+    def test_compare_against_quark(self):
+        def both(key, index=None):
+            o = ours[key]
+            t = theirs[key]
+            if index is None:
+                return o, t
+            else:
+                return o[index], t[index]
+
+        mapping = dict()
+        for i in range(32):
+            hf = f"model.layers.{i}"
+            gg = f"attn_blocks.{i}"
+            base_pairs = [
+                [f"{hf}.input_layernorm", f"{gg}.attn.attn_norm"],
+                [f"{hf}.self_attn.k_proj", f"{gg}.attn.attn_k"],
+                [f"{hf}.self_attn.q_proj", f"{gg}.attn.attn_q"],
+                [f"{hf}.self_attn.v_proj", f"{gg}.attn.attn_v"],
+                [f"{hf}.self_attn.o_proj", f"{gg}.attn.attn_output"],
+                [f"{hf}.post_attention_layernorm", f"{gg}.ffn_norm"],
+                [f"{hf}.mlp.down_proj", f"{gg}.ffn.ffn_down"],
+                [f"{hf}.mlp.gate_proj", f"{gg}.ffn.ffn_gate"],
+                [f"{hf}.mlp.up_proj", f"{gg}.ffn.ffn_up"],
+            ]
+            for a, b in base_pairs:
+                mapping[a] = b
+                mapping[a + "_input_0"] = b + "_input_0"
+
+        ours = dict()
+        with safe_open("../ours_newest_prefill.safetensors", "pytorch") as st:
+            for key in st.keys():
+                ours[key] = st.get_tensor(key)
+
+        theirs = dict()
+        with safe_open("../theirs2.safetensors", "pytorch") as st:
+            for key in st.keys():
+                if key in mapping:
+                    theirs[mapping[key]] = st.get_tensor(key)
+
+        test_layers = [v for k, v in mapping.items()]
+        for lyr in test_layers:
+            name = lyr
+            if name in ours.keys() and name != "freqs":
+                o, t = both(name)
+                torch.testing.assert_close(o, t, atol=0, rtol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -248,7 +248,7 @@ class RmsNormTest(unittest.TestCase):
     def testTorchImpl(self):
         t1 = torch.rand(16, 128, dtype=torch.float32)
         t2 = torch.rand(16, 128, dtype=torch.float32)
-        result = ops.rms_norm(t1, t2, epsilon=1e-10)
+        result = ops.rms_norm(t1, t2, epsilon=1e-10, orig_dtype=torch.float32)
         actual = self._ref(t1, t2, epsilon=1e-10)
         torch.testing.assert_close(actual, result)
 
@@ -256,7 +256,7 @@ class RmsNormTest(unittest.TestCase):
         t1 = torch.rand(16, 128, dtype=torch.float32)
         t2 = torch.rand(16, 128, dtype=torch.float32)
         t2_pt = DefaultPrimitiveTensor(data=t2)
-        result = ops.rms_norm(t1, t2_pt, epsilon=1e-10)
+        result = ops.rms_norm(t1, t2_pt, epsilon=1e-10, orig_dtype=torch.float32)
         actual = self._ref(t1, t2, epsilon=1e-10)
         torch.testing.assert_close(actual, result)
 


### PR DESCRIPTION
This patch enables the use of quark quantized models of the latest generation. Many changes were required to enable parity with the source model which is very sensitive to any numerical fluctuations. There is a test added to maintain this parity but is disabled until I can get the relevant data set up on the ci machine. 