### PR TITLE
Accept token_ids in Shortfin LLM Server

### DIFF
--- a/app_tests/integration_tests/llm/shortfin/conftest.py
+++ b/app_tests/integration_tests/llm/shortfin/conftest.py
@@ -95,5 +95,5 @@ def server(model_artifacts, request):
 
 @pytest.fixture(scope="module")
 def encoded_prompt(model_artifacts: ModelArtifacts, request) -> list[int]:
-    tokenizer = Tokenizer.from_file(model_artifacts.tokenizer_path)
+    tokenizer = Tokenizer.from_file(str(model_artifacts.tokenizer_path))
     return tokenizer.encode(request.param).ids

--- a/app_tests/integration_tests/llm/shortfin/conftest.py
+++ b/app_tests/integration_tests/llm/shortfin/conftest.py
@@ -27,8 +27,8 @@ TEST_MODELS = {
     ),
     "llama3.1_8b": ModelConfig(
         source=ModelSource.LOCAL,
-        local_path=Path("/data/llama3.1/8b/llama8b_f16.irpa"),
-        model_file="llama8b_f16.irpa",
+        local_path=Path("/data/llama3.1/weights/8b/llama3.1_8b_fp16_instruct.irpa"),
+        model_file="llama3.1_8b_fp16_instruct.irpa",
         tokenizer_id="NousResearch/Meta-Llama-3.1-8B",
         batch_sizes=(1, 4),
         device_settings=device_settings.CPU,

--- a/app_tests/integration_tests/llm/shortfin/conftest.py
+++ b/app_tests/integration_tests/llm/shortfin/conftest.py
@@ -93,7 +93,7 @@ def server(model_artifacts, request):
     process.wait()
 
 
-@pytest.fixture(scope="function")
-def encoded_prompt(model_artifacts: ModelArtifacts, prompt: str) -> list[int]:
+@pytest.fixture(scope="module")
+def encoded_prompt(model_artifacts: ModelArtifacts, request) -> list[int]:
     tokenizer = Tokenizer.from_file(model_artifacts.tokenizer_path)
-    return tokenizer.encode(prompt).ids
+    return tokenizer.encode(request.param).ids

--- a/app_tests/integration_tests/llm/shortfin/conftest.py
+++ b/app_tests/integration_tests/llm/shortfin/conftest.py
@@ -27,7 +27,9 @@ TEST_MODELS = {
     ),
     "llama3.1_8b": ModelConfig(
         source=ModelSource.LOCAL,
-        local_path=Path("/data/llama3.1/weights/8b/llama3.1_8b_fp16_instruct.irpa"),
+        local_path=Path(
+            "/data/llama3.1/weights/8b/fp16/llama3.1_8b_fp16_instruct.irpa"
+        ),
         model_file="llama3.1_8b_fp16_instruct.irpa",
         tokenizer_id="NousResearch/Meta-Llama-3.1-8B",
         batch_sizes=(1, 4),

--- a/app_tests/integration_tests/llm/shortfin/conftest.py
+++ b/app_tests/integration_tests/llm/shortfin/conftest.py
@@ -1,7 +1,9 @@
 """Test fixtures and configurations."""
+
+import hashlib
 import pytest
 from pathlib import Path
-import hashlib
+from tokenizers import Tokenizer, Encoding
 
 from ..model_management import (
     ModelProcessor,
@@ -89,3 +91,9 @@ def server(model_artifacts, request):
 
     process.terminate()
     process.wait()
+
+
+@pytest.fixture(scope="function")
+def encoded_prompt(model_artifacts: ModelArtifacts, prompt: str) -> list[int]:
+    tokenizer = Tokenizer.from_file(model_artifacts.tokenizer_path)
+    return tokenizer.encode(prompt).ids

--- a/app_tests/integration_tests/llm/shortfin/cpu_llm_server_test.py
+++ b/app_tests/integration_tests/llm/shortfin/cpu_llm_server_test.py
@@ -40,16 +40,10 @@ class TestLLMServer:
             pytest.param(
                 "llama3.1_8b",
                 {"model": "llama3.1_8b", "prefix_sharing": "none"},
-                marks=pytest.mark.xfail(
-                    reason="llama3.1_8b irpa file not available on CI machine"
-                ),
             ),
             pytest.param(
                 "llama3.1_8b",
                 {"model": "llama3.1_8b", "prefix_sharing": "trie"},
-                marks=pytest.mark.xfail(
-                    reason="llama3.1_8b irpa file not available on CI machine"
-                ),
             ),
         ],
         ids=[
@@ -95,17 +89,11 @@ class TestLLMServer:
                 "llama3.1_8b",
                 {"model": "llama3.1_8b", "prefix_sharing": "none"},
                 "0 1 2 3 4 5 ",
-                marks=pytest.mark.xfail(
-                    reason="llama3.1_8b irpa file not available on CI machine"
-                ),
             ),
             pytest.param(
                 "llama3.1_8b",
                 {"model": "llama3.1_8b", "prefix_sharing": "trie"},
                 "0 1 2 3 4 5 ",
-                marks=pytest.mark.xfail(
-                    reason="llama3.1_8b irpa file not available on CI machine"
-                ),
             ),
         ],
         ids=[

--- a/app_tests/integration_tests/llm/shortfin/cpu_llm_server_test.py
+++ b/app_tests/integration_tests/llm/shortfin/cpu_llm_server_test.py
@@ -1,11 +1,11 @@
 """Main test module for LLM server functionality."""
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import logging
 import pytest
 import requests
-import uuid
-import logging
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Dict, Any
+import uuid
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +79,64 @@ class TestLLMServer:
             )
 
     @pytest.mark.parametrize(
+        "model_artifacts,server,encoded_prompt",
+        [
+            (
+                "open_llama_3b",
+                {"model": "open_llama_3b", "prefix_sharing": "none"},
+                "0 1 2 3 4 5 ",
+            ),
+            (
+                "open_llama_3b",
+                {"model": "open_llama_3b", "prefix_sharing": "trie"},
+                "0 1 2 3 4 5 ",
+            ),
+            pytest.param(
+                "llama3.1_8b",
+                {"model": "llama3.1_8b", "prefix_sharing": "none"},
+                "0 1 2 3 4 5 ",
+                marks=pytest.mark.xfail(
+                    reason="llama3.1_8b irpa file not available on CI machine"
+                ),
+            ),
+            pytest.param(
+                "llama3.1_8b",
+                {"model": "llama3.1_8b", "prefix_sharing": "trie"},
+                "0 1 2 3 4 5 ",
+                marks=pytest.mark.xfail(
+                    reason="llama3.1_8b irpa file not available on CI machine"
+                ),
+            ),
+        ],
+        ids=[
+            "open_llama_3b_none",
+            "open_llama_3b_trie",
+            "llama31_8b_none",
+            "llama31_8b_trie",
+        ],
+        indirect=True,
+    )
+    def test_basic_generation_input_ids(
+        self, server: tuple[Any, int], encoded_prompt
+    ) -> None:
+        """Tests basic text generation capabilities.
+
+        Args:
+            server: Tuple of (process, port) from server fixture
+        """
+        process, port = server
+        assert process.poll() is None, "Server process terminated unexpectedly"
+
+        response = self._generate(encoded_prompt, port, input_ids=True)
+        expected_prefix = "6 7 8"
+        if not response.startswith(expected_prefix):
+            raise AccuracyValidationException(
+                expected=f"{expected_prefix}...",
+                actual=response,
+                message=f"Generation did not match expected pattern.\nExpected to start with: {expected_prefix}\nActual response: {response}",
+            )
+
+    @pytest.mark.parametrize(
         "model_artifacts,server",
         [
             ("open_llama_3b", {"model": "open_llama_3b", "prefix_sharing": "none"}),
@@ -121,7 +179,7 @@ class TestLLMServer:
                         message=f"Concurrent generation did not match expected pattern.\nExpected to start with: {expected_prefix}\nActual response: {response}",
                     )
 
-    def _generate(self, prompt: str, port: int) -> str:
+    def _generate(self, prompt: str | list[int], port: int, input_ids=False) -> str:
         """Helper method to make generation request to server.
 
         Args:
@@ -135,15 +193,19 @@ class TestLLMServer:
             requests.exceptions.RequestException: If request fails
             AccuracyValidationException: If response format is invalid
         """
+        payload = {
+            "sampling_params": {"max_completion_tokens": 15, "temperature": 0.7},
+            "rid": uuid.uuid4().hex,
+            "stream": False,
+        }
+        if input_ids:
+            payload["input_ids"] = prompt
+        else:
+            payload["text"] = prompt
         response = requests.post(
             f"http://localhost:{port}/generate",
             headers={"Content-Type": "application/json"},
-            json={
-                "text": prompt,
-                "sampling_params": {"max_completion_tokens": 15, "temperature": 0.7},
-                "rid": uuid.uuid4().hex,
-                "stream": False,
-            },
+            json=payload,
             timeout=30,  # Add reasonable timeout
         )
         response.raise_for_status()

--- a/app_tests/integration_tests/llm/shortfin/cpu_llm_server_test.py
+++ b/app_tests/integration_tests/llm/shortfin/cpu_llm_server_test.py
@@ -109,10 +109,10 @@ class TestLLMServer:
             ),
         ],
         ids=[
-            "open_llama_3b_none",
-            "open_llama_3b_trie",
-            "llama31_8b_none",
-            "llama31_8b_trie",
+            "open_llama_3b_none_input_ids",
+            "open_llama_3b_trie_input_ids",
+            "llama31_8b_none_input_ids",
+            "llama31_8b_trie_input_ids",
         ],
         indirect=True,
     )


### PR DESCRIPTION
The mlperf harness that I'm building sends over input_ids instead of text. We had the option to send input_ids in a request, but never actually implemented it. This makes it so that you can either send a string prompt or a pre-tokenized prompt.