### PR TITLE
Temporarily move workflows off sharkmi300x-4 runner.

### DIFF
--- a/.github/workflows/ci-sdxl.yaml
+++ b/.github/workflows/ci-sdxl.yaml
@@ -37,7 +37,7 @@ env:
 jobs:
   install-and-test:
     name: Install and test
-    runs-on: mi300x-4
+    runs-on: mi300x-3
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: mi300x-4
+    runs-on: mi300x-3
     defaults:
       run:
         shell: bash
@@ -97,7 +97,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: mi300x-4
+    runs-on: mi300x-3
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci-sglang-integration-tests.yml
+++ b/.github/workflows/ci-sglang-integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: mi300x-4
+    runs-on: mi300x-3
     defaults:
       run:
         shell: bash

--- a/.github/workflows/pkgci_shark_ai.yml
+++ b/.github/workflows/pkgci_shark_ai.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: mi300x-4
+    runs-on: mi300x-3
     # runs-on: ubuntu-latest # everything else works but this throws an "out of resources" during model loading
     # TODO: make a copy of this that runs on standard runners with tiny llama instead of a 8b model
     defaults:


### PR DESCRIPTION
As we are dedicatedly using the sharkmi300x-4 runner for dev work and ml perf experiments, I've started a new runner on sharkmi300x-3 and the workflows that were previously running on sharkmi300x-4 will now run on this runner. We now have 3 active runners on sharkmi300x-3 machine:
<img width="739" alt="{C81DEA8E-47ED-4EE8-9A9F-5645CD193CF2}" src="https://github.com/user-attachments/assets/56b72c31-2a4e-4ac7-b212-8e100a1862c7" />
This shouldn't affect queue times as workflow distribution is the same.