### PR TITLE
[sharktank] Use pytest-timeout in ci-sharktank.yml.

### DIFF
--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Run sharktank tests
         if: ${{ !cancelled() }}
         run: |
-          pytest -n 4 sharktank/ --durations=10
+          pytest -n 4 sharktank/ --durations=10 --timeout=60
 
 
   test_with_data:
@@ -145,7 +145,8 @@ jobs:
             sharktank/tests/models/t5/t5_test.py \
             sharktank/tests/models/flux/flux_test.py \
             sharktank/tests/models/vae/vae_test.py \
-            --durations=0
+            --durations=0 \
+            --timeout=600
 
 
   test_integration:
@@ -186,7 +187,8 @@ jobs:
       - name: Run punet tests
         run: |
           pytest -v sharktank/ -m punet_quick \
-            --durations=0
+            --durations=0 \
+            --timeout=600
 
   # Depends on other jobs to provide an aggregate job status.
   # TODO(#584): move test_with_data and test_integration to a pkgci integration test workflow?

--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -146,7 +146,7 @@ jobs:
             sharktank/tests/models/flux/flux_test.py \
             sharktank/tests/models/vae/vae_test.py \
             --durations=0 \
-            --timeout=10
+            --timeout=600
 
 
   test_integration:
@@ -188,7 +188,7 @@ jobs:
         run: |
           pytest -v sharktank/ -m punet_quick \
             --durations=0 \
-            --timeout=10
+            --timeout=600
 
   # Depends on other jobs to provide an aggregate job status.
   # TODO(#584): move test_with_data and test_integration to a pkgci integration test workflow?

--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Run sharktank tests
         if: ${{ !cancelled() }}
         run: |
-          pytest -n 4 sharktank/ --durations=10 --timeout=5
+          pytest -n 4 sharktank/ --durations=10
 
 
   test_with_data:

--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Run sharktank tests
         if: ${{ !cancelled() }}
         run: |
-          pytest -n 4 sharktank/ --durations=10 --timeout=60
+          pytest -n 4 sharktank/ --durations=10 --timeout=5
 
 
   test_with_data:
@@ -146,7 +146,7 @@ jobs:
             sharktank/tests/models/flux/flux_test.py \
             sharktank/tests/models/vae/vae_test.py \
             --durations=0 \
-            --timeout=600
+            --timeout=10
 
 
   test_integration:
@@ -188,7 +188,7 @@ jobs:
         run: |
           pytest -v sharktank/ -m punet_quick \
             --durations=0 \
-            --timeout=600
+            --timeout=10
 
   # Depends on other jobs to provide an aggregate job status.
   # TODO(#584): move test_with_data and test_integration to a pkgci integration test workflow?

--- a/sharktank/requirements-tests.txt
+++ b/sharktank/requirements-tests.txt
@@ -10,4 +10,5 @@ parameterized
 protobuf
 pytest==8.0.0
 pytest-html
+pytest-timeout
 pytest-xdist==3.5.0


### PR DESCRIPTION
Some of these jobs have been taking the full [6 hour default timeout](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes) before failing. Example stalls:
* https://github.com/nod-ai/shark-ai/actions/runs/12875057753/job/35895676842
* https://github.com/nod-ai/shark-ai/actions/runs/12948380437/job/36116930181
* https://github.com/nod-ai/shark-ai/actions/runs/12939601933/job/36092205910

Introducing timeouts in the test runner gives us a chance of seeing a callstack when a test case is stalled and not burning CI time. Sample output from using a shorter timeout:

Job name | Logs
-- | --
Data-dependent Tests | https://github.com/nod-ai/shark-ai/actions/runs/12953817421/job/36134335605
Model Integration Tests | https://github.com/nod-ai/shark-ai/actions/runs/12953817421/job/36134336455