### PR TITLE
Fix Masking-related token corruption issue that oddly only manifests when trie is enabled

### DIFF
--- a/app_tests/integration_tests/llm/shortfin/cpu_llm_server_test.py
+++ b/app_tests/integration_tests/llm/shortfin/cpu_llm_server_test.py
@@ -133,10 +133,6 @@ class TestLLMServer:
         indirect=True,
     )
     @pytest.mark.parametrize("concurrent_requests", [2, 4, 8])
-    @pytest.mark.xfail(
-        raises=AccuracyValidationException,
-        reason="Concurreny issues in Shortfin batch processing",
-    )
     def test_concurrent_generation(
         self, server: tuple[Any, int], concurrent_requests: int
     ) -> None:

--- a/shortfin/python/shortfin_apps/llm/components/service.py
+++ b/shortfin/python/shortfin_apps/llm/components/service.py
@@ -401,10 +401,7 @@ class InferenceExecutorProcess(sf.Process):
                     m.fill(
                         1  # Must pad with a nonzero value because a division by 0 during softmax floods clobber page (page 0) in cache with NaN values.
                     )
-                    m.items = [
-                        req.start_position + len(req.input_token_ids)
-                        for req in self.exec_requests
-                    ]
+                    m.items = [req.start_position + 1 for req in self.exec_requests]
                 seq_lens_host.copy_to(seq_lens)
 
             # Populate cache pages.


### PR DESCRIPTION
Earlier, I changed the generation requests to store the whole token history instead of just the most recent token.

Missed a spot, which caused seq_len to be a lot longer than it should be, which caused the kvcache read to be wrong.

