### PR TITLE
Fix LLM CI by temporarily skipping local model tests.

### DIFF
--- a/app_tests/integration_tests/llm/shortfin/conftest.py
+++ b/app_tests/integration_tests/llm/shortfin/conftest.py
@@ -54,9 +54,6 @@ TEST_MODELS = {
 def model_artifacts(tmp_path_factory, request):
     """Prepares model artifacts in a cached directory."""
     model_config = TEST_MODELS[request.param]
-    if model_config.source == ModelSource.LOCAL:
-        # skip all local-model tests
-        pytest.skip("Local models not supported in this context")
     cache_key = hashlib.md5(str(model_config).encode()).hexdigest()
 
     cache_dir = tmp_path_factory.mktemp("model_cache")

--- a/app_tests/integration_tests/llm/shortfin/conftest.py
+++ b/app_tests/integration_tests/llm/shortfin/conftest.py
@@ -54,6 +54,9 @@ TEST_MODELS = {
 def model_artifacts(tmp_path_factory, request):
     """Prepares model artifacts in a cached directory."""
     model_config = TEST_MODELS[request.param]
+    if model_config.source == ModelSource.LOCAL:
+        # skip all local-model tests
+        pytest.skip("Local models not supported in this context")
     cache_key = hashlib.md5(str(model_config).encode()).hexdigest()
 
     cache_dir = tmp_path_factory.mktemp("model_cache")

--- a/app_tests/integration_tests/llm/shortfin/cpu_llm_server_test.py
+++ b/app_tests/integration_tests/llm/shortfin/cpu_llm_server_test.py
@@ -40,10 +40,16 @@ class TestLLMServer:
             pytest.param(
                 "llama3.1_8b",
                 {"model": "llama3.1_8b", "prefix_sharing": "none"},
+                mark=pytest.mark.skip(
+                    "Skipping meta llama because we haven't set up the model artifact downloading yet."
+                ),
             ),
             pytest.param(
                 "llama3.1_8b",
                 {"model": "llama3.1_8b", "prefix_sharing": "trie"},
+                mark=pytest.mark.skip(
+                    "Skipping meta llama because we haven't set up the model artifact downloading yet."
+                ),
             ),
         ],
         ids=[
@@ -89,11 +95,17 @@ class TestLLMServer:
                 "llama3.1_8b",
                 {"model": "llama3.1_8b", "prefix_sharing": "none"},
                 "0 1 2 3 4 5 ",
+                marks=pytest.mark.skip(
+                    "Skipping meta llama because we haven't set up the model artifact downloading yet."
+                ),
             ),
             pytest.param(
                 "llama3.1_8b",
                 {"model": "llama3.1_8b", "prefix_sharing": "trie"},
                 "0 1 2 3 4 5 ",
+                marks=pytest.mark.skip(
+                    "Skipping meta llama because we haven't set up the model artifact downloading yet."
+                ),
             ),
         ],
         ids=[

--- a/app_tests/integration_tests/llm/shortfin/cpu_llm_server_test.py
+++ b/app_tests/integration_tests/llm/shortfin/cpu_llm_server_test.py
@@ -40,14 +40,14 @@ class TestLLMServer:
             pytest.param(
                 "llama3.1_8b",
                 {"model": "llama3.1_8b", "prefix_sharing": "none"},
-                mark=pytest.mark.skip(
+                marks=pytest.mark.skip(
                     "Skipping meta llama because we haven't set up the model artifact downloading yet."
                 ),
             ),
             pytest.param(
                 "llama3.1_8b",
                 {"model": "llama3.1_8b", "prefix_sharing": "trie"},
-                mark=pytest.mark.skip(
+                marks=pytest.mark.skip(
                     "Skipping meta llama because we haven't set up the model artifact downloading yet."
                 ),
             ),


### PR DESCRIPTION
By temporarily skipping local model tests.

Working on removing all local-model tests because we want CI machines to be interchangeable and want to not have to depend on local files.