### PR TITLE
Revert "Bump IREE requirement pins to their latest versions."

### DIFF
--- a/requirements-iree-pinned.txt
+++ b/requirements-iree-pinned.txt
@@ -2,6 +2,6 @@
 
 # Keep these versions synced with SHORTFIN_IREE_GIT_TAG in shortfin/CMakeLists.txt
 --find-links https://iree.dev/pip-release-links.html
-iree-base-compiler==3.2.0rc20250124
-iree-base-runtime==3.2.0rc20250124
-iree-turbine==3.2.0rc20250124
+iree-base-compiler==3.2.0rc20250120
+iree-base-runtime==3.2.0rc20250120
+iree-turbine==3.2.0rc20250121

--- a/shortfin/CMakeLists.txt
+++ b/shortfin/CMakeLists.txt
@@ -47,7 +47,7 @@ add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 # Prefer to keep the IREE git tag synced with the Python package version in the
 # requirements-iree-pinned.txt file. At a minimum, the compiler from those
 # packages must be compatible with the runtime at this source ref.
-set(SHORTFIN_IREE_GIT_TAG "iree-3.2.0rc20250124")
+set(SHORTFIN_IREE_GIT_TAG "iree-3.2.0rc20250120")
 
 
 # build options


### PR DESCRIPTION
Reverts nod-ai/shark-ai#867

This might have regressed something in the "Data-dependent Tests" job. Seeing more jobs hitting 6 hour timeouts :/