### PR TITLE
Adding conv igemm layout support

### DIFF
--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -97,9 +97,9 @@ class ConvolutionOpInterfaceTuner(DispatchTuner, ConvolutionOpInterfaceParser):
         rhs_type = ir.ShapedType(conv_op.operands[1].type)
         acc_type = ir.ShapedType(conv_op.operands[2].type)
 
-        M_str = "x".join([str(mDim) for mDim in problem_size.matmul_size.M])
-        N_str = "x".join([str(nDim) for nDim in problem_size.matmul_size.N])
-        K_str = "x".join([str(kDim) for kDim in problem_size.matmul_size.K])
+        M_str = "x".join(map(str, problem_size.matmul_size.M))
+        N_str = "x".join(map(str, problem_size.matmul_size.N))
+        K_str = "x".join(map(str, problem_size.matmul_size.K))
 
         conv_type = conv_op.name.split(".")[-1]
         # TODO(Max191): Get the function name from the func.func in the input module.

--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -41,7 +41,7 @@ class DispatchTuner(DispatchParser):
         self,
         ir_module: ir.Module,
         compilation_info: iree_codegen.CompilationInfoAttr,
-        problem_size: ProblemSize,
+        problem_size: Optional[ProblemSize],
     ) -> ir.Module:
         """Generate a transform dialect spec that applies the compilation info attr."""
         pass
@@ -67,7 +67,7 @@ class ContractionOpInterfaceTuner(DispatchTuner, ContractionOpInterfaceParser):
         self,
         ir_module: ir.Module,
         compilation_info: iree_codegen.CompilationInfoAttr,
-        problem_size: ProblemSize,
+        problem_size: Optional[ProblemSize],
     ) -> ir.Module:
         contraction_op: ir.Operation = self.get_contraction_operation(ir_module)
         lhs_type = ir.ShapedType(contraction_op.operands[0].type)
@@ -88,8 +88,10 @@ class ConvolutionOpInterfaceTuner(DispatchTuner, ConvolutionOpInterfaceParser):
         self,
         ir_module: ir.Module,
         compilation_info: iree_codegen.CompilationInfoAttr,
-        problem_size: ProblemSize,
+        problem_size: Optional[ProblemSize],
     ) -> ir.Module:
+        assert problem_size, "Problem size not found"
+
         conv_op: ir.Operation = self.get_conv_operation(ir_module)
         lhs_type = ir.ShapedType(conv_op.operands[0].type)
         rhs_type = ir.ShapedType(conv_op.operands[1].type)

--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -41,6 +41,7 @@ class DispatchTuner(DispatchParser):
         self,
         ir_module: ir.Module,
         compilation_info: iree_codegen.CompilationInfoAttr,
+        problem_size: ProblemSize
     ) -> ir.Module:
         """Generate a transform dialect spec that applies the compilation info attr."""
         pass
@@ -66,6 +67,7 @@ class ContractionOpInterfaceTuner(DispatchTuner, ContractionOpInterfaceParser):
         self,
         ir_module: ir.Module,
         compilation_info: iree_codegen.CompilationInfoAttr,
+        problem_size: ProblemSize
     ) -> ir.Module:
         contraction_op: ir.Operation = self.get_contraction_operation(ir_module)
         lhs_type = ir.ShapedType(contraction_op.operands[0].type)
@@ -86,24 +88,26 @@ class ConvolutionOpInterfaceTuner(DispatchTuner, ConvolutionOpInterfaceParser):
         self,
         ir_module: ir.Module,
         compilation_info: iree_codegen.CompilationInfoAttr,
+        problem_size: ProblemSize
     ) -> ir.Module:
         conv_op: ir.Operation = self.get_conv_operation(ir_module)
-        assert (
-            conv_op.name == "linalg.conv_2d_nhwc_hwcf"
-        ), "expected linalg.conv_2d_nhwc_hwcf"
         lhs_type = ir.ShapedType(conv_op.operands[0].type)
         rhs_type = ir.ShapedType(conv_op.operands[1].type)
         acc_type = ir.ShapedType(conv_op.operands[2].type)
-        N = acc_type.get_dim_size(0)
-        H = acc_type.get_dim_size(1)
-        W = acc_type.get_dim_size(2)
-        C = rhs_type.get_dim_size(2)
-        P = rhs_type.get_dim_size(0)
-        Q = rhs_type.get_dim_size(1)
-        F = rhs_type.get_dim_size(3)
+
+        M = [mDim for mDim in problem_size.matmul_size.M]
+        M_str = 'x'.join([str(mDim) for mDim in M])
+        N = [nDim for nDim in problem_size.matmul_size.N]
+        N_str = 'x'.join([str(nDim) for nDim in N])
+        K = [kDim for kDim in problem_size.matmul_size.K]
+        K_str = 'x'.join([str(kDim) for kDim in K])
+
         conv_type = conv_op.name.split(".")[-1]
         # TODO(Max191): Get the function name from the func.func in the input module.
-        func_name = f"match_{conv_type}_{N}x{H}x{W}x{C}x{P}x{Q}x{F}_{lhs_type.element_type}x{rhs_type.element_type}x{acc_type.element_type}"
+        func_name = f"match_{conv_type}_{M_str}_{N_str}_{K_str}_{
+            lhs_type.element_type}x{rhs_type.element_type}x{acc_type.element_type}"
+        tune_logger.debug(f"func_name: {func_name}")
+
         return build_td_spec(ir_module.context, conv_op, compilation_info, func_name)
 
 
@@ -195,7 +199,7 @@ def generate_configs_and_td_specs(
         if i >= limit:
             break
         tune_logger.debug(f"Solution #{i+1}: {config}")
-        td_spec_module = dispatch_tuner.get_td_spec(input_module, config)
+        td_spec_module = dispatch_tuner.get_td_spec(input_module, config, problem_size)
         assert td_spec_module, "Failed to generate transform dialect spec"
         config_specs.append(td_spec_module)
 

--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -97,12 +97,9 @@ class ConvolutionOpInterfaceTuner(DispatchTuner, ConvolutionOpInterfaceParser):
         rhs_type = ir.ShapedType(conv_op.operands[1].type)
         acc_type = ir.ShapedType(conv_op.operands[2].type)
 
-        M = [mDim for mDim in problem_size.matmul_size.M]
-        M_str = "x".join([str(mDim) for mDim in M])
-        N = [nDim for nDim in problem_size.matmul_size.N]
-        N_str = "x".join([str(nDim) for nDim in N])
-        K = [kDim for kDim in problem_size.matmul_size.K]
-        K_str = "x".join([str(kDim) for kDim in K])
+        M_str = "x".join([str(mDim) for mDim in problem_size.matmul_size.M])
+        N_str = "x".join([str(nDim) for nDim in problem_size.matmul_size.N])
+        K_str = "x".join([str(kDim) for kDim in problem_size.matmul_size.K])
 
         conv_type = conv_op.name.split(".")[-1]
         # TODO(Max191): Get the function name from the func.func in the input module.

--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -41,7 +41,7 @@ class DispatchTuner(DispatchParser):
         self,
         ir_module: ir.Module,
         compilation_info: iree_codegen.CompilationInfoAttr,
-        problem_size: ProblemSize
+        problem_size: ProblemSize,
     ) -> ir.Module:
         """Generate a transform dialect spec that applies the compilation info attr."""
         pass
@@ -67,7 +67,7 @@ class ContractionOpInterfaceTuner(DispatchTuner, ContractionOpInterfaceParser):
         self,
         ir_module: ir.Module,
         compilation_info: iree_codegen.CompilationInfoAttr,
-        problem_size: ProblemSize
+        problem_size: ProblemSize,
     ) -> ir.Module:
         contraction_op: ir.Operation = self.get_contraction_operation(ir_module)
         lhs_type = ir.ShapedType(contraction_op.operands[0].type)
@@ -88,7 +88,7 @@ class ConvolutionOpInterfaceTuner(DispatchTuner, ConvolutionOpInterfaceParser):
         self,
         ir_module: ir.Module,
         compilation_info: iree_codegen.CompilationInfoAttr,
-        problem_size: ProblemSize
+        problem_size: ProblemSize,
     ) -> ir.Module:
         conv_op: ir.Operation = self.get_conv_operation(ir_module)
         lhs_type = ir.ShapedType(conv_op.operands[0].type)
@@ -96,16 +96,16 @@ class ConvolutionOpInterfaceTuner(DispatchTuner, ConvolutionOpInterfaceParser):
         acc_type = ir.ShapedType(conv_op.operands[2].type)
 
         M = [mDim for mDim in problem_size.matmul_size.M]
-        M_str = 'x'.join([str(mDim) for mDim in M])
+        M_str = "x".join([str(mDim) for mDim in M])
         N = [nDim for nDim in problem_size.matmul_size.N]
-        N_str = 'x'.join([str(nDim) for nDim in N])
+        N_str = "x".join([str(nDim) for nDim in N])
         K = [kDim for kDim in problem_size.matmul_size.K]
-        K_str = 'x'.join([str(kDim) for kDim in K])
+        K_str = "x".join([str(kDim) for kDim in K])
 
         conv_type = conv_op.name.split(".")[-1]
         # TODO(Max191): Get the function name from the func.func in the input module.
-        func_name = f"match_{conv_type}_{M_str}_{N_str}_{K_str}_{
-            lhs_type.element_type}x{rhs_type.element_type}x{acc_type.element_type}"
+        func_name = f"match_{conv_type}_{M_str}_{N_str}_{K_str}_"
+        f"{lhs_type.element_type}x{rhs_type.element_type}x{acc_type.element_type}"
         tune_logger.debug(f"func_name: {func_name}")
 
         return build_td_spec(ir_module.context, conv_op, compilation_info, func_name)

--- a/tuner/tuner/candidate_gen_test.py
+++ b/tuner/tuner/candidate_gen_test.py
@@ -85,7 +85,7 @@ def test_get_td_spec_contraction(tuner_ctx: common.TunerContext) -> None:
     ir_module = ir.Module.parse(module_str, context)
 
     tuner = candidate_gen.ContractionOpInterfaceTuner()
-    td_spec_module = tuner.get_td_spec(ir_module, compilation_info)
+    td_spec_module = tuner.get_td_spec(ir_module, compilation_info, None)
     assert td_spec_module
 
     named_sequence_ops: list[
@@ -167,7 +167,8 @@ def test_get_td_spec_convolution(tuner_ctx: common.TunerContext) -> None:
     ir_module = ir.Module.parse(module_str, context)
 
     tuner = candidate_gen.ConvolutionOpInterfaceTuner()
-    td_spec_module = tuner.get_td_spec(ir_module, compilation_info)
+    problem_size = tuner.get_shapes(str(ir_module).splitlines())
+    td_spec_module = tuner.get_td_spec(ir_module, compilation_info, problem_size)
     assert td_spec_module
 
     named_sequence_ops: list[

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -145,6 +145,10 @@ class ProblemSize:
     res_type: ShapedType
     dispatch_kind: DispatchKind
     contraction_dims: ContractionDimensions
+    lhs_dims: Optional[list[list[int]]]
+    rhs_dims: Optional[list[list[int]]]
+    res_dims: Optional[list[list[int]]]
+    conv_dims: Optional[ConvolutionDimensions] = None
 
     @property
     def MNK(self) -> tuple[list[int], list[int], list[int]]:
@@ -261,14 +265,31 @@ class ConvDimInfo:
     ic: int
 
     @staticmethod
-    def from_rhs_res(rhs_shaped_type: ShapedType, res_shaped_type: ShapedType):
-        n, oh, ow, oc = res_shaped_type.shape
-        fh, fw, ic, _ = rhs_shaped_type.shape
+    def from_rhs_res(rhs_shaped_type: ShapedType, rhs_dims: Optional[list[list[int]]], res_shaped_type: ShapedType, res_dims: Optional[list[list[int]]], conv_dims: Optional[ConvolutionDimensions]):
+        assert rhs_dims is not None, "no rhs dimensions"
+        assert res_dims is not None, "no result dimensions"
+        assert conv_dims is not None, "no convolution dimensions"
+
+        rhs_shape = rhs_shaped_type.shape
+        filter_dict = {inner_list[0]: index for index,
+                       inner_list in enumerate(rhs_dims)}
+        fh = rhs_shape[filter_dict.get(conv_dims.filterLoop[0], -1)]
+        fw = rhs_shape[filter_dict.get(conv_dims.filterLoop[1], -1)]
+        oc = rhs_shape[filter_dict.get(conv_dims.outputChannel[0], -1)]
+        ic = rhs_shape[filter_dict.get(conv_dims.inputChannel[0], -1)]
+
+        res_shape = res_shaped_type.shape
+        res_dict = {inner_list[0]: index for index,
+                    inner_list in enumerate(res_dims)}
+        n = res_shape[res_dict.get(conv_dims.batch[0], -1)]
+        oh = res_shape[res_dict.get(conv_dims.outputImage[0], -1)]
+        ow = res_shape[res_dict.get(conv_dims.outputImage[1], -1)]
+
         return ConvDimInfo(n, oh, ow, oc, fh, fw, ic)
 
     @staticmethod
     def from_problem_size(problem_size: ProblemSize):
-        return ConvDimInfo.from_rhs_res(problem_size.rhs_type, problem_size.res_type)
+        return ConvDimInfo.from_rhs_res(problem_size.rhs_type, problem_size.rhs_dims, problem_size.res_type, problem_size.res_dims, problem_size.conv_dims)
 
 
 @dataclass

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -127,6 +127,25 @@ class ContractionDimensions:
 
 @dataclass
 class ConvolutionDimensions:
+    """
+    Stores which dimensions of the iteration space belong to the convolution.
+    For example, the following is a simple nhwc_fhwc conv:
+    linalg.generic ... indexing_maps = [
+        affine_map<(b, oh, ow, oc, fh, fw, ic) -> (b, ih, iw, ic)>,
+        affine_map<(b, oh, ow, oc, fh, fw, ic) -> (oc, fh, fw, ic)>,
+        affine_map<(b, oh, ow, oc, fh, fw, ic) -> (b, oh, ow, oc)>,
+        ]
+    The ConvolutionDimensions would be:
+    batch = [0]
+    outputImage = [1, 2]
+    outputChannel = [3]
+    filterLoop = [4, 5]
+    inputChannel = [6]
+    depth = []
+    strides = [1, 1]
+    dilations = [1, 1]
+    """
+
     batch: list[int] = field(default_factory=list)
     outputImage: list[int] = field(default_factory=list)
     outputChannel: list[int] = field(default_factory=list)
@@ -139,15 +158,39 @@ class ConvolutionDimensions:
 
 @dataclass
 class ProblemSize:
+    """
+    Represents a problem size for a contraction or convolution operation. When it is
+    a convolution the lhs_expr_dims, rhs_expr_dims, res_expr_dims and conv_dims are required to be set.
+
+    For example, the following is a simple convolution:
+    %conv = linalg.conv_2d_nhwc_hwcf
+        {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
+        ins(%6, %7 : tensor<2x62x66x960xf16>, tensor<3x3x960x640xf16>)
+        outs(%13 : tensor<2x60x64x640xf32>) -> tensor<2x60x64x640xf32>
+
+    The ProblemSize would be:
+    matmul_size = ContractionSizes(M=[2, 60, 64], N=[640], K=[3, 3, 960], B=[]),
+    lhs_type = ShapedType(shape=[2, 62, 66, 960], element_type=F16Type(f16)),
+    rhs_type = ShapedType(shape=[3, 3, 960, 640], element_type=F16Type(f16)),
+    res_type = ShapedType(shape=[2, 60, 64, 640], element_type=F32Type(f32)),
+    dispatch_kind = DispatchKind.conv
+    contraction_dims = ContractionDimensions(m=[0, 1, 2], n=[3], k=[4, 5, 6], batch=[]),
+    lhs_expr_dims = [[0], [1, 4], [2, 5], [6]],
+    rhs_expr_dims = [[4], [5], [6], [3]],
+    res_expr_dims = [[0], [1], [2], [3]],
+    conv_dims = ConvolutionDimensions(...)
+
+    """
+
     matmul_size: ContractionSizes
     lhs_type: ShapedType
     rhs_type: ShapedType
     res_type: ShapedType
     dispatch_kind: DispatchKind
     contraction_dims: ContractionDimensions
-    lhs_dims: Optional[list[list[int]]]
-    rhs_dims: Optional[list[list[int]]]
-    res_dims: Optional[list[list[int]]]
+    lhs_expr_dims: Optional[list[list[int]]] = None
+    rhs_expr_dims: Optional[list[list[int]]] = None
+    res_expr_dims: Optional[list[list[int]]] = None
     conv_dims: Optional[ConvolutionDimensions] = None
 
     @property
@@ -271,10 +314,17 @@ class ConvDimInfo:
         res_shaped_type: ShapedType,
         res_dims: Optional[list[list[int]]],
         conv_dims: Optional[ConvolutionDimensions],
-    ):
+    ) -> "ConvDimInfo":
         assert rhs_dims is not None, "no rhs dimensions"
         assert res_dims is not None, "no result dimensions"
         assert conv_dims is not None, "no convolution dimensions"
+        assert len(conv_dims.filterLoop) == 2, "only 2 filter loops supported"
+        assert len(conv_dims.outputChannel) == 1, "only 1 output channel supported"
+        assert len(conv_dims.inputChannel) == 1, "only 1 input channel supported"
+        assert len(conv_dims.batch) == 1, "only 1 batch dimension supported"
+        assert (
+            len(conv_dims.outputImage) == 2
+        ), "only 2 output image dimensions supported"
 
         rhs_shape = rhs_shaped_type.shape
         filter_dict = {
@@ -297,9 +347,9 @@ class ConvDimInfo:
     def from_problem_size(problem_size: ProblemSize):
         return ConvDimInfo.from_rhs_res(
             problem_size.rhs_type,
-            problem_size.rhs_dims,
+            problem_size.rhs_expr_dims,
             problem_size.res_type,
-            problem_size.res_dims,
+            problem_size.res_expr_dims,
             problem_size.conv_dims,
         )
 

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -160,7 +160,8 @@ class ConvolutionDimensions:
 class ProblemSize:
     """
     Represents a problem size for a contraction or convolution operation. When it is
-    a convolution the lhs_expr_dims, rhs_expr_dims, res_expr_dims and conv_dims are required to be set.
+    a convolution all fields including: contraction_dims, lhs_expr_dims, rhs_expr_dims,
+    res_expr_dims and conv_dims are required to be set.
 
     For example, the following is a simple convolution:
     %conv = linalg.conv_2d_nhwc_hwcf
@@ -174,7 +175,16 @@ class ProblemSize:
     rhs_type = ShapedType(shape=[3, 3, 960, 640], element_type=F16Type(f16)),
     res_type = ShapedType(shape=[2, 60, 64, 640], element_type=F32Type(f32)),
     dispatch_kind = DispatchKind.conv
+
+    # The contraction_dims field is intuitive for gemms. For convolutions, it recorded the convolution
+    # dimension to contraction dimension mapping. In igemm setting:
+    # - [d0, d1, d2] map to [b, oh, ow], or m dimension of the gemm
+    # - [d3] map to [oc], or n dimension of the gemm
+    # - [d4, d5, d6] map to [fh, fw, ic], or k dimension of the gemm
     contraction_dims = ContractionDimensions(m=[0, 1, 2], n=[3], k=[4, 5, 6], batch=[]),
+
+    # *expr_dims fields represent the dimensions that appear in the affine map result expressions at
+    # each dimension of the operator tensor.
     lhs_expr_dims = [[0], [1, 4], [2, 5], [6]],
     rhs_expr_dims = [[4], [5], [6], [3]],
     res_expr_dims = [[0], [1], [2], [3]],

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -126,6 +126,18 @@ class ContractionDimensions:
 
 
 @dataclass
+class ConvolutionDimensions:
+  batch: list[int] = field(default_factory=list)
+  outputImage: list[int] = field(default_factory=list)
+  outputChannel: list[int] = field(default_factory=list)
+  filterLoop: list[int] = field(default_factory=list)
+  inputChannel: list[int] = field(default_factory=list)
+  depth: list[int] = field(default_factory=list)
+  strides: list[int] = field(default_factory=list)
+  dilations: list[int] = field(default_factory=list)
+
+
+@dataclass
 class ProblemSize:
     matmul_size: ContractionSizes
     lhs_type: ShapedType

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -127,14 +127,14 @@ class ContractionDimensions:
 
 @dataclass
 class ConvolutionDimensions:
-  batch: list[int] = field(default_factory=list)
-  outputImage: list[int] = field(default_factory=list)
-  outputChannel: list[int] = field(default_factory=list)
-  filterLoop: list[int] = field(default_factory=list)
-  inputChannel: list[int] = field(default_factory=list)
-  depth: list[int] = field(default_factory=list)
-  strides: list[int] = field(default_factory=list)
-  dilations: list[int] = field(default_factory=list)
+    batch: list[int] = field(default_factory=list)
+    outputImage: list[int] = field(default_factory=list)
+    outputChannel: list[int] = field(default_factory=list)
+    filterLoop: list[int] = field(default_factory=list)
+    inputChannel: list[int] = field(default_factory=list)
+    depth: list[int] = field(default_factory=list)
+    strides: list[int] = field(default_factory=list)
+    dilations: list[int] = field(default_factory=list)
 
 
 @dataclass
@@ -265,22 +265,28 @@ class ConvDimInfo:
     ic: int
 
     @staticmethod
-    def from_rhs_res(rhs_shaped_type: ShapedType, rhs_dims: Optional[list[list[int]]], res_shaped_type: ShapedType, res_dims: Optional[list[list[int]]], conv_dims: Optional[ConvolutionDimensions]):
+    def from_rhs_res(
+        rhs_shaped_type: ShapedType,
+        rhs_dims: Optional[list[list[int]]],
+        res_shaped_type: ShapedType,
+        res_dims: Optional[list[list[int]]],
+        conv_dims: Optional[ConvolutionDimensions],
+    ):
         assert rhs_dims is not None, "no rhs dimensions"
         assert res_dims is not None, "no result dimensions"
         assert conv_dims is not None, "no convolution dimensions"
 
         rhs_shape = rhs_shaped_type.shape
-        filter_dict = {inner_list[0]: index for index,
-                       inner_list in enumerate(rhs_dims)}
+        filter_dict = {
+            inner_list[0]: index for index, inner_list in enumerate(rhs_dims)
+        }
         fh = rhs_shape[filter_dict.get(conv_dims.filterLoop[0], -1)]
         fw = rhs_shape[filter_dict.get(conv_dims.filterLoop[1], -1)]
         oc = rhs_shape[filter_dict.get(conv_dims.outputChannel[0], -1)]
         ic = rhs_shape[filter_dict.get(conv_dims.inputChannel[0], -1)]
 
         res_shape = res_shaped_type.shape
-        res_dict = {inner_list[0]: index for index,
-                    inner_list in enumerate(res_dims)}
+        res_dict = {inner_list[0]: index for index, inner_list in enumerate(res_dims)}
         n = res_shape[res_dict.get(conv_dims.batch[0], -1)]
         oh = res_shape[res_dict.get(conv_dims.outputImage[0], -1)]
         ow = res_shape[res_dict.get(conv_dims.outputImage[1], -1)]
@@ -289,7 +295,13 @@ class ConvDimInfo:
 
     @staticmethod
     def from_problem_size(problem_size: ProblemSize):
-        return ConvDimInfo.from_rhs_res(problem_size.rhs_type, problem_size.rhs_dims, problem_size.res_type, problem_size.res_dims, problem_size.conv_dims)
+        return ConvDimInfo.from_rhs_res(
+            problem_size.rhs_type,
+            problem_size.rhs_dims,
+            problem_size.res_type,
+            problem_size.res_dims,
+            problem_size.conv_dims,
+        )
 
 
 @dataclass

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -131,7 +131,7 @@ class ConvolutionDimensions:
     Stores which dimensions of the iteration space belong to the convolution.
     For example, the following is a simple nhwc_fhwc conv:
     linalg.generic ... indexing_maps = [
-        affine_map<(b, oh, ow, oc, fh, fw, ic) -> (b, ih, iw, ic)>,
+        affine_map<(b, oh, ow, oc, fh, fw, ic) -> (b, oh + fh, ow + fw, ic)>,
         affine_map<(b, oh, ow, oc, fh, fw, ic) -> (oc, fh, fw, ic)>,
         affine_map<(b, oh, ow, oc, fh, fw, ic) -> (b, oh, ow, oc)>,
         ]

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -125,10 +125,6 @@ def test_get_compatible_mfma_intrinsics(tuner_ctx: common.TunerContext) -> None:
             common.ShapedType([2048, 1280], tuner_ctx.type.f32),
             common.DispatchKind.contraction,
             common.ContractionDimensions([0], [1], [2]),
-            None,
-            None,
-            None,
-            None,
         ),
         [
             iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
@@ -149,10 +145,6 @@ def test_get_compatible_mfma_intrinsics(tuner_ctx: common.TunerContext) -> None:
             common.ShapedType([2048, 1280], tuner_ctx.type.i32),
             common.DispatchKind.contraction,
             common.ContractionDimensions([0], [1], [2]),
-            None,
-            None,
-            None,
-            None,
         ),
         [
             iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
@@ -174,10 +166,6 @@ def test_get_compatible_mfma_intrinsics(tuner_ctx: common.TunerContext) -> None:
                 common.ShapedType([64, 968, 320], tuner_ctx.type.f32),
                 common.DispatchKind.contraction,
                 common.ContractionDimensions([1], [2], [3], [0]),
-                None,
-                None,
-                None,
-                None,
             ),
             [
                 iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -125,6 +125,10 @@ def test_get_compatible_mfma_intrinsics(tuner_ctx: common.TunerContext) -> None:
             common.ShapedType([2048, 1280], tuner_ctx.type.f32),
             common.DispatchKind.contraction,
             common.ContractionDimensions([0], [1], [2]),
+            None,
+            None,
+            None,
+            None,
         ),
         [
             iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
@@ -145,6 +149,10 @@ def test_get_compatible_mfma_intrinsics(tuner_ctx: common.TunerContext) -> None:
             common.ShapedType([2048, 1280], tuner_ctx.type.i32),
             common.DispatchKind.contraction,
             common.ContractionDimensions([0], [1], [2]),
+            None,
+            None,
+            None,
+            None,
         ),
         [
             iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
@@ -166,6 +174,10 @@ def test_get_compatible_mfma_intrinsics(tuner_ctx: common.TunerContext) -> None:
                 common.ShapedType([64, 968, 320], tuner_ctx.type.f32),
                 common.DispatchKind.contraction,
                 common.ContractionDimensions([1], [2], [3], [0]),
+                None,
+                None,
+                None,
+                None,
             ),
             [
                 iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,

--- a/tuner/tuner/dispatch_constraints.py
+++ b/tuner/tuner/dispatch_constraints.py
@@ -352,9 +352,10 @@ def adjust_problem_size_for_pipeline(
     if (
         codegen_pipeline != iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse
         or problem_size.dispatch_kind != DispatchKind.conv
-        or problem_size.rhs_expr_dims is None
     ):
         return
+    assert problem_size.rhs_expr_dims is not None
+
     pipeline_options_search_space.use_igemm_convolution = [True]
 
     k_contraction_dims = set(problem_size.contraction_dims.k)
@@ -380,6 +381,8 @@ def adjust_problem_size_for_pipeline(
 
     # Reset the contraction dims and matmul sizes using the new K contraction dims.
     k_contraction_dims_start = problem_size.contraction_dims.k[0]
+    assert k_contraction_dims_start == 4, "We assume k dims are innermost."
+
     k_index_dict = {
         rhs_result_expr_dim_set[0]: i
         for i, rhs_result_expr_dim_set in enumerate(rhs_result_expr_dim_sets)

--- a/tuner/tuner/dispatch_constraints.py
+++ b/tuner/tuner/dispatch_constraints.py
@@ -352,13 +352,45 @@ def adjust_problem_size_for_pipeline(
     if (
         codegen_pipeline != iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse
         or problem_size.dispatch_kind != DispatchKind.conv
+        or problem_size.rhs_dims is None
     ):
         return
     pipeline_options_search_space.use_igemm_convolution = [True]
-    # Flatten the K dimensions into a single dimension. The IGEMM transformation
-    # flattens the reduction channel and filter dimensions into one.
-    problem_size.contraction_dims.k = [problem_size.contraction_dims.k[0]]
-    problem_size.matmul_size.K = [math.prod(problem_size.matmul_size.K)]
+
+    k_group = set(problem_size.contraction_dims.k)
+    rhs_dims = problem_size.rhs_dims
+    k_contraction_dims = []
+    k_contraction_dim_current = []
+    # Iterate through the filter shape. For each dimension, check if it is in the
+    # K contraction dimensions. If it is, add it to the current contraction_dim
+    for dim in rhs_dims:
+        element = dim[0]
+        if element in k_group:
+            k_contraction_dim_current.append(element)
+        else:
+            # If the first element is not in the K contraction dims, then the
+            # current contraction dim might still be empty. Skip it in this case.
+            if k_contraction_dim_current:
+                k_contraction_dims.append(k_contraction_dim_current)
+                k_contraction_dim_current = []
+
+    # Append the last contraction dim if it exists
+    if k_contraction_dim_current:
+        k_contraction_dims.append(k_contraction_dim_current)
+
+    # Reset the contraction dims and matmul sizes using the new K contraction dims
+    k_start = problem_size.contraction_dims.k[0]
+    k_index_dict = {dim[0]: i for i, dim in enumerate(rhs_dims)}
+    filter_shape = problem_size.rhs_type.shape
+    problem_size.contraction_dims.k = []
+    problem_size.matmul_size.K = []
+    for contraction_dim in k_contraction_dims:
+        problem_size.contraction_dims.k.append(k_start)
+        dim_indexes = [k_index_dict[dim] for dim in contraction_dim]
+        filter_shapes = [filter_shape[index] for index in dim_indexes]
+        collapsed_dim_size = math.prod(filter_shapes)
+        problem_size.matmul_size.K.append(collapsed_dim_size)
+        k_start += 1
 
 
 def generate_solutions(

--- a/tuner/tuner/dispatch_constraints_test.py
+++ b/tuner/tuner/dispatch_constraints_test.py
@@ -43,10 +43,6 @@ def test_generate_solutions(tuner_ctx: common.TunerContext) -> None:
         res_type,
         common.DispatchKind.contraction,
         contraction_dims,
-        None,
-        None,
-        None,
-        None,
     )
     configs = dispatch_constraints.generate_solutions(
         tuner_ctx,
@@ -76,10 +72,6 @@ def test_calculate_shared_memory_usage_in_bytes(tuner_ctx: common.TunerContext) 
         res_type,
         common.DispatchKind.contraction,
         contraction_dims,
-        None,
-        None,
-        None,
-        None,
     )
     assert (
         dispatch_constraints.calculate_shared_memory_usage_in_bytes(
@@ -96,10 +88,6 @@ def test_calculate_shared_memory_usage_in_bytes(tuner_ctx: common.TunerContext) 
         res_type,
         common.DispatchKind.contraction,
         contraction_dims,
-        None,
-        None,
-        None,
-        None,
     )
     assert (
         dispatch_constraints.calculate_shared_memory_usage_in_bytes(
@@ -116,10 +104,6 @@ def test_calculate_shared_memory_usage_in_bytes(tuner_ctx: common.TunerContext) 
         res_type,
         common.DispatchKind.contraction,
         contraction_dims,
-        None,
-        None,
-        None,
-        None,
     )
     assert (
         dispatch_constraints.calculate_shared_memory_usage_in_bytes(
@@ -162,10 +146,6 @@ def test_adjust_problem_size_for_pipeline(
         res_type,
         common.DispatchKind.contraction,
         contraction_dims,
-        None,
-        None,
-        None,
-        None,
     )
     pipeline_options_space = dispatch_constraints.PipelineOptionsSearchSpace(
         prefetch_shared_memory=[True],
@@ -299,10 +279,6 @@ def test_generate_tile_and_fuse_constraints_valid_input(
         res_type,
         common.DispatchKind.contraction,
         contraction_dims,
-        None,
-        None,
-        None,
-        None,
     )
     # Define input parameters as z3 Ints
     m, n, k = (
@@ -375,10 +351,6 @@ def test_generate_tile_and_fuse_constraints_invalid_input(
         res_type,
         common.DispatchKind.contraction,
         contraction_dims,
-        None,
-        None,
-        None,
-        None,
     )
     # Define input parameters as z3 Ints
     m, n, k = (
@@ -441,10 +413,6 @@ def test_generate_vector_distribute_constraints_valid_input(
         res_type,
         common.DispatchKind.contraction,
         contraction_dims,
-        None,
-        None,
-        None,
-        None,
     )
     # Define input parameters as z3 Ints
     m, n, k = (
@@ -503,10 +471,6 @@ def test_generate_vector_distribute_constraints_invalid_input(
         res_type,
         common.DispatchKind.contraction,
         contraction_dims,
-        None,
-        None,
-        None,
-        None,
     )
     m, n, k = (
         [z3.Int("m")],

--- a/tuner/tuner/dispatch_constraints_test.py
+++ b/tuner/tuner/dispatch_constraints_test.py
@@ -43,6 +43,10 @@ def test_generate_solutions(tuner_ctx: common.TunerContext) -> None:
         res_type,
         common.DispatchKind.contraction,
         contraction_dims,
+        None,
+        None,
+        None,
+        None,
     )
     configs = dispatch_constraints.generate_solutions(
         tuner_ctx,
@@ -72,6 +76,10 @@ def test_calculate_shared_memory_usage_in_bytes(tuner_ctx: common.TunerContext) 
         res_type,
         common.DispatchKind.contraction,
         contraction_dims,
+        None,
+        None,
+        None,
+        None,
     )
     assert (
         dispatch_constraints.calculate_shared_memory_usage_in_bytes(
@@ -88,6 +96,10 @@ def test_calculate_shared_memory_usage_in_bytes(tuner_ctx: common.TunerContext) 
         res_type,
         common.DispatchKind.contraction,
         contraction_dims,
+        None,
+        None,
+        None,
+        None,
     )
     assert (
         dispatch_constraints.calculate_shared_memory_usage_in_bytes(
@@ -104,6 +116,10 @@ def test_calculate_shared_memory_usage_in_bytes(tuner_ctx: common.TunerContext) 
         res_type,
         common.DispatchKind.contraction,
         contraction_dims,
+        None,
+        None,
+        None,
+        None,
     )
     assert (
         dispatch_constraints.calculate_shared_memory_usage_in_bytes(
@@ -146,6 +162,10 @@ def test_adjust_problem_size_for_pipeline(
         res_type,
         common.DispatchKind.contraction,
         contraction_dims,
+        None,
+        None,
+        None,
+        None,
     )
     pipeline_options_space = dispatch_constraints.PipelineOptionsSearchSpace(
         prefetch_shared_memory=[True],
@@ -187,6 +207,16 @@ def test_adjust_problem_size_for_pipeline(
     lhs_type = common.ShapedType([2, 34, 34, 512], tuner_ctx.type.f16)
     rhs_type = common.ShapedType([3, 3, 512, 256], tuner_ctx.type.f16)
     res_type = common.ShapedType([2, 32, 32, 256], tuner_ctx.type.f32)
+    conv_dims = common.ConvolutionDimensions(
+        batch=[0],
+        outputImage=[1, 2],
+        outputChannel=[3],
+        filterLoop=[4, 5],
+        inputChannel=[6],
+        depth=[],
+        strides=[1, 1],
+        dilations=[1, 1],
+    )
     conv_problem_size = common.ProblemSize(
         conv_size,
         lhs_type,
@@ -194,6 +224,10 @@ def test_adjust_problem_size_for_pipeline(
         res_type,
         common.DispatchKind.conv,
         contraction_dims,
+        [[0], [1, 4], [2, 5], [6]],
+        [[4], [5], [6], [3]],
+        [[0], [1], [2], [3]],
+        conv_dims,
     )
     vec_dist_pipeline = (
         iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
@@ -265,6 +299,10 @@ def test_generate_tile_and_fuse_constraints_valid_input(
         res_type,
         common.DispatchKind.contraction,
         contraction_dims,
+        None,
+        None,
+        None,
+        None,
     )
     # Define input parameters as z3 Ints
     m, n, k = (
@@ -337,6 +375,10 @@ def test_generate_tile_and_fuse_constraints_invalid_input(
         res_type,
         common.DispatchKind.contraction,
         contraction_dims,
+        None,
+        None,
+        None,
+        None,
     )
     # Define input parameters as z3 Ints
     m, n, k = (
@@ -399,6 +441,10 @@ def test_generate_vector_distribute_constraints_valid_input(
         res_type,
         common.DispatchKind.contraction,
         contraction_dims,
+        None,
+        None,
+        None,
+        None,
     )
     # Define input parameters as z3 Ints
     m, n, k = (
@@ -457,6 +503,10 @@ def test_generate_vector_distribute_constraints_invalid_input(
         res_type,
         common.DispatchKind.contraction,
         contraction_dims,
+        None,
+        None,
+        None,
+        None,
     )
     m, n, k = (
         [z3.Int("m")],

--- a/tuner/tuner/dispatch_parser.py
+++ b/tuner/tuner/dispatch_parser.py
@@ -93,6 +93,9 @@ class ContractionOpInterfaceParser(DispatchParser):
             res_type=ShapedType(res_type.shape, res_type.element_type),
             dispatch_kind=DispatchKind.contraction,
             contraction_dims=contraction_dims,
+            lhs_dims=[[d] for d in matcher.lhs_dims],
+            rhs_dims=[[d] for d in matcher.rhs_dims],
+            res_dims=[[d] for d in matcher.res_dims]
         )
 
 
@@ -119,20 +122,15 @@ class ConvolutionOpInterfaceParser(DispatchParser):
         matcher = ConvolutionOpInterfaceMatcher()
         conv_op = match_root_op(ir_module, matcher)
         conv_dims = matcher.convolution_dimensions
-        lhs_dims = matcher.lhs_dims
-        rhs_dims = matcher.rhs_dims
-        res_dims = matcher.res_dims
-        print(f"conv_dims:\n{conv_dims}")
-        print(f"\nlhs_dims:\n{lhs_dims}")
-        print(f"rhs_dims:\n{rhs_dims}")
-        print(f"res_dims:\n{res_dims}")
+
         assert conv_op is not None, f"convolution op not found"
+
         lhs_type = ir.RankedTensorType(conv_op.operands[0].type)
         rhs_type = ir.RankedTensorType(conv_op.operands[1].type)
         res_type = ir.RankedTensorType(conv_op.operands[2].type)
 
-        # TODO: Use the convolution dims to replace the below logic
-        dim_info = ConvDimInfo.from_rhs_res(rhs_type, res_type)
+        dim_info = ConvDimInfo.from_rhs_res(
+            rhs_type, matcher.rhs_dims, res_type, matcher.res_dims, conv_dims)
         return ProblemSize(
             matmul_size=ContractionSizes(
                 M=[dim_info.n, dim_info.oh, dim_info.ow],
@@ -148,4 +146,8 @@ class ConvolutionOpInterfaceParser(DispatchParser):
                 n=[3],
                 k=[4, 5, 6],
             ),
+            lhs_dims=matcher.lhs_dims,
+            rhs_dims=matcher.rhs_dims,
+            res_dims=matcher.res_dims,
+            conv_dims=conv_dims
         )

--- a/tuner/tuner/dispatch_parser.py
+++ b/tuner/tuner/dispatch_parser.py
@@ -93,9 +93,9 @@ class ContractionOpInterfaceParser(DispatchParser):
             res_type=ShapedType(res_type.shape, res_type.element_type),
             dispatch_kind=DispatchKind.contraction,
             contraction_dims=contraction_dims,
-            lhs_dims=[[d] for d in matcher.lhs_dims],
-            rhs_dims=[[d] for d in matcher.rhs_dims],
-            res_dims=[[d] for d in matcher.res_dims],
+            lhs_expr_dims=[[d] for d in matcher.lhs_dims],
+            rhs_expr_dims=[[d] for d in matcher.rhs_dims],
+            res_expr_dims=[[d] for d in matcher.res_dims],
         )
 
 
@@ -130,7 +130,7 @@ class ConvolutionOpInterfaceParser(DispatchParser):
         res_type = ir.RankedTensorType(conv_op.operands[2].type)
 
         dim_info = ConvDimInfo.from_rhs_res(
-            rhs_type, matcher.rhs_dims, res_type, matcher.res_dims, conv_dims
+            rhs_type, matcher.rhs_expr_dims, res_type, matcher.res_expr_dims, conv_dims
         )
         return ProblemSize(
             matmul_size=ContractionSizes(
@@ -147,8 +147,8 @@ class ConvolutionOpInterfaceParser(DispatchParser):
                 n=[3],
                 k=[4, 5, 6],
             ),
-            lhs_dims=matcher.lhs_dims,
-            rhs_dims=matcher.rhs_dims,
-            res_dims=matcher.res_dims,
+            lhs_expr_dims=matcher.lhs_expr_dims,
+            rhs_expr_dims=matcher.rhs_expr_dims,
+            res_expr_dims=matcher.res_expr_dims,
             conv_dims=conv_dims,
         )

--- a/tuner/tuner/dispatch_parser.py
+++ b/tuner/tuner/dispatch_parser.py
@@ -95,7 +95,7 @@ class ContractionOpInterfaceParser(DispatchParser):
             contraction_dims=contraction_dims,
             lhs_dims=[[d] for d in matcher.lhs_dims],
             rhs_dims=[[d] for d in matcher.rhs_dims],
-            res_dims=[[d] for d in matcher.res_dims]
+            res_dims=[[d] for d in matcher.res_dims],
         )
 
 
@@ -130,7 +130,8 @@ class ConvolutionOpInterfaceParser(DispatchParser):
         res_type = ir.RankedTensorType(conv_op.operands[2].type)
 
         dim_info = ConvDimInfo.from_rhs_res(
-            rhs_type, matcher.rhs_dims, res_type, matcher.res_dims, conv_dims)
+            rhs_type, matcher.rhs_dims, res_type, matcher.res_dims, conv_dims
+        )
         return ProblemSize(
             matmul_size=ContractionSizes(
                 M=[dim_info.n, dim_info.oh, dim_info.ow],
@@ -149,5 +150,5 @@ class ConvolutionOpInterfaceParser(DispatchParser):
             lhs_dims=matcher.lhs_dims,
             rhs_dims=matcher.rhs_dims,
             res_dims=matcher.res_dims,
-            conv_dims=conv_dims
+            conv_dims=conv_dims,
         )

--- a/tuner/tuner/op_matchers.py
+++ b/tuner/tuner/op_matchers.py
@@ -93,7 +93,7 @@ class GenericOpMatcher(NamedOpMatcher):
 
         maps_attr = None
         for attr in op.opview.attributes:
-            if attr.name == "indexing_maps" and isinstance(attr.attr, ir.ArrayAttr):
+            if (attr.name == "indexing_maps" or attr.name == "linalg.memoized_indexing_maps") and isinstance(attr.attr, ir.ArrayAttr):
                 maps_attr = attr.attr
         if maps_attr is None:
             return False
@@ -122,6 +122,108 @@ def get_map_result_dim_positions(map: ir.AffineMap):
         dim_position = int(dim_str[1:])
         exprs.append(dim_position)
     return exprs
+
+
+def get_convolution_dims(lhs_map: ir.AffineMap, rhs_map: ir.AffineMap, res_map: ir.AffineMap):
+    if not rhs_map.is_projected_permutation or not res_map.is_projected_permutation:
+        return None
+    lhs_dims = []
+    rhs_dims = get_map_result_dim_positions(rhs_map)
+    res_dims = get_map_result_dim_positions(res_map)
+    batch_dims = []
+    input_channel_dims = []
+    output_channel_dims = []
+    output_img_dims = []
+    filter_loop_dims = []
+    strides = []
+    dilations = []
+    
+    def get_dim_pos(dim):
+        if len(dim) < 1 or dim[0] != "d" or not dim[1:].isdigit():
+            return None
+        return int(dim[1:])
+
+    def verify_and_add_img_and_filter_dims(img_dim, filter_dim):
+        # Verify set for img dim
+        if img_dim in rhs_dims or img_dim not in res_dims:
+            return None
+        output_img_dims.append(img_dim)
+        # Verify set for filter dim
+        if filter_dim not in rhs_dims or filter_dim in res_dims:
+            return None
+        filter_loop_dims.append(filter_dim)
+
+    for expr in lhs_map.results:
+        dim_strs = str(expr).split(" ")
+        if len(dim_strs) == 1:
+            dim = get_dim_pos(dim_strs[0])
+            if dim is None:
+                return None
+            if dim not in rhs_dims and dim in res_dims:
+                batch_dims.append(dim)
+            elif dim in rhs_dims and dim not in res_dims:
+                input_channel_dims.append(dim)
+            else:
+                return None
+            lhs_dims.append([dim])
+            continue
+        # Convolved dim with no stride
+        if len(dim_strs) == 3:
+            if dim_strs[1] != "+":
+                return None
+            img_dim = get_dim_pos(dim_strs[0])
+            filter_dim = get_dim_pos(dim_strs[2])
+            if img_dim is None or filter_dim is None:
+                return None
+            verify_and_add_img_and_filter_dims(img_dim, filter_dim)
+            strides.append(1)
+            dilations.append(1)
+            lhs_dims.append([img_dim, filter_dim])
+            continue
+        # Convolved dim with stride
+        if len(dim_strs) == 5:
+            if dim_strs[1] != "*" or dim_strs[3] != "+":
+                return None
+            img_dim = get_dim_pos(dim_strs[0])
+            filter_dim = get_dim_pos(dim_strs[4])
+            if img_dim is None or filter_dim is None:
+                return None
+            verify_and_add_img_and_filter_dims(img_dim, filter_dim)
+            if not dim_strs[2].isdigit():
+                return None
+            strides.append(int(dim_strs[2]))
+            dilations.append(1)
+            lhs_dims.append([img_dim, filter_dim])
+            continue
+    
+    # lhs_dims is a 2D array. Get the set of dims lhs dims.
+    lhs_dim_set = set()
+    for dims in lhs_dims:
+        for dim in dims:
+            lhs_dim_set.add(dim)
+    # Collect output channel dims
+    for d in range(rhs_map.n_dims):
+        if d not in lhs_dim_set and d in rhs_dims and d in res_dims:
+            output_channel_dims.append(d)
+    
+    # Verify that there are convolved dims
+    if len(filter_loop_dims) == 0:
+        return None
+
+    return (
+        ConvolutionDimensions(
+            batch=batch_dims,
+            outputImage=output_img_dims,
+            outputChannel=output_channel_dims,
+            filterLoop=filter_loop_dims,
+            inputChannel=input_channel_dims,
+            strides=strides,
+            dilations=dilations,
+        ),
+        lhs_dims,
+        [[d] for d in rhs_dims],
+        [[d] for d in res_dims],
+    )
 
 
 class ContractionOpInterfaceMatcher(GenericOpMatcher):
@@ -175,6 +277,41 @@ class ContractionOpInterfaceMatcher(GenericOpMatcher):
             k=k_dims,
             batch=batch_dims,
         )
+        self.lhs_dims = lhs_dims
+        self.rhs_dims = rhs_dims
+        self.res_dims = res_dims
+        return True
+
+
+class ConvolutionOpInterfaceMatcher(GenericOpMatcher):
+    def __init__(self) -> None:
+        super().__init__()
+        self.supported_named_ops = ["linalg.conv_2d_nhwc_hwcf"]
+        self.op_names.extend(self.supported_named_ops)
+        self.convolution_dimensions: Optional[ConvolutionDimensions] = None
+        self.lhs_dims: Optional[list[list[int]]] = None
+        self.rhs_dims: Optional[list[list[int]]] = None
+        self.res_dims: Optional[list[list[int]]] = None
+
+    def match_operands(self, operands: ir.OpOperandList) -> bool:
+        if len(operands) != 3:
+            return False
+        for operand in operands:
+            if not isinstance(operand.type, ir.ShapedType):
+                return False
+        return True
+
+    def match_indexing_maps(self, maps: list[ir.AffineMap]) -> bool:
+        if len(maps) != 3:
+            return False
+
+        conv_dim_info = get_convolution_dims(maps[0], maps[1], maps[2])
+        if conv_dim_info is None:
+            return False
+
+        conv_dims, lhs_dims, rhs_dims, res_dims = conv_dim_info
+        self.convolution_dimensions = conv_dims
+
         self.lhs_dims = lhs_dims
         self.rhs_dims = rhs_dims
         self.res_dims = res_dims

--- a/tuner/tuner/op_matchers.py
+++ b/tuner/tuner/op_matchers.py
@@ -137,7 +137,7 @@ def get_convolution_dims(lhs_map: ir.AffineMap, rhs_map: ir.AffineMap, res_map: 
     filter_loop_dims = []
     strides = []
     dilations = []
-    
+
     def get_dim_pos(dim):
         if len(dim) < 1 or dim[0] != "d" or not dim[1:].isdigit():
             return None
@@ -195,7 +195,7 @@ def get_convolution_dims(lhs_map: ir.AffineMap, rhs_map: ir.AffineMap, res_map: 
             dilations.append(1)
             lhs_dims.append([img_dim, filter_dim])
             continue
-    
+
     # lhs_dims is a 2D array. Get the set of dims lhs dims.
     lhs_dim_set = set()
     for dims in lhs_dims:
@@ -205,7 +205,7 @@ def get_convolution_dims(lhs_map: ir.AffineMap, rhs_map: ir.AffineMap, res_map: 
     for d in range(rhs_map.n_dims):
         if d not in lhs_dim_set and d in rhs_dims and d in res_dims:
             output_channel_dims.append(d)
-    
+
     # Verify that there are convolved dims
     if len(filter_loop_dims) == 0:
         return None
@@ -286,7 +286,8 @@ class ContractionOpInterfaceMatcher(GenericOpMatcher):
 class ConvolutionOpInterfaceMatcher(GenericOpMatcher):
     def __init__(self) -> None:
         super().__init__()
-        self.supported_named_ops = ["linalg.conv_2d_nhwc_hwcf"]
+        self.supported_named_ops = [
+            "linalg.conv_2d_nhwc_hwcf", "linalg.conv_2d_nhwc_hwfc"]
         self.op_names.extend(self.supported_named_ops)
         self.convolution_dimensions: Optional[ConvolutionDimensions] = None
         self.lhs_dims: Optional[list[list[int]]] = None

--- a/tuner/tuner/op_matchers.py
+++ b/tuner/tuner/op_matchers.py
@@ -93,7 +93,10 @@ class GenericOpMatcher(NamedOpMatcher):
 
         maps_attr = None
         for attr in op.opview.attributes:
-            if (attr.name == "indexing_maps" or attr.name == "linalg.memoized_indexing_maps") and isinstance(attr.attr, ir.ArrayAttr):
+            if (
+                attr.name == "indexing_maps"
+                or attr.name == "linalg.memoized_indexing_maps"
+            ) and isinstance(attr.attr, ir.ArrayAttr):
                 maps_attr = attr.attr
         if maps_attr is None:
             return False
@@ -124,7 +127,9 @@ def get_map_result_dim_positions(map: ir.AffineMap):
     return exprs
 
 
-def get_convolution_dims(lhs_map: ir.AffineMap, rhs_map: ir.AffineMap, res_map: ir.AffineMap):
+def get_convolution_dims(
+    lhs_map: ir.AffineMap, rhs_map: ir.AffineMap, res_map: ir.AffineMap
+):
     if not rhs_map.is_projected_permutation or not res_map.is_projected_permutation:
         return None
     lhs_dims = []
@@ -287,7 +292,9 @@ class ConvolutionOpInterfaceMatcher(GenericOpMatcher):
     def __init__(self) -> None:
         super().__init__()
         self.supported_named_ops = [
-            "linalg.conv_2d_nhwc_hwcf", "linalg.conv_2d_nhwc_hwfc"]
+            "linalg.conv_2d_nhwc_hwcf",
+            "linalg.conv_2d_nhwc_hwfc",
+        ]
         self.op_names.extend(self.supported_named_ops)
         self.convolution_dimensions: Optional[ConvolutionDimensions] = None
         self.lhs_dims: Optional[list[list[int]]] = None

--- a/tuner/tuner/op_matchers.py
+++ b/tuner/tuner/op_matchers.py
@@ -293,7 +293,7 @@ class ConvolutionOpInterfaceMatcher(GenericOpMatcher):
         super().__init__()
         self.supported_named_ops = [
             "linalg.conv_2d_nhwc_hwcf",
-            "linalg.conv_2d_nhwc_hwfc",
+            "linalg.conv_2d_nhwc_fhwc",
         ]
         self.op_names.extend(self.supported_named_ops)
         self.convolution_dimensions: Optional[ConvolutionDimensions] = None

--- a/tuner/tuner/op_matchers.py
+++ b/tuner/tuner/op_matchers.py
@@ -93,9 +93,9 @@ class GenericOpMatcher(NamedOpMatcher):
 
         maps_attr = None
         for attr in op.opview.attributes:
-            if (
-                attr.name == "indexing_maps"
-                or attr.name == "linalg.memoized_indexing_maps"
+            if attr.name in (
+                "indexing_maps",
+                "linalg.memoized_indexing_maps",
             ) and isinstance(attr.attr, ir.ArrayAttr):
                 maps_attr = attr.attr
         if maps_attr is None:
@@ -297,9 +297,9 @@ class ConvolutionOpInterfaceMatcher(GenericOpMatcher):
         ]
         self.op_names.extend(self.supported_named_ops)
         self.convolution_dimensions: Optional[ConvolutionDimensions] = None
-        self.lhs_dims: Optional[list[list[int]]] = None
-        self.rhs_dims: Optional[list[list[int]]] = None
-        self.res_dims: Optional[list[list[int]]] = None
+        self.lhs_expr_dims: Optional[list[list[int]]] = None
+        self.rhs_expr_dims: Optional[list[list[int]]] = None
+        self.res_expr_dims: Optional[list[list[int]]] = None
 
     def match_operands(self, operands: ir.OpOperandList) -> bool:
         if len(operands) != 3:
@@ -320,7 +320,7 @@ class ConvolutionOpInterfaceMatcher(GenericOpMatcher):
         conv_dims, lhs_dims, rhs_dims, res_dims = conv_dim_info
         self.convolution_dimensions = conv_dims
 
-        self.lhs_dims = lhs_dims
-        self.rhs_dims = rhs_dims
-        self.res_dims = res_dims
+        self.lhs_expr_dims = lhs_dims
+        self.rhs_expr_dims = rhs_dims
+        self.res_expr_dims = res_dims
         return True


### PR DESCRIPTION
The motivation of this PR is to enable SDXL convolution tuning support for different layouts. Some early prototyping has demonstrated 30% perf uplift within only 50 tuning candidates. Please review the PR by commit:
 - 1st commit is authored by @Max191 
   - Created new `ConvolutionDimensions` class and `ConvolutionInterfaceMatcher` class
   - `dispatch_parser` can take advantage of the new matcher and populate conv dimensions from convolution affine maps
 - 2nd commit is authored by me
   - Furthered the implementation of `dispatch_parser` to populate `ConvDimInfo` according to `ConvolutionDimensions`
   - Updated the `ProblemSize` to incorporate a few new fields necessary for igemm: `lhs_dims, `rhs_dims`, res_dims` and `conv_dims`
   - Updated `dispatch_constraints` to flatten K dimension based on existing layouts
   - Updated `candidate_gen` to populate gemm dimension instead of conv dimension for convolution candidates

This PR has been tested with selected conv configs in SDXL in 3 layouts: fhwc, hwfc and hwcf; each with 10 candidates. I can confirm convolution information are populated correctly.