### PR TITLE
Add deepseek v3 model support

### DIFF
--- a/sharktank/sharktank/layers/configs/llm_configs.py
+++ b/sharktank/sharktank/layers/configs/llm_configs.py
@@ -44,6 +44,15 @@ class LlamaHParams:
     expert_count: Optional[int] = None
     expert_used_count: Optional[int] = None
 
+    # Latent Attention Config - Deepseek specific
+    nope_dim: Optional[int] = None
+    kv_latent_dim: Optional[int] = None
+    v_head_dim: Optional[int] = None
+
+    # Expert cnofigs - Deep seek Specific
+    expert_score_func: Optional[str] = None
+    route_scale: Optional[float] = None
+
     @staticmethod
     def from_gguf_props(p: dict[str, Any]):
         name_prefix = p.get("general.architecture", "llama")

--- a/sharktank/sharktank/layers/mixture_of_experts_block.py
+++ b/sharktank/sharktank/layers/mixture_of_experts_block.py
@@ -41,7 +41,7 @@ class MoeBlock(ThetaLayer):
         score_experts=softmax,
         normalize_experts=True,
         add_residual=True,
-        route_scale: Optional[float]
+        route_scale: Optional[float] = None,
     ):
         super().__init__(theta)
         self.expert_used_count = expert_used_count
@@ -95,7 +95,9 @@ class MoeBlock(ThetaLayer):
             expert_gate /= expert_gate.sum(dim=-1, keepdim=True)
 
         expert_gate = expert_gate.to(ffn_input.dtype)
-        expert_gate = expert_gate * self.route_scale
+
+        if self.route_scale is not None:
+            expert_gate = expert_gate * self.route_scale
 
         moe_output = self.experts(ffn_input, top_k_experts, expert_gate)
 

--- a/sharktank/sharktank/layers/mixture_of_experts_block.py
+++ b/sharktank/sharktank/layers/mixture_of_experts_block.py
@@ -13,7 +13,10 @@ import torch.nn.functional as F
 from .base import Theta, ThetaLayer
 from .linear import LinearLayer
 from .norm import RMSNormLayer
+from .ffn_block import FFN
 from .ffn_moe_block import FFNMOE, PreGatherFFNMOE
+
+from ..ops import softmax, topk
 
 __all__ = [
     "MoeBlock",
@@ -31,32 +34,41 @@ class MoeBlock(ThetaLayer):
     def __init__(
         self,
         theta: Theta,
-        expert_count: int,
         expert_used_count: int,
         rms_epsilon: float,
         moe_activation=F.silu,
+        *,
+        score_experts=softmax,
+        normalize_experts=True,
+        add_residual=True,
+        route_scale: Optional[float]
     ):
         super().__init__(theta)
-
-        self.expert_count = expert_count
         self.expert_used_count = expert_used_count
+        self.score_experts = score_experts
+        self.normalize_experts = normalize_experts
+        self.add_residual = add_residual
 
         # Add router gate
         self.add_module("ffn_gate_inp", LinearLayer(theta("ffn_gate_inp")))
 
+        self.ffn_norm = torch.nn.Identity()
+        self.layer_output_norm = torch.nn.Identity()
+        self.shared_experts = None
+        self.route_scale = route_scale
+
         # Add FFN norm
-        self.add_module(
-            "ffn_norm", RMSNormLayer(theta("ffn_norm"), epsilon=rms_epsilon)
-        )
+        if "ffn_norm" in theta:
+            self.ffn_norm = RMSNormLayer(theta("ffn_norm"), epsilon=rms_epsilon)
+
+        if "shared_experts" in theta:
+            self.shared_experts = FFN(theta("shared_experts"))
 
         # Add optional FFN output norm layer
         if theta.optional_tensor("layer_output_norm") is not None:
-            self.add_module(
-                "layer_output_norm",
-                RMSNormLayer(theta("layer_output_norm"), epsilon=rms_epsilon),
+            self.layer_output_norm = RMSNormLayer(
+                theta("layer_output_norm"), epsilon=rms_epsilon
             )
-        else:
-            self.add_module("layer_output_norm", torch.nn.Identity())
 
         # Add expert_count x FFN
         self.experts = PreGatherFFNMOE(theta, activation=moe_activation)
@@ -72,19 +84,28 @@ class MoeBlock(ThetaLayer):
         # For each token, the router calculates the router weights for all experts
         # router_logits: (batch_size * sequence_length, expert_count)
         router_logits = self.ffn_gate_inp(ffn_input)
-        router_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
+        router_weights = self.score_experts(router_logits.to(torch.float))
 
         # Select top k experts from router weights
-        expert_gate, top_k_experts = torch.topk(
+        expert_gate, top_k_experts = topk(
             router_weights, self.expert_used_count, dim=-1
         )
 
-        expert_gate /= expert_gate.sum(dim=-1, keepdim=True)
+        if self.normalize_experts:
+            expert_gate /= expert_gate.sum(dim=-1, keepdim=True)
+
         expert_gate = expert_gate.to(ffn_input.dtype)
+        expert_gate = expert_gate * self.route_scale
 
         moe_output = self.experts(ffn_input, top_k_experts, expert_gate)
+
+        if self.shared_experts:
+            moe_output = moe_output + self.shared_experts(ffn_input)
+
         moe_output = moe_output.reshape(batch_size, sequence_length, feature_dim)
 
         moe_output = self.layer_output_norm(moe_output)
+        if self.add_residual:
+            moe_output = h + moe_output
 
-        return h + moe_output
+        return moe_output

--- a/sharktank/sharktank/layers/testing.py
+++ b/sharktank/sharktank/layers/testing.py
@@ -51,6 +51,49 @@ def make_llama_attention_block_theta(
     )
 
 
+def make_latent_attention_block_theta(
+    *,
+    block_idx: int,
+    dim: int,
+    heads: int,
+    rope_dim: int,
+    nope_dim: int,
+    kv_latent_dim: int,
+    v_head_dim: int,
+    dtype: torch.dtype | None = None,
+) -> Theta:
+    return Theta(
+        {
+            "wq.weight": DefaultPrimitiveTensor(
+                name=f"blk.{block_idx}.wq.weight",
+                data=make_rand_torch((heads * (rope_dim + nope_dim), dim), dtype=dtype),
+            ),
+            "wkv_a.weight": DefaultPrimitiveTensor(
+                name=f"blk.{block_idx}.wkv_a.weight",
+                data=make_rand_torch((kv_latent_dim + rope_dim, dim), dtype=dtype),
+            ),
+            "wkv_b.weight": DefaultPrimitiveTensor(
+                name=f"blk.{block_idx}.wkv_b.weight",
+                data=make_rand_torch(
+                    (heads * (v_head_dim + nope_dim), kv_latent_dim), dtype=dtype
+                ),
+            ),
+            "wo.weight": DefaultPrimitiveTensor(
+                name=f"blk.{block_idx}.wo.weight",
+                data=make_rand_torch((dim, heads * v_head_dim), dtype=dtype),
+            ),
+            "attn_norm.weight": DefaultPrimitiveTensor(
+                name=f"blk.{block_idx}.attn_norm.weight",
+                data=make_rand_torch((dim,), dtype=dtype),
+            ),
+            "kv_norm.weight": DefaultPrimitiveTensor(
+                name=f"blk.{block_idx}.kv_norm.weight",
+                data=make_rand_torch((kv_latent_dim,), dtype=dtype),
+            ),
+        }
+    )
+
+
 def make_mmdit_double_block_random_theta(
     in_channels: int = 128,
     hidden_size: int = 3072,

--- a/sharktank/sharktank/models/deepseek/__init__.py
+++ b/sharktank/sharktank/models/deepseek/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2024 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+from .deepseek import *

--- a/sharktank/sharktank/models/deepseek/deepseek.py
+++ b/sharktank/sharktank/models/deepseek/deepseek.py
@@ -1,0 +1,261 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Optional
+
+from dataclasses import dataclass
+from typing import Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from ...layers import *
+from ...types import *
+from ...utils.create_cache import *
+from ... import ops
+
+__all__ = [
+    "PagedDeepseekModelV1",
+]
+
+################################################################################
+# Models
+################################################################################
+
+
+class PagedDeepseekModelV1(BaseCausalLMModel):
+    """DeepseekModel with a paged KV cache and supporting variable sequence"""
+
+    def __init__(self, theta: Theta, config: LlamaModelConfig):
+        hp = config.hp
+        super().__init__(
+            theta,
+            context_length=config.hp.context_length,
+            device=config.device,
+            activation_dtype=config.activation_dtype,
+            attention_dtype=config.attention_dtype,
+            static_tables=config.static_tables,
+        )
+        self.config = config
+        self.hp = hp
+        self.cache = create_paged_kv_cache(self.config)
+        self.activation_dtype = config.activation_dtype
+
+        self.add_module(
+            "token_embedding",
+            TokenEmbeddingLayer(theta("token_embd"), dtype=config.activation_dtype),
+        )
+        self.add_module(
+            "attention_embedding",
+            RotaryEmbeddingLayer(
+                rope_dimension_count=hp.rope_dimension_count,
+                rope_freq_base=hp.rope_freq_base,
+                max_seqlen=hp.context_length,
+                tensor_parallelism_size=config.tensor_parallelism_size,
+            ),
+        )
+        self.add_module(
+            "output_norm",
+            RMSNormLayer(
+                theta("output_norm"), epsilon=self.hp.attention_layer_norm_rms_epsilon
+            ),
+        )
+        self.add_module("output_lm_head", LinearLayer(theta("output")))
+        self.attn_blocks = nn.ModuleList(
+            [
+                AttentionFFNBlock(
+                    theta("blk", n),
+                    block_index=n,
+                    cache=self.cache,
+                    head_count=hp.attention_head_count,
+                    head_dim=hp.attn_head_dim,
+                    head_count_kv=hp.attention_head_count_kv,
+                    rms_epsilon=hp.attention_layer_norm_rms_epsilon,
+                    rope_dimension_count=hp.rope_dimension_count,
+                    route_scale=hp.route_scale,
+                    score_func=hp.expert_score_func,
+                )
+                for n in range(hp.block_count)
+            ]
+        )
+
+    def prefill(
+        self,
+        # [bs, batch_seq_len]
+        tokens: Union[torch.Tensor, ReplicatedTensor],
+    ):
+        h = self.token_embedding(tokens)
+
+        # Iterate over attention blocks.
+        for _, block in enumerate(self.attn_blocks):
+            h = block(h, embedding=self.attention_embedding)
+
+        h = self.output_norm(h)
+        h = self.output_lm_head(h)
+        return h
+
+
+################################################################################
+# Layers
+################################################################################
+
+
+class PagedLatentAttentionBlock(ThetaLayer):
+    def __init__(
+        self,
+        theta: Theta,
+        *,
+        block_index: int,
+        cache: PagedKVCache,
+        head_count: int,
+        head_dim: int,
+        head_count_kv: int,
+        rms_epsilon: float,
+        rope_dimension_count: int,
+        attention_scale: Optional[float] = None,
+    ):
+        super().__init__(theta)
+
+        self.block_index = block_index
+        self.cache = cache
+        self.head_count = head_count
+        self.head_dim = head_dim
+        self.head_count_kv = head_count_kv
+        self.attention_scale = attention_scale
+        self.rope_dimension_count = rope_dimension_count
+
+        self.add_module(
+            "attn_norm", RMSNormLayer(theta("attn_norm"), epsilon=rms_epsilon)
+        )
+        self.add_module("kv_norm", RMSNormLayer(theta("kv_norm"), epsilon=rms_epsilon))
+
+        self.add_module("wq", LinearLayer(theta("wq")))
+        self.add_module("wkv_a", LinearLayer(theta("wkv_a")))
+        self.add_module("wkv_b", LinearLayer(theta("wkv_b")))
+        self.add_module("wo", LinearLayer(theta("wo")))
+
+    def forward(
+        self,
+        h: torch.Tensor,
+        *,
+        embedding: RotaryEmbeddingLayer,
+    ):
+        h = self.attn_norm(h)
+        q = self.wq(h).unflatten(2, (self.head_count, -1))
+        qk_nope_head_dim = q.shape[-1] - self.rope_dimension_count
+        q_nope = q[:, :, :, :qk_nope_head_dim]
+        q_rope = q[:, :, :, qk_nope_head_dim:]
+        q_rope = embedding(xt=q_rope, start_index=0)
+        q = torch.cat((q_nope, q_rope), dim=-1)
+
+        kv = self.wkv_a(h)
+        kv_nope_size = kv.shape[-1] - self.rope_dimension_count
+        kv_nope = kv[:, :, :kv_nope_size]
+        k_rope = kv[:, :, kv_nope_size:]
+        k_rope = embedding(xt=k_rope.unsqueeze(2), start_index=0)
+
+        ## We should restructure this to apply the wkv_b post attention.
+        kv_norm = self.kv_norm(kv_nope)
+        wkv_b = self.wkv_b(kv_norm).unflatten(2, (self.head_count, -1))
+
+        k_nope = wkv_b[:, :, :, :qk_nope_head_dim]
+        v = wkv_b[:, :, :, qk_nope_head_dim:]
+
+        k_rope = ops.repeat(k_rope, (1, 1, k_nope.shape[2] // k_rope.shape[2], 1))
+        k = ops.cat((k_nope, k_rope), dim=-1)
+
+        q = q.transpose(1, 2)
+        k = k.transpose(1, 2)
+        v = v.transpose(1, 2)
+
+        attn = ops.scaled_dot_product_attention(
+            q=q,  # [bs, ..., sl, dim]
+            k=k,  # [bs, ..., sl, dim]
+            v=v,  # [bs, ..., sl, dim]
+            a=None,  # [bs, ..., sl, sl]
+            is_causal=True,  # assumes causal masking when true
+            scale=self.attention_scale,  # defaults to 1/sqrt(dim)
+        )
+
+        attn = attn.transpose(1, 2)
+        return self.wo(attn.flatten(2))
+
+
+class AttentionFFNBlock(ThetaLayer):
+    """Implements a self attention layer in the style of Deepseek using a
+    paged cache."""
+
+    def __init__(
+        self,
+        theta: Theta,
+        *,
+        block_index: int,
+        cache: PagedKVCache,
+        head_count: int,
+        head_dim: int,
+        head_count_kv: int,
+        rms_epsilon: float,
+        rope_dimension_count: int,
+        route_scale: Optional[float],
+        score_func: Optional[str],
+    ):
+        super().__init__(theta)
+        self.add_module(
+            "attn",
+            PagedLatentAttentionBlock(
+                theta=theta,
+                block_index=block_index,
+                cache=cache,
+                head_count=head_count,
+                head_dim=head_dim,
+                head_count_kv=head_count_kv,
+                rms_epsilon=rms_epsilon,
+                rope_dimension_count=rope_dimension_count,
+            ),
+        )
+
+        func_map = {
+            "sigmoid": (torch.nn.functional.sigmoid, True),
+            "softmax": (torch.nn.functional.softmax, False),
+        }
+
+        score_experts, normalize_experts = func_map[score_func]
+
+        if "ffn" in theta:
+            self.add_module("ffn", FFN(theta=theta("ffn")))
+        else:
+            self.add_module(
+                "ffn",
+                MoeBlock(
+                    theta=theta("moe"),
+                    rms_epsilon=1,
+                    expert_used_count=1,
+                    add_residual=False,
+                    route_scale=route_scale,
+                    score_experts=score_experts,
+                    normalize_experts=normalize_experts,
+                ),
+            )
+
+        self.add_module(
+            "ffn_norm", RMSNormLayer(theta("ffn_norm"), epsilon=rms_epsilon)
+        )
+
+    def forward(
+        self,
+        h: Union[torch.Tensor, ReplicatedTensor],
+        *,
+        embedding: RotaryEmbeddingLayer,
+    ):
+        h = h + self.attn(h, embedding=embedding)
+
+        # Feed forward network.
+        ffn_input = self.ffn_norm(h)
+        ffn_down = self.ffn(ffn_input)
+        final_output = h + ffn_down
+
+        return final_output

--- a/sharktank/sharktank/models/deepseek/run_deepseek.py
+++ b/sharktank/sharktank/models/deepseek/run_deepseek.py
@@ -35,11 +35,15 @@ if __name__ == "__main__":
     )
 
     model = PagedDeepseekModelV1(theta=theta, config=config)
-    x = torch.from_numpy(numpy.load(args.ids_path))
-    results = model.prefill(tokens=x)
+    ids = torch.from_numpy(numpy.load(args.ids_path))
+    results = model.prefill(tokens=ids)
 
     if args.results_path:
         expected = torch.from_numpy(numpy.load(args.results_path))
         diff = expected - results
+        expected_ce = torch.nn.functional.cross_entropy(expected[0, :-1], ids[0, 1:])
+        result_ce = torch.nn.functional.cross_entropy(results[0, :-1], ids[0, 1:])
         sqdiff = math.sqrt(torch.sum(diff * diff) / diff.numel())
         print(f"Squared error {sqdiff}")
+        print(f"Expected Cross Entropy {expected_ce}")
+        print(f"Result Cross Entropy {result_ce}")

--- a/sharktank/sharktank/models/deepseek/run_deepseek.py
+++ b/sharktank/sharktank/models/deepseek/run_deepseek.py
@@ -1,0 +1,45 @@
+# Copyright 2025 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+from sharktank.types.theta import Dataset
+from sharktank.models.deepseek.deepseek import PagedDeepseekModelV1
+from sharktank.models.deepseek.toy_deepseek import generate
+from sharktank.models.llama.llama import LlamaModelConfig, LlamaHParams
+
+import argparse
+import math
+import numpy
+import torch
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ids-path", type=str, required=True)
+    parser.add_argument("--irpa-path", type=str, required=True)
+    parser.add_argument("--results-path", type=str)
+
+    args = parser.parse_args()
+
+    dataset = Dataset.load(args.irpa_path)
+    properties = dataset.properties
+    theta = dataset.root_theta
+
+    config = LlamaModelConfig(
+        hp=LlamaHParams(**properties["hparams"]),
+        block_seq_stride=8,
+        activation_dtype=torch.float32,
+        attention_dtype=torch.float32,
+    )
+
+    model = PagedDeepseekModelV1(theta=theta, config=config)
+    x = torch.from_numpy(numpy.load(args.ids_path))
+    results = model.prefill(tokens=x)
+
+    if args.results_path:
+        expected = torch.from_numpy(numpy.load(args.results_path))
+        diff = expected - results
+        sqdiff = math.sqrt(torch.sum(diff * diff) / diff.numel())
+        print(f"Squared error {sqdiff}")

--- a/sharktank/sharktank/models/deepseek/testing.py
+++ b/sharktank/sharktank/models/deepseek/testing.py
@@ -1,0 +1,119 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import List
+
+import torch
+
+from ...types.tensors import *
+from ...types.theta import Theta
+from typing import Optional
+from ..llama.llama import LlamaModelConfig
+import torch
+from ...utils.testing import make_rand_torch
+from ...layers.testing import make_latent_attention_block_theta
+
+
+def make_deepseek_attention_block(
+    *,
+    block_idx: int,
+    dim: int,
+    heads: int,
+    rope_dim: int,
+    nope_dim: int,
+    kv_latent_dim: int,
+    v_head_dim: int,
+    dtype: torch.dtype | None = None,
+) -> Theta:
+    attention_theta = make_latent_attention_block_theta(
+        block_idx=block_idx,
+        dim=dim,
+        heads=heads,
+        rope_dim=rope_dim,
+        nope_dim=nope_dim,
+        kv_latent_dim=kv_latent_dim,
+        v_head_dim=v_head_dim,
+        dtype=dtype,
+    )
+    moe_theta = make_moe_block_theta(block_idx=block_idx)
+    res_dict = attention_theta.tree
+    res_dict.update(moe_theta.tree)
+    return Theta(res_dict)
+
+
+def make_moe_block_theta(
+    block_idx=0, inter_dim=16, ffn_dim=32, num_experts=4, shared_experts=1
+) -> Theta:
+    return Theta(
+        {
+            f"ffn_norm.weight": DefaultPrimitiveTensor(
+                name=f"blk.{block_idx}.ffn_norm.weight", data=make_rand_torch((ffn_dim))
+            ),
+            # Routed experts tensors
+            f"moe.ffn_gate_inp.weight": DefaultPrimitiveTensor(
+                name=f"blk.{block_idx}.moe.ffn_gate_inp.weight",
+                data=make_rand_torch((num_experts, ffn_dim)),
+            ),
+            f"moe.ffn_gate_exps.weight": DefaultPrimitiveTensor(
+                name=f"blk.{block_idx}.moe.ffn_gate_exps.weight",
+                data=make_rand_torch((num_experts, inter_dim, ffn_dim)),
+            ),
+            f"moe.ffn_up_exps.weight": DefaultPrimitiveTensor(
+                name=f"blk.{block_idx}.moe.ffn_up_exps.weight",
+                data=make_rand_torch((num_experts, inter_dim, ffn_dim)),
+            ),
+            f"moe.ffn_down_exps.weight": DefaultPrimitiveTensor(
+                name=f"blk.{block_idx}.moe.ffn_down_exps.weight",
+                data=make_rand_torch((num_experts, ffn_dim, inter_dim)),
+            ),
+            # Shared experts tensors
+            f"shared_experts.ffn_gate_exps.weight": DefaultPrimitiveTensor(
+                name=f"blk.{block_idx}.shared_experts.ffn_gate_exps.weight",
+                data=make_rand_torch((shared_experts * inter_dim, ffn_dim)),
+            ),
+            f"shared_experts.ffn_up_exps.weight": DefaultPrimitiveTensor(
+                name=f"blk.{block_idx}.shared_experts.ffn_up_exps.weight",
+                data=make_rand_torch((shared_experts * inter_dim, ffn_dim)),
+            ),
+            f"shared_experts.ffn_down_exps.weight": DefaultPrimitiveTensor(
+                name=f"blk.{block_idx}.shared_experts.ffn_down_exps.weight",
+                data=make_rand_torch((ffn_dim, shared_experts * inter_dim)),
+            ),
+        }
+    )
+
+
+def make_random_deepseek_theta(
+    config: LlamaModelConfig, vocab_size: int, dtype: Optional[torch.dtype] = None
+) -> Theta:
+    res = {
+        "token_embd.weight": DefaultPrimitiveTensor(
+            name="token_embd.weight",
+            data=make_rand_torch((vocab_size, config.hp.embedding_length), dtype=dtype),
+        )
+    }
+    for i in range(config.hp.block_count):
+        res[f"blk.{i}"] = make_deepseek_attention_block(
+            block_idx=i,
+            dim=config.hp.embedding_length,
+            heads=config.hp.attention_head_count,
+            rope_dim=config.hp.rope_dimension_count,
+            nope_dim=config.hp.nope_dim,
+            kv_latent_dim=config.hp.kv_latent_dim,
+            v_head_dim=config.hp.v_head_dim,
+            dtype=dtype,
+        ).tree
+
+    res[f"output.weight"] = DefaultPrimitiveTensor(
+        name="output.weight",
+        data=make_rand_torch((vocab_size, config.hp.embedding_length), dtype=dtype),
+    )
+    res[f"output_norm.weight"] = DefaultPrimitiveTensor(
+        name="output_norm.weight",
+        data=make_rand_torch((config.hp.embedding_length), dtype=dtype),
+    )
+
+    return Theta(res)

--- a/sharktank/sharktank/models/deepseek/toy_deepseek.py
+++ b/sharktank/sharktank/models/deepseek/toy_deepseek.py
@@ -1,0 +1,85 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from .testing import make_random_deepseek_theta
+
+from sharktank.layers.configs import LlamaHParams
+from sharktank.models.llama.llama import LlamaModelConfig
+from sharktank.types import Dataset
+
+import argparse
+import torch
+
+from dataclasses import asdict
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-s", "--seed", default=12345)
+parser.add_argument("-o", "--output", default="/tmp/toy_deepseek.irpa")
+
+
+def generate(seed):
+    torch.manual_seed(seed=12345)
+    dtype = torch.float32
+    block_seq_stride = 16
+    max_blocks = 8
+
+    attn_head_dim = 16
+    rope_dimension_count = 16
+    vocabulary_size = 256
+    expert_count = 4
+    used_experts = 2
+
+    config = LlamaModelConfig(
+        hp=LlamaHParams(
+            context_length=block_seq_stride * max_blocks,
+            embedding_length=32,
+            block_count=1,
+            feed_forward_length=23,
+            rope_dimension_count=rope_dimension_count,
+            rope_freq_base=500000.0,
+            attention_head_count=4,
+            attn_head_dim=attn_head_dim,
+            attention_layer_norm_rms_epsilon=0.01,
+            attention_head_count_kv=4,
+            nope_dim=32,
+            kv_latent_dim=16,
+            v_head_dim=32,
+            expert_count=expert_count,
+            expert_used_count=used_experts,
+            model_arch="deepseek",
+            expert_score_func="sigmoid",
+            route_scale=2.0,
+        ),
+        block_seq_stride=block_seq_stride,
+        activation_dtype=dtype,
+        attention_dtype=dtype,
+    )
+
+    theta = make_random_deepseek_theta(
+        config=config,
+        vocab_size=vocabulary_size,
+    )
+    return theta, config
+
+
+def main():
+    args = parser.parse_args()
+    theta, config = generate(args.seed)
+
+    flat = theta.flatten()
+    for k in sorted(flat.keys()):
+        print(f"{k:<50} {str(flat[k].shape):<20} {str(flat[k].dtype):<10}")
+
+    config_dict = {
+        "hparams": asdict(config.hp),
+    }
+
+    dataset = Dataset(config_dict, theta)
+    dataset.save(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/sharktank/sharktank/models/grok/grok.py
+++ b/sharktank/sharktank/models/grok/grok.py
@@ -102,7 +102,6 @@ class PagedGrokModelV1(BaseCausalLMModel):
             self.moe_blocks.append(
                 MoeBlock(
                     theta("blk", n),
-                    expert_count=hp.expert_count,
                     expert_used_count=hp.expert_used_count,
                     rms_epsilon=hp.attention_layer_norm_rms_epsilon,
                     moe_activation=F.gelu,

--- a/sharktank/sharktank/models/mixtral/mixtral.py
+++ b/sharktank/sharktank/models/mixtral/mixtral.py
@@ -102,7 +102,6 @@ class PagedMixtralModelV1(BaseCausalLMModel):
             self.moe_blocks.append(
                 MoeBlock(
                     theta("blk", n),
-                    expert_count=hp.expert_count,
                     expert_used_count=hp.expert_used_count,
                     rms_epsilon=hp.attention_layer_norm_rms_epsilon,
                 )

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -501,6 +501,11 @@ def squeeze_default(tensor, dim: Optional[int] = None) -> AnyTensor:
         return torch.squeeze(unbox_tensor(tensor), dim)
 
 
+@topk.override(AllOfType(AnyTensor, PrimitiveTensor))
+def topk_default(tensor, k: int, dim: int) -> AnyTensor:
+    return torch.topk(tensor, k=k, dim=dim)
+
+
 @view.override(Tensor)
 def view_default(tensor: Union[Tensor, PrimitiveTensor], shape: List[int]) -> Tensor:
     return unbox_tensor(tensor).view(*shape)

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -58,6 +58,7 @@ __all__ = [
     "softmax",
     "squeeze",
     "to",
+    "topk",
     "trace_tensor",
     "transfer_to_logical_device",
     "transpose",
@@ -1176,6 +1177,23 @@ def _squeeze_trampoline(
     tensors = (tensor,)
     for override in d.find_overrides(tensor):
         result = override(tensor, dim)
+        if result is not NotImplemented:
+            return override, result
+    else:
+        d.fail(tensors)
+
+
+@overridable
+def topk(tensor, k: int, dim: int) -> AnyTensor:
+    """See torch.topk"""
+    ...
+
+
+@topk.trampoline
+def _topk_trampoline(d: SignatureDispatcher, tensor, k: int, dim: int) -> AnyTensor:
+    tensors = (tensor,)
+    for override in d.find_overrides(tensor):
+        result = override(tensor, k=k, dim=dim)
         if result is not NotImplemented:
             return override, result
     else:

--- a/sharktank/sharktank/tools/import_deepseek.py
+++ b/sharktank/sharktank/tools/import_deepseek.py
@@ -1,0 +1,205 @@
+import argparse
+import dataclasses
+import json
+import logging
+import torch
+
+from safetensors.torch import save_file, safe_open
+from sharktank.layers.configs.llm_configs import LlamaHParams
+from sharktank.types import Dataset, Theta
+from sharktank.types.tensors import DefaultPrimitiveTensor
+from typing import Literal
+
+
+@dataclasses.dataclass
+class ModelArgs:
+    """
+    Data class for defining model arguments and hyperparameters.
+
+    Attributes:
+        max_batch_size (int): Maximum batch size.
+        max_seq_len (int): Maximum sequence length.
+        dtype (Literal["bf16", "fp8"]): Data type for computations.
+        vocab_size (int): Vocabulary size.
+        dim (int): Model dimension.
+        inter_dim (int): Intermediate dimension for MLP layers.
+        moe_inter_dim (int): Intermediate dimension for MoE layers.
+        n_layers (int): Number of transformer layers.
+        n_dense_layers (int): Number of dense layers in the model.
+        n_heads (int): Number of attention heads.
+        n_routed_experts (int): Number of routed experts for MoE layers.
+        n_shared_experts (int): Number of shared experts for MoE layers.
+        n_activated_experts (int): Number of activated experts in MoE layers.
+        n_expert_groups (int): Number of expert groups.
+        n_limited_groups (int): Number of limited groups for MoE routing.
+        score_func (Literal["softmax", "sigmoid"]): Scoring function for MoE routing.
+        route_scale (float): Scaling factor for routing scores.
+        q_lora_rank (int): LoRA rank for query projections.
+        kv_lora_rank (int): LoRA rank for key-value projections.
+        qk_nope_head_dim (int): Dimension for query-key projections without positional embeddings.
+        qk_rope_head_dim (int): Dimension for query-key projections with rotary embeddings.
+        v_head_dim (int): Dimension for value projections.
+        original_seq_len (int): Original sequence length.
+        rope_theta (float): Base for rotary positional encoding.
+        rope_factor (float): Scaling factor for extended sequence lengths.
+        beta_fast (int): Fast beta correction factor.
+        beta_slow (int): Slow beta correction factor.
+        mscale (float): Scaling factor for extended attention.
+    """
+
+    max_batch_size: int = 8
+    max_seq_len: int = 4096 * 4
+    dtype: Literal["bf16", "fp8"] = "bf16"
+    vocab_size: int = 102400
+    dim: int = 2048
+    inter_dim: int = 10944
+    moe_inter_dim: int = 1408
+    n_layers: int = 27
+    n_dense_layers: int = 1
+    n_heads: int = 16
+    # moe
+    n_routed_experts: int = 64
+    n_shared_experts: int = 2
+    n_activated_experts: int = 6
+    n_expert_groups: int = 1
+    n_limited_groups: int = 1
+    score_func: Literal["softmax", "sigmoid"] = "softmax"
+    route_scale: float = 1.0
+    # mla
+    q_lora_rank: int = 0
+    kv_lora_rank: int = 512
+    qk_nope_head_dim: int = 128
+    qk_rope_head_dim: int = 64
+    v_head_dim: int = 128
+    # yarn
+    original_seq_len: int = 4096
+    rope_theta: float = 10000.0
+    rope_factor: float = 40
+    beta_fast: int = 32
+    beta_slow: int = 1
+    mscale: float = 1.0
+
+
+if __name__ == "__main__":
+    logger = logging.getLogger(__name__)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=str, required=True)
+    parser.add_argument("--safetensors", type=str, required=True)
+    parser.add_argument("--irpa-path", type=str, required=True)
+    parser.add_argument("--json-path", type=str, required=True)
+    args = parser.parse_args()
+
+    config = json.load(open(args.config, "r"))
+    modelargs = ModelArgs(**config)
+    hp = LlamaHParams(
+        model_arch="deepseek_v3",
+        context_length=modelargs.original_seq_len,
+        embedding_length=modelargs.vocab_size,
+        block_count=modelargs.n_layers,
+        feed_forward_length=modelargs.inter_dim,
+        attention_head_count=modelargs.n_heads,
+        attn_head_dim=modelargs.dim,
+        attention_layer_norm_rms_epsilon=1e-6,
+        attention_head_count_kv=-1,
+        rope_freq_base=modelargs.rope_theta,
+        expert_count=modelargs.n_routed_experts,
+        expert_used_count=modelargs.n_activated_experts,
+        expert_score_func=modelargs.score_func,
+        rope_dimension_count=modelargs.qk_rope_head_dim,
+        route_scale=modelargs.route_scale,
+    )
+
+    x = torch.randint(0, modelargs.vocab_size, (2, 16))
+
+    st_path = args.safetensors
+    json_path = args.json_path
+    irpa_path = args.irpa_path
+
+    st = safe_open(st_path, framework="pt")
+
+    baseMapping = {
+        "token_embd.weight": "embed.weight",
+        "output_norm.weight": "norm.weight",
+        "output.weight": "head.weight",
+    }
+
+    attnMapping = {
+        "attn.kv_norm.weight": "kv_norm.weight",
+        "attn.wkv_a.weight": "wkv_a.weight",
+        "attn.wkv_b.weight": "wkv_b.weight",
+        "attn.wo.weight": "wo.weight",
+        "attn.wq.weight": "wq.weight",
+        "attn_norm.weight": "attn_norm.weight",
+        "ffn.w1.weight": "ffn.ffn_gate.weight",
+        "ffn.w2.weight": "ffn.ffn_down.weight",
+        "ffn.w3.weight": "ffn.ffn_up.weight",
+        "ffn_norm.weight": "ffn_norm.weight",
+        "ffn.gate.weight": "moe.ffn_gate_inp.weight",
+        "ffn.shared_experts.w1.weight": "moe.shared_experts.ffn_gate.weight",
+        "ffn.shared_experts.w2.weight": "moe.shared_experts.ffn_down.weight",
+        "ffn.shared_experts.w3.weight": "moe.shared_experts.ffn_up.weight",
+    }
+
+    expertMapping = {
+        "w1.weight": "ffn_gate_exps.weight",
+        "w2.weight": "ffn_down_exps.weight",
+        "w3.weight": "ffn_up_exps.weight",
+    }
+
+    tensors = {}
+    for key in baseMapping:
+        tensors[key] = st.get_tensor(baseMapping[key])
+
+    layers = {}
+    for key in st.keys():
+        parts = key.split(".", 2)
+        if parts[0] != "layers":
+            continue
+        layer = int(parts[1])
+        if layer not in layers:
+            layers[layer] = {}
+        layers[layer][parts[2]] = st.get_tensor(key)
+
+    for layer in layers:
+        weights = layers[layer]
+        experts = {}
+        for name in weights:
+            weight = weights[name]
+            if name in attnMapping:
+                tensors[f"blk.{layer}.{attnMapping[name]}"] = weight
+                continue
+
+            if name.startswith("ffn.experts."):
+                split = name.split(".", 3)
+                id = int(split[2])
+                if id not in experts:
+                    experts[id] = {}
+                experts[id][split[3]] = weight
+                continue
+            assert False and "unhandled tensor found"
+
+        expert_keys = experts[0].keys() if experts else []
+        for key in expert_keys:
+            exs = [experts[expert][key] for expert in experts]
+            tensor = torch.stack(exs, dim=0)
+            for t in exs:
+                del t
+            newKey = expertMapping[key]
+            tensors[f"blk.{layer}.moe.{newKey}"] = tensor
+
+    config_json = dataclasses.asdict(hp)
+    meta_params = {k: v for k, v in config_json.items() if k.startswith("_")}
+    hparams = {k: v for k, v in config_json.items() if not k.startswith("_")}
+    props = {
+        "meta": meta_params,
+        "hparams": hparams,
+    }
+
+    tensors = [
+        DefaultPrimitiveTensor(name=name, data=tensors[name]) for name in tensors.keys()
+    ]
+    theta = Theta(tensors)
+
+    dataset = Dataset(props, theta)
+    dataset.save(irpa_path, io_report_callback=logger.info)

--- a/sharktank/sharktank/tools/import_deepseek.py
+++ b/sharktank/sharktank/tools/import_deepseek.py
@@ -130,6 +130,9 @@ if __name__ == "__main__":
         "attn.wkv_b.weight": "wkv_b.weight",
         "attn.wo.weight": "wo.weight",
         "attn.wq.weight": "wq.weight",
+        "attn.wq_a.weight": "wq_a.weight",
+        "attn.wq_b.weight": "wq_b.weight",
+        "attn.q_norm.weight": "q_norm.weight",
         "attn_norm.weight": "attn_norm.weight",
         "ffn.w1.weight": "ffn.ffn_gate.weight",
         "ffn.w2.weight": "ffn.ffn_down.weight",
@@ -177,6 +180,7 @@ if __name__ == "__main__":
                     experts[id] = {}
                 experts[id][split[3]] = weight
                 continue
+            print(name)
             assert False and "unhandled tensor found"
 
         expert_keys = experts[0].keys() if experts else []

--- a/sharktank/tests/models/deepseek/test_deepseek.py
+++ b/sharktank/tests/models/deepseek/test_deepseek.py
@@ -1,0 +1,27 @@
+# Copyright 2025 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+from sharktank.models.deepseek.deepseek import PagedDeepseekModelV1
+from sharktank.models.deepseek.toy_deepseek import generate
+
+import pytest
+import torch
+
+
+def test_deepseek():
+    theta, config = generate(12345)
+    model = PagedDeepseekModelV1(theta=theta, config=config)
+
+    ids = torch.asarray(
+        [[3, 22, 13, 114, 90, 232, 61, 13, 244, 13, 212]], dtype=torch.int64
+    )
+    logits = model.prefill(tokens=ids)
+    ids = ids[0, :-1]
+    logits = logits[0, 1:]
+    cross_entropy = torch.nn.functional.cross_entropy(logits, ids)
+
+    assert pytest.approx(5.3062, 1e-4) == cross_entropy

--- a/sharktank/tests/models/llama/moe_block_test.py
+++ b/sharktank/tests/models/llama/moe_block_test.py
@@ -18,7 +18,6 @@ class MoeBlockTest(unittest.TestCase):
     def test(self):
         model = MoeBlock(
             theta=make_moe_block_theta()("blk.0"),
-            expert_count=8,
             expert_used_count=2,
             rms_epsilon=1e-5,
         )


### PR DESCRIPTION
This adds an e2e implementation of deepseek for prefill. Additional features were required by the MoE block, specifically surrounding how gate scores are computed and including mixture of experts.

A latent attention implementation is also included though this is a reference implementation that does not take advantage of the latent space during decode.