### PR TITLE
[Tuner] Allow passing extra TD specs during tuning

### DIFF
--- a/tuner/examples/simple/simple_tuner.py
+++ b/tuner/examples/simple/simple_tuner.py
@@ -6,6 +6,7 @@
 
 import argparse
 from pathlib import Path
+import shutil
 from tuner import libtuner
 from tuner.common import *
 
@@ -45,6 +46,12 @@ def main():
     client_args = parser.add_argument_group("Simple Example Tuner Options")
     client_args.add_argument(
         "simple_model_file", type=Path, help="Path to the model file to tune (.mlir)"
+    )
+    client_args.add_argument(
+        "--simple-best-spec-output-path",
+        type=Path,
+        help="Path to write the best tuned spec after",
+        default=None,
     )
     client_args.add_argument(
         "--simple-num-dispatch-candidates",
@@ -135,6 +142,10 @@ def main():
         for id in top_candidates:
             logging.info(f"{candidate_trackers[id].spec_path.resolve()}")
         if stop_after_phase == libtuner.ExecutionPhases.benchmark_dispatches:
+            if args.simple_best_spec_output_path:
+                top_spec_path = path_config.specs_dir / path_config.get_candidate_spec_filename(top_candidates[0])
+                shutil.copy(top_spec_path, args.simple_best_spec_output_path)
+                print(f"Saved top spec ({top_spec_path}) to {args.simple_best_spec_output_path}")
             return
 
         print("Compiling models with top candidates...")
@@ -167,6 +178,11 @@ def main():
         for id in top_model_candidates:
             logging.info(f"{candidate_trackers[id].spec_path.resolve()}")
         print(f"Top model candidates: {top_model_candidates}")
+        
+        if args.simple_best_spec_output_path:
+            top_spec_path = path_config.specs_dir / path_config.get_candidate_spec_filename(top_model_candidates[0])
+            shutil.copy(top_spec_path, args.simple_best_spec_output_path)
+            print(f"Saved top spec ({top_spec_path}) to {args.simple_best_spec_output_path}")
 
         print("Check the detailed execution logs in:")
         print(path_config.run_log.resolve())

--- a/tuner/tuner/libtuner.py
+++ b/tuner/tuner/libtuner.py
@@ -258,6 +258,9 @@ def parse_arguments(
     # General options
     general_args = parser.add_argument_group("General Options")
     general_args.add_argument(
+        "--extra-spec-file", type=Path, help="Path to an additional spec file to append to each spec"
+    )
+    general_args.add_argument(
         "--verbose", "-v", action="store_true", help="Enable verbose output to stdout"
     )
     general_args.add_argument(
@@ -685,6 +688,7 @@ def generate_candidate_specs(
         config_specs: list[ir.Module] = candidate_gen.generate_configs_and_td_specs(
             input_module=mlir_module,
             tuner_context=tuning_client.tuner_context,
+            args=args,
             limit=args.num_candidates,
             num_subgroups=args.num_subgroups,
             allowed_waves_per_eu=args.waves_per_eu_options,


### PR DESCRIPTION
Adds a new flag to libtuner `--extra-spec-file`, which allows specifying a path for an additional tuning spec to use during compilation. This allows the tuner to account for already tuned shapes when compiling models, which can have an affect on what the optimal candidate is.

Another flag is added to the simple tuner (`--simple-best-spec-output-path`), which specifies a path to dump the final best spec after tuning. If stop-after is set to stop after dispatch benchmarking, then it will dump the best dispatch tuning spec, and otherwise the top model tuning spec will be saved.

These 2 flags together now allows tuning loops to be set up where a full tuning spec can be generated automatically/directly from tuning several dispatches in a loop, by dumping the spec from the previous dispatch, and passing it to the tuning for the next dispatch. This has 2 benefits:

1. We can account for other tuned dispatches when building a spec.
2. The concatenated spec will be automatically generated by the tuner, removing the manual concatenation step at the end of the tuning process.