### PR TITLE
[CI][sharktank] Move Sharktank Data-Dependent Tests to OSSCI Cluster

### DIFF
--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -93,7 +93,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.11]
-        runs-on: [llama-mi300x-3]
+        runs-on: [linux-mi300-gpu-1]
       fail-fast: false
     runs-on: ${{matrix.runs-on}}
     defaults:


### PR DESCRIPTION
We've been getting memory-allocation related errors possibly due to oversaturation on shark-mi300x-3.