### PR TITLE
[shortfin llm integration tests] Add tinystories llama2 25m model as a smoke test

### DIFF
--- a/.github/workflows/pkgci_shark_ai.yml
+++ b/.github/workflows/pkgci_shark_ai.yml
@@ -88,6 +88,11 @@ jobs:
           source ${VENV_DIR}/bin/activate
           uv pip install -r requirements-iree-pinned.txt
 
+      - name: Run LLM Smoke Test
+        run: |
+          source ${VENV_DIR}/bin/activate
+          pytest -v -s --test_device=${{ matrix.test_device }} app_tests/integration_tests/llm/shortfin/tinystories_llama2_25m_test.py --log-cli-level=INFO
+
       - name: Run LLM Integration Tests
         run: |
           source ${VENV_DIR}/bin/activate

--- a/app_tests/benchmark_tests/llm/sglang_benchmarks/conftest.py
+++ b/app_tests/benchmark_tests/llm/sglang_benchmarks/conftest.py
@@ -33,7 +33,7 @@ MODEL_DIR_CACHE = {}
 # we can replace this with an import after #890 merges
 TEST_MODELS = {
     "llama3.1_8b": ModelConfig(
-        source=ModelSource.HUGGINGFACE,
+        source=ModelSource.HUGGINGFACE_FROM_GGUF,
         repo_id="SanctumAI/Meta-Llama-3.1-8B-Instruct-GGUF",
         model_file="meta-llama-3.1-8b-instruct.f16.gguf",
         tokenizer_id="NousResearch/Meta-Llama-3.1-8B",

--- a/app_tests/integration_tests/llm/model_management.py
+++ b/app_tests/integration_tests/llm/model_management.py
@@ -433,6 +433,7 @@ Dataset(
     (
         RemoteFile(
             file_id = "model.safetensors",
+            filename= "model.safetensors",
             repo_id = "Mxode/TinyStories-LLaMA2-25M-256h-4l-GQA",
             extra_filenames =  (
                 "config.json",

--- a/app_tests/integration_tests/llm/model_management.py
+++ b/app_tests/integration_tests/llm/model_management.py
@@ -453,36 +453,3 @@ TEST_MODELS["tinystories_llama2_25m"] = ModelConfig(
     batch_sizes=(1, 4),
     device_settings=None,
 )
-
-
-# Usage example
-# This uses a small model that takes roughly 2 minutes to run
-# from pathlib import Path
-# import sys
-# sys.path.append("/home/xidaren2/shark-ai")
-
-
-# from app_tests.integration_tests.llm.model_management import ModelConfig, ModelSource, ModelProcessor
-# from app_tests.integration_tests.llm.device_settings import GFX942
-
-# # Setup base directory
-# base_dir = Path("./model_artifacts")
-# base_dir.mkdir(exist_ok=True)
-
-# # Configure model
-# config = ModelConfig(
-#     source=ModelSource.HUGGINGFACE_TO_GGUF_TO_IRPA,
-#     repo_id="Mxode/TinyStories-LLaMA2-25M-256h-4l-GQA",
-#     model_file="model.irpa",
-#     tokenizer_id="Mxode/TinyStories-LLaMA2-25M-256h-4l-GQA",
-#     batch_sizes=(1, 4),
-#     device_settings=GFX942
-# )
-
-# # Process model
-# processor = ModelProcessor(base_dir)
-# artifacts = processor.process_model(config)
-
-# # Print results
-# print(f"Artifacts location: {base_dir}")
-# print(f"VMFB path: {artifacts.vmfb_path}")

--- a/app_tests/integration_tests/llm/model_management.py
+++ b/app_tests/integration_tests/llm/model_management.py
@@ -430,18 +430,18 @@ TEST_MODELS[
 # TODO: upstream this to sharktank
 Dataset(
     "Mxode/TinyStories-LLaMA2-25M-256h-4l-GQA",
-    files = [
+    files=[
         RemoteFile(
-            file_id = "model.safetensors",
-            filename= "model.safetensors",
-            repo_id = "Mxode/TinyStories-LLaMA2-25M-256h-4l-GQA",
-            extra_filenames =  (
+            file_id="model.safetensors",
+            filename="model.safetensors",
+            repo_id="Mxode/TinyStories-LLaMA2-25M-256h-4l-GQA",
+            extra_filenames=(
                 "config.json",
                 "tokenizer.json",
                 "tokenizer_config.json",
             ),
         ),
-    ]
+    ],
 )
 
 TEST_MODELS["tinystories_llama2_25m"] = ModelConfig(

--- a/app_tests/integration_tests/llm/model_management.py
+++ b/app_tests/integration_tests/llm/model_management.py
@@ -191,14 +191,14 @@ class ModelStageManager:
 
         if not irpa_path.exists():
             logger.info(
-                f"Processing model {self.config.repo_id} from HuggingFace through GGUF to IRPA"
+                f"Processing model `{self.config.dataset_name}` from HuggingFace through GGUF to IRPA"
             )
 
             # Step 1: Download from HuggingFace
             hf_model_path = self.model_dir / "model_hf_repo_clone"
             if not hf_model_path.exists():
                 logger.info(
-                    f"Downloading model from HuggingFace: {self.config.repo_id}"
+                    f"Downloading model from HuggingFace: `{self.config.dataset_name}`"
                 )
                 dataset = get_dataset(self.config.dataset_name)
                 downloaded_files = dataset.download(local_dir=self.model_dir)

--- a/app_tests/integration_tests/llm/model_management.py
+++ b/app_tests/integration_tests/llm/model_management.py
@@ -430,7 +430,7 @@ TEST_MODELS[
 # TODO: upstream this to sharktank
 Dataset(
     "Mxode/TinyStories-LLaMA2-25M-256h-4l-GQA",
-    (
+    files = [
         RemoteFile(
             file_id = "model.safetensors",
             filename= "model.safetensors",
@@ -440,8 +440,8 @@ Dataset(
                 "tokenizer.json",
                 "tokenizer_config.json",
             ),
-        )
-    ),
+        ),
+    ]
 )
 
 TEST_MODELS["tinystories_llama2_25m"] = ModelConfig(

--- a/app_tests/integration_tests/llm/model_management.py
+++ b/app_tests/integration_tests/llm/model_management.py
@@ -455,7 +455,8 @@ TEST_MODELS["tinystories_llama2_25m"] = ModelConfig(
 )
 
 
-# test like so
+# Usage example
+# This uses a small model that takes roughly 2 minutes to run
 # from pathlib import Path
 # import sys
 # sys.path.append("/home/xidaren2/shark-ai")

--- a/app_tests/integration_tests/llm/model_management.py
+++ b/app_tests/integration_tests/llm/model_management.py
@@ -8,7 +8,6 @@ import subprocess
 from dataclasses import dataclass
 from typing import Optional, Tuple
 from enum import Enum, auto
-from huggingface_hub import snapshot_download
 
 from sharktank.utils.hf_datasets import Dataset, RemoteFile, get_dataset
 
@@ -428,6 +427,7 @@ TEST_MODELS[
     device_settings=None,
 )
 
+# TODO: upstream this to sharktank
 Dataset(
     "Mxode/TinyStories-LLaMA2-25M-256h-4l-GQA",
     (

--- a/app_tests/integration_tests/llm/sglang/conftest.py
+++ b/app_tests/integration_tests/llm/sglang/conftest.py
@@ -40,7 +40,7 @@ def model_artifacts(request, tmp_path_factory):
     tmp_dir = tmp_path_factory.mktemp("sglang_integration_tests")
 
     model_config = ModelConfig(
-        source=ModelSource.HUGGINGFACE,
+        source=ModelSource.HUGGINGFACE_FROM_GGUF,
         repo_id="SanctumAI/Meta-Llama-3.1-8B-Instruct-GGUF",
         model_file="meta-llama-3.1-8b-instruct.f16.gguf",
         tokenizer_id="NousResearch/Meta-Llama-3.1-8B",

--- a/app_tests/integration_tests/llm/shortfin/conftest.py
+++ b/app_tests/integration_tests/llm/shortfin/conftest.py
@@ -33,7 +33,7 @@ def test_device(request):
     return ret
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def model_artifacts(tmp_path_factory, request, test_device):
     """Prepares model artifacts in a cached directory."""
     model_config = TEST_MODELS[request.param]

--- a/app_tests/integration_tests/llm/shortfin/tinystories_llama2_25m_test.py
+++ b/app_tests/integration_tests/llm/shortfin/tinystories_llama2_25m_test.py
@@ -27,7 +27,7 @@ pytestmark = pytest.mark.parametrize(
 
 # goldens are generated in: https://colab.research.google.com/drive/1pFiyvyIxk1RsHnw5gTk_gu9QiQNy9gfW?usp=sharing
 GOLDEN_PROMPT = "Once upon a time"
-GOLDEN_RESPONSE = ", there was a little girl named Lily."
+GOLDEN_RESPONSE = ", there was a little girl named Lily."  # this assumes purely deterministic greedy search
 
 
 class TestLLMServer:

--- a/app_tests/integration_tests/llm/shortfin/tinystories_llama2_25m_test.py
+++ b/app_tests/integration_tests/llm/shortfin/tinystories_llama2_25m_test.py
@@ -25,6 +25,11 @@ pytestmark = pytest.mark.parametrize(
 )
 
 
+# goldens are generated in: https://colab.research.google.com/drive/1pFiyvyIxk1RsHnw5gTk_gu9QiQNy9gfW?usp=sharing
+GOLDEN_PROMPT = "Once upon a time"
+GOLDEN_RESPONSE = ", there was a little girl named Lily."
+
+
 class TestLLMServer:
     """Test suite for LLM server functionality."""
 
@@ -36,10 +41,9 @@ class TestLLMServer:
         """
         process, port = server
         assert process.poll() is None, "Server process terminated unexpectedly"
-        expected_prefix = "to"
-        response = self._generate(
-            "Alice was so tired when she got back home so she went ", port
-        )
+        prompt = GOLDEN_PROMPT
+        expected_prefix = GOLDEN_RESPONSE
+        response = self._generate(prompt, port)
         if not expected_prefix in response:
             raise AccuracyValidationException(
                 expected=f"{expected_prefix}...",
@@ -60,8 +64,8 @@ class TestLLMServer:
         process, port = server
         assert process.poll() is None, "Server process terminated unexpectedly"
 
-        prompt = "Alice was so tired when she got back home so she went "
-        expected_prefix = "to"
+        prompt = GOLDEN_PROMPT
+        expected_prefix = GOLDEN_RESPONSE
 
         with ThreadPoolExecutor(max_workers=concurrent_requests) as executor:
             futures = [

--- a/app_tests/integration_tests/llm/shortfin/tinystories_llama2_25m_test.py
+++ b/app_tests/integration_tests/llm/shortfin/tinystories_llama2_25m_test.py
@@ -1,0 +1,121 @@
+"""
+Simple smoke tests to:
+- ensure the full fastapi server works
+- ensure the smoke test model works so we know it's not a model issue when another test using this model fails.
+"""
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import logging
+import pytest
+import requests
+from typing import Dict, Any
+import uuid
+
+logger = logging.getLogger(__name__)
+
+from ..model_management import AccuracyValidationException
+
+
+pytestmark = pytest.mark.parametrize(
+    "model_artifacts,server",
+    [
+        ["tinystories_llama2_25m", {"prefix_sharing": "none"}],
+    ],
+    indirect=True,
+)
+
+
+class TestLLMServer:
+    """Test suite for LLM server functionality."""
+
+    def test_basic_generation(self, server: tuple[Any, int]) -> None:
+        """Tests basic text generation capabilities.
+
+        Args:
+            server: Tuple of (process, port) from server fixture
+        """
+        process, port = server
+        assert process.poll() is None, "Server process terminated unexpectedly"
+        expected_prefix = "to"
+        response = self._generate(
+            "Alice was so tired when she got back home so she went ", port
+        )
+        if not expected_prefix in response:
+            raise AccuracyValidationException(
+                expected=f"{expected_prefix}...",
+                actual=response,
+                message=f"Generation did not match expected pattern.\nExpected to start with: {expected_prefix}\nActual response: {response}",
+            )
+
+    @pytest.mark.parametrize("concurrent_requests", [2, 4, 8])
+    def test_concurrent_generation(
+        self, server: tuple[Any, int], concurrent_requests: int
+    ) -> None:
+        """Tests concurrent text generation requests.
+
+        Args:
+            server: Tuple of (process, port) from server fixture
+            concurrent_requests: Number of concurrent requests to test
+        """
+        process, port = server
+        assert process.poll() is None, "Server process terminated unexpectedly"
+
+        prompt = "Alice was so tired when she got back home so she went "
+        expected_prefix = "to"
+
+        with ThreadPoolExecutor(max_workers=concurrent_requests) as executor:
+            futures = [
+                executor.submit(self._generate, prompt, port)
+                for _ in range(concurrent_requests)
+            ]
+
+            for future in as_completed(futures):
+                response = future.result()
+                if not response.startswith(expected_prefix):
+                    raise AccuracyValidationException(
+                        expected=f"{expected_prefix}...",
+                        actual=response,
+                        message=f"Concurrent generation did not match expected pattern.\nExpected to start with: {expected_prefix}\nActual response: {response}",
+                    )
+
+    def _generate(self, prompt: str | list[int], port: int, input_ids=False) -> str:
+        """Helper method to make generation request to server.
+
+        Args:
+            prompt: Input text prompt
+            port: Server port number
+
+        Returns:
+            Generated text response
+
+        Raises:
+            requests.exceptions.RequestException: If request fails
+            AccuracyValidationException: If response format is invalid
+        """
+        payload = {
+            "sampling_params": {"max_completion_tokens": 15, "temperature": 0.7},
+            "rid": uuid.uuid4().hex,
+            "stream": False,
+        }
+        if input_ids:
+            payload["input_ids"] = prompt
+        else:
+            payload["text"] = prompt
+        response = requests.post(
+            f"http://localhost:{port}/generate",
+            headers={"Content-Type": "application/json"},
+            json=payload,
+            timeout=30,  # Add reasonable timeout
+        )
+        response.raise_for_status()
+
+        # Parse and validate streaming response format
+        data = response.text
+        if not data.startswith("data: "):
+            raise AccuracyValidationException(
+                expected="Response starting with 'data: '",
+                actual=data,
+                message=f"Invalid response format.\nExpected format starting with 'data: '\nActual response: {data}",
+            )
+
+        return data[6:].rstrip("\n")


### PR DESCRIPTION
This is a tiny model that would take less than a minute to download / export / compile.

The smoke test is intended to run before we run the full integration CI suite. This would give us early visibility into shortfin failures & save CI resources. 

This PR adds an integration_tests function to:
- download hf repo with `model.safetensors`
- convert to gguf 
- convert to irpa

Closes #933 