### PR TITLE
Update shortfin user instructions to use up to the supported torch version of 2.5.1+cpu

### DIFF
--- a/docs/shortfin/llm/user/llama_serving.md
+++ b/docs/shortfin/llm/user/llama_serving.md
@@ -80,7 +80,7 @@ following either https://pytorch.org/get-started/locally/ or our recommendation:
 
 ```bash
 # Fast installation of torch with just CPU support.
-pip install torch --index-url https://download.pytorch.org/whl/cpu
+pip install torch --index-url https://download.pytorch.org/whl/cpu torch==2.3.0
 ```
 
 ### Prepare a working directory

--- a/docs/shortfin/llm/user/llama_serving.md
+++ b/docs/shortfin/llm/user/llama_serving.md
@@ -80,7 +80,7 @@ following either https://pytorch.org/get-started/locally/ or our recommendation:
 
 ```bash
 # Fast installation of torch with just CPU support.
-pip install torch --index-url https://download.pytorch.org/whl/cpu torch==2.3.0
+pip install torch --index-url https://download.pytorch.org/whl/cpu "torch>=2.3.0,<2.6.0"
 ```
 
 ### Prepare a working directory


### PR DESCRIPTION
Update shortfin user instructions to use up to the supported torch version of 2.5.1+cpu. The exported IR using torch2.6.0+cpu fails to compile and needs further investigating.