### PR TITLE
Refs/heads/eliasj42/llama runner migration

### DIFF
--- a/.github/workflows/ci-llama-large-tests.yaml
+++ b/.github/workflows/ci-llama-large-tests.yaml
@@ -49,6 +49,9 @@ jobs:
       - name: Create Python venv
         run: python -m venv ${VENV_DIR}
 
+      - name: Confirm successful mount
+        run: ls /shark-dev
+
       - name: Install pip deps
         run: |
           source ${VENV_DIR}/bin/activate

--- a/.github/workflows/ci-llama-large-tests.yaml
+++ b/.github/workflows/ci-llama-large-tests.yaml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: linux-mi300-gpu-1
+    runs-on: llama-mi300x-1
     defaults:
       run:
         shell: bash
@@ -48,9 +48,6 @@ jobs:
           python-version: ${{matrix.version}}
       - name: Create Python venv
         run: python -m venv ${VENV_DIR}
-
-      - name: Confirm successful mount
-        run: ls /shark-dev
 
       - name: Install pip deps
         run: |

--- a/.github/workflows/ci-llama-large-tests.yaml
+++ b/.github/workflows/ci-llama-large-tests.yaml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: llama-mi300x-1
+    runs-on: linux-mi300-gpu-1
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci-llama-quick-tests.yaml
+++ b/.github/workflows/ci-llama-quick-tests.yaml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: llama-mi300x-1
+    runs-on: linux-mi300-gpu-1
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci-llama-quick-tests.yaml
+++ b/.github/workflows/ci-llama-quick-tests.yaml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: linux-mi300-gpu-1
+    runs-on: linux-mi300-1gpu-ossci
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci_eval.yaml
+++ b/.github/workflows/ci_eval.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         version: [3.11]
-        runs-on: [llama-mi300x-3]
+        runs-on: [linux-mi300-gpu-1]
       fail-fast: false
     runs-on: ${{matrix.runs-on}}
     defaults:
@@ -65,7 +65,7 @@ jobs:
       - name: Run perplexity test with IREE
         run: |
           source ${VENV_DIR}/bin/activate
-          pytest -n 8 -v -s sharktank/tests/evaluate/perplexity_iree_test.py --run-nightly-llama-tests --bs=100 --iree-device=hip://0 --iree-hip-target=gfx942 --iree-hal-target-device=hip --llama3-8b-f16-model-path=/data/llama3.1/weights/8b/fp16/llama3.1_8b_fp16_instruct.irpa --llama3-8b-tokenizer-path=/data/llama3.1/weights/8b/fp16/tokenizer_config.json --html=out/llm/llama/perplexity/iree_perplexity/index.html --log-cli-level=INFO
+          pytest -n 8 -v -s sharktank/tests/evaluate/perplexity_iree_test.py --run-nightly-llama-tests --bs=100 --iree-device=hip://0 --iree-hip-target=gfx942 --iree-hal-target-device=hip --llama3-8b-f16-model-path=/shark-dev/data/llama3.1/weights/8b/fp16/llama3.1_8b_fp16_instruct.irpa --llama3-8b-tokenizer-path=/shark-dev/data/llama3.1/weights/8b/fp16/tokenizer_config.json --html=out/llm/llama/perplexity/iree_perplexity/index.html --log-cli-level=INFO
           ls -lha ${{ github.workspace }}/perplexity_ci_artifacts
 
 
@@ -121,7 +121,7 @@ jobs:
       - name: Run perplexity test with Torch
         run: |
           source ${VENV_DIR}/bin/activate
-          pytest -n 8 -v -s sharktank/tests/evaluate/perplexity_torch_test.py --longrun --llama3-8b-f16-model-path=/data/llama3.1/weights/8b/fp16/llama3.1_8b_fp16_instruct.irpa --llama3-8b-tokenizer-path=/data/llama3.1/weights/8b/fp16/tokenizer_config.json --html=out/llm/llama/perplexity/torch_perplexity/index.html
+          pytest -n 8 -v -s sharktank/tests/evaluate/perplexity_torch_test.py --longrun --llama3-8b-f16-model-path=/shark-dev/data/llama3.1/weights/8b/fp16/llama3.1_8b_fp16_instruct.irpa --llama3-8b-tokenizer-path=/shark-dev/data/llama3.1/weights/8b/fp16/tokenizer_config.json --html=out/llm/llama/perplexity/torch_perplexity/index.html
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0

--- a/.github/workflows/ci_eval.yaml
+++ b/.github/workflows/ci_eval.yaml
@@ -84,7 +84,7 @@ jobs:
     strategy:
       matrix:
         version: [3.11]
-        runs-on: [llama-mi300x-3]
+        runs-on: [linux-mi300-gpu-1]
       fail-fast: false
     runs-on: ${{matrix.runs-on}}
     defaults:

--- a/.github/workflows/ci_eval.yaml
+++ b/.github/workflows/ci_eval.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         version: [3.11]
-        runs-on: [linux-mi300-gpu-1]
+        runs-on: [linux-mi300-1gpu-ossci]
       fail-fast: false
     runs-on: ${{matrix.runs-on}}
     defaults:
@@ -84,7 +84,7 @@ jobs:
     strategy:
       matrix:
         version: [3.11]
-        runs-on: [linux-mi300-gpu-1]
+        runs-on: [linux-mi300-1gpu-ossci]
       fail-fast: false
     runs-on: ${{matrix.runs-on}}
     defaults:

--- a/.github/workflows/ci_eval_short.yaml
+++ b/.github/workflows/ci_eval_short.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         version: [3.11]
-        runs-on: [llama-mi300x-3]
+        runs-on: [linux-mi300-gpu-1]
       fail-fast: false
     runs-on: ${{matrix.runs-on}}
     defaults:
@@ -64,5 +64,5 @@ jobs:
       - name: Run perplexity test with vmfb
         run: |
           source ${VENV_DIR}/bin/activate
-          pytest -n 8 -v -s sharktank/tests/evaluate/perplexity_iree_test.py --bs=5 --iree-device=hip://0 --iree-hip-target=gfx942 --iree-hal-target-device=hip --llama3-8b-f16-model-path=/data/llama3.1/weights/8b/fp16/llama3.1_8b_fp16_instruct.irpa --llama3-8b-tokenizer-path=/data/llama3.1/weights/8b/fp16/tokenizer_config.json --log-cli-level=INFO
+          pytest -n 8 -v -s sharktank/tests/evaluate/perplexity_iree_test.py --bs=5 --iree-device=hip://0 --iree-hip-target=gfx942 --iree-hal-target-device=hip --llama3-8b-f16-model-path=/shark-dev/data/llama3.1/weights/8b/fp16/llama3.1_8b_fp16_instruct.irpa --llama3-8b-tokenizer-path=/shark-dev/data/llama3.1/weights/8b/fp16/tokenizer_config.json --log-cli-level=INFO
           ls -lha ${{ github.workspace }}/perplexity_ci_artifacts

--- a/.github/workflows/ci_eval_short.yaml
+++ b/.github/workflows/ci_eval_short.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         version: [3.11]
-        runs-on: [linux-mi300-gpu-1]
+        runs-on: [linux-mi300-1gpu-ossci]
       fail-fast: false
     runs-on: ${{matrix.runs-on}}
     defaults:

--- a/.github/workflows/pkgci_shark_ai.yml
+++ b/.github/workflows/pkgci_shark_ai.yml
@@ -93,4 +93,3 @@ jobs:
         run: |
           source ${VENV_DIR}/bin/activate
           pytest -v -s --test_device=${{ matrix.test_device }} app_tests/integration_tests/llm/shortfin/open_llama_3b_llm_server_test.py --log-cli-level=INFO
-

--- a/.github/workflows/pkgci_shark_ai.yml
+++ b/.github/workflows/pkgci_shark_ai.yml
@@ -33,7 +33,6 @@ jobs:
             python-version: 3.11
           - name: amdgpu_rocm_mi300_gfx942
             runs-on: linux-mi300-1gpu-ossci
-
             test_device: gfx942
             python-version: 3.11
           # temporarily disable mi250 because the cluster is unsable & slow

--- a/.github/workflows/pkgci_shark_ai.yml
+++ b/.github/workflows/pkgci_shark_ai.yml
@@ -22,13 +22,24 @@ on:
 jobs:
   test_shortfin_llm_server:
     name: "Integration Tests - Shortfin LLM Server"
+    runs-on: ${{ matrix.runs-on }}
     strategy:
-      matrix:
-        version: [3.11]
       fail-fast: false
-    runs-on: azure-cpubuilder-linux-scale
-    # runs-on: ubuntu-latest # everything else works but this throws an "out of resources" during model loading
-    # TODO: make a copy of this that runs on standard runners with tiny llama instead of a 8b model
+      matrix:
+        include:
+          - name: cpu
+            runs-on: azure-cpubuilder-linux-scale
+            test_device: cpu
+            python-version: 3.11
+          - name: amdgpu_rocm_mi300_gfx942
+            runs-on: linux-mi300-1gpu-ossci
+            test_device: gfx942
+            python-version: 3.11
+          # temporarily disable mi250 because the cluster is unsable & slow
+          # - name: amdgpu_rocm_mi250_gfx90a
+          #   runs-on: nodai-amdgpu-mi250-x86-64
+          #   test_device: gfx90a
+
     defaults:
       run:
         shell: bash
@@ -36,13 +47,16 @@ jobs:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       VENV_DIR: ${{ github.workspace }}/.venv
     steps:
+      - name: Run rocminfo
+        if: contains(matrix.test_device, 'gfx')
+        run: rocminfo
       - name: "Checkout Code"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: "Setting up Python"
         id: setup_python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
-          python-version: ${{matrix.version}}
+          python-version: ${{matrix.python-version}}
 
       - name: Setup UV caching
         run: |
@@ -54,7 +68,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: .uv-cache
-          key: ${{ runner.os }}-uv-py${{ matrix.version }}-${{ hashFiles('requirements-iree-pinned.txt', 'pytorch-cpu-requirements.txt', 'sharktank/requirements.txt', 'sharktank/requirements-tests.txt', 'shortfin/requirements-tests.txt') }}
+          key: ${{ runner.os }}-uv-py${{ matrix.python-version }}-${{ hashFiles('requirements-iree-pinned.txt', 'pytorch-cpu-requirements.txt', 'sharktank/requirements.txt', 'sharktank/requirements-tests.txt', 'shortfin/requirements-tests.txt') }}
 
       - name: Download package artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -77,4 +91,4 @@ jobs:
       - name: Run LLM Integration Tests
         run: |
           source ${VENV_DIR}/bin/activate
-          pytest -v -s app_tests/integration_tests/llm/shortfin --log-cli-level=INFO
+          pytest -v -s --test_device=${{ matrix.test_device }} app_tests/integration_tests/llm/shortfin/open_llama_3b_llm_server_test.py --log-cli-level=INFO


### PR DESCRIPTION
moving llama workflows to mi300x machine

moved PkgCI - shark-ai (this workkflow was already on the OSSCI cluster but was using an outdated runner name), CI - sharktank perplexity short, CI - sharktank perplexity and Llama Benchmarking 8B Tests to new OSSCI cluster arc runners on mi300x machines