### PR TITLE
Migrate sglang and sdxl workflows to kubernetes cluster.

### DIFF
--- a/.github/workflows/ci-sdxl.yaml
+++ b/.github/workflows/ci-sdxl.yaml
@@ -37,7 +37,7 @@ env:
 jobs:
   install-and-test:
     name: Install and test
-    runs-on: mi300x-3
+    runs-on: linux-mi300-1gpu-ossci
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: mi300x-3
+    runs-on: linux-mi300-1gpu-ossci
     defaults:
       run:
         shell: bash
@@ -101,7 +101,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: mi300x-3
+    runs-on: linux-mi300-1gpu-ossci
     defaults:
       run:
         shell: bash
@@ -181,20 +181,6 @@ jobs:
         with:
           name: sglang_benchmark
           path: sglang_index.html
-
-  # Ensure that the container is always cleaned up after job
-  container_cleanup:
-    needs: benchmark_sglang
-    name: "Docker Cleanup"
-    if: always()
-    runs-on: mi300x-3
-    steps:
-      - name: Stop sglang-server
-        run: docker stop sglang-server || true # Stop container if it's running
-
-      # Deleting image after run due to large disk space requirement (83 GB)
-      - name: Cleanup SGLang Image
-        run: docker image rm lmsysorg/sglang:v0.3.5.post1-rocm620
 
   merge_and_upload_reports:
     name: "Merge and upload benchmark reports"

--- a/.github/workflows/ci-sglang-integration-tests.yml
+++ b/.github/workflows/ci-sglang-integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: mi300x-3
+    runs-on: linux-mi300-1gpu-ossci
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
This patch migrates the two sglang and one sdxl workflow to ossci too. These don't any use persistent cache.