### PR TITLE
Use llama-8b-instruct tokenizer.json and tokenizer_config.json for `llama3_8b_fp16` dataset

### DIFF
--- a/sharktank/sharktank/utils/hf_datasets.py
+++ b/sharktank/sharktank/utils/hf_datasets.py
@@ -103,7 +103,7 @@ Dataset(
         ),
         RemoteFile(
             "tokenizer_config.json",
-            "NousResearch/Meta-Llama-3-8B",
+            "NousResearch/Meta-Llama-3-8B-Instruct",
             "tokenizer_config.json",
             extra_filenames=["tokenizer.json"],
         ),


### PR DESCRIPTION
The tokenizers specified for this dataset are for `llama3_8b_fp16`, while the model is `llama3_8b_fp16_instruct`. The `eos_token` for `8b` and `8b-instruct` are different:

```text
8b:

<|begin_of_text|> {generated_text} <|end_of_text|>

<|end_of_text|> - 128001

8b-Instruct:

<|begin_of_text|> {generated_text} <|eot_id|>


<|eot_id|> - 128009
```

Using the wrong config causes Llama to output text forever. Our model generated `128009`s, but the server doesn't recognize it as the proper stop token and keeps calling for generations.

More details [here](https://github.com/nod-ai/shark-ai/issues/934#issuecomment-2649718739)