### PR TITLE
Add InferenceExecRequest.__repr__() for debug logging

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/messages.py
+++ b/shortfin/python/shortfin_apps/llm/components/messages.py
@@ -71,6 +71,27 @@ class InferenceExecRequest(sf.Message):
             self.allocation.release_pages()
             self.allocation = None
 
+    def __repr__(self) -> str:
+        """
+        String representation for logging purposes. It looks like this:
+
+        InferenceExecRequest[phase=P,pos=0,rid=test123,flags=host,input_token_ids=[1, 2, 3, 4]]
+
+        Use
+        `logging.debug("Request: %r", request)`
+        and not
+        `logging.debug(f"Request: {request}")
+        to avoid running through this method all the time.
+        """
+        phase_char = "D" if self.phase == InferencePhase.DECODE else "P"
+        flags = []
+        if self.return_all_logits:
+            flags.append("all")
+        if self.return_host_array:
+            flags.append("host")
+        flags_str = ",".join(flags)
+        return f"InferenceExecRequest[phase={phase_char},pos={self.start_position},rid={self.rid},flags={flags_str},input_token_ids={self.input_token_ids}]"
+
 
 class StrobeMessage(sf.Message):
     """Sent to strobe a queue with fake activity (generate a wakeup)."""

--- a/shortfin/tests/apps/llm/components/messages_test.py
+++ b/shortfin/tests/apps/llm/components/messages_test.py
@@ -6,48 +6,25 @@
 
 import pytest
 from shortfin_apps.llm.components.messages import InferenceExecRequest, InferencePhase
+from unittest.mock import patch
 
 
-@pytest.fixture
-def mock_request():
-    """
-    A mock InferenceExecRequest class that doesn't require worker context.
-
-    Useful for testing init and printing.
-    """
-    original_init = InferenceExecRequest.__init__
-
-    def mock_init(self, phase, input_token_ids, rid=None):
-        self.phase = phase
-        self.start_position = 0
-        self.input_token_ids = input_token_ids
-        self.rid = rid
-        self.return_all_logits = False
-        self.return_host_array = True
-        self.result_logits = None
-        self._cache = None
-        self.allocation = None
-
-    InferenceExecRequest.__init__ = mock_init
-    yield InferenceExecRequest
-    InferenceExecRequest.__init__ = original_init
-
-
-def test_inference_exec_request_repr(mock_request):
+@patch("shortfin.VoidFuture")
+def test_inference_exec_request_repr(mock_void_future):
     """
     Test the string representation of InferenceExecRequest in different states.
 
     This is useful for debugging and logging. Other test cases may depend on the debug log formats.
+
+    Patches shortfin.VoidFuture with a mock because we're not running this testcase on a worker thread.
     """
-    # default settings
-    req = mock_request(InferencePhase.PREFILL, [1, 2, 3, 4], rid="test123")
+    req = InferenceExecRequest(InferencePhase.PREFILL, [1, 2, 3, 4], rid="test123")
     assert (
         str(req)
         == "InferenceExecRequest[phase=P,pos=0,rid=test123,flags=host,input_token_ids=[1, 2, 3, 4]]"
     )
 
-    # mutated settings
-    req = mock_request(InferencePhase.DECODE, [], rid="test123")
+    req = InferenceExecRequest(InferencePhase.DECODE, [], rid="test123")
     req.return_host_array = False
     req.return_all_logits = False
     req.rid = None

--- a/shortfin/tests/apps/llm/components/messages_test.py
+++ b/shortfin/tests/apps/llm/components/messages_test.py
@@ -39,28 +39,19 @@ def test_inference_exec_request_repr(mock_request):
 
     This is useful for debugging and logging. Other test cases may depend on the debug log formats.
     """
-    # Basic request with default settings
+    # default settings
     req = mock_request(InferencePhase.PREFILL, [1, 2, 3, 4], rid="test123")
     assert (
         str(req)
         == "InferenceExecRequest[phase=P,pos=0,rid=test123,flags=host,input_token_ids=[1, 2, 3, 4]]"
     )
 
-    # With mutated flags
-    req.return_all_logits = True
-    req.phase = InferencePhase.DECODE
-    req.rid = 1
-    assert (
-        str(req)
-        == "InferenceExecRequest[phase=D,pos=0,rid=1,flags=all,host,input_token_ids=[1, 2, 3, 4]]"
-    )
-
-    # With no flags set
-    req = mock_request(InferencePhase.PREFILL, [], rid="test123")
+    # mutated settings
+    req = mock_request(InferencePhase.DECODE, [], rid="test123")
     req.return_host_array = False
     req.return_all_logits = False
     req.rid = None
     assert (
         str(req)
-        == "InferenceExecRequest[phase=P,pos=0,rid=None,flags=,input_token_ids=[]]"
+        == "InferenceExecRequest[phase=D,pos=0,rid=None,flags=,input_token_ids=[]]"
     )

--- a/shortfin/tests/apps/llm/components/messages_test.py
+++ b/shortfin/tests/apps/llm/components/messages_test.py
@@ -56,11 +56,11 @@ def test_inference_exec_request_repr(mock_request):
     )
 
     # With no flags set
+    req = mock_request(InferencePhase.PREFILL, [], rid="test123")
     req.return_host_array = False
     req.return_all_logits = False
     req.rid = None
-    req.input_token_ids = list(range(100))
     assert (
         str(req)
-        == "InferenceExecRequest[phase=P,pos=0,rid=test123,flags=,input_token_ids=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99]]"
+        == "InferenceExecRequest[phase=P,pos=0,rid=None,flags=,input_token_ids=[]]"
     )

--- a/shortfin/tests/apps/llm/components/messages_test.py
+++ b/shortfin/tests/apps/llm/components/messages_test.py
@@ -1,0 +1,66 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+from shortfin_apps.llm.components.messages import InferenceExecRequest, InferencePhase
+
+
+@pytest.fixture
+def mock_request():
+    """
+    A mock InferenceExecRequest class that doesn't require worker context.
+
+    Useful for testing init and printing.
+    """
+    original_init = InferenceExecRequest.__init__
+
+    def mock_init(self, phase, input_token_ids, rid=None):
+        self.phase = phase
+        self.start_position = 0
+        self.input_token_ids = input_token_ids
+        self.rid = rid
+        self.return_all_logits = False
+        self.return_host_array = True
+        self.result_logits = None
+        self._cache = None
+        self.allocation = None
+
+    InferenceExecRequest.__init__ = mock_init
+    yield InferenceExecRequest
+    InferenceExecRequest.__init__ = original_init
+
+
+def test_inference_exec_request_repr(mock_request):
+    """
+    Test the string representation of InferenceExecRequest in different states.
+
+    This is useful for debugging and logging. Other test cases may depend on the debug log formats.
+    """
+    # Basic request with default settings
+    req = mock_request(InferencePhase.PREFILL, [1, 2, 3, 4], rid="test123")
+    assert (
+        str(req)
+        == "InferenceExecRequest[phase=P,pos=0,rid=test123,flags=host,input_token_ids=[1, 2, 3, 4]]"
+    )
+
+    # With mutated flags
+    req.return_all_logits = True
+    req.phase = InferencePhase.DECODE
+    req.rid = 1
+    assert (
+        str(req)
+        == "InferenceExecRequest[phase=D,pos=0,rid=1,flags=all,host,input_token_ids=[1, 2, 3, 4]]"
+    )
+
+    # With no flags set
+    req.return_host_array = False
+    req.return_all_logits = False
+    req.rid = None
+    req.input_token_ids = list(range(100))
+    assert (
+        str(req)
+        == "InferenceExecRequest[phase=P,pos=0,rid=test123,flags=,input_token_ids=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99]]"
+    )


### PR DESCRIPTION
In the cycle leading up to the 3.2.0 release, we had some trouble triaging CI error reports / routing bugs to the appropriate teams / people. This and #917 are part of that.

The plan is to make shortfin's llm server log all relevant InferenceExecRequests when something (e.g. kvcache allocations / nans in logits) doesn't check out.