### PR TITLE
Add integration test harness that bypasses the FastAPI server to directly test the batcher 

### DIFF
--- a/app_tests/benchmark_tests/llm/sglang_benchmarks/conftest.py
+++ b/app_tests/benchmark_tests/llm/sglang_benchmarks/conftest.py
@@ -80,7 +80,7 @@ def server(model_artifacts, request):
     )
 
     server_instance = ServerInstance(server_config)
-    server_instance.start()
+    server_instance.start_full_fastapi_server()
     process, port = server_instance.process, server_instance.port
     yield process, port
 

--- a/app_tests/integration_tests/llm/sglang/conftest.py
+++ b/app_tests/integration_tests/llm/sglang/conftest.py
@@ -64,7 +64,7 @@ def start_server(request, model_artifacts):
     )
 
     server_instance = ServerInstance(server_config)
-    server_instance.start()
+    server_instance.start_full_fastapi_server()
     process, port = server_instance.process, server_instance.port
 
     yield process, port

--- a/app_tests/integration_tests/llm/shortfin/batching.py
+++ b/app_tests/integration_tests/llm/shortfin/batching.py
@@ -1,0 +1,98 @@
+import logging
+from pathlib import Path
+import math
+
+import shortfin as sf
+import shortfin.array as sfnp
+from shortfin_apps.llm.components.service import (
+    GenerateService,
+    InferenceExecutorProcess,
+)
+from shortfin_apps.llm.components.messages import InferenceExecRequest, InferencePhase
+from shortfin_apps.llm.components.config_struct import ModelParams, ServerParams
+from shortfin_apps.llm.components.manager import SystemManager
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+art_path = Path("")
+weights_path = art_path / "model.gguf"
+vmfb_path = art_path / "model.vmfb"
+config_path = art_path / "config.json"
+
+# Create system manager
+sysman = SystemManager(
+    device="hip",
+    device_ids=None,  # Full visibility
+    async_allocs=True,
+    amdgpu_allocators=None,
+)
+
+sysman.start()
+
+model_params = ModelParams.load_json(config_path)
+
+server_params = ServerParams()
+server_params.prefix_sharing_algorithm = "default"  # Adjust as needed
+
+service = GenerateService(
+    name="notebook-service",
+    sysman=sysman,
+    tokenizer=None,  # No tokenizer needed for basic setup
+    model_params=model_params,
+    server_params=server_params,
+    program_isolation="per_call",
+)
+
+# Load inference module and parameters
+service.load_inference_module(vmfb_path)
+service.load_inference_parameters(weights_path, parameter_scope="model")
+
+# Start the service
+service.start()
+
+from shortfin_apps.llm.components.messages import InferenceExecRequest, InferencePhase
+
+
+def test_batch_sizes_same_inputs_same_outputs():
+    """
+    Tests submitting various numbers of inference requests with the same input token ids,
+    and check to make sure no matter what the batch size is, we get the same output.
+    """
+    token_ids = [1, 2, 3]
+    max_batch_size = 3
+    reqs = []
+
+    b = service.batcher
+
+    # create
+    for bi in range(max_batch_size):
+        token_ids = [x for x in token_ids]  # copy list
+        reqs[i] = InferenceExecRequest(
+            phase=InferencePhase.PREFILL, input_token_ids=token_ids, rid=bi
+        )
+
+    for r in reqs:
+        b.submit(r)
+
+    # submit
+    exec_process = InferenceExecutorProcess(
+        service,
+        InferencePhase.PREFILL,
+        seq_stri=model_params.block_seq_stride,
+        page_tables=service.page_cache.page_pool.page_tables,
+    )
+    for r in reqs:
+        exec_process.exec_requests.append(r)
+
+    exec_process.launch()
+
+    # check to make sure the
+    # run one batch
+
+
+# Now the service is ready to use
+# When done, you can shut down with:
+# service.shutdown()
+# sysman.shutdown()

--- a/app_tests/integration_tests/llm/shortfin/batching.py
+++ b/app_tests/integration_tests/llm/shortfin/batching.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 import math
-
+import pytest
 import shortfin as sf
 import shortfin.array as sfnp
 from shortfin_apps.llm.components.service import (
@@ -53,6 +53,15 @@ service.load_inference_parameters(weights_path, parameter_scope="model")
 service.start()
 
 from shortfin_apps.llm.components.messages import InferenceExecRequest, InferencePhase
+
+pytestmark = pytest.mark.parametrize(
+    "model_artifacts,server",
+    [
+        ["llama3.1_8b", {"prefix_sharing": "none"}],
+        ["llama3.1_8b", {"prefix_sharing": "trie"}],
+    ],
+    indirect=True,
+)
 
 
 def test_batch_sizes_same_inputs_same_outputs():

--- a/shortfin/python/shortfin_apps/llm/server.py
+++ b/shortfin/python/shortfin_apps/llm/server.py
@@ -97,7 +97,7 @@ def configure(args) -> SystemManager:
     return sysman
 
 
-def main(argv, log_config=uvicorn.config.LOGGING_CONFIG):
+def parse_args(argv):
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", type=str, default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8000)
@@ -194,6 +194,12 @@ def main(argv, log_config=uvicorn.config.LOGGING_CONFIG):
             args.tokenizer_json.stem + "_config.json"
         )
         args.tokenizer_config_json = inferred_tokenizer_config_path
+
+    return args
+
+
+def main(argv, log_config=uvicorn.config.LOGGING_CONFIG):
+    args = parse_args(argv)
     lifecycle_hooks.sysman = configure(args)
 
     uvicorn.run(


### PR DESCRIPTION
Previously, to test concurrent generation, we quickly submit multiple requests.

This does not consistently result in the same batching, and timing differences across shortfin can cause e.g. 4 requests to go from being all batches together to boarding a batch of 3 and then a batch of 1. This caused some very difficult-to-replicate errors and accounted for some of the regressions we observed leading up to the v3.2.0 release.

This harness and it's associated tests will eliminate inconsistent batching as an untested point of failure, allowing us to detect and replicate future errors that depend on certain batching conditions to appear.