### PR TITLE
Don't use GGUF but convert T5 directly from Hugging Face

### DIFF
--- a/sharktank/sharktank/layers/configs/llm_configs.py
+++ b/sharktank/sharktank/layers/configs/llm_configs.py
@@ -14,7 +14,7 @@ When in question, we draw from the vocabulary and normalization they have done
 (and indeed, can bootstrap these off of GGUF files).
 """
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from typing import Any, Optional
 import torch
 from transformers import T5Config as T5ConfigHf
@@ -236,29 +236,13 @@ class T5Config:
     def from_hugging_face_config(
         config: T5ConfigHf, tokenizer_config: dict[str, Any], **kwargs
     ) -> "T5Config":
-        all_kwargs = {
-            "return_dict": config.return_dict,
-            "output_hidden_states": config.output_hidden_states,
-            "output_attentions": config.output_attentions,
-            "is_encoder_decoder": config.is_encoder_decoder,
-            "is_decoder": config.is_decoder,
-            "vocab_size": config.vocab_size,
-            "context_length": tokenizer_config["model_max_length"],
-            "d_model": config.d_model,
-            "d_kv": config.d_kv,
-            "d_ff": config.d_ff,
-            "num_layers": config.num_layers,
-            "num_decoder_layers": config.num_decoder_layers,
-            "num_heads": config.num_heads,
-            "relative_attention_num_buckets": config.relative_attention_num_buckets,
-            "relative_attention_max_distance": config.relative_attention_max_distance,
-            "layer_norm_epsilon": config.layer_norm_epsilon,
-            "feed_forward_proj": config.feed_forward_proj,
-            "use_cache": config.use_cache,
-            "pad_token_id": config.pad_token_id,
-            "eos_token_id": config.eos_token_id,
-            "decoder_start_token_id": config.decoder_start_token_id,
-        }
+        all_kwargs = {}
+        for filed in fields(T5Config):
+            if hasattr(config, filed.name):
+                all_kwargs[filed.name] = getattr(config, filed.name)
+        all_kwargs["context_length"] = tokenizer_config["model_max_length"]
+        del all_kwargs["is_gated_act"]
+        del all_kwargs["dense_act_fn"]
         all_kwargs.update(kwargs)
         return T5Config(**all_kwargs)
 

--- a/sharktank/sharktank/layers/configs/llm_configs.py
+++ b/sharktank/sharktank/layers/configs/llm_configs.py
@@ -17,8 +17,10 @@ When in question, we draw from the vocabulary and normalization they have done
 from dataclasses import asdict, dataclass, field
 from typing import Any, Optional
 import torch
+from transformers import T5Config as T5ConfigHf
 
 from ...types.tensors import serialized_name_to_dtype, dtype_to_serialized_name
+
 
 __all__ = ["ClipTextConfig", "LlamaHParams", "LlamaModelConfig", "T5Config"]
 
@@ -231,52 +233,56 @@ class T5Config:
             self.dense_act_fn = "gelu_new"
 
     @staticmethod
-    def from_gguf_properties(properties: dict[str, Any], **kwargs):
-        assert properties["general.architecture"] == "t5"
-        assert (
-            properties["t5.attention.layer_norm_epsilon"]
-            == properties["t5.attention.layer_norm_rms_epsilon"]
-        )
-
-        all_kwargs = {"vocab_size": None, "feed_forward_proj": None}
-
-        gguf_to_config_names_map = {
-            "t5.context_length": ["context_length"],
-            "t5.embedding_length": ["d_model"],
-            "t5.feed_forward_length": ["d_ff"],
-            "t5.block_count": ["num_layers", "num_decoder_layers"],
-            "t5.attention.head_count": ["num_heads"],
-            "t5.attention.key_length": ["d_kv"],
-            "t5.attention.layer_norm_epsilon": ["layer_norm_epsilon"],
-            "t5.attention.relative_buckets_count": ["relative_attention_num_buckets"],
-            "tokenizer.ggml.eos_token_id": ["eos_token_id"],
-            "tokenizer.ggml.padding_token_id": ["pad_token_id"],
+    def from_hugging_face_config(
+        config: T5ConfigHf, tokenizer_config: dict[str, Any], **kwargs
+    ) -> "T5Config":
+        all_kwargs = {
+            "return_dict": config.return_dict,
+            "output_hidden_states": config.output_hidden_states,
+            "output_attentions": config.output_attentions,
+            "is_encoder_decoder": config.is_encoder_decoder,
+            "is_decoder": config.is_decoder,
+            "vocab_size": config.vocab_size,
+            "context_length": tokenizer_config["model_max_length"],
+            "d_model": config.d_model,
+            "d_kv": config.d_kv,
+            "d_ff": config.d_ff,
+            "num_layers": config.num_layers,
+            "num_decoder_layers": config.num_decoder_layers,
+            "num_heads": config.num_heads,
+            "relative_attention_num_buckets": config.relative_attention_num_buckets,
+            "relative_attention_max_distance": config.relative_attention_max_distance,
+            "layer_norm_epsilon": config.layer_norm_epsilon,
+            "feed_forward_proj": config.feed_forward_proj,
+            "use_cache": config.use_cache,
+            "pad_token_id": config.pad_token_id,
+            "eos_token_id": config.eos_token_id,
+            "decoder_start_token_id": config.decoder_start_token_id,
         }
-        all_kwargs.update(
-            {
-                config_name: properties[gguf_name]
-                for gguf_name, config_names in gguf_to_config_names_map.items()
-                for config_name in config_names
-            }
-        )
-
-        gguf_to_optional_config_names_map = {
-            "t5.decoder_start_token_id": ["decoder_start_token_id"],
-        }
-        all_kwargs.update(
-            {
-                config_name: properties[gguf_name]
-                for gguf_name, config_names in gguf_to_optional_config_names_map.items()
-                for config_name in config_names
-                if gguf_name in properties
-            }
-        )
-
-        if "tokenizer.ggml.tokens" in properties:
-            all_kwargs["vocab_size"] = len(properties["tokenizer.ggml.tokens"])
         all_kwargs.update(kwargs)
-
         return T5Config(**all_kwargs)
+
+    @staticmethod
+    def from_properties(properties: dict[str, Any]) -> "T5Config":
+        kwargs = dict(properties)
+        if "SHARK_DATASET_VERSION" in kwargs:
+            kwargs.pop("SHARK_DATASET_VERSION")
+        if "activation_dtype" in kwargs and kwargs["activation_dtype"] is not None:
+            kwargs["activation_dtype"] = serialized_name_to_dtype(
+                kwargs["activation_dtype"]
+            )
+        if "is_gated_act" in kwargs:
+            kwargs.pop("is_gated_act")
+        if "dense_act_fn" in kwargs:
+            kwargs.pop("dense_act_fn")
+
+        return T5Config(**kwargs)
+
+    def to_properties(self) -> dict[str, Any]:
+        res = asdict(self)
+        if self.activation_dtype is not None:
+            res["activation_dtype"] = dtype_to_serialized_name(self.activation_dtype)
+        return res
 
 
 @dataclass
@@ -336,7 +342,8 @@ class ClipTextConfig:
     @staticmethod
     def from_properties(properties: dict[str, Any]) -> "ClipTextConfig":
         kwargs = dict(properties)
-        kwargs.pop("SHARK_DATASET_VERSION")
+        if "SHARK_DATASET_VERSION" in kwargs:
+            kwargs.pop("SHARK_DATASET_VERSION")
         if "dtype" in kwargs and kwargs["dtype"] is not None:
             kwargs["dtype"] = serialized_name_to_dtype(kwargs["dtype"])
 

--- a/sharktank/tests/models/t5/t5_test.py
+++ b/sharktank/tests/models/t5/t5_test.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import functools
+from copy import copy
 from transformers.models.t5.modeling_t5 import (
     T5Attention as ReferenceT5Attention,
     T5LayerSelfAttention as ReferenceT5LayerSelfAttention,
@@ -15,6 +16,7 @@ from transformers import (
     T5EncoderModel as ReferenceT5EncoderModel,
     T5Config as ReferenceT5Config,
 )
+from transformers.models.auto.tokenization_auto import get_tokenizer_config
 from typing import Optional
 import os
 from collections import OrderedDict
@@ -39,6 +41,7 @@ from sharktank.models.t5 import (
     T5LayerFF,
     export_encoder_mlir,
     export_encoder_iree_parameters,
+    import_encoder_dataset_from_hugging_face,
 )
 from sharktank.utils.testing import (
     assert_text_encoder_state_close,
@@ -168,17 +171,12 @@ class T5EncoderEagerTest(TestCase):
         )
         reference_model.eval()
 
-        target_model_name = (
-            f"{huggingface_repo_id.replace('/', '__').replace('-', '_')}_f32_model"
-        )
-        target_model_path = getattr(self, target_model_name)
-        dataset = Dataset.load(target_model_path)
+        dataset = import_encoder_dataset_from_hugging_face(huggingface_repo_id)
         dataset.root_theta = dataset.root_theta.transform(
             functools.partial(set_float_dtype, dtype=target_dtype)
         )
-        config = T5Config.from_gguf_properties(
+        config = T5Config.from_properties(
             dataset.properties,
-            feed_forward_proj="gated-gelu",
         )
 
         input_ids = tokenizer(
@@ -258,6 +256,7 @@ class T5EncoderEagerTest(TestCase):
             "google/t5-v1_1-small",
             reference_dtype=torch.float32,
             target_dtype=torch.bfloat16,
+            # The observed error is 0.055.
             atol=1e-1,
         )
 
@@ -285,6 +284,7 @@ class T5EncoderEagerTest(TestCase):
             "google/t5-v1_1-xxl",
             reference_dtype=torch.float32,
             target_dtype=torch.bfloat16,
+            # The observed error is 0.026.
             atol=5e-2,
         )
 
@@ -310,19 +310,20 @@ class T5EncoderIreeTest(TempDirTestBase):
         ).download()
         tokenizer = AutoTokenizer.from_pretrained(huggingface_repo_id)
 
-        huggingface_repo_id_as_path = (
-            f"{huggingface_repo_id.replace('/', '__').replace('-', '_')}"
+        reference_dataset = import_encoder_dataset_from_hugging_face(
+            huggingface_repo_id
         )
-        source_model_name = f"{huggingface_repo_id_as_path}_f32_model"
-        source_model_path = getattr(self, source_model_name)
+        target_dataset = copy(reference_dataset)
 
-        reference_dataset = Dataset.load(source_model_path)
         reference_dataset.root_theta = reference_dataset.root_theta.transform(
             functools.partial(set_float_dtype, dtype=reference_dtype)
         )
-        config = T5Config.from_gguf_properties(
+        config = T5Config.from_properties(
             reference_dataset.properties,
-            feed_forward_proj="gated-gelu",
+        )
+
+        target_dataset.root_theta = target_dataset.root_theta.transform(
+            functools.partial(set_float_dtype, dtype=target_dtype)
         )
 
         input_ids = tokenizer(
@@ -334,32 +335,26 @@ class T5EncoderIreeTest(TempDirTestBase):
         input_args = OrderedDict([("input_ids", input_ids)])
         batch_size = input_ids.shape[0]
 
-        reference_dtype_name = dtype_to_serialized_short_name(reference_dtype)
-        target_dtype_name = dtype_to_serialized_short_name(target_dtype)
-        target_model_path_prefix = f"{self.path_prefix}{huggingface_repo_id_as_path}_encoder_{target_dtype_name}"
-
         reference_model = T5Encoder(theta=reference_dataset.root_theta, config=config)
         reference_result_dict = call_torch_module_function(
             module=reference_model,
             function_name="forward",
             kwargs=input_args,
-            trace_path_prefix=f"{self.path_prefix}{huggingface_repo_id_as_path}_encoder_{reference_dtype_name}_torch_",
+            trace_path_prefix=f"{self.path_prefix}torch_",
         )
         reference_result = flatten_for_iree_signature(reference_result_dict)
 
-        parameters_path = f"{target_model_path_prefix}.irpa"
+        parameters_path = f"{self.path_prefix}parameters.irpa"
         if not self.caching or not os.path.exists(parameters_path):
-            export_encoder_iree_parameters(
-                source_model_path, parameters_path, dtype=target_dtype
-            )
+            target_dataset.save(parameters_path)
 
-        mlir_path = f"{target_model_path_prefix}.mlir"
+        mlir_path = f"{self.path_prefix}model.mlir"
         if not self.caching or not os.path.exists(mlir_path):
             logger.info("Exporting T5 encoder model to MLIR...")
             export_encoder_mlir(
                 parameters_path, batch_sizes=[batch_size], mlir_output_path=mlir_path
             )
-        iree_module_path = f"{target_model_path_prefix}.vmfb"
+        iree_module_path = f"{self.path_prefix}model.vmfb"
         if not self.caching or not os.path.exists(iree_module_path):
             logger.info("Compiling MLIR file...")
             iree.compiler.compile_file(
@@ -386,7 +381,7 @@ class T5EncoderIreeTest(TempDirTestBase):
                 args=iree_args,
                 device=iree_devices[0],
                 function_name=f"forward_bs{batch_size}",
-                trace_path_prefix=f"{target_model_path_prefix}_iree_",
+                trace_path_prefix=f"{self.path_prefix}iree_",
             )
         )
         iree_result = [
@@ -498,19 +493,19 @@ class T5AttentionTest(TestCase):
 
         theta = Theta(
             {
-                "attn_q.weight": DefaultPrimitiveTensor(
+                "q.weight": DefaultPrimitiveTensor(
                     data=reference_model.q.weight.to(dtype=target_dtype)
                 ),
-                "attn_k.weight": DefaultPrimitiveTensor(
+                "k.weight": DefaultPrimitiveTensor(
                     data=reference_model.k.weight.to(dtype=target_dtype)
                 ),
-                "attn_v.weight": DefaultPrimitiveTensor(
+                "v.weight": DefaultPrimitiveTensor(
                     data=reference_model.v.weight.to(dtype=target_dtype)
                 ),
-                "attn_o.weight": DefaultPrimitiveTensor(
+                "o.weight": DefaultPrimitiveTensor(
                     data=reference_model.o.weight.to(dtype=target_dtype)
                 ),
-                "attn_rel_b.weight": DefaultPrimitiveTensor(
+                "relative_attention_bias.weight": DefaultPrimitiveTensor(
                     data=reference_model.relative_attention_bias.weight.to(
                         dtype=target_dtype
                     )
@@ -593,24 +588,24 @@ class T5AttentionTest(TestCase):
 
         theta = Theta(
             {
-                "attn_q.weight": DefaultPrimitiveTensor(
+                "SelfAttention.q.weight": DefaultPrimitiveTensor(
                     data=reference_model.SelfAttention.q.weight.to(dtype=target_dtype)
                 ),
-                "attn_k.weight": DefaultPrimitiveTensor(
+                "SelfAttention.k.weight": DefaultPrimitiveTensor(
                     data=reference_model.SelfAttention.k.weight.to(dtype=target_dtype)
                 ),
-                "attn_v.weight": DefaultPrimitiveTensor(
+                "SelfAttention.v.weight": DefaultPrimitiveTensor(
                     data=reference_model.SelfAttention.v.weight.to(dtype=target_dtype)
                 ),
-                "attn_o.weight": DefaultPrimitiveTensor(
+                "SelfAttention.o.weight": DefaultPrimitiveTensor(
                     data=reference_model.SelfAttention.o.weight.to(dtype=target_dtype)
                 ),
-                "attn_rel_b.weight": DefaultPrimitiveTensor(
+                "SelfAttention.relative_attention_bias.weight": DefaultPrimitiveTensor(
                     data=reference_model.SelfAttention.relative_attention_bias.weight.to(
                         dtype=target_dtype
                     )
                 ),
-                "attn_norm.weight": DefaultPrimitiveTensor(
+                "layer_norm.weight": DefaultPrimitiveTensor(
                     data=reference_model.layer_norm.weight.to(dtype=target_dtype)
                 ),
             }
@@ -708,20 +703,20 @@ class T5LayerFFTest(TestCase):
 
         theta = Theta(
             {
-                "ffn_gate.weight": DefaultPrimitiveTensor(
+                "DenseReluDense.wi_0.weight": DefaultPrimitiveTensor(
                     data=reference_model.DenseReluDense.wi_0.weight.to(
                         dtype=target_dtype
                     )
                 ),
-                "ffn_up.weight": DefaultPrimitiveTensor(
+                "DenseReluDense.wi_1.weight": DefaultPrimitiveTensor(
                     data=reference_model.DenseReluDense.wi_1.weight.to(
                         dtype=target_dtype
                     )
                 ),
-                "ffn_down.weight": DefaultPrimitiveTensor(
+                "DenseReluDense.wo.weight": DefaultPrimitiveTensor(
                     data=reference_model.DenseReluDense.wo.weight.to(dtype=target_dtype)
                 ),
-                "ffn_norm.weight": DefaultPrimitiveTensor(
+                "layer_norm.weight": DefaultPrimitiveTensor(
                     data=reference_model.layer_norm.weight.to(dtype=target_dtype)
                 ),
             }

--- a/sharktank/tests/models/t5/t5_test.py
+++ b/sharktank/tests/models/t5/t5_test.py
@@ -23,7 +23,7 @@ from collections import OrderedDict
 import logging
 import pytest
 import torch
-from torch.utils._pytree import tree_map, tree_unflatten, tree_flatten_with_path
+from torch.utils._pytree import tree_map
 from unittest import TestCase
 from parameterized import parameterized
 from sharktank.types import (
@@ -31,7 +31,6 @@ from sharktank.types import (
     DefaultPrimitiveTensor,
     unbox_tensor,
     Dataset,
-    dtype_to_serialized_short_name,
 )
 from sharktank.models.t5 import (
     T5Attention,
@@ -40,7 +39,6 @@ from sharktank.models.t5 import (
     T5Encoder,
     T5LayerFF,
     export_encoder_mlir,
-    export_encoder_iree_parameters,
     import_encoder_dataset_from_hugging_face,
 )
 from sharktank.utils.testing import (


### PR DESCRIPTION
We don't want the stack to depend on the conversion tool from the lamma.cpp repo. Also the conversion to GGUF would not convert all tensors to bf16, but leave some in f32. We would like to control that ourselves if needed.

This change makes any previously generated IRPA files obsolete.