### PR TITLE
SDXL app: move await device to fix empty results

### DIFF
--- a/shortfin/python/shortfin_apps/sd/components/service.py
+++ b/shortfin/python/shortfin_apps/sd/components/service.py
@@ -549,8 +549,8 @@ class InferenceExecutorProcess(sf.Process):
         (cb.images,) = await fn(cb.latents, fiber=self.fiber)
         cb.images_host.copy_from(cb.images)
 
-        # The device wait needs to happen here.  Any later and image_array
-        # ends up with all 0's.
+        # Wait for the device-to-host transfer, so that we can read the
+        # data with .items.
         await device
 
         image_array = cb.images_host.items


### PR DESCRIPTION
The output array was coming out empty.  We discovered that the `await device` needs to be moved after the transfer to host but before the device array's `items` is read.