### PR TITLE
Explicitly check for None when using prefill `attn_mask`

### DIFF
--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -229,7 +229,7 @@ def main():
                 shard_count = llama_config.tensor_parallelism_size
 
                 tokens = ops.replicate(tokens, count=shard_count)
-                if attention_mask:
+                if attention_mask is not None:
                     attention_mask = ops.replicate(attention_mask, count=shard_count)
                 seq_block_ids = ops.replicate(seq_block_ids, count=shard_count)
                 cache_tensors = repack_cache(cs, cache_shard_dim)


### PR DESCRIPTION
When you attempt to implicitly null-check the attention_mask, you hit a torch error:

```bash
RuntimeError: Cannot call numel() on tensor with symbolic sizes/strides
```

Simply adding an explicit check for null fixes it, and the `--use-attention-mask` export path for prefill