### PR TITLE
[sharktank] Add common model config, export and compile

### DIFF
--- a/sharktank/sharktank/build/__init__.py
+++ b/sharktank/sharktank/build/__init__.py
@@ -1,8 +1,7 @@
-# Copyright 2024 Advanced Micro Devices, Inc.
+# Copyright 2025 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from .base import *
-from .layouts import *
+from .actions import *

--- a/sharktank/sharktank/build/actions.py
+++ b/sharktank/sharktank/build/actions.py
@@ -1,0 +1,109 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Any, Callable
+from iree.build.executor import (
+    ActionConcurrency,
+    BuildAction,
+    BuildContext,
+    BuildFile,
+    Executor,
+)
+from os import PathLike
+import importlib
+
+from ..layers import ModelConfig, get_model_type_id
+
+__all__ = ["export_model"]
+
+PickleableType = Any
+
+
+def export_model(
+    config: dict[str, PickleableType] | PathLike,
+    *,
+    concurrency: ActionConcurrency = ActionConcurrency.PROCESS,
+) -> list[BuildFile]:
+    """Export a model from config.
+    This function is meant to be used in an IREE build pipeline."""
+    if isinstance(config, dict):
+        model_config = ModelConfig.create(**config)
+    else:
+        model_config = ModelConfig.load(config)
+
+    desc = f"Export sharktank model {get_model_type_id(model_config.model_type)}"
+    if model_config.config_path is not None:
+        desc += f" with config {model_config.config_path}"
+    elif model_config.mlir_path is not None:
+        desc += f" into {model_config.mlir_path}"
+
+    context = BuildContext.current()
+    action = Action(
+        desc=desc,
+        concurrency=concurrency,
+        executor=BuildContext.current().executor,
+        thunk=Thunk(
+            export_model_thunk,
+            args=tuple(),
+            kwargs={
+                "config": config,
+                "model_python_module": str(model_config.model_type.__module__),
+            },
+        ),
+    )
+    output_file_paths = [model_config.mlir_path]
+    if model_config.parameters_path is not None:
+        output_file_paths.append(model_config.parameters_path)
+    output_files = []
+    for p in output_file_paths:
+        output_file = context.allocate_file(str(p.absolute()))
+        output_file.deps.add(action)
+        output_files.append(output_file)
+    return output_files
+
+
+def export_model_thunk(
+    config: dict[str, PickleableType] | PathLike, model_python_module: str
+):
+    from ..layers import create_model
+
+    # This is required in order for the model to get auto-registered when scheduling
+    # execution in a subprocess. Without it model creation would fail.
+    importlib.import_module(model_python_module)
+    model = create_model(config)
+    model.export()
+
+
+class Thunk:
+    def __init__(
+        self,
+        fn: Callable[..., Any],
+        *,
+        args: tuple[PickleableType, ...],
+        kwargs: dict[str, PickleableType],
+    ):
+        self.fn = fn
+        self.args = args
+        self.kwargs = kwargs
+
+    def __call__(self) -> Any:
+        return self.fn(*self.args, **self.kwargs)
+
+
+class Action(BuildAction):
+    def __init__(
+        self,
+        desc: str,
+        *,
+        concurrency: ActionConcurrency,
+        executor: Executor | None = None,
+        thunk: Thunk,
+    ):
+        super().__init__(desc=desc, executor=executor, concurrency=concurrency)
+        self.thunk = thunk
+
+    def _remotable_thunk(self):
+        return self.thunk

--- a/sharktank/sharktank/layers/__init__.py
+++ b/sharktank/sharktank/layers/__init__.py
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from .base import BaseLayer, ThetaLayer
+from .base import *
 from .conv import Conv2DLayer
 from .paged_attention import PagedAttention
 from .causal_llm import BaseCausalLMModel

--- a/sharktank/sharktank/layers/configs/__init__.py
+++ b/sharktank/sharktank/layers/configs/__init__.py
@@ -5,3 +5,4 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .llm_configs import *
+from .config import *

--- a/sharktank/sharktank/layers/configs/config.py
+++ b/sharktank/sharktank/layers/configs/config.py
@@ -1,0 +1,292 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Any, TYPE_CHECKING, ClassVar
+import os
+from os import PathLike
+import json
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from ...types.theta import load_properties
+from ...utils import tree, parse_version
+
+if TYPE_CHECKING:
+    from ..base import BaseLayer
+
+__all__ = [
+    "ExportFunctionConfig",
+    "DynamicBatchSize",
+    "ModelConfig",
+]
+
+
+class DynamicBatchSize:
+    pass
+
+
+@dataclass
+class ExportFunctionConfig:
+    function: str | None = None
+    batch_sizes: list[int | DynamicBatchSize | None] | None = None
+    """The set of batch sizes to export for.
+    The model drives what is the meaning of default values."""
+
+
+@dataclass(kw_only=True)
+class ModelConfig:
+    """Base config for common model parameters.
+    Specific model configs are meant to inherit this.
+
+    Supports loading and saving from/to json.
+    ```
+    cfg = ModelConfig.load("/path/to/some.json")
+    cfg.save("/path/to/some-other.json")
+    ```
+
+    All relative paths in a file config are relative to the config path directory if
+    specified. If not specified they are relative to current working directory.
+    After the config is loaded relative paths are made relative to CWD.
+    """
+
+    current_config_version: ClassVar[str] = "0.1.0"
+
+    model_type: type["BaseLayer"] = None
+    """The type of the model that this config is configuring.
+    This is used to dispatch to the model to create itself."""
+
+    config_path: Path | None = None
+    mlir_path: Path | None = None
+    """Export MLIR to this path."""
+    iree_module_path: Path | None = None
+
+    parameters_path: Path | None = None
+    """Load parameters from this path. IRPA, GGUF, etc."""
+    export_parameters_path: Path | None = None
+    """Location of parameters when exporting. IRPA, GGUF, etc."""
+
+    hugging_face_repo_id: str | None = None
+    hugging_face_revision: str | None = None
+    hugging_face_subfolder: str | None = None
+
+    export_functions: list[ExportFunctionConfig] | None = None
+    """function, batch size pairs that are to be exported."""
+
+    tensor_parallelism: int | None = None
+    """If specified exported model parameters will be shard."""
+
+    compile_args: list[str] | None = None
+
+    rng_seed: int | None = None
+    """Generation of random model weights would use this seed."""
+
+    def __post_init__(self):
+        assert self.model_type is not None
+        self.model_type = _get_model_type(self.model_type)
+        self.config_path = _make_optional_path(self.config_path)
+        self.mlir_path = self._config_relative_to_cwd_relative_path(self.mlir_path)
+        self.parameters_path = self._config_relative_to_cwd_relative_path(
+            self.parameters_path
+        )
+        self.iree_module_path = self._config_relative_to_cwd_relative_path(
+            self.iree_module_path
+        )
+        if self.export_functions is not None:
+            self.export_functions = [
+                export_function
+                if isinstance(export_function, ExportFunctionConfig)
+                else ExportFunctionConfig(**export_function)
+                for export_function in self.export_functions
+            ]
+
+    @classmethod
+    def create(cls, model_type: type["BaseLayer"] | str, **kwargs) -> "ModelConfig":
+        """Create a config with type associated with the model_type."""
+        model_type_cls = _get_model_type(model_type)
+        config_type = model_type_cls.config_type()
+        parsed_kwargs = config_type.parse_for_init_kwargs(
+            model_type=model_type, **kwargs
+        )
+        return config_type(**parsed_kwargs)
+
+    @classmethod
+    def load(cls, config_path: PathLike, /, **kwargs) -> "ModelConfig":
+        """Load a config from json."""
+        with open(config_path, "rb") as f:
+            config_dict = json.load(f)
+
+        config_dict["config_path"] = config_path
+        config_dict.update(kwargs)
+
+        return cls.create(**config_dict)
+
+    def save(self, config_path: PathLike | None = None, /):
+        config_path = config_path or self.config_path
+        if config_path is None:
+            raise ValueError("Could not save config, missing save path")
+        with open(config_path, "w") as f:
+            json.dump(self.asdict_for_saving(config_path), f)
+
+    def asdict_for_saving(
+        self, config_path: PathLike | None = None, /
+    ) -> dict[str, Any]:
+        """Prepares the parameters to be saved.
+        This is meant to be overridden in derived classes where
+        special handling of some values is required.
+        Here for example Path objects are made relative to the config dir and converted
+        to str."""
+        config_path = config_path or self.config_path
+        config_dir = None
+        if config_path is not None:
+            config_dir = Path(config_path).parent
+
+        res = self.asdict()
+
+        res["mlir_path"] = self._cwd_relative_to_config_relative_path(
+            res["mlir_path"], config_dir
+        )
+        res["parameters_path"] = self._cwd_relative_to_config_relative_path(
+            res["parameters_path"], config_dir
+        )
+        res["iree_module_path"] = self._cwd_relative_to_config_relative_path(
+            res["iree_module_path"], config_dir
+        )
+
+        res = {k: v for k, v in res.items() if v is not None}
+        if "config_path" in res:
+            del res["config_path"]
+
+        def map_leaf_fn(x: Any) -> Any:
+            if isinstance(x, Path):
+                return str(x)
+            return x
+
+        res = tree.map_leaves(
+            res, f=map_leaf_fn, is_leaf=tree.is_not_tuple_list_or_dict
+        )
+
+        res["config_version"] = self.current_config_version
+
+        from ..base import get_model_type_id
+
+        res["model_type"] = get_model_type_id(self.model_type)
+        return res
+
+    def asdict(self) -> dict[str, Any]:
+        """This will recurse any fields that are dataclasses and convert them."""
+        return asdict(self)
+
+    def get_compile_args(self) -> list[str]:
+        if self.compile_args is None:
+            return []
+        return self.compile_args
+
+    @classmethod
+    def translate_hugging_face_config_into_init_kwargs(
+        cls, /, repo_id: str, revision: str | None = None, subfolder: str | None = None
+    ) -> dict[str, Any]:
+        """Download and translate Hugging Face config into key-value pairs that can be
+        used to initialize a config."""
+        from huggingface_hub import hf_hub_download
+
+        resolved_file = hf_hub_download(
+            repo_id, "config.json", subfolder=subfolder, revision=revision
+        )
+        with open(resolved_file, "rb") as f:
+            return cls.translate_hugging_face_config_dict_into_init_kwargs(json.load(f))
+
+    @classmethod
+    def translate_hugging_face_config_dict_into_init_kwargs(
+        cls, properties: dict[str, Any], /
+    ) -> dict[str, Any]:
+        """Translate Hugging Face config into key-value pairs that can be used to
+        initialize a config."""
+        raise NotImplementedError()
+
+    @classmethod
+    def parse_for_init_kwargs(cls, **config_dict) -> dict[str, Any]:
+        """Prepare arguments for initialization.
+        Override in derived classes."""
+
+        cls._check_config_version(config_dict)
+        config_dict.pop("config_version")
+
+        config_path = config_dict.get("config_path", ".")
+
+        parameters_path = config_dict.get("parameters_path")
+        hugging_face_repo_id = config_dict.get("hugging_face_repo_id")
+        if parameters_path is not None and hugging_face_repo_id is not None:
+            raise ValueError(
+                f"Config values parameters_path and hugging_face_repo_id are mutually exclusive"
+            )
+
+        if parameters_path is not None:
+            config_dict_from_parameters_file = load_properties(
+                Path(config_path) / config_dict["parameters_path"]
+            )
+            config_dict_from_parameters_file.update(config_dict)
+            config_dict = config_dict_from_parameters_file
+            if "SHARK_DATASET_VERSION" in config_dict:
+                config_dict.pop("SHARK_DATASET_VERSION")
+
+        if hugging_face_repo_id is not None:
+            config_form_hf = cls.translate_hugging_face_config_into_init_kwargs(
+                config_dict["hugging_face_repo_id"],
+                revision=config_dict.get("hugging_face_revision", None),
+                subfolder=config_dict.get("hugging_face_subfolder", None),
+            )
+            config_form_hf.update(config_dict)
+            config_dict = config_form_hf
+
+        return config_dict
+
+    @classmethod
+    def _check_config_version(cls, config_dict: dict[str, Any], /):
+        """Check config version such that the config can be parsed.
+        This base class method checks config_version.
+        Specific model configs can override this and have other version filed(s) to
+        distinguish between versions."""
+
+        version = config_dict.get("config_version")
+        if version is None:
+            raise ValueError("Missing model config version.")
+        if parse_version(version) != parse_version(cls.current_config_version):
+            raise ValueError(
+                f"Could not load config with a version {version},"
+                f"expected version is {parse_version(cls.current_config_version)}"
+            )
+
+    def _config_relative_to_cwd_relative_path(
+        self, path: Path | str | None
+    ) -> Path | None:
+        if path is None:
+            return path
+        path = Path(path)
+        if path.is_absolute() or self.config_path is None:
+            return path
+        return Path(os.path.normpath(self.config_path.parent / path))
+
+    def _cwd_relative_to_config_relative_path(
+        self, path: Path | None, config_dir: Path | None = None
+    ) -> Path | None:
+        if path is None or path.is_absolute() or config_dir is None:
+            return path
+        return Path(os.path.normpath(os.path.relpath(path, config_dir)))
+
+
+def _make_optional_path(path: PathLike | None = None) -> Path | None:
+    if path is None:
+        return None
+    return Path(path)
+
+
+def _get_model_type(
+    model_type: str | type["BaseLayer"],
+) -> type["BaseLayer"]:
+    if not isinstance(model_type, str):
+        return model_type
+    from ..base import model_registry
+
+    return model_registry[model_type]

--- a/sharktank/sharktank/layers/configs/llm_configs.py
+++ b/sharktank/sharktank/layers/configs/llm_configs.py
@@ -14,13 +14,19 @@ When in question, we draw from the vocabulary and normalization they have done
 (and indeed, can bootstrap these off of GGUF files).
 """
 
+from typing import TYPE_CHECKING, ClassVar
 from dataclasses import asdict, dataclass, field, fields
 from typing import Any, Optional
 import torch
 from transformers import T5Config as T5ConfigHf
+from .config import ModelConfig
+from ...utils import parse_version
+from os import PathLike
 
 from ...types.tensors import serialized_name_to_dtype, dtype_to_serialized_name
 
+if TYPE_CHECKING:
+    import transformers
 
 __all__ = ["ClipTextConfig", "LlamaHParams", "LlamaModelConfig", "T5Config"]
 
@@ -278,8 +284,9 @@ class T5Config:
         return res
 
 
-@dataclass
-class ClipTextConfig:
+@dataclass(kw_only=True)
+class ClipTextConfig(ModelConfig):
+    current_clip_config_version: ClassVar[str] = "0.1.0"
     vocab_size: int = 49408
     hidden_size: int = 512
     intermediate_size: int = 2048
@@ -299,35 +306,54 @@ class ClipTextConfig:
     use_return_dict: bool = True
     dtype: torch.dtype = torch.float32
 
+    def __post_init__(self):
+        from ...models.clip import ClipTextModel
+
+        self.model_type = ClipTextModel
+        super().__post_init__()
+
+        self.layer_norm_eps = float(self.layer_norm_eps)
+        if isinstance(self.dtype, str):
+            self.dtype = serialized_name_to_dtype(self.dtype)
+
     @staticmethod
     def from_hugging_face_clip_text_model_config(
-        config: "transformers.CLIPTextConfig",  # type: ignore
+        config: "transformers.CLIPTextConfig",
     ) -> "ClipTextConfig":
+        from ...models.clip import ClipTextModel
+        from ..base import get_model_type_id
+
         return ClipTextConfig(
-            vocab_size=config.vocab_size,
-            hidden_size=config.hidden_size,
-            intermediate_size=config.intermediate_size,
-            projection_dim=config.projection_dim,
-            num_hidden_layers=config.num_hidden_layers,
-            num_attention_heads=config.num_attention_heads,
-            max_position_embeddings=config.max_position_embeddings,
-            hidden_act=config.hidden_act,
-            layer_norm_eps=config.layer_norm_eps,
-            pad_token_id=config.pad_token_id,
-            bos_token_id=config.bos_token_id,
-            eos_token_id=config.eos_token_id,
-            output_attentions=config.output_attentions,
-            output_hidden_states=config.output_hidden_states,
-            use_return_dict=config.use_return_dict,
-            dtype=config.torch_dtype or torch.float32,
+            model_type=get_model_type_id(ClipTextModel),
+            **ClipTextConfig.translate_hugging_face_config_dict_into_init_kwargs(
+                config.to_dict()
+            ),
         )
 
-    def to_hugging_face_clip_text_model_config(self) -> "transformers.CLIPTextConfig":  # type: ignore
-        kwargs = self.to_properties()
-        kwargs["torch_dtype"] = kwargs["dtype"]
-        del kwargs["dtype"]
-        kwargs["return_dict"] = kwargs["use_return_dict"]
-        del kwargs["use_return_dict"]
+    @classmethod
+    def translate_hugging_face_config_dict_into_init_kwargs(
+        cls, properties: dict[str, Any], /
+    ) -> dict[str, Any]:
+        architectures: list[str] = properties["architectures"]
+        if architectures is not None and architectures.count("CLIPModel") < 1:
+            raise ValueError(
+                f"Could not translate Hugging Face Clip text model config, unknown architectures {architectures}"
+            )
+        import transformers
+
+        hf_config = transformers.CLIPTextConfig(**properties)
+        res = {
+            name: getattr(hf_config, hf_name)
+            for name, hf_name in cls.get_config_name_to_hugging_face_map().items()
+        }
+        res["dtype"] = res["dtype"] or torch.float32
+        return res
+
+    def to_hugging_face_clip_text_model_config(self) -> "transformers.CLIPTextConfig":
+        kwargs = {
+            hf_name: getattr(self, name)
+            for name, hf_name in self.get_config_name_to_hugging_face_map().items()
+        }
         from transformers import CLIPTextConfig
 
         return CLIPTextConfig(**kwargs)
@@ -337,13 +363,55 @@ class ClipTextConfig:
         kwargs = dict(properties)
         if "SHARK_DATASET_VERSION" in kwargs:
             kwargs.pop("SHARK_DATASET_VERSION")
-        if "dtype" in kwargs and kwargs["dtype"] is not None:
-            kwargs["dtype"] = serialized_name_to_dtype(kwargs["dtype"])
 
         return ClipTextConfig(**kwargs)
 
-    def to_properties(self) -> dict[str, Any]:
-        res = asdict(self)
-        if self.dtype is not None:
+    def asdict_for_saving(
+        self, config_path: PathLike | None = None, /
+    ) -> dict[str, Any]:
+        res = super().asdict_for_saving(config_path)
+        if res["dtype"] == torch.float32:
+            del res["dtype"]
+        if "dtype" in res:
             res["dtype"] = dtype_to_serialized_name(self.dtype)
+        res["clip_config_version"] = self.current_clip_config_version
         return res
+
+    @classmethod
+    def get_config_name_to_hugging_face_map(cls) -> dict[str, str]:
+        return {
+            "vocab_size": "vocab_size",
+            "hidden_size": "hidden_size",
+            "intermediate_size": "intermediate_size",
+            "projection_dim": "projection_dim",
+            "num_hidden_layers": "num_hidden_layers",
+            "num_attention_heads": "num_attention_heads",
+            "max_position_embeddings": "max_position_embeddings",
+            "hidden_act": "hidden_act",
+            "layer_norm_eps": "layer_norm_eps",
+            "pad_token_id": "pad_token_id",
+            "bos_token_id": "bos_token_id",
+            "eos_token_id": "eos_token_id",
+            "output_attentions": "output_attentions",
+            "output_hidden_states": "output_hidden_states",
+            "use_return_dict": "return_dict",
+            "dtype": "torch_dtype",
+        }
+
+    @classmethod
+    def parse_for_init_kwargs(cls, **config_dict) -> dict[str, Any]:
+        config_dict = super().parse_for_init_kwargs(**config_dict)
+        cls._check_clip_config_version(config_dict)
+        config_dict.pop("clip_config_version")
+        return config_dict
+
+    @classmethod
+    def _check_clip_config_version(cls, config_dict: dict[str, Any], /):
+        version = config_dict.get("clip_config_version")
+        if version is None:
+            raise ValueError("Missing CLIP config version.")
+        if parse_version(version) != parse_version(cls.current_clip_config_version):
+            raise ValueError(
+                f"Could not load config with a CLIP config version {version},"
+                f"expected version is {parse_version(cls.current_clip_config_version)}"
+            )

--- a/sharktank/sharktank/models/clip/export_toy_text_model_iree_test_data.py
+++ b/sharktank/sharktank/models/clip/export_toy_text_model_iree_test_data.py
@@ -15,7 +15,7 @@ def main(args: Optional[list[str]] = None):
     parser = ArgumentParser(
         description=(
             "Export test data for toy-sized CLIP text model."
-            " This program MLIR, parameters sample input and expected output."
+            " This is program MLIR, parameters sample input and expected output."
             " Exports float32 and bfloat16 model variants."
             " The expected output is always in float32 precision."
         )

--- a/sharktank/sharktank/models/clip/testing.py
+++ b/sharktank/sharktank/models/clip/testing.py
@@ -7,19 +7,16 @@
 import functools
 import torch
 from os import PathLike, makedirs
-from typing import Union, Optional
-from copy import copy
-from iree.turbine.aot.params import ParameterArchiveBuilder
+from typing import Any, Optional
 
+from ...layers.configs import ExportFunctionConfig
 from ...layers.configs.llm_configs import ClipTextConfig
 from .clip import ClipTextModel
 from ...types.theta import Theta, Dataset
 from ...types.tensors import dtype_to_serialized_short_name
 from ...utils.io import save_tensor_as_irpa
 from .export import (
-    clip_text_model_to_dataset,
     hugging_face_clip_text_model_to_theta,
-    export_clip_text_model_to_iree,
 )
 from ...transforms.dataset import set_float_dtype
 
@@ -47,35 +44,33 @@ def export_clip_toy_text_model_default_iree_test_data(output_dir: PathLike):
 
     # We want to always export the same without interfering with RNG for the rest of
     # the program.
-    rng_state = torch.get_rng_state()
-    torch.random.manual_seed(12345)
+    with torch.random.fork_rng():
+        torch.random.manual_seed(12345)
 
-    reference_dtype = torch.float32
-    target_dtypes = [torch.float32, torch.bfloat16]
-    target_iree_parameters_output_paths = []
-    target_mlir_output_paths = []
-    batch_size = 4
-    for dtype in target_dtypes:
-        prefix = output_dir / f"{dtype_to_serialized_short_name(dtype)}"
-        target_iree_parameters_output_paths.append(f"{prefix}_parameters.irpa")
-        target_mlir_output_paths.append(f"{prefix}.mlir")
-    call_prefix = output_dir / f"forward_bs{batch_size}"
-    input_ids_output_path = f"{call_prefix}_arg0_input_ids.irpa"
-    expected_last_hidden_state_output_path = (
-        f"{call_prefix}_expected_result0_last_hidden_state_"
-        f"{dtype_to_serialized_short_name(reference_dtype)}.irpa"
-    )
-    export_clip_toy_text_model_iree_test_data(
-        reference_dtype=reference_dtype,
-        target_dtypes=target_dtypes,
-        batch_size=batch_size,
-        input_ids_output_path=input_ids_output_path,
-        expected_last_hidden_state_output_path=expected_last_hidden_state_output_path,
-        target_iree_parameters_output_paths=target_iree_parameters_output_paths,
-        target_mlir_output_paths=target_mlir_output_paths,
-    )
-
-    torch.set_rng_state(rng_state)
+        reference_dtype = torch.float32
+        target_dtypes = [torch.float32, torch.bfloat16]
+        target_iree_parameters_output_paths = []
+        target_mlir_output_paths = []
+        batch_size = 4
+        for dtype in target_dtypes:
+            prefix = output_dir / f"{dtype_to_serialized_short_name(dtype)}"
+            target_iree_parameters_output_paths.append(f"{prefix}_parameters.irpa")
+            target_mlir_output_paths.append(f"{prefix}.mlir")
+        call_prefix = output_dir / f"forward_bs{batch_size}"
+        input_ids_output_path = f"{call_prefix}_arg0_input_ids.irpa"
+        expected_last_hidden_state_output_path = (
+            f"{call_prefix}_expected_result0_last_hidden_state_"
+            f"{dtype_to_serialized_short_name(reference_dtype)}.irpa"
+        )
+        export_clip_toy_text_model_iree_test_data(
+            reference_dtype=reference_dtype,
+            target_dtypes=target_dtypes,
+            batch_size=batch_size,
+            input_ids_output_path=input_ids_output_path,
+            expected_last_hidden_state_output_path=expected_last_hidden_state_output_path,
+            target_iree_parameters_output_paths=target_iree_parameters_output_paths,
+            target_mlir_output_paths=target_mlir_output_paths,
+        )
 
 
 def export_clip_toy_text_model_iree_test_data(
@@ -88,11 +83,8 @@ def export_clip_toy_text_model_iree_test_data(
     expected_last_hidden_state_output_path: PathLike,
 ):
     reference_config = clip_toy_text_model_config(reference_dtype)
-    input_ids = make_random_input_token_sequences(
-        batch_size=batch_size, config=reference_config
-    )
-    reference_theta = make_clip_text_model_random_theta(reference_config)
-    reference_model = ClipTextModel(theta=reference_theta, config=reference_config)
+    reference_model = ClipTextModel(config=reference_config)
+    input_ids = reference_model.sample_inputs(batch_size=batch_size)[1]["input_ids"]
     for i, (
         target_dtype,
         target_iree_parameters_output_path,
@@ -123,6 +115,24 @@ def export_clip_toy_text_model_iree_test_data(
         )
 
 
+def clip_text_model_from_reference_model(
+    reference_model: ClipTextModel,
+    target_dtype: torch.dtype,
+    extra_config_kwargs: dict[str, Any] = {},
+) -> ClipTextModel:
+    target_config_kwargs = reference_model.config.asdict()
+    target_config_kwargs.update(extra_config_kwargs)
+    target_config = ClipTextConfig(**target_config_kwargs)
+    target_config.dtype = target_dtype
+    target_dataset = Dataset(
+        root_theta=reference_model.theta.transform(
+            functools.partial(set_float_dtype, dtype=target_dtype)
+        ),
+        properties={},
+    )
+    return ClipTextModel(theta=target_dataset.root_theta, config=target_config)
+
+
 def export_clip_text_model_iree_test_data(
     reference_model: ClipTextModel,
     target_dtype: torch.dtype,
@@ -133,22 +143,18 @@ def export_clip_text_model_iree_test_data(
     expected_last_hidden_state_output_path: Optional[PathLike] = None,
 ):
     batch_size = input_ids.shape[0]
-    reference_dataset = clip_text_model_to_dataset(reference_model)
-    target_config = copy(reference_model.config)
-    target_config.dtype = target_dtype
-    target_dataset = Dataset(
-        root_theta=reference_dataset.root_theta.transform(
-            functools.partial(set_float_dtype, dtype=target_dtype)
-        ),
-        properties=target_config.to_properties(),
+    export_functions = [ExportFunctionConfig(function=None, batch_sizes=[batch_size])]
+    target_model = clip_text_model_from_reference_model(
+        reference_model,
+        target_dtype,
+        extra_config_kwargs={
+            "config_path": None,
+            "mlir_path": target_mlir_output_path,
+            "export_parameters_path": target_iree_parameters_output_path,
+            "export_functions": export_functions,
+        },
     )
-    target_model = ClipTextModel(theta=target_dataset.root_theta, config=target_config)
-    export_clip_text_model_to_iree(
-        target_model,
-        batch_sizes=[batch_size],
-        mlir_output_path=target_mlir_output_path,
-        parameters_output_path=target_iree_parameters_output_path,
-    )
+    target_model.export()
 
     if input_ids_output_path is not None:
         save_tensor_as_irpa(input_ids, input_ids_output_path)
@@ -170,21 +176,3 @@ def make_clip_text_model_random_theta(config: ClipTextConfig) -> Theta:
     hf_config = config.to_hugging_face_clip_text_model_config()
     model = HfCLIPTextModel(hf_config)
     return hugging_face_clip_text_model_to_theta(model)
-
-
-def make_random_input_token_sequences(
-    batch_size: int, config: ClipTextConfig
-) -> torch.LongTensor:
-    sequence_lens = torch.randint(
-        low=1, high=config.max_position_embeddings + 1, size=(batch_size,)
-    )
-    sequences = torch.full(
-        size=(batch_size, config.max_position_embeddings),
-        fill_value=config.eos_token_id,
-        dtype=torch.long,
-    )
-    for batch_idx, l in enumerate(sequence_lens):
-        sequences[batch_idx][0:l] = torch.randint(
-            low=0, high=config.vocab_size - 1, size=(l,), dtype=torch.long
-        )
-    return sequences

--- a/sharktank/sharktank/models/flux/export.py
+++ b/sharktank/sharktank/models/flux/export.py
@@ -10,7 +10,7 @@ import os
 from pathlib import Path
 import torch
 
-from ...export import export_static_model_mlir
+from ...export import export_model_mlir
 from ...tools.import_hf_dataset import import_hf_dataset
 from .flux import FluxModelV1, FluxParams
 from ...types import Dataset
@@ -40,7 +40,7 @@ def export_flux_transformer_model_mlir(
 
     for t in model.theta.flatten().values():
         ExternalTensorTrait(external_name=t.name, external_scope="").set(t.as_torch())
-    export_static_model_mlir(model, output_path=output_path, batch_sizes=batch_sizes)
+    export_model_mlir(model, output_path=output_path, batch_sizes=batch_sizes)
 
 
 def export_flux_transformer_iree_parameters(

--- a/sharktank/sharktank/testing/example_builder.py
+++ b/sharktank/sharktank/testing/example_builder.py
@@ -1,0 +1,77 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import torch
+from collections import OrderedDict
+from iree.build import compile, entrypoint, iree_build_main
+import os
+from dataclasses import dataclass
+
+from ..layers import ThetaLayer, ModelConfig, LinearLayer
+from ..types import Theta, DefaultPrimitiveTensor
+from ..build import export_model
+from ..utils.testing import make_rand_torch
+
+
+@dataclass(kw_only=True)
+class ExampleModelConfig(ModelConfig):
+    in_size: int
+    out_size: int
+
+
+class ExampleModel(ThetaLayer):
+    def __init__(self, theta: Theta | None = None, config: ModelConfig | None = None):
+        super().__init__(config=config, theta=theta)
+        self.linear = LinearLayer(theta=self.theta)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x)
+
+    @classmethod
+    def config_type(cls) -> type[ModelConfig]:
+        return ExampleModelConfig
+
+    def generate_random_theta(self) -> Theta:
+        return Theta(
+            {
+                "weight": DefaultPrimitiveTensor(
+                    data=make_rand_torch(
+                        shape=[self.config.out_size, self.config.in_size]
+                    ),
+                    name="weight",
+                ),
+                "bias": DefaultPrimitiveTensor(
+                    data=make_rand_torch(shape=[1, self.config.out_size]), name="bias"
+                ),
+            }
+        )
+
+    def sample_inputs(self, batch_size: int = 1, function: str | None = None):
+        return tuple(), OrderedDict(
+            [("x", make_rand_torch(shape=[batch_size, self.config.in_size]))]
+        )
+
+
+@entrypoint(description="Pipeline to build an example model")
+def pipe():
+    export_model(
+        ExampleModelConfig(
+            model_type=ExampleModel,
+            mlir_path="model.mlir",
+            export_parameters_path="model.irpa",
+            in_size=3,
+            out_size=4,
+        ).asdict_for_saving(),
+    ),
+    # TODO: add compile action that consumes a config.
+    return compile(
+        name=f"model",
+        source=os.path.abspath("model.mlir"),
+    )
+
+
+if __name__ == "__main__":
+    iree_build_main()

--- a/sharktank/sharktank/types/gguf_interop/base.py
+++ b/sharktank/sharktank/types/gguf_interop/base.py
@@ -33,6 +33,7 @@ from . import layouts
 
 __all__ = [
     "load_file",
+    "load_properties",
 ]
 
 logger = get_logger("gguf")
@@ -161,3 +162,8 @@ def load_file(gguf_path: Union[str, os.PathLike]) -> Dataset:
         tensors[tensor.name] = gguf_tensor
     root_theta = Theta(tensors)
     return Dataset(properties=properties, root_theta=root_theta)
+
+
+def load_properties(gguf_path: Union[str, os.PathLike], /) -> dict[str, Any]:
+    reader = GGUFReader(gguf_path)
+    return _load_properties(reader)

--- a/sharktank/sharktank/utils/cli.py
+++ b/sharktank/sharktank/utils/cli.py
@@ -13,7 +13,7 @@ import logging
 from pathlib import Path
 import torch
 from ..types import Dataset
-
+from ..types import serialized_name_to_dtype
 from . import hf_datasets
 from . import tokenizer
 
@@ -36,7 +36,7 @@ def parse(parser: argparse.ArgumentParser, *, args: Sequence[str] | None = None)
         if hasattr(parsed_args, attr):
             dtype = getattr(parsed_args, attr)
             if dtype is not None:
-                dtype = getattr(torch, dtype)
+                dtype = serialized_name_to_dtype(dtype)
                 assert isinstance(dtype, torch.dtype)
             setattr(parsed_args, attr, dtype)
     return parsed_args

--- a/sharktank/sharktank/utils/misc.py
+++ b/sharktank/sharktank/utils/misc.py
@@ -7,6 +7,8 @@
 from typing import Any, Callable, List
 from collections.abc import Iterable
 from operator import eq
+import os
+from contextlib import AbstractContextManager
 
 
 def longest_equal_range(l1: List[Any], l2: List[Any]) -> int:
@@ -22,9 +24,42 @@ def iterables_equal(
     iterable1: Iterable,
     iterable2: Iterable,
     *,
-    elements_equal: Callable[[Any, Any], bool] | None = None
+    elements_equal: Callable[[Any, Any], bool] | None = None,
 ) -> bool:
     elements_equal = elements_equal or eq
     return all(
         elements_equal(v1, v2) for v1, v2 in zip(iterable1, iterable2, strict=True)
     )
+
+
+class chdir(AbstractContextManager):
+    """Context that changes the current working directory.
+
+    with chdir("/path/to/new/cwd"):
+        ...
+
+    TODO: swap with contextlib.chdir once we drop support for Python 3.10
+    """
+
+    def __init__(self, path):
+        self.path = path
+        self._old_cwd = []
+
+    def __enter__(self):
+        self._old_cwd.append(os.getcwd())
+        os.chdir(self.path)
+
+    def __exit__(self, *excinfo):
+        os.chdir(self._old_cwd.pop())
+
+
+def parse_version(v: str, /) -> tuple[int, ...]:
+    """Parse a version string into a tuple of ints.
+    E.g.
+    "1.2.3" -> (1, 2, 3)
+    "3.4" -> (3, 4, 0)
+    """
+    res = [int(num_str) for num_str in v.split(".")]
+    if len(res) < 3:
+        res += [0] * (3 - len(res))
+    return tuple(res)

--- a/sharktank/sharktank/utils/tree.py
+++ b/sharktank/sharktank/utils/tree.py
@@ -17,6 +17,10 @@ def is_leaf_default(tree: Tree) -> bool:
     return not isinstance(tree, IterableABC)
 
 
+def is_not_tuple_list_or_dict(tree: Tree) -> bool:
+    return not isinstance(tree, (tuple, list, dict))
+
+
 def map_nodes(
     tree: Tree, f: Callable[[Tree], Tree], is_leaf: IsLeaf | None = None
 ) -> Tree:
@@ -32,6 +36,22 @@ def map_nodes(
         return f({k: map_nodes(v, f, is_leaf) for k, v in tree.items()})
     else:
         return f([map_nodes(v, f, is_leaf) for v in tree])
+
+
+def map_leaves(
+    tree: Tree, f: Callable[[Tree], Tree], is_leaf: IsLeaf | None = None
+) -> Tree:
+    """Apply `f` for each leaf in the tree."""
+    if is_leaf is None:
+        is_leaf = is_leaf_default
+
+    def f_leaves_and_nodes(t: Tree) -> Tree:
+        if is_leaf(t):
+            return f(t)
+        else:
+            return t
+
+    return map_nodes(tree, f_leaves_and_nodes, is_leaf)
 
 
 def flatten(tree: Tree, is_leaf: IsLeaf | None = None) -> Sequence[Leaf]:

--- a/sharktank/tests/layers/base_test.py
+++ b/sharktank/tests/layers/base_test.py
@@ -1,0 +1,45 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from pathlib import Path
+
+from sharktank.layers.configs import ModelConfig, ExportFunctionConfig
+from sharktank.layers import BaseLayer, create_model
+from sharktank.types import Dataset, Theta
+
+
+class Model(BaseLayer):
+    def __init__(self, config: ModelConfig):
+        pass
+
+    @classmethod
+    def config_type(cls) -> type[ModelConfig]:
+        return ModelConfig
+
+
+def test_create_model_from_config(tmp_path: Path):
+    config = ModelConfig(
+        model_type=Model,
+    )
+    config_path = tmp_path / "config.json"
+    config.save(config_path)
+    model = create_model(config_path)
+    assert isinstance(model, Model)
+
+
+def test_save_load_model_config(tmp_path: Path):
+    config = ModelConfig(
+        model_type=Model,
+        config_path=f"{tmp_path / 'config.json'}",
+        mlir_path="model.mlir",
+        parameters_path="model.irpa",
+        iree_module_path="model.vmfb",
+        export_functions=[ExportFunctionConfig(function="forward", batch_sizes=[1])],
+    )
+    config.save()
+    Dataset(properties={}, root_theta=Theta(tensors={})).save(config.parameters_path)
+    config2 = ModelConfig.load(config.config_path)
+    assert config == config2

--- a/sharktank/tests/models/clip/clip_test.py
+++ b/sharktank/tests/models/clip/clip_test.py
@@ -8,17 +8,15 @@ from collections import OrderedDict
 import functools
 import iree.compiler
 import iree.runtime
-import os
+import json
 from pathlib import Path
 from parameterized import parameterized
-from copy import copy
 import logging
 import pytest
 import torch
 from torch.utils._pytree import tree_map
 from typing import Optional
 from unittest import TestCase
-import transformers
 from transformers import CLIPTextModel as HfCLIPTextModel, CLIPTokenizer
 from transformers.models.clip.modeling_clip import (
     CLIPAttention as HfCLIPAttention,
@@ -26,6 +24,7 @@ from transformers.models.clip.modeling_clip import (
     CLIPEncoder as HfCLIPEncoder,
 )
 
+import iree.runtime
 from sharktank.utils.iree import (
     with_iree_device_context,
     get_iree_devices,
@@ -39,7 +38,6 @@ from sharktank.utils.iree import (
 from sharktank.types import (
     DefaultPrimitiveTensor,
     dtype_to_serialized_short_name,
-    Dataset,
 )
 from sharktank.transforms.dataset import set_float_dtype
 from sharktank.utils.hf_datasets import get_dataset
@@ -52,17 +50,13 @@ from sharktank.utils.testing import (
     test_prompts,
 )
 from sharktank.models.clip.export import (
-    export_clip_text_model_dataset_from_hugging_face,
     hugging_face_clip_attention_to_theta,
     hugging_face_clip_encoder_layer_to_theta,
     hugging_face_clip_encoder_to_theta,
-    hugging_face_clip_text_model_to_dataset,
     hugging_face_clip_text_model_to_theta,
 )
 from sharktank.models.clip.testing import (
-    make_random_input_token_sequences,
-    make_clip_text_model_random_theta,
-    export_clip_text_model_iree_test_data,
+    clip_text_model_from_reference_model,
     clip_toy_text_model_config,
 )
 from sharktank.models.clip import (
@@ -72,6 +66,12 @@ from sharktank.models.clip import (
     ClipTextModel,
 )
 from sharktank.layers.configs.llm_configs import ClipTextConfig
+from sharktank.layers import (
+    ExportFunctionConfig,
+    ModelConfig,
+    get_model_type_id,
+    create_model,
+)
 from sharktank import ops
 
 with_clip_data = pytest.mark.skipif("not config.getoption('with_clip_data')")
@@ -92,22 +92,22 @@ class ClipTextIreeTest(TempDirTestBase):
     @with_clip_data
     @pytest.mark.expensive
     def testSmokeExportLargeF32FromHuggingFace(self):
-        huggingface_repo_id = "openai/clip-vit-large-patch14"
-        huggingface_repo_id_as_path = (
-            f"{huggingface_repo_id.replace('/', '__').replace('-', '_')}"
-        )
-        get_dataset(
-            huggingface_repo_id,
-        ).download()
-        target_dtype_name = dtype_to_serialized_short_name(torch.float32)
-        target_model_path_prefix = (
-            self.path_prefix
-            / f"{huggingface_repo_id_as_path}_text_model_{target_dtype_name}"
-        )
-        output_path = f"{target_model_path_prefix}.irpa"
-        export_clip_text_model_dataset_from_hugging_face(
-            huggingface_repo_id, output_path
-        )
+        parameters_path = self.path_prefix / "model.irpa"
+        config_dict = {
+            "model_type": get_model_type_id(ClipTextModel),
+            "config_version": ModelConfig.current_config_version,
+            "clip_config_version": ClipTextConfig.current_clip_config_version,
+            "hugging_face_repo_id": "openai/clip-vit-large-patch14",
+            "export_parameters_path": str(parameters_path),
+        }
+        config_path = self.path_prefix / "config.json"
+        with open(str(config_path), "w") as f:
+            json.dump(config_dict, f)
+
+        model: ClipTextModel = create_model(config_path)
+        parameters_path.unlink(missing_ok=True)
+        model.export_parameters()
+        assert config_path.exists()
 
     def testSmokeExportToyIreeTestData(self):
         from sharktank.models.clip.export_toy_text_model_iree_test_data import main
@@ -181,26 +181,31 @@ class ClipTextIreeTest(TempDirTestBase):
         input_args = OrderedDict([("input_ids", input_ids)])
         batch_size = input_ids.shape[0]
         mlir_path = f"{target_model_path_prefix}.mlir"
-
-        logger.info("Exporting clip text model to MLIR...")
-        export_clip_text_model_iree_test_data(
+        iree_module_path = f"{target_model_path_prefix}.vmfb"
+        export_functions = [
+            ExportFunctionConfig(function=None, batch_sizes=[batch_size])
+        ]
+        target_model = clip_text_model_from_reference_model(
             reference_model=reference_model,
             target_dtype=target_dtype,
-            input_ids=input_ids,
-            target_mlir_output_path=mlir_path,
-            target_iree_parameters_output_path=parameters_path,
+            extra_config_kwargs={
+                "config_path": None,
+                "export_functions": export_functions,
+                "mlir_path": mlir_path,
+                "export_parameters_path": parameters_path,
+                "iree_module_path": iree_module_path,
+                "compile_args": [
+                    f"--iree-hal-target-device={self.iree_hal_target_device}",
+                    f"--iree-hip-target={self.iree_hip_target}",
+                ],
+            },
         )
 
-        iree_module_path = f"{target_model_path_prefix}.vmfb"
+        logger.info("Exporting clip text model to MLIR...")
+        target_model.export()
+
         logger.info("Compiling MLIR file...")
-        iree.compiler.compile_file(
-            mlir_path,
-            output_file=iree_module_path,
-            extra_args=[
-                f"--iree-hal-target-device={self.iree_hal_target_device}",
-                f"--iree-hip-target={self.iree_hip_target}",
-            ],
-        )
+        target_model.compile()
 
         logger.info("Invoking reference torch function...")
         reference_result_dict = call_torch_module_function(
@@ -211,7 +216,7 @@ class ClipTextIreeTest(TempDirTestBase):
         )
         expected_outputs = flatten_for_iree_signature(reference_result_dict)
 
-        iree_devices = get_iree_devices(driver=self.iree_device, device_count=1)
+        iree_devices = get_iree_devices(device=self.iree_device)
 
         def run_iree_module(iree_devices: list[iree.runtime.HalDevice]):
             logger.info("Loading IREE module...")
@@ -258,11 +263,10 @@ class ClipTextIreeTest(TempDirTestBase):
         atol: float,
         file_artifact_prefix_name: str,
     ):
-        input_ids = make_random_input_token_sequences(
-            batch_size=batch_size, config=reference_config
-        )
-        reference_theta = make_clip_text_model_random_theta(reference_config)
-        reference_model = ClipTextModel(theta=reference_theta, config=reference_config)
+        reference_model = ClipTextModel(config=reference_config)
+        input_ids = reference_model.sample_inputs(batch_size=batch_size,)[
+            1
+        ]["input_ids"]
         self.runTestCompareIreeAgainstTorchEagerWithInputTokens(
             reference_model=reference_model,
             target_dtype=target_dtype,
@@ -304,13 +308,11 @@ class ClipTextIreeTest(TempDirTestBase):
         hf_model: HfCLIPTextModel = HfCLIPTextModel.from_pretrained(
             huggingface_repo_id, torch_dtype=reference_dtype
         )
-        reference_dataset = hugging_face_clip_text_model_to_dataset(hf_model)
+        reference_theta = hugging_face_clip_text_model_to_theta(hf_model)
         config = ClipTextConfig.from_hugging_face_clip_text_model_config(
             hf_model.config
         )
-        reference_model = ClipTextModel(
-            theta=reference_dataset.root_theta, config=config
-        )
+        reference_model = ClipTextModel(theta=reference_theta, config=config)
 
         tokenizer: CLIPTokenizer = CLIPTokenizer.from_pretrained(huggingface_repo_id)
         input_ids = tokenizer(
@@ -355,12 +357,11 @@ class ClipTextEagerTest(TestCase):
         )
 
         theta = hugging_face_clip_text_model_to_theta(reference_model)
-        theta.rename_tensors_to_paths()
         theta = theta.transform(functools.partial(set_float_dtype, dtype=target_dtype))
         config = ClipTextConfig.from_hugging_face_clip_text_model_config(
             reference_model.config
         )
-        model = ClipTextModel(theta, config)
+        model = ClipTextModel(theta=theta, config=config)
 
         tokenizer: CLIPTokenizer = CLIPTokenizer.from_pretrained(
             huggingface_repo_id,
@@ -433,12 +434,11 @@ class ClipTextEagerTest(TestCase):
         reference_model.eval()
 
         theta = hugging_face_clip_text_model_to_theta(reference_model)
-        theta.rename_tensors_to_paths()
         theta = theta.transform(functools.partial(set_float_dtype, dtype=target_dtype))
         config = ClipTextConfig.from_hugging_face_clip_text_model_config(
             reference_config
         )
-        model = ClipTextModel(theta, config)
+        model = ClipTextModel(theta=theta, config=config)
 
         input_ids = torch.randint(
             low=0, high=vocab_size, size=[batch_size, config.max_position_embeddings]


### PR DESCRIPTION
We don't have a standard way to configure, export and compile sharktank models.

Here is introduced such mechanism and for demonstration the CLIP text model is refactored to utilize this new approach.

`config.json`:
```
{
    "model_type": "my_package.MyModel",
    "mlir_path": "model.mlir",
    "parameters_path": "model.irpa",
    "iree_module_path": "model.vmfb",
    "compile_args": ["--iree-hal-target-device=local"],
    "export_functions": [
        {
            "function": "forward",
            "batch_sizes": [1, 2, 3]
        }
    ]
    "my_model_arg": 5,
}
```

usage
```
model = create_model("config.json")
model.export()
model.compile()
```