### PR TITLE
[tuner] add default attribute to tuning spec

### DIFF
--- a/tuner/tuner/spec_builder.py
+++ b/tuner/tuner/spec_builder.py
@@ -18,7 +18,7 @@ from .op_matchers import ROOT_OP_ATTR_NAME
 
 def get_placeholder_spec(context: ir.Context) -> ir.Module:
     spec_text = f"""
-        module attributes {{ transform.with_named_sequence }} {{
+        module attributes {{ transform.with_named_sequence, iree_codegen.tuning_spec_with_default_entrypoint }} {{
             transform.named_sequence
             @__kernel_config(%variant_op: !transform.any_op {{transform.readonly}}) -> !transform.any_op
                 attributes {{ iree_codegen.tuning_spec_entrypoint }} {{
@@ -76,7 +76,7 @@ def build_td_spec(
         captured_values.add(operand)
     bbargs_str = ", ".join(bbargs)
     spec_text = f"""
-        module attributes {{ transform.with_named_sequence }} {{
+        module attributes {{ transform.with_named_sequence, iree_codegen.tuning_spec_with_default_entrypoint }} {{
             // Annotation Transform
             transform.named_sequence @apply_op_config(%op: !transform.any_op {{transform.readonly}},
                                                         %config: !transform.any_param {{transform.readonly}}) {{


### PR DESCRIPTION
This PR adds the default attribute `iree_codegen.tuning_spec_with_default_entrypoint` to the generated tuning spec. 

fixes #816