### PR TITLE
[sharktank] Add exporting of sharded toy sized Resnet block IREE test data

### DIFF
--- a/sharktank/sharktank/models/clip/export_toy_text_model_iree_test_data.py
+++ b/sharktank/sharktank/models/clip/export_toy_text_model_iree_test_data.py
@@ -15,7 +15,7 @@ def main(args: Optional[list[str]] = None):
     parser = ArgumentParser(
         description=(
             "Export test data for toy-sized CLIP text model."
-            " This is program MLIR, parameters sample input and expected output."
+            " This includes the program MLIR, parameters, sample input and expected output."
             " Exports float32 and bfloat16 model variants."
             " The expected output is always in float32 precision."
         )

--- a/sharktank/sharktank/models/punet/export_sharded_toy_resnet_block_iree_test_data.py
+++ b/sharktank/sharktank/models/punet/export_sharded_toy_resnet_block_iree_test_data.py
@@ -1,0 +1,37 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from argparse import ArgumentParser
+from typing import Optional
+from pathlib import Path
+import torch
+
+from .testing import export_sharded_toy_resnet_block_iree_test_data
+
+
+def main(args: Optional[list[str]] = None):
+    parser = ArgumentParser(
+        description=(
+            "Export test data for toy-sized Resnet block."
+            " This includes the program MLIR, parameters, sample input and expected output."
+            " Exports a float32 model variant."
+            " The expected output is in float64 precision."
+        )
+    )
+    parser.add_argument("--output-dir", type=str, default=".")
+    args = parser.parse_args(args=args)
+    output_dir = Path(args.output_dir)
+    export_sharded_toy_resnet_block_iree_test_data(
+        mlir_path=output_dir / "model.mlir",
+        parameters_path=output_dir / "model.irpa",
+        input_args_path=output_dir / "input_args.irpa",
+        expected_results_path=output_dir / "expected_results.irpa",
+        target_dtype=torch.float32,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/sharktank/sharktank/models/punet/testing.py
+++ b/sharktank/sharktank/models/punet/testing.py
@@ -4,20 +4,20 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from typing import Any, List
-from pathlib import Path
-import torch
-import functools
 from iree.turbine import aot
-
-from sharktank.types.tensors import *
-from sharktank.types.theta import Theta, Dataset
-from sharktank.utils.testing import make_rand_torch
+from pathlib import Path
+from sharktank import ops
 from sharktank.models.punet.layers import ResnetBlock2D
 from sharktank.models.punet.sharding import ResnetBlock2DSplitOutputChannelsSharding
-from sharktank import ops
 from sharktank.transforms.dataset import set_float_dtype
+from sharktank.types.tensors import *
+from sharktank.types.theta import Theta, Dataset
 from sharktank.utils.iree import flatten_for_iree_signature
+from sharktank.utils.testing import make_rand_torch
+from typing import Any, List
+
+import functools
+import torch
 
 
 def make_conv2d_layer_theta(

--- a/sharktank/sharktank/models/punet/testing.py
+++ b/sharktank/sharktank/models/punet/testing.py
@@ -4,12 +4,20 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from typing import List
-
+from typing import Any, List
+from pathlib import Path
 import torch
+import functools
+from iree.turbine import aot
 
 from sharktank.types.tensors import *
-from sharktank.types.theta import Theta
+from sharktank.types.theta import Theta, Dataset
+from sharktank.utils.testing import make_rand_torch
+from sharktank.models.punet.layers import ResnetBlock2D
+from sharktank.models.punet.sharding import ResnetBlock2DSplitOutputChannelsSharding
+from sharktank import ops
+from sharktank.transforms.dataset import set_float_dtype
+from sharktank.utils.iree import flatten_for_iree_signature
 
 
 def make_conv2d_layer_theta(
@@ -22,16 +30,18 @@ def make_conv2d_layer_theta(
     return Theta(
         {
             "weight": DefaultPrimitiveTensor(
-                data=torch.rand(
-                    out_channels,
-                    in_channels,
-                    kernel_height,
-                    kernel_width,
+                data=make_rand_torch(
+                    shape=[
+                        out_channels,
+                        in_channels,
+                        kernel_height,
+                        kernel_width,
+                    ],
                     dtype=dtype,
                 )
             ),
             "bias": DefaultPrimitiveTensor(
-                data=torch.rand(out_channels, dtype=dtype),
+                data=make_rand_torch(shape=[out_channels], dtype=dtype),
             ),
         }
     )
@@ -48,10 +58,10 @@ def make_resnet_block_2d_theta(
     return Theta(
         {
             "norm1.weight": DefaultPrimitiveTensor(
-                data=torch.rand(in_channels, dtype=dtype)
+                data=make_rand_torch(shape=[in_channels], dtype=dtype)
             ),
             "norm1.bias": DefaultPrimitiveTensor(
-                data=torch.rand(in_channels, dtype=dtype)
+                data=make_rand_torch(shape=[in_channels], dtype=dtype)
             ),
             "conv1": make_conv2d_layer_theta(
                 in_channels=in_channels,
@@ -61,10 +71,10 @@ def make_resnet_block_2d_theta(
                 dtype=dtype,
             ).tree,
             "norm2.weight": DefaultPrimitiveTensor(
-                data=torch.rand(out_channels[0], dtype=dtype)
+                data=make_rand_torch(shape=[out_channels[0]], dtype=dtype)
             ),
             "norm2.bias": DefaultPrimitiveTensor(
-                data=torch.rand(out_channels[0], dtype=dtype)
+                data=make_rand_torch(shape=[out_channels[0]], dtype=dtype)
             ),
             "conv2": make_conv2d_layer_theta(
                 in_channels=out_channels[0],
@@ -74,10 +84,12 @@ def make_resnet_block_2d_theta(
                 dtype=dtype,
             ).tree,
             "time_emb_proj.weight": DefaultPrimitiveTensor(
-                data=torch.rand(out_channels[0], input_time_emb_channels, dtype=dtype),
+                data=make_rand_torch(
+                    shape=[out_channels[0], input_time_emb_channels], dtype=dtype
+                ),
             ),
             "time_emb_proj.bias": DefaultPrimitiveTensor(
-                data=torch.rand(out_channels[0], dtype=dtype),
+                data=make_rand_torch(shape=[out_channels[0]], dtype=dtype),
             ),
             "conv_shortcut": make_conv2d_layer_theta(
                 in_channels=in_channels,
@@ -139,3 +151,131 @@ def make_up_down_block_2d_theta(
         dtype=dtype,
     ).tree
     return Theta(res)
+
+
+def toy_size_sharded_resnet_block_config() -> dict[str, Any]:
+    batch_size = 2
+    return {
+        "batch_size": 2,
+        "in_channels": 6,
+        "out_channels": [12, 8],
+        "height": 11,
+        "width": 13,
+        "kernel_height": 5,
+        "kernel_width": 5,
+        "temb_channels": 8,
+        "norm_groups": 2,
+        "eps": 0.01,
+        "shard_count": 2,
+        "non_linearity": "relu",
+        "dropout": 0.0,
+        "output_scale_factor": None,
+    }
+
+
+def export_sharded_toy_resnet_block_iree_test_data(
+    mlir_path: Path,
+    parameters_path: Path,
+    input_args_path: Path,
+    expected_results_path: Path,
+    target_dtype: torch.dtype,
+    reference_dtype: torch.dtype = torch.float64,
+    shard_count: int = 2,
+):
+    with torch.random.fork_rng():
+        torch.manual_seed(12345)
+        config = toy_size_sharded_resnet_block_config()
+        reference_theta = make_resnet_block_2d_theta(
+            in_channels=config["in_channels"],
+            out_channels=config["out_channels"],
+            kernel_height=config["kernel_height"],
+            kernel_width=config["kernel_width"],
+            input_time_emb_channels=config["temb_channels"],
+            dtype=reference_dtype,
+        )
+        reference_theta.rename_tensors_to_paths()
+
+        reference_input_image = torch.rand(
+            config["batch_size"],
+            config["in_channels"],
+            config["height"],
+            config["width"],
+            dtype=reference_dtype,
+        )
+        reference_input_time_emb = torch.rand(
+            config["batch_size"], config["temb_channels"], dtype=reference_dtype
+        )
+
+        reference_resnet_block = ResnetBlock2D(
+            theta=reference_theta,
+            groups=config["norm_groups"],
+            eps=config["eps"],
+            non_linearity=config["non_linearity"],
+            output_scale_factor=config["output_scale_factor"],
+            dropout=config["dropout"],
+            temb_channels=config["temb_channels"],
+            time_embedding_norm="default",
+        )
+
+        unsharded_theta = reference_theta.transform(
+            functools.partial(set_float_dtype, dtype=target_dtype)
+        )
+        sharding_spec = ResnetBlock2DSplitOutputChannelsSharding(
+            shard_count=shard_count
+        )
+        sharded_theta = ops.reshard(unsharded_theta, sharding_spec)
+        sharded_dataset = Dataset({}, sharded_theta)
+        sharded_dataset.save(parameters_path)
+        sharded_dataset = Dataset.load(parameters_path)
+        sharded_theta = sharded_dataset.root_theta
+
+        sharded_resnet_block = ResnetBlock2D(
+            theta=sharded_theta,
+            groups=config["norm_groups"],
+            eps=config["eps"],
+            non_linearity=config["non_linearity"],
+            output_scale_factor=config["output_scale_factor"],
+            dropout=config["dropout"],
+            temb_channels=config["temb_channels"],
+            time_embedding_norm="default",
+        )
+
+        input_image = reference_input_image.to(dtype=target_dtype)
+        input_time_emb = reference_input_time_emb.to(dtype=target_dtype)
+        sharded_input_image = ops.reshard_split(input_image, dim=1, count=shard_count)
+        sharded_input_time_emb = ops.replicate(input_time_emb, count=shard_count)
+
+        args = (
+            sharded_input_image,
+            sharded_input_time_emb,
+        )
+        exported_resnet_block = aot.export(sharded_resnet_block, args=args)
+        exported_resnet_block.save_mlir(mlir_path)
+
+        expected_result = reference_resnet_block(
+            reference_input_image, reference_input_time_emb
+        )
+        expected_result = ops.reshard_split(expected_result, dim=1, count=shard_count)
+
+        iree_args = flatten_for_iree_signature(args)
+        iree_expected_results = flatten_for_iree_signature(expected_result)
+
+        iree_args_thata = Theta(
+            {
+                f"{i}": DefaultPrimitiveTensor(name=f"{i}", data=iree_args[i])
+                for i in range(len(iree_args))
+            }
+        )
+        iree_expected_results_theta = Theta(
+            {
+                f"{i}": DefaultPrimitiveTensor(
+                    name=f"{i}", data=iree_expected_results[i]
+                )
+                for i in range(len(iree_expected_results))
+            }
+        )
+
+        Dataset(root_theta=iree_args_thata, properties={}).save(input_args_path)
+        Dataset(root_theta=iree_expected_results_theta, properties={}).save(
+            expected_results_path
+        )

--- a/sharktank/tests/models/punet/resnet_test.py
+++ b/sharktank/tests/models/punet/resnet_test.py
@@ -18,69 +18,76 @@ from sharktank import ops
 
 class ResnetBlockTest(unittest.TestCase):
     def testResnetBlock2DSplitInputAndOutputChannelsSharding(self):
-        torch.set_default_dtype(torch.float32)
-        batches = 2
-        in_channels = 6
-        out_channels = [12, 8]
-        height = 11
-        width = 13
-        kernel_height = 5
-        kernel_width = 5
-        input_time_emb_shape = [batches, 8]
-        norm_groups = 2
-        eps = 0.01
-        shard_count = 2
-        theta = make_resnet_block_2d_theta(
-            in_channels=in_channels,
-            out_channels=out_channels,
-            kernel_height=kernel_height,
-            kernel_width=kernel_width,
-            input_time_emb_channels=input_time_emb_shape[1],
-        )
-        resnet_block = ResnetBlock2D(
-            theta=theta,
-            groups=norm_groups,
-            eps=eps,
-            non_linearity="relu",
-            output_scale_factor=None,
-            dropout=0.0,
-            temb_channels=input_time_emb_shape[1],
-            time_embedding_norm="default",
-        )
-        input_image = torch.rand(
-            batches,
-            in_channels,
-            height,
-            width,
-        )
-        input_time_emb = torch.rand(input_time_emb_shape)
-        expected_result = resnet_block(input_image, input_time_emb)
+        with torch.random.fork_rng():
+            torch.random.manual_seed(12345)
+            torch.set_default_dtype(torch.float32)
+            batches = 2
+            in_channels = 6
+            out_channels = [12, 8]
+            height = 11
+            width = 13
+            kernel_height = 5
+            kernel_width = 5
+            input_time_emb_shape = [batches, 8]
+            norm_groups = 2
+            eps = 0.01
+            shard_count = 2
+            theta = make_resnet_block_2d_theta(
+                in_channels=in_channels,
+                out_channels=out_channels,
+                kernel_height=kernel_height,
+                kernel_width=kernel_width,
+                input_time_emb_channels=input_time_emb_shape[1],
+            )
+            resnet_block = ResnetBlock2D(
+                theta=theta,
+                groups=norm_groups,
+                eps=eps,
+                non_linearity="relu",
+                output_scale_factor=None,
+                dropout=0.0,
+                temb_channels=input_time_emb_shape[1],
+                time_embedding_norm="default",
+            )
+            input_image = torch.rand(
+                batches,
+                in_channels,
+                height,
+                width,
+            )
+            input_time_emb = torch.rand(input_time_emb_shape)
+            expected_result = resnet_block(input_image, input_time_emb)
 
-        sharding_spec = ResnetBlock2DSplitOutputChannelsSharding(
-            shard_count=shard_count
-        )
-        sharded_theta = ops.reshard(theta, sharding_spec)
-        sharded_resnet_block = ResnetBlock2D(
-            theta=sharded_theta,
-            groups=norm_groups,
-            eps=eps,
-            non_linearity="relu",
-            output_scale_factor=None,
-            dropout=0.0,
-            temb_channels=input_time_emb_shape[1],
-            time_embedding_norm="default",
-        )
-        sharded_input_image = ops.reshard_split(input_image, dim=1, count=shard_count)
-        sharded_input_time_emb = ops.replicate(input_time_emb, count=shard_count)
-        sharded_result = sharded_resnet_block(
-            sharded_input_image, sharded_input_time_emb
-        )
-        assert isinstance(sharded_result, SplitPrimitiveTensor)
-        assert (
-            sharded_result.shard_dim == 1 and sharded_result.shard_count == shard_count
-        )
-        actual_result = ops.unshard(sharded_result)
-        torch.testing.assert_close(expected_result, actual_result)
+            sharding_spec = ResnetBlock2DSplitOutputChannelsSharding(
+                shard_count=shard_count
+            )
+            sharded_theta = ops.reshard(theta, sharding_spec)
+            sharded_resnet_block = ResnetBlock2D(
+                theta=sharded_theta,
+                groups=norm_groups,
+                eps=eps,
+                non_linearity="relu",
+                output_scale_factor=None,
+                dropout=0.0,
+                temb_channels=input_time_emb_shape[1],
+                time_embedding_norm="default",
+            )
+            sharded_input_image = ops.reshard_split(
+                input_image, dim=1, count=shard_count
+            )
+            sharded_input_time_emb = ops.replicate(input_time_emb, count=shard_count)
+            sharded_result = sharded_resnet_block(
+                sharded_input_image, sharded_input_time_emb
+            )
+            assert isinstance(sharded_result, SplitPrimitiveTensor)
+            assert (
+                sharded_result.shard_dim == 1
+                and sharded_result.shard_count == shard_count
+            )
+            actual_result = ops.unshard(sharded_result)
+            torch.testing.assert_close(
+                expected_result, actual_result, rtol=0, atol=5e-4
+            )
 
 
 if __name__ == "__main__":

--- a/sharktank/tests/models/punet/sharded_resnet_block_with_iree_test.py
+++ b/sharktank/tests/models/punet/sharded_resnet_block_with_iree_test.py
@@ -6,25 +6,28 @@
 
 import pytest
 import sys
-
+import iree.runtime
+from typing import List
 from pathlib import Path
 import tempfile
-
 import torch
+import iree.compiler
+import gc
 
-
-from iree.turbine import aot
-from sharktank.models.punet.testing import make_resnet_block_2d_theta
-from sharktank.models.punet.layers import ResnetBlock2D
-from sharktank.models.punet.sharding import ResnetBlock2DSplitOutputChannelsSharding
-from sharktank import ops
+from sharktank.models.punet.testing import (
+    export_sharded_toy_resnet_block_iree_test_data,
+)
 from sharktank.types import *
-from sharktank.utils.iree import with_iree_device_context
-import iree.runtime
-from typing import List, Optional
-import os
+from sharktank import ops
 
-vm_context: iree.runtime.VmContext = None
+from sharktank.utils.iree import (
+    with_iree_device_context,
+    get_iree_devices,
+    load_iree_module,
+    run_iree_module_function,
+    prepare_iree_module_function_args,
+    iree_to_torch,
+)
 
 
 def get_compiler_args(target_device_kind: str, shard_count: int) -> List[str]:
@@ -32,247 +35,98 @@ def get_compiler_args(target_device_kind: str, shard_count: int) -> List[str]:
         f"--iree-hal-target-device={target_device_kind}[{i}]"
         for i in range(shard_count)
     ]
-    if target_device_kind == "local":
-        result.append("--iree-hal-local-target-device-backends=llvm-cpu")
+    result += [
+        "--iree-hal-local-target-device-backends=llvm-cpu",
+        "--iree-llvmcpu-target-cpu=host",
+    ]
     return result
 
 
-def compile_iree_module(
-    export_output: aot.ExportOutput, module_path: str, shard_count: int
-):
-    export_output.session.set_flags(
-        *get_compiler_args(target_device_kind="local", shard_count=shard_count)
+def compile_iree_module(mlir_path: str, module_path: str, shard_count: int):
+    iree.compiler.compile_file(
+        mlir_path,
+        output_file=module_path,
+        extra_args=get_compiler_args(
+            target_device_kind="local", shard_count=shard_count
+        ),
     )
-    export_output.compile(save_to=module_path, target_backends=None)
 
 
-# TODO: improve IREE's Python API to be more concise in a multi-device context.
-# This run function should be way shorter.
-def run_iree_module(
-    sharded_input_image: ShardedTensor,
-    sharded_input_time_emb: ShardedTensor,
-    module_path: str,
-    parameters_path: str,
-) -> ShardedTensor:
-    assert sharded_input_image.shard_count == sharded_input_time_emb.shard_count
-    shard_count = sharded_input_image.shard_count
-    hal_driver = iree.runtime.get_driver("local-task")
-    vm_instance = iree.runtime.VmInstance()
-    available_devices = hal_driver.query_available_devices()
-    # Use the same actual device for all devices.
-    devices = [
-        hal_driver.create_device(available_devices[0]) for _ in range(shard_count)
+def run_test_toy_size_sharded_resnet_block_with_iree(artifacts_dir: Path):
+    mlir_path = artifacts_dir / "model.mlir"
+    module_path = artifacts_dir / "model.vmfb"
+    parameters_path = artifacts_dir / "model.irpa"
+    input_args_path = artifacts_dir / "input_args.irpa"
+    expected_results_path = artifacts_dir / "expected_results.irpa"
+
+    target_dtype = torch.float32
+    shard_count = 2
+    export_sharded_toy_resnet_block_iree_test_data(
+        mlir_path=mlir_path,
+        parameters_path=parameters_path,
+        input_args_path=input_args_path,
+        expected_results_path=expected_results_path,
+        target_dtype=target_dtype,
+        shard_count=shard_count,
+    )
+
+    compile_iree_module(
+        mlir_path=str(mlir_path),
+        module_path=str(module_path),
+        shard_count=shard_count,
+    )
+
+    input_args = Dataset.load(input_args_path).root_theta.flatten()
+    expected_results = Dataset.load(expected_results_path).root_theta.flatten()
+
+    input_args = [input_args[f"{i}"] for i in range(len(input_args))]
+    expected_results = [
+        unbox_tensor(expected_results[f"{i}"]) for i in range(len(expected_results))
     ]
 
-    def run_iree_module(devices: list[iree.runtime.HalDevice]):
-        hal_module = iree.runtime.create_hal_module(
-            instance=vm_instance, devices=devices
-        )
-        params_path = Path(parameters_path)
-        # TODO: make IREE able to load the parameters from the top parameter file
-        # without having to specify the parameter file for each shard separately.
-        parameter_index = iree.runtime.ParameterIndex()
-        for i in range(shard_count):
-            parameter_index.load(
-                file_path=str(
-                    Path(params_path).with_suffix(f".rank{i}{params_path.suffix}")
-                )
-            )
-        parameter_provider = parameter_index.create_provider(scope="model")
-        parameters_module = iree.runtime.create_io_parameters_module(
-            vm_instance, parameter_provider
-        )
+    iree_devices = get_iree_devices(driver="local-task", device_count=shard_count)
 
-        vm_module = iree.runtime.VmModule.mmap(vm_instance, str(module_path))
-
-        # The context needs to be destroyed after the buffers, although
-        # it is not associate with them on the API level.
-        global vm_context
-        vm_context = iree.runtime.VmContext(
-            instance=vm_instance, modules=(hal_module, parameters_module, vm_module)
-        )
-        module_input_args = [
-            iree.runtime.asdevicearray(
-                devices[i], sharded_input_image.shards[i].as_torch().to("cpu").numpy()
-            )
-            for i in range(shard_count)
-        ]
-        module_input_args += [
-            iree.runtime.asdevicearray(
-                devices[i],
-                sharded_input_time_emb.shards[i].as_torch().to("cpu").numpy(),
-            )
-            for i in range(shard_count)
-        ]
-
-        vm_function = vm_module.lookup_function("main")
-        invoker = iree.runtime.FunctionInvoker(
-            vm_context=vm_context,
-            # TODO: rework iree.runtime.FunctionInvoker interface for multiple devices.
-            # This works, but does not look right.
-            device=devices[0],
-            vm_function=vm_function,
-        )
-        results = invoker(*module_input_args)
-        shards = [torch.tensor(tensor.to_host()).clone() for tensor in results]
-        return SplitPrimitiveTensor(ts=shards, shard_dim=1)
-
-    return with_iree_device_context(run_iree_module, devices)
-
-
-def run_test_sharded_resnet_block_with_iree(
-    mlir_path: Path, module_path: Path, parameters_path: Path, caching: bool
-):
-    torch.set_default_dtype(torch.float32)
-    batches = 2
-    in_channels = 6
-    out_channels = [12, 8]
-    height = 11
-    width = 13
-    kernel_height = 5
-    kernel_width = 5
-    input_time_emb_shape = [batches, 8]
-    norm_groups = 2
-    eps = 0.01
-    shard_count = 2
-
-    torch.manual_seed(123456)
-
-    input_image = torch.rand(
-        batches,
-        in_channels,
-        height,
-        width,
-    )
-    input_time_emb = torch.rand(input_time_emb_shape)
-
-    unsharded_theta = make_resnet_block_2d_theta(
-        in_channels=in_channels,
-        out_channels=out_channels,
-        kernel_height=kernel_height,
-        kernel_width=kernel_width,
-        input_time_emb_channels=input_time_emb_shape[1],
-    )
-    unsharded_theta.rename_tensors_to_paths()
-
-    if not caching or not os.path.exists(parameters_path):
-        sharding_spec = ResnetBlock2DSplitOutputChannelsSharding(
-            shard_count=shard_count
-        )
-        sharded_theta = ops.reshard(unsharded_theta, sharding_spec)
-
-        # Roundtrip the dataset, which anchors the tensors as parameters to be loaded
-        # vs constants to be frozen (TODO: This is a bit wonky).
-        sharded_dataset = Dataset({}, sharded_theta)
-        sharded_dataset.save(parameters_path)
-
-    sharded_dataset = Dataset.load(parameters_path)
-
-    sharded_resnet_block = ResnetBlock2D(
-        theta=sharded_dataset.root_theta,
-        groups=norm_groups,
-        eps=eps,
-        non_linearity="relu",
-        output_scale_factor=None,
-        dropout=0.0,
-        temb_channels=input_time_emb_shape[1],
-        time_embedding_norm="default",
-    )
-    sharded_input_image = ops.reshard_split(input_image, dim=1, count=shard_count)
-    sharded_input_time_emb = ops.replicate(input_time_emb, count=shard_count)
-    expected_result = sharded_resnet_block(sharded_input_image, sharded_input_time_emb)
-
-    # Verify as a sanity check that the sharded torch model matches the result
-    # of the unsharded torch model.
-    unsharded_resnet_block = ResnetBlock2D(
-        theta=unsharded_theta,
-        groups=norm_groups,
-        eps=eps,
-        non_linearity="relu",
-        output_scale_factor=None,
-        dropout=0.0,
-        temb_channels=input_time_emb_shape[1],
-        time_embedding_norm="default",
-    )
-    unsharded_result = unsharded_resnet_block(input_image, input_time_emb)
-    torch.testing.assert_close(unsharded_result, ops.unshard(expected_result))
-
-    if not caching or not os.path.exists(module_path):
-        exported_resnet_block = aot.export(
-            sharded_resnet_block,
-            args=(
-                sharded_input_image,
-                sharded_input_time_emb,
-            ),
-        )
-        exported_resnet_block.save_mlir(mlir_path)
-
-        compile_iree_module(
-            export_output=exported_resnet_block,
+    def run_iree_module(iree_devices: list[iree.runtime.HalDevice]):
+        iree_module, iree_vm_context, iree_vm_instance = load_iree_module(
             module_path=module_path,
-            shard_count=shard_count,
+            devices=iree_devices,
+            parameters_path=parameters_path,
         )
-
-    actual_result = run_iree_module(
-        sharded_input_image=sharded_input_image,
-        sharded_input_time_emb=sharded_input_time_emb,
-        module_path=module_path,
-        parameters_path=parameters_path,
-    )
-    assert len(actual_result.shards) == len(expected_result.shards)
-    # TODO: reenable this test once numerical issues are resolved.
-    # The absolute accuracy is > 0.00042. Is this good enough?
-    # Maybe add a test with fp64, where if the accuracy is high would give us more
-    # confidence that fp32 is also OK.
-    for actual_shard, expected_shard in zip(
-        actual_result.shards, expected_result.shards
-    ):
-        torch.testing.assert_close(
-            unbox_tensor(actual_shard), unbox_tensor(expected_shard)
+        iree_args = prepare_iree_module_function_args(
+            args=input_args, devices=iree_devices
         )
+        iree_results = iree_to_torch(
+            *run_iree_module_function(
+                module=iree_module,
+                vm_context=iree_vm_context,
+                args=iree_args,
+                device=iree_devices[0],
+                function_name=f"main",
+            )
+        )
+        return [
+            ops.to(iree_results[i], dtype=expected_results[i].dtype).clone()
+            for i in range(len(expected_results))
+        ]
 
-    global vm_context
-    del vm_context
+    actual_outputs = with_iree_device_context(run_iree_module, iree_devices)
+
+    # Observed atol is 1e-5.
+    torch.testing.assert_close(actual_outputs, expected_results, rtol=0, atol=5e-5)
 
 
-@pytest.mark.xfail(
-    reason="Maybe numerical issues with low accuracy.",
-    strict=True,
-    raises=AssertionError,
-)
 @pytest.mark.xfail(
     torch.__version__ >= (2, 5), reason="https://github.com/nod-ai/shark-ai/issues/683"
 )
 @pytest.mark.skipif(
     sys.platform == "win32", reason="https://github.com/nod-ai/shark-ai/issues/698"
 )
-def test_sharded_resnet_block_with_iree(
-    mlir_path: Optional[Path],
-    module_path: Optional[Path],
-    parameters_path: Optional[Path],
-    caching: bool,
-):
+def test_toy_size_sharded_resnet_block_with_iree():
     """Test sharding, exportation and execution with IREE local-task of a Resnet block.
     The result is compared against execution with torch.
     The model is tensor sharded across 2 devices.
     """
 
-    with tempfile.TemporaryDirectory(
-        # TODO: verify hypothesis and remove ignore_cleanup_errors=True
-        # torch.export.export is spawning some processes that don't exit when the
-        # function returns, this causes some objects to not get destroyed, which
-        # in turn holds files params.rank0.irpa and params.rank1.irpa open.
-        ignore_cleanup_errors=True
-    ) as tmp_dir:
-        mlir_path = Path(tmp_dir) / "model.mlir" if mlir_path is None else mlir_path
-        module_path = (
-            Path(tmp_dir) / "module.vmfb" if module_path is None else module_path
-        )
-        parameters_path = (
-            Path(tmp_dir) / "params.irpa"
-            if parameters_path is None
-            else parameters_path
-        )
-        run_test_sharded_resnet_block_with_iree(
-            mlir_path, module_path, parameters_path, caching
-        )
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        run_test_toy_size_sharded_resnet_block_with_iree(artifacts_dir=Path(tmp_dir))
+        gc.collect()

--- a/sharktank/tests/models/punet/sharded_resnet_block_with_iree_test.py
+++ b/sharktank/tests/models/punet/sharded_resnet_block_with_iree_test.py
@@ -4,30 +4,29 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import gc
+import iree.compiler
+import iree.runtime
 import pytest
 import sys
-import iree.runtime
-from typing import List
-from pathlib import Path
 import tempfile
 import torch
-import iree.compiler
-import gc
 
+from pathlib import Path
+from sharktank import ops
 from sharktank.models.punet.testing import (
     export_sharded_toy_resnet_block_iree_test_data,
 )
 from sharktank.types import *
-from sharktank import ops
-
 from sharktank.utils.iree import (
-    with_iree_device_context,
     get_iree_devices,
-    load_iree_module,
-    run_iree_module_function,
-    prepare_iree_module_function_args,
     iree_to_torch,
+    load_iree_module,
+    prepare_iree_module_function_args,
+    run_iree_module_function,
+    with_iree_device_context,
 )
+from typing import List
 
 
 def get_compiler_args(target_device_kind: str, shard_count: int) -> List[str]:

--- a/sharktank/tests/models/punet/up_down_block_test.py
+++ b/sharktank/tests/models/punet/up_down_block_test.py
@@ -26,118 +26,122 @@ class UpBlock2DTest(unittest.TestCase):
         ]
     )
     def testUpDownBlock2DSplitInputAndOutputChannelsSharding(self, is_up_block: bool):
-        torch.set_default_dtype(torch.float32)
-        batches = 2
-        channels = 12
-        height = 11
-        width = 13
-        kernel_height = 5
-        kernel_width = 5
-        input_time_emb_shape = [batches, channels]
-        norm_groups = 2
-        eps = 0.01
-        shard_count = 2
-        resnet_layers = 2
-        theta = make_up_down_block_2d_theta(
-            channels=channels,
-            kernel_height=kernel_height,
-            kernel_width=kernel_width,
-            input_time_emb_channels=channels,
-            resnet_layers=resnet_layers,
-            is_up_block=is_up_block,
-        )
-        block = UpDownBlock2D(
-            theta=theta,
-            num_layers=resnet_layers,
-            resnet_eps=eps,
-            resnet_act_fn="relu",
-            resnet_groups=norm_groups,
-            resnet_out_scale_factor=None,
-            resnet_time_scale_shift="default",
-            temb_channels=channels,
-            dropout=0.0,
-            add_upsample=is_up_block,
-            add_downsample=not is_up_block,
-            downsample_padding=1,
-        )
-        input_image = torch.rand(
-            batches,
-            channels // 2,
-            height,
-            width,
-        )
-        input_time_emb = torch.rand(input_time_emb_shape)
-        res_hidden_states_tuple = [
-            torch.rand(
+        with torch.random.fork_rng():
+            torch.random.manual_seed(12345)
+            torch.set_default_dtype(torch.float32)
+            batches = 2
+            channels = 12
+            height = 11
+            width = 13
+            kernel_height = 5
+            kernel_width = 5
+            input_time_emb_shape = [batches, channels]
+            norm_groups = 2
+            eps = 0.01
+            shard_count = 2
+            resnet_layers = 2
+            theta = make_up_down_block_2d_theta(
+                channels=channels,
+                kernel_height=kernel_height,
+                kernel_width=kernel_width,
+                input_time_emb_channels=channels,
+                resnet_layers=resnet_layers,
+                is_up_block=is_up_block,
+            )
+            block = UpDownBlock2D(
+                theta=theta,
+                num_layers=resnet_layers,
+                resnet_eps=eps,
+                resnet_act_fn="relu",
+                resnet_groups=norm_groups,
+                resnet_out_scale_factor=None,
+                resnet_time_scale_shift="default",
+                temb_channels=channels,
+                dropout=0.0,
+                add_upsample=is_up_block,
+                add_downsample=not is_up_block,
+                downsample_padding=1,
+            )
+            input_image = torch.rand(
                 batches,
                 channels // 2,
-                height - 2 * i * (kernel_height // 2),
-                width - 2 * i * (kernel_width // 2),
+                height,
+                width,
             )
-            for i in range(resnet_layers)
-        ]
-        res_hidden_states_tuple.reverse()
-
-        expected_result = flatten_tensor_tree(
-            block(
-                hidden_states=input_image,
-                temb=input_time_emb,
-                res_hidden_states_tuple=res_hidden_states_tuple,
-                encoder_hidden_states=None,
-                attention_mask=None,
-                encoder_attention_mask=None,
-            )
-        )
-
-        sharding_spec = UpDownBlock2DSplitChannelsSharing(
-            shard_count=shard_count,
-            resnet_layers_count=resnet_layers,
-            upsamplers_count=1 if is_up_block else 0,
-            downsamplers_count=1 if not is_up_block else 0,
-        )
-        sharded_theta = ops.reshard(theta, sharding_spec)
-        sharded_block = UpDownBlock2D(
-            theta=sharded_theta,
-            num_layers=resnet_layers,
-            resnet_eps=eps,
-            resnet_act_fn="relu",
-            resnet_groups=norm_groups,
-            resnet_out_scale_factor=None,
-            resnet_time_scale_shift="default",
-            temb_channels=channels,
-            dropout=0.0,
-            add_upsample=is_up_block,
-            add_downsample=not is_up_block,
-            downsample_padding=1,
-        )
-        sharded_input_image = ops.reshard_split(input_image, dim=1, count=shard_count)
-        sharded_input_time_emb = ops.replicate(input_time_emb, count=shard_count)
-        sharded_res_hidden_states_tuple = [
-            ops.reshard_split(tensor, dim=1, count=shard_count)
-            for tensor in res_hidden_states_tuple
-        ]
-        sharded_result = flatten_tensor_tree(
-            sharded_block(
-                hidden_states=sharded_input_image,
-                temb=sharded_input_time_emb,
-                res_hidden_states_tuple=sharded_res_hidden_states_tuple,
-                encoder_hidden_states=None,
-                attention_mask=None,
-                encoder_attention_mask=None,
-            )
-        )
-        assert all(
-            [
-                isinstance(r, SplitPrimitiveTensor)
-                and r.shard_dim == 1
-                and r.shard_count == shard_count
-                for r in sharded_result
+            input_time_emb = torch.rand(input_time_emb_shape)
+            res_hidden_states_tuple = [
+                torch.rand(
+                    batches,
+                    channels // 2,
+                    height - 2 * i * (kernel_height // 2),
+                    width - 2 * i * (kernel_width // 2),
+                )
+                for i in range(resnet_layers)
             ]
-        )
-        actual_result = [ops.unshard(r) for r in sharded_result]
-        assert len(expected_result) == len(actual_result)
-        for actual, expected in zip(actual_result, expected_result):
-            torch.testing.assert_close(actual, expected)
+            res_hidden_states_tuple.reverse()
+
+            expected_result = flatten_tensor_tree(
+                block(
+                    hidden_states=input_image,
+                    temb=input_time_emb,
+                    res_hidden_states_tuple=res_hidden_states_tuple,
+                    encoder_hidden_states=None,
+                    attention_mask=None,
+                    encoder_attention_mask=None,
+                )
+            )
+
+            sharding_spec = UpDownBlock2DSplitChannelsSharing(
+                shard_count=shard_count,
+                resnet_layers_count=resnet_layers,
+                upsamplers_count=1 if is_up_block else 0,
+                downsamplers_count=1 if not is_up_block else 0,
+            )
+            sharded_theta = ops.reshard(theta, sharding_spec)
+            sharded_block = UpDownBlock2D(
+                theta=sharded_theta,
+                num_layers=resnet_layers,
+                resnet_eps=eps,
+                resnet_act_fn="relu",
+                resnet_groups=norm_groups,
+                resnet_out_scale_factor=None,
+                resnet_time_scale_shift="default",
+                temb_channels=channels,
+                dropout=0.0,
+                add_upsample=is_up_block,
+                add_downsample=not is_up_block,
+                downsample_padding=1,
+            )
+            sharded_input_image = ops.reshard_split(
+                input_image, dim=1, count=shard_count
+            )
+            sharded_input_time_emb = ops.replicate(input_time_emb, count=shard_count)
+            sharded_res_hidden_states_tuple = [
+                ops.reshard_split(tensor, dim=1, count=shard_count)
+                for tensor in res_hidden_states_tuple
+            ]
+            sharded_result = flatten_tensor_tree(
+                sharded_block(
+                    hidden_states=sharded_input_image,
+                    temb=sharded_input_time_emb,
+                    res_hidden_states_tuple=sharded_res_hidden_states_tuple,
+                    encoder_hidden_states=None,
+                    attention_mask=None,
+                    encoder_attention_mask=None,
+                )
+            )
+            assert all(
+                [
+                    isinstance(r, SplitPrimitiveTensor)
+                    and r.shard_dim == 1
+                    and r.shard_count == shard_count
+                    for r in sharded_result
+                ]
+            )
+            actual_result = [ops.unshard(r) for r in sharded_result]
+            assert len(expected_result) == len(actual_result)
+            for actual, expected in zip(actual_result, expected_result):
+                torch.testing.assert_close(actual, expected, rtol=0, atol=5e-4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Export test data to add a test in the IREE test suite.

Refactor the test in sharktank to utilize the shared export function. Make the test not xfail due to numerical precision as the error is around 1e-5 for f32 which should be good enough.

2 other tests required adjusting the numerical tolerance due to a change in random theta generation such that it does not generate in range [0, 1], but in range [-1, 1].