### PR TITLE
Pin actions (and add missing tags)

### DIFF
--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -92,7 +92,7 @@ jobs:
           pytest -v app_tests/benchmark_tests/llm/sglang_benchmarks/shortfin_benchmark_test.py --log-cli-level=INFO --html=shortfin_index.html --self-contained-html
 
       - name: Upload pytest report
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: shortfin_benchmark
           path: shortfin_index.html
@@ -136,7 +136,7 @@ jobs:
           pip freeze
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       # Instruction for SGLang image sourced from here:
       #   https://sgl-project.github.io/start/install.html#method-3-using-docker
@@ -179,7 +179,7 @@ jobs:
           pytest -v app_tests/benchmark_tests/llm/sglang_benchmarks/sglang_benchmark_test.py --port 30000 --log-cli-level=INFO --html=sglang_index.html --self-contained-html
 
       - name: Upload pytest report
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: sglang_benchmark
           path: sglang_index.html

--- a/.github/workflows/pkgci_shark_ai.yml
+++ b/.github/workflows/pkgci_shark_ai.yml
@@ -61,7 +61,7 @@ jobs:
             --log-cli-level=INFO
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: smoke-test-${{ matrix.name }}
           path: smoke-test-${{ matrix.name }}.xml
@@ -108,7 +108,7 @@ jobs:
             --log-cli-level=INFO
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: direct-to-batcher-test-${{ matrix.name }}
           path: direct-to-batcher-test-${{ matrix.name }}.xml
@@ -155,7 +155,7 @@ jobs:
             --log-cli-level=INFO
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: integration-test-${{ matrix.name }}
           path: integration-test-${{ matrix.name }}.xml


### PR DESCRIPTION
Pins some not yet pinned actions, as recommended by the OpenSSF scorecard project:
https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies

Further adds comments to point to the tags that the hashes are associated with.