### PR TITLE
Add page pool retain/release system with attention cache support

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/kvcache/trie_attention_cache.py
+++ b/shortfin/python/shortfin_apps/llm/components/kvcache/trie_attention_cache.py
@@ -209,6 +209,11 @@ class TriePagedAttentionCacheAllocation(PageAllocation):
         self.last_cached_node.ref_count.decrement()
         self._is_released = True
 
+    def replicate_self(self):
+        raise NotImplementedError(
+            "Replication not yet implemented for TriePagedAttentionCacheAllocation."
+        )
+
     def extend_allocation(self, tokens: List[int], *, extra_token_slots=0) -> None:
         """Extend the current allocation to accommodate additional tokens.
 


### PR DESCRIPTION
Pages can be used by multiple instances. Maintaining retention counts allows the same page to be allocated to multiple perspective clients and release only when no more retains exist.