### PR TITLE
Fix llm model tests to set dtype

### DIFF
--- a/sharktank/tests/models/deepseek/test_deepseek.py
+++ b/sharktank/tests/models/deepseek/test_deepseek.py
@@ -12,12 +12,8 @@ import pytest
 import torch
 
 
-@pytest.mark.xfail(
-    reason="https://github.com/nod-ai/shark-ai/issues/1015",
-    strict=False,
-    raises=AssertionError,
-)
 def test_deepseek():
+    torch.set_default_dtype(torch.float32)
     theta, config = generate(12345)
     model = PagedDeepseekModelV1(theta=theta, config=config)
 

--- a/sharktank/tests/models/llama/kv_cache_test.py
+++ b/sharktank/tests/models/llama/kv_cache_test.py
@@ -20,6 +20,7 @@ from sharktank.layers import causal_llm
 
 class KVCacheTest(unittest.TestCase):
     def setUp(self):
+        torch.set_default_dtype(torch.float32)
         self.block_count = 5
         self.seq_len = 16
         self.head_count = 32

--- a/sharktank/tests/models/llama/test_llama.py
+++ b/sharktank/tests/models/llama/test_llama.py
@@ -12,12 +12,8 @@ import pytest
 import torch
 
 
-@pytest.mark.xfail(
-    reason="https://github.com/nod-ai/shark-ai/issues/1015",
-    strict=False,
-    raises=AssertionError,
-)
 def test_llama():
+    torch.set_default_dtype(torch.float32)
     theta, config = generate(12345)
     model = PagedLlamaModelV1(theta=theta, config=config)
 


### PR DESCRIPTION
Other tests are changing the default dtype causing flakes on RNG and KVache tests. Setting to `torch.float32` before initializing data guarantees correct type / value generation.