### PR TITLE
Split prefill and decode batchers to separate implementations

### DIFF
--- a/app_tests/integration_tests/llm/device_settings.py
+++ b/app_tests/integration_tests/llm/device_settings.py
@@ -32,9 +32,18 @@ GFX90A = DeviceSettings(
     server_flags=("--device=hip",),
 )
 
+GFX1100 = DeviceSettings(
+    compile_flags=(
+        "--iree-hal-target-backends=rocm",
+        "--iree-hip-target=gfx1100",
+    ),
+    server_flags=("--device=hip",),
+)
+
 table = {
     "gfx942": GFX942,
     "gfx90a": GFX90A,
+    "gfx1100": GFX1100,
     "host": CPU,
     "hostcpu": CPU,
     "local-task": CPU,

--- a/shortfin/python/shortfin_apps/llm/components/batcher.py
+++ b/shortfin/python/shortfin_apps/llm/components/batcher.py
@@ -43,6 +43,7 @@ class LlmBatcherProcess(BatcherProcess):
 
     def __init__(
         self,
+        name: str,
         fiber: Fiber,
         page_cache: BasePagedAttentionCache,
         model_params: ModelParams,
@@ -50,6 +51,7 @@ class LlmBatcherProcess(BatcherProcess):
         ideal_batch_size: int,
     ):
         super().__init__(fiber=fiber)
+        self.name = name
         self.page_cache = page_cache
         self.model_params = model_params
         self.functions = functions
@@ -130,6 +132,7 @@ class PrefillBatcherProcess(LlmBatcherProcess):
         prefill_functions: dict[int, sf.ProgramFunction],
     ):
         super().__init__(
+            name="prefill",
             fiber=fiber,
             page_cache=page_cache,
             model_params=model_params,
@@ -181,6 +184,7 @@ class DecodeBatcherProcess(LlmBatcherProcess):
         decode_functions: dict[int, sf.ProgramFunction],
     ):
         super().__init__(
+            name="decode",
             fiber=fiber,
             page_cache=page_cache,
             model_params=model_params,
@@ -213,12 +217,14 @@ class LlmExecutorProcess(sf.Process):
 
     def __init__(
         self,
+        name: str,
         fiber: Fiber,
         functions: dict[int, sf.ProgramFunction],
         seq_stride: int,
         page_tables,
     ):
         super().__init__(fiber=fiber)
+        self.name = name
         self.seq_stride = seq_stride
         self.exec_requests: list[LlmInferenceExecRequest] = []
         self.page_tables = page_tables
@@ -303,6 +309,7 @@ class PrefillExecutorProcess(LlmExecutorProcess):
         page_tables,
     ):
         super().__init__(
+            name="prefill_process",
             fiber=fiber,
             functions=functions,
             seq_stride=seq_stride,
@@ -399,6 +406,7 @@ class DecodeExecutorProcess(LlmExecutorProcess):
         page_tables,
     ):
         super().__init__(
+            name="decode_process",
             fiber=fiber,
             functions=functions,
             seq_stride=seq_stride,

--- a/shortfin/python/shortfin_apps/llm/components/batcher.py
+++ b/shortfin/python/shortfin_apps/llm/components/batcher.py
@@ -74,6 +74,7 @@ class LlmBatcherProcess(BatcherProcess):
         if waiting_count < self.ideal_batch_size and self.strobes < 2:
             logger.info("Waiting a bit longer to fill flight")
             return
+
         self.strobes = 0
         cache = self.page_cache
 
@@ -161,15 +162,6 @@ class PrefillBatcherProcess(LlmBatcherProcess):
         request.allocation = allocation
 
         return request
-
-    async def board_flights(self):
-        await super().board_flights()
-
-        # For now, kill anything that is left.
-        for prefill_request in self.pending:
-            prefill_request.done.set_success()
-        self.pending.clear()
-
 
 class DecodeBatcherProcess(LlmBatcherProcess):
     """The batcher is a persistent process responsible for flighting incoming work

--- a/shortfin/python/shortfin_apps/llm/components/batcher.py
+++ b/shortfin/python/shortfin_apps/llm/components/batcher.py
@@ -163,6 +163,7 @@ class PrefillBatcherProcess(LlmBatcherProcess):
 
         return request
 
+
 class DecodeBatcherProcess(LlmBatcherProcess):
     """The batcher is a persistent process responsible for flighting incoming work
     into batches and handling the requisite cache allocations (since every batch needs

--- a/shortfin/python/shortfin_apps/llm/components/batcher.py
+++ b/shortfin/python/shortfin_apps/llm/components/batcher.py
@@ -1,0 +1,498 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import logging
+import os
+from pathlib import Path
+
+
+import shortfin as sf
+import shortfin.array as sfnp
+
+from shortfin import Fiber
+
+from ...utils import BatcherProcess
+
+from .config_struct import ModelParams
+from .kvcache.base_attention_cache import (
+    BasePagedAttentionCache,
+    CacheAllocationFailure,
+)
+
+from .messages import LlmInferenceExecRequest, InferencePhase
+from .service_debug_dumper import SERVICE_DEBUG_DUMPER
+
+logger = logging.getLogger(__name__)
+
+
+########################################################################################
+# Batcher
+########################################################################################
+
+import math
+
+
+class LlmBatcherProcess(BatcherProcess):
+    """This batcher provides a high-level mechanism for dispatching LLM tasks."""
+
+    STROBE_SHORT_DELAY = 0.1
+    STROBE_LONG_DELAY = 0.25
+
+    def __init__(
+        self,
+        fiber: Fiber,
+        page_cache: BasePagedAttentionCache,
+        model_params: ModelParams,
+        functions: dict[int, sf.ProgramFunction],
+        ideal_batch_size: int,
+    ):
+        super().__init__(fiber=fiber)
+        self.page_cache = page_cache
+        self.model_params = model_params
+        self.functions = functions
+        self.pending: set[LlmInferenceExecRequest] = set()
+        # TODO: There is no "ideal" batch size. Use prefill/decode dynamic
+        # batching in the scheduling algo.
+        self.ideal_batch_size: int = ideal_batch_size
+        self.page_seq_stride = self.model_params.paged_kv_cache.block_seq_stride
+
+    def handle_inference_request(self, request):
+        """Handle an inference request."""
+        self.pending.add(request)
+
+    async def process_batches(self):
+        """Process batches of requests."""
+        await self.board_flights()
+
+    async def board_flights(self):
+        waiting_count = len(self.pending)
+        if waiting_count == 0:
+            return
+        if waiting_count < self.ideal_batch_size and self.strobes < 2:
+            logger.info("Waiting a bit longer to fill flight")
+            return
+        self.strobes = 0
+        cache = self.page_cache
+
+        self.board(cache)
+        logger.debug("Post boarding cache state: %r", cache)
+
+    def make_process(self, cache: BasePagedAttentionCache):
+        ...
+
+    def board_request(self, cache, request: LlmInferenceExecRequest):
+        ...
+
+    def board(self, cache: BasePagedAttentionCache):
+        # Fill prefill flights.
+        pending = self.pending
+        if len(pending) == 0:
+            return
+
+        exec_process = self.make_process(cache)
+
+        for request in pending:
+            if len(exec_process.exec_requests) >= self.ideal_batch_size:
+                break
+
+            request = self.board_request(cache, request)
+
+            # Can flight this request.
+            if request is not None:
+                exec_process.exec_requests.append(request)
+
+        # We've filled our flight. Remove from the boarding area.
+        if exec_process.exec_requests:
+            for flighted_request in exec_process.exec_requests:
+                self.pending.remove(flighted_request)
+            # And takeoff.
+            exec_process.launch()
+
+
+class PrefillBatcherProcess(LlmBatcherProcess):
+    """The batcher is a persistent process responsible for flighting incoming work
+    into batches and handling the requisite cache allocations (since every batch needs
+    committed cache state).
+    """
+
+    STROBE_SHORT_DELAY = 0.1
+    STROBE_LONG_DELAY = 0.25
+
+    def __init__(
+        self,
+        fiber: Fiber,
+        page_cache: BasePagedAttentionCache,
+        model_params: ModelParams,
+        prefill_functions: dict[int, sf.ProgramFunction],
+    ):
+        super().__init__(
+            fiber=fiber,
+            page_cache=page_cache,
+            model_params=model_params,
+            functions=prefill_functions,
+            ideal_batch_size=max(model_params.prefill_batch_sizes),
+        )
+
+    def make_process(self, cache: BasePagedAttentionCache):
+        return PrefillExecutorProcess(
+            self.fiber,
+            self.functions,
+            self.page_seq_stride,
+            cache.page_pool.page_tables,
+        )
+
+    def board_request(self, cache, request: LlmInferenceExecRequest):
+        needed_pages = math.ceil(len(request.input_token_ids) / self.page_seq_stride)
+        # allocate kv cache pages
+        try:
+            allocation = cache.acquire_pages_for_tokens(
+                request.input_token_ids,
+                extra_token_slots=0,  # prefill needs no extra kvcache slots to write to
+            )
+        except CacheAllocationFailure:
+            logger.debug("Cannot fulfill request for %d pages", needed_pages)
+            return None
+
+        logger.debug(f"Successfully acquired allocation: {allocation}")
+        request.free_cache_pages()
+        request.allocation = allocation
+
+        return request
+
+    async def board_flights(self):
+        await super().board_flights()
+
+        # For now, kill anything that is left.
+        for prefill_request in self.pending:
+            prefill_request.done.set_success()
+        self.pending.clear()
+
+
+class DecodeBatcherProcess(LlmBatcherProcess):
+    """The batcher is a persistent process responsible for flighting incoming work
+    into batches and handling the requisite cache allocations (since every batch needs
+    committed cache state).
+    """
+
+    STROBE_SHORT_DELAY = 0.1
+    STROBE_LONG_DELAY = 0.25
+
+    def __init__(
+        self,
+        fiber: Fiber,
+        page_cache: BasePagedAttentionCache,
+        model_params: ModelParams,
+        decode_functions: dict[int, sf.ProgramFunction],
+    ):
+        super().__init__(
+            fiber=fiber,
+            page_cache=page_cache,
+            model_params=model_params,
+            functions=decode_functions,
+            ideal_batch_size=max(model_params.decode_batch_sizes),
+        )
+
+    def make_process(self, cache: BasePagedAttentionCache):
+        return DecodeExecutorProcess(
+            self.fiber,
+            self.functions,
+            self.page_seq_stride,
+            cache.page_pool.page_tables,
+        )
+
+    def board_request(self, cache, request: LlmInferenceExecRequest):
+        request.allocation.extend_allocation(
+            request.input_token_ids, extra_token_slots=1
+        )
+        return request
+
+
+########################################################################################
+# Inference Executor
+########################################################################################
+
+
+class LlmExecutorProcess(sf.Process):
+    """Executes a prefill batch."""
+
+    def __init__(
+        self,
+        fiber: Fiber,
+        functions: dict[int, sf.ProgramFunction],
+        seq_stride: int,
+        page_tables,
+    ):
+        super().__init__(fiber=fiber)
+        self.seq_stride = seq_stride
+        self.exec_requests: list[LlmInferenceExecRequest] = []
+        self.page_tables = page_tables
+        self.functions = functions
+
+    async def get_args(self, bs, device0):
+        ...
+
+    async def get_results(self, logits, req_count, device0):
+        ...
+
+    async def run(self):
+        try:
+            req_bs = len(self.exec_requests)
+            seq_stride = self.seq_stride
+            device0 = self.fiber.device(0)
+            # Select an entrypoint for the batch.
+            entrypoints = self.functions
+            for bs, fn in entrypoints.items():
+                if bs >= req_bs:
+                    break
+            else:
+                raise RuntimeError(f"No available entry point for bs {req_bs}")
+
+            args, req_count = await self.get_args(bs, device0)
+
+            logger.info(
+                "INVOKE %r: %s",
+                fn,
+                "".join(
+                    [
+                        (
+                            f"\n  {i}: {ary.shape}"
+                            if not isinstance(ary, sfnp.disable_barrier)
+                            else f"\n  {i}: {ary.delegate().shape}"
+                        )
+                        for i, ary in enumerate(args)
+                    ]
+                ),
+            )
+
+            # pre-invocation args dump
+            if os.getenv("SHORTFIN_DEBUG_LLM_SERVICE", "False").lower() in (
+                "true",
+                "yes",
+                "1",
+                "y",
+            ):
+                await SERVICE_DEBUG_DUMPER.pre_invocation_debug_dump(
+                    executor=self, local_vars=locals()
+                )
+
+            # Invoke VMFB. Logits are of shape [bs, bsl, d].
+            (logits,) = await fn(*args, fiber=self.fiber)
+
+            # publish cache pages
+            for r in self.exec_requests:
+                total_tokens = r.start_position + len(r.input_token_ids)
+                number_of_complete_pages = total_tokens // seq_stride
+                r.publish_allocated_pages(number_of_complete_pages)
+
+            # Return results.
+            await self.get_results(logits, req_count, device0)
+
+        except Exception:
+            logger.exception("Fatal error in prefetch invocation")
+            # TODO: Cancel and set error correctly
+            for req in self.exec_requests:
+                req.result_logits = None
+                req.free_cache_pages()
+                req.done.set_success()
+
+
+class PrefillExecutorProcess(LlmExecutorProcess):
+    """Executes a prefill batch."""
+
+    def __init__(
+        self,
+        fiber: Fiber,
+        functions: dict[int, sf.ProgramFunction],
+        seq_stride: int,
+        page_tables,
+    ):
+        super().__init__(
+            fiber=fiber,
+            functions=functions,
+            seq_stride=seq_stride,
+            page_tables=page_tables,
+        )
+
+    async def get_args(self, bs, device0):
+        seq_stride = self.seq_stride
+
+        # Compute block sequence length as maximum sequence length, rounded
+        # up to the seq_stride.
+        for r in self.exec_requests:
+            assert r.start_position == 0
+
+        bsl = max((len(r.input_token_ids)) for r in self.exec_requests)
+        bsl = int(math.ceil(bsl / seq_stride) * seq_stride)
+        block_count = bsl // seq_stride
+        req_count = len(self.exec_requests)
+        logger.debug("Prefill bs=%d, bsl=%d", bs, bsl)
+
+        # Prepare inputs.
+        # TODO: Better support in shortfin for h2d. The best way to do it is
+        # device dependent.
+        int_dtype = sfnp.int64
+        tokens = sfnp.device_array.for_device(device0, [bs, bsl], int_dtype)
+        seq_lens = sfnp.device_array.for_device(device0, [bs], int_dtype)
+        seq_block_ids = sfnp.device_array.for_device(
+            device0, [bs, block_count], int_dtype
+        )
+
+        # Populate tokens.
+        tokens_host = tokens.for_transfer()
+        for i in range(bs):
+            with tokens_host.view(i).map(discard=True) as m:
+                m.fill(0)
+                if i < req_count:
+                    m.items = self.exec_requests[i].input_token_ids
+        tokens_host.copy_to(tokens)
+
+        # Populate seq_lens
+        seq_lens_host = seq_lens.for_transfer()
+        with seq_lens_host.map(discard=True) as m:
+            m.fill(1)
+            m.items = [len(req.input_token_ids) for req in self.exec_requests]
+        seq_lens_host.copy_to(seq_lens)
+
+        # Populate cache pages.
+        seq_block_ids_host = seq_block_ids.for_transfer()
+        for i in range(bs):
+            with seq_block_ids_host.view(i).map(discard=True) as m:
+                m.fill(0)
+                if i < req_count:
+                    m.items = self.exec_requests[i].cache_page_indices(block_count)
+        seq_block_ids_host.copy_to(seq_block_ids)
+
+        # V1 args:
+        #  prefill:
+        #    tokens: [bs, bsl]
+        #    seq_lens: [bs]
+        #    seq_block_ids: [bs, blocks]
+        #    cache_slabs: ...
+        args = [tokens, seq_lens, seq_block_ids]
+        for page_table in self.page_tables:
+            args.append(sfnp.disable_barrier(page_table))
+
+        return args, req_count
+
+    async def get_results(self, logits, req_count, device0):
+        # Return results.
+        for i in range(req_count):
+            req = self.exec_requests[i]
+            sl = len(req.input_token_ids)
+            if req.return_all_logits:
+                logits_item = logits.view(i, slice(0, sl))
+            else:
+                logits_item = logits.view(i, sl - 1)
+            if req.return_host_array:
+                req.result_logits = logits_item.for_transfer()
+                req.result_logits.copy_from(logits_item)
+                await device0
+            else:
+                req.result_logits = logits_item
+            req.done.set_success()
+
+
+class DecodeExecutorProcess(LlmExecutorProcess):
+    """Executes a decode batch."""
+
+    def __init__(
+        self,
+        fiber: Fiber,
+        functions: dict[int, sf.ProgramFunction],
+        seq_stride: int,
+        page_tables,
+    ):
+        super().__init__(
+            fiber=fiber,
+            functions=functions,
+            seq_stride=seq_stride,
+            page_tables=page_tables,
+        )
+
+    async def get_args(self, bs, device0):
+        # Compute block sequence length as maximum sequence length, rounded
+        # up to the seq_stride.
+        seq_stride = self.seq_stride
+        bsl = max((1 + len(r.input_token_ids)) for r in self.exec_requests)
+        bsl = int(math.ceil(bsl / seq_stride) * seq_stride)
+        block_count = bsl // seq_stride
+        req_count = len(self.exec_requests)
+        logger.debug("Prefill bs=%d, bsl=%d", bs, bsl)
+
+        # Prepare inputs.
+        # TODO: Better support in shortfin for h2d. The best way to do it is
+        # device dependent.
+        int_dtype = sfnp.int64
+        tokens = sfnp.device_array.for_device(device0, [bs, 1], int_dtype)
+        start_positions = sfnp.device_array.for_device(device0, [bs], int_dtype)
+        seq_lens = sfnp.device_array.for_device(device0, [bs], int_dtype)
+        seq_block_ids = sfnp.device_array.for_device(
+            device0, [bs, block_count], int_dtype
+        )
+
+        # Populate tokens.
+        tokens_host = tokens.for_transfer()
+        for i in range(bs):
+            with tokens_host.view(i).map(discard=True) as m:
+                m.fill(0)
+                if i < req_count:
+                    m.items = self.exec_requests[i].input_token_ids[-1:]
+        tokens_host.copy_to(tokens)
+
+        # For decode, populate start_positions and seq_lens.
+        start_positions_host = start_positions.for_transfer()
+        with start_positions_host.map(discard=True) as m:
+            m.fill(0)
+            m.items = [req.start_position for req in self.exec_requests]
+        start_positions_host.copy_to(start_positions)
+
+        seq_lens_host = seq_lens.for_transfer()
+        with seq_lens_host.map(discard=True) as m:
+            # Pad unused requests.
+            m.fill(
+                1  # Must pad with a nonzero value because a division by 0 during softmax floods clobber page (page 0) in cache with NaN values.
+            )
+            m.items = [req.start_position + 1 for req in self.exec_requests]
+        seq_lens_host.copy_to(seq_lens)
+
+        # Populate cache pages.
+        seq_block_ids_host = seq_block_ids.for_transfer()
+        for i in range(bs):
+            with seq_block_ids_host.view(i).map(discard=True) as m:
+                m.fill(0)
+                if i < req_count:
+                    m.items = self.exec_requests[i].cache_page_indices(block_count)
+        seq_block_ids_host.copy_to(seq_block_ids)
+
+        # V1 args:
+        #  decode:
+        #    tokens: [bs, 1]
+        #    seq_lens: [bs]
+        #    start_positions: [bs]
+        #    seq_block_ids: [bs, blocks]
+        #    cache_slabs: ...
+        args = [tokens, seq_lens, start_positions, seq_block_ids]
+        for page_table in self.page_tables:
+            args.append(sfnp.disable_barrier(page_table))
+
+        return args, req_count
+
+    async def get_results(self, logits, req_count, device0):
+        # Return results.
+        for i in range(req_count):
+            req = self.exec_requests[i]
+            sl = 1
+            if req.return_all_logits:
+                logits_item = logits.view(i, slice(0, sl))
+            else:
+                logits_item = logits.view(i, sl - 1)
+            if req.return_host_array:
+                req.result_logits = logits_item.for_transfer()
+                req.result_logits.copy_from(logits_item)
+                await device0
+            else:
+                req.result_logits = logits_item
+            req.done.set_success()

--- a/shortfin/python/shortfin_apps/llm/components/generate.py
+++ b/shortfin/python/shortfin_apps/llm/components/generate.py
@@ -68,7 +68,7 @@ class GenerateItemProcess(sf.Process):
             self.append_token(token_int)
             # Decode loop.
             exec.start_position = len(self.input_token_ids) - 1
-            for i in range(self.max_completion_tokens):
+            for _ in range(self.max_completion_tokens):
                 exec.reset(InferencePhase.DECODE)
                 exec.input_token_ids.append(token_int)
                 exec.start_position += 1

--- a/shortfin/python/shortfin_apps/llm/components/generate.py
+++ b/shortfin/python/shortfin_apps/llm/components/generate.py
@@ -58,7 +58,7 @@ class GenerateItemProcess(sf.Process):
             rid=self.gen_req.rid,
         )
         try:
-            self.client.batcher.submit(exec)
+            self.client.prefill_batcher.submit(exec)
             await exec.done
 
             # Prefill result.
@@ -72,7 +72,7 @@ class GenerateItemProcess(sf.Process):
                 exec.reset(InferencePhase.DECODE)
                 exec.input_token_ids.append(token_int)
                 exec.start_position += 1
-                self.client.batcher.submit(exec)
+                self.client.decode_batcher.submit(exec)
                 await exec.done
                 token = sfnp.argmax(exec.result_logits)
                 token_int = token.items[0]
@@ -99,9 +99,10 @@ class ClientGenerateBatchProcess(sf.Process):
     """
 
     __slots__ = [
-        "batcher",
         "complete_infeed",
+        "decode_batcher",
         "gen_req",
+        "prefill_batcher",
         "responder",
         "tokenizer",
     ]
@@ -116,7 +117,8 @@ class ClientGenerateBatchProcess(sf.Process):
         self.gen_req = gen_req
         self.responder = responder
         self.tokenizer = service.tokenizer
-        self.batcher = service.batcher
+        self.prefill_batcher = service.prefill_batcher
+        self.decode_batcher = service.decode_batcher
         self.complete_infeed = self.system.create_queue()
 
     async def run(self):

--- a/shortfin/python/shortfin_apps/llm/components/service.py
+++ b/shortfin/python/shortfin_apps/llm/components/service.py
@@ -4,27 +4,21 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import asyncio
 import logging
-import os
-from pathlib import Path
 
 
 import shortfin as sf
-import shortfin.array as sfnp
 
-from ...utils import GenerateService, BatcherProcess
+from ...utils import GenerateService
 
 from .kvcache.base_attention_cache import (
     BasePagedAttentionCache,
-    CacheAllocationFailure,
-    PageAllocation,
 )
+from .batcher import PrefillBatcherProcess, DecodeBatcherProcess
 from .kvcache.trie_attention_cache import TriePagedAttentionCache
-from .kvcache.page_pool import PagePoolConfig, PagePool, PageInfo
+from .kvcache.page_pool import PagePoolConfig, PagePool
 from .config_struct import ModelParams, ServerParams
 from .manager import LlmSystemManager
-from .messages import LlmInferenceExecRequest, InferencePhase
 from .tokenizer import Tokenizer
 from .service_debug_dumper import SERVICE_DEBUG_DUMPER
 
@@ -57,7 +51,6 @@ class LlmGenerateService(GenerateService):
         self.set_isolation(program_isolation)
         self.initialize_worker_and_fiber()
         self.initialize_page_cache()
-        self.batcher = LlmBatcherProcess(self)
 
     def initialize_worker_and_fiber(self):
         self.main_worker = self.sysman.ls.create_worker(f"{self.name}-inference")
@@ -95,7 +88,23 @@ class LlmGenerateService(GenerateService):
             modules=component_modules, devices=self.sysman.ls.devices
         )
         self.initialize_function_references()
-        self.batcher.launch()
+
+        self.prefill_batcher = PrefillBatcherProcess(
+            self.main_fiber,
+            self.page_cache,
+            self.model_params,
+            self.prefill_functions,
+        )
+
+        self.decode_batcher = DecodeBatcherProcess(
+            self.main_fiber,
+            self.page_cache,
+            self.model_params,
+            self.decode_functions,
+        )
+
+        self.prefill_batcher.launch()
+        self.decode_batcher.launch()
 
     def initialize_function_references(self):
         self.prefill_functions = {}
@@ -118,327 +127,3 @@ class LlmGenerateService(GenerateService):
             f"  page_cache={self.page_cache}\n"
             f")"
         )
-
-
-########################################################################################
-# Batcher
-########################################################################################
-
-import math
-
-
-class LlmBatcherProcess(BatcherProcess):
-    """The batcher is a persistent process responsible for flighting incoming work
-    into batches and handling the requisite cache allocations (since every batch needs
-    committed cache state).
-    """
-
-    STROBE_SHORT_DELAY = 0.1
-    STROBE_LONG_DELAY = 0.25
-
-    def __init__(self, service: LlmGenerateService):
-        super().__init__(fiber=service.main_fiber)
-        self.service = service
-        self.pending_prefills: set[LlmInferenceExecRequest] = set()
-        self.pending_decodes: set[LlmInferenceExecRequest] = set()
-        # TODO: There is no "ideal" batch size. Use prefill/decode dynamic
-        # batching in the scheduling algo.
-        self.ideal_batch_size: int = max(service.model_params.prefill_batch_sizes)
-        self.page_seq_stride = service.model_params.paged_kv_cache.block_seq_stride
-
-    def handle_inference_request(self, request):
-        """Handle an inference request."""
-        phase = request.phase
-        if phase == InferencePhase.PREFILL:
-            self.pending_prefills.add(request)
-        elif phase == InferencePhase.DECODE:
-            self.pending_decodes.add(request)
-        else:
-            logger.error("Illegal LlmInferenceExecRequest phase: %r", phase)
-
-    async def process_batches(self):
-        """Process batches of requests."""
-        await self.board_flights()
-
-    async def board_flights(self):
-        waiting_count = len(self.pending_prefills) + len(self.pending_decodes)
-        if waiting_count == 0:
-            return
-        if waiting_count < self.ideal_batch_size and self.strobes < 2:
-            logger.info("Waiting a bit longer to fill flight")
-            return
-        self.strobes = 0
-        cache = self.service.page_cache
-
-        # TODO: This is a very naive cache management algorithm. Burn with fire
-        # and implement a real one.
-        self.board_prefills(cache)
-        self.board_decodes(cache)
-
-        # For now, kill anything that is left.
-        for prefill_request in self.pending_prefills:
-            prefill_request.done.set_success()
-        self.pending_prefills.clear()
-        logger.debug("Post boarding cache state: %r", cache)
-
-    def board_prefills(self, cache: BasePagedAttentionCache):
-        # Fill prefill flights.
-        pending_prefills = self.pending_prefills
-        if len(pending_prefills) == 0:
-            return
-        exec_process = InferenceExecutorProcess(
-            self.service,
-            InferencePhase.PREFILL,
-            self.page_seq_stride,
-            cache.page_pool.page_tables,
-        )
-        for prefill_request in pending_prefills:
-            assert prefill_request.phase == InferencePhase.PREFILL
-            if len(exec_process.exec_requests) >= self.ideal_batch_size:
-                break
-            needed_pages = math.ceil(
-                len(prefill_request.input_token_ids) / self.page_seq_stride
-            )
-            # allocate kv cache pages
-            try:
-                allocation = cache.acquire_pages_for_tokens(
-                    prefill_request.input_token_ids,
-                    extra_token_slots=0,  # prefill needs no extra kvcache slots to write to
-                )
-            except CacheAllocationFailure:
-                logger.debug("Cannot fulfill request for %d pages", needed_pages)
-                continue
-            logger.debug(f"Successfully acquired allocation: {allocation}")
-            prefill_request.free_cache_pages()
-            prefill_request.allocation = allocation
-
-            # Can flight this request.
-            exec_process.exec_requests.append(prefill_request)
-
-        # We've filled our flight. Remove from the boarding area.
-        if exec_process.exec_requests:
-            for flighted_request in exec_process.exec_requests:
-                self.pending_prefills.remove(flighted_request)
-            # And takeoff.
-            exec_process.launch()
-
-    def board_decodes(self, cache: BasePagedAttentionCache):
-        # Fill decode flights.
-        pending_decodes = self.pending_decodes
-        if len(pending_decodes) == 0:
-            return
-        exec_process = InferenceExecutorProcess(
-            self.service,
-            InferencePhase.DECODE,
-            self.page_seq_stride,
-            cache.page_pool.page_tables,
-        )
-        for decode_request in pending_decodes:
-            assert decode_request.phase == InferencePhase.DECODE
-            if len(exec_process.exec_requests) >= self.ideal_batch_size:
-                break
-            decode_request.allocation.extend_allocation(
-                decode_request.input_token_ids, extra_token_slots=1
-            )
-
-            # Can flight this request.
-            exec_process.exec_requests.append(decode_request)
-
-        # We've filled our flight. Remove from the boarding area.
-        if exec_process.exec_requests:
-            for flighted_request in exec_process.exec_requests:
-                self.pending_decodes.remove(flighted_request)
-            # And takeoff.
-            exec_process.launch()
-
-
-########################################################################################
-# Inference Executor
-########################################################################################
-
-
-class InferenceExecutorProcess(sf.Process):
-    """Executes a prefill or decode batch."""
-
-    def __init__(
-        self,
-        service: LlmGenerateService,
-        phase: InferencePhase,
-        seq_stride: int,
-        page_tables,
-    ):
-        super().__init__(fiber=service.main_fiber)
-        self.service = service
-        self.phase = phase
-        self.seq_stride = seq_stride
-        self.exec_requests: list[LlmInferenceExecRequest] = []
-        self.page_tables = page_tables
-
-    async def run(self):
-        try:
-            is_decode = self.phase == InferencePhase.DECODE
-            req_bs = len(self.exec_requests)
-            seq_stride = self.seq_stride
-            # Select an entrypoint for the batch.
-            if is_decode:
-                entrypoints = self.service.decode_functions
-            else:
-                entrypoints = self.service.prefill_functions
-            for bs, fn in entrypoints.items():
-                if bs >= req_bs:
-                    break
-            else:
-                raise RuntimeError(f"No available entry point for bs {req_bs}")
-
-            # Compute block sequence length as maximum sequence length, rounded
-            # up to the seq_stride.
-            if self.phase == InferencePhase.PREFILL:
-                for r in self.exec_requests:
-                    assert r.start_position == 0
-
-            extra_token_slots = 1 if is_decode else 0
-            bsl = max(
-                (extra_token_slots + len(r.input_token_ids)) for r in self.exec_requests
-            )
-            bsl = int(math.ceil(bsl / seq_stride) * seq_stride)
-            block_count = bsl // seq_stride
-            req_count = len(self.exec_requests)
-            logger.debug("Prefill bs=%d, bsl=%d", bs, bsl)
-
-            # Prepare inputs.
-            # TODO: Better support in shortfin for h2d. The best way to do it is
-            # device dependent.
-            device0 = self.fiber.device(0)
-            int_dtype = sfnp.int64
-            if is_decode:
-                tokens = sfnp.device_array.for_device(device0, [bs, 1], int_dtype)
-                start_positions = sfnp.device_array.for_device(device0, [bs], int_dtype)
-            else:
-                tokens = sfnp.device_array.for_device(device0, [bs, bsl], int_dtype)
-            seq_lens = sfnp.device_array.for_device(device0, [bs], int_dtype)
-            seq_block_ids = sfnp.device_array.for_device(
-                device0, [bs, block_count], int_dtype
-            )
-
-            # Populate tokens.
-            tokens_host = tokens.for_transfer()
-            for i in range(bs):
-                with tokens_host.view(i).map(discard=True) as m:
-                    m.fill(0)
-                    if i < req_count:
-                        if self.phase == InferencePhase.PREFILL:
-                            m.items = self.exec_requests[i].input_token_ids
-                        elif self.phase == InferencePhase.DECODE:
-                            m.items = self.exec_requests[i].input_token_ids[-1:]
-            tokens_host.copy_to(tokens)
-
-            # For prefill, populate seq_lens
-            if self.phase == InferencePhase.PREFILL:
-                seq_lens_host = seq_lens.for_transfer()
-                with seq_lens_host.map(discard=True) as m:
-                    m.fill(1)
-                    m.items = [len(req.input_token_ids) for req in self.exec_requests]
-                seq_lens_host.copy_to(seq_lens)
-
-            # For decode, populate start_positions and seq_lens.
-            if self.phase == InferencePhase.DECODE:
-                start_positions_host = start_positions.for_transfer()
-                with start_positions_host.map(discard=True) as m:
-                    m.fill(0)
-                    m.items = [req.start_position for req in self.exec_requests]
-                start_positions_host.copy_to(start_positions)
-
-                seq_lens_host = seq_lens.for_transfer()
-                with seq_lens_host.map(discard=True) as m:
-                    # Pad unused requests.
-                    m.fill(
-                        1  # Must pad with a nonzero value because a division by 0 during softmax floods clobber page (page 0) in cache with NaN values.
-                    )
-                    m.items = [req.start_position + 1 for req in self.exec_requests]
-                seq_lens_host.copy_to(seq_lens)
-
-            # Populate cache pages.
-            seq_block_ids_host = seq_block_ids.for_transfer()
-            for i in range(bs):
-                with seq_block_ids_host.view(i).map(discard=True) as m:
-                    m.fill(0)
-                    if i < req_count:
-                        m.items = self.exec_requests[i].cache_page_indices(block_count)
-            seq_block_ids_host.copy_to(seq_block_ids)
-
-            # V1 args:
-            #  prefill:
-            #    tokens: [bs, bsl]
-            #    seq_lens: [bs]
-            #    seq_block_ids: [bs, blocks]
-            #    cache_slabs: ...
-            #  decode:
-            #    tokens: [bs, 1]
-            #    seq_lens: [bs]
-            #    start_positions: [bs]
-            #    seq_block_ids: [bs, blocks]
-            #    cache_slabs: ...
-            if is_decode:
-                args = [tokens, seq_lens, start_positions, seq_block_ids]
-            else:
-                args = [tokens, seq_lens, seq_block_ids]
-            for page_table in self.page_tables:
-                args.append(sfnp.disable_barrier(page_table))
-            logger.info(
-                "INVOKE %r: %s",
-                fn,
-                "".join(
-                    [
-                        (
-                            f"\n  {i}: {ary.shape}"
-                            if not isinstance(ary, sfnp.disable_barrier)
-                            else f"\n  {i}: {ary.delegate().shape}"
-                        )
-                        for i, ary in enumerate(args)
-                    ]
-                ),
-            )
-
-            # pre-invocation args dump
-            if os.getenv("SHORTFIN_DEBUG_LLM_SERVICE", "False").lower() in (
-                "true",
-                "yes",
-                "1",
-                "y",
-            ):
-                await SERVICE_DEBUG_DUMPER.pre_invocation_debug_dump(
-                    executor=self, local_vars=locals()
-                )
-
-            # Invoke VMFB. Logits are of shape [bs, bsl, d].
-            (logits,) = await fn(*args, fiber=self.fiber)
-
-            # publish cache pages
-            for r in self.exec_requests:
-                total_tokens = r.start_position + len(r.input_token_ids)
-                number_of_complete_pages = total_tokens // seq_stride
-                r.publish_allocated_pages(number_of_complete_pages)
-
-            # Return results.
-            for i in range(req_count):
-                req = self.exec_requests[i]
-                sl = 1 if is_decode else len(req.input_token_ids)
-                if req.return_all_logits:
-                    logits_item = logits.view(i, slice(0, sl))
-                else:
-                    logits_item = logits.view(i, sl - 1)
-                if req.return_host_array:
-                    req.result_logits = logits_item.for_transfer()
-                    req.result_logits.copy_from(logits_item)
-                    await device0
-                else:
-                    req.result_logits = logits_item
-                req.done.set_success()
-
-        except Exception:
-            logger.exception("Fatal error in prefetch invocation")
-            # TODO: Cancel and set error correctly
-            for req in self.exec_requests:
-                req.result_logits = None
-                req.free_cache_pages()
-                req.done.set_success()

--- a/shortfin/python/shortfin_apps/llm/components/service.py
+++ b/shortfin/python/shortfin_apps/llm/components/service.py
@@ -55,6 +55,8 @@ class LlmGenerateService(GenerateService):
     def initialize_worker_and_fiber(self):
         self.main_worker = self.sysman.ls.create_worker(f"{self.name}-inference")
         self.main_fiber = self.sysman.ls.create_fiber(self.main_worker)
+        self.prefill_fiber = self.sysman.ls.create_fiber(self.main_worker)
+        self.decode_fiber = self.sysman.ls.create_fiber(self.main_worker)
 
     def initialize_page_cache(self):
         """Initialize page pool and attention cache."""
@@ -90,14 +92,14 @@ class LlmGenerateService(GenerateService):
         self.initialize_function_references()
 
         self.prefill_batcher = PrefillBatcherProcess(
-            self.main_fiber,
+            self.prefill_fiber,
             self.page_cache,
             self.model_params,
             self.prefill_functions,
         )
 
         self.decode_batcher = DecodeBatcherProcess(
-            self.main_fiber,
+            self.decode_fiber,
             self.page_cache,
             self.model_params,
             self.decode_functions,


### PR DESCRIPTION
Prefill and decode should be batched separately as their preferred batch sizes for each piece of hardware.