### PR TITLE
[sharktank] Add toy size Flux transformer

### DIFF
--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -144,6 +144,9 @@ jobs:
             --with-flux-data \
             --with-vae-data \
             --with-quark-data \
+            --iree-hal-target-device=hip \
+            --iree-hip-target=gfx942 \
+            --iree-device=hip://0 \
             sharktank/tests/models/clip/clip_test.py \
             sharktank/tests/models/t5/t5_test.py \
             sharktank/tests/models/flux/flux_test.py \

--- a/sharktank/sharktank/layers/testing.py
+++ b/sharktank/sharktank/layers/testing.py
@@ -95,24 +95,22 @@ def make_latent_attention_block_theta(
 
 
 def make_mmdit_double_block_random_theta(
-    in_channels: int = 128,
     hidden_size: int = 3072,
+    num_heads: int = 24,
     mlp_ratio: float = 4.0,
     dtype: torch.dtype | None = None,
 ) -> Theta:
-    in_channels = 128
-    hidden_size = 3072
-    mlp_ratio = 4.0
-    mlp_hidden_size = int((mlp_ratio - 1) * hidden_size)
-    mlp_hidden_size2 = int(mlp_ratio * hidden_size)
-    mlp_hidden_size3 = int(2 * (mlp_ratio - 1) * hidden_size)
+    head_dim = hidden_size // num_heads
+    mlp_hidden_size = int(mlp_ratio * hidden_size)
+    qkv_out_size = 3 * hidden_size
+    modulation_size = hidden_size * 6
     return Theta(
         {
             "img_attn.norm.key_norm.scale": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((in_channels,), dtype=dtype)
+                data=make_rand_torch((head_dim,), dtype=dtype)
             ),
             "img_attn.norm.query_norm.scale": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((in_channels,), dtype=dtype)
+                data=make_rand_torch((head_dim,), dtype=dtype)
             ),
             "img_attn.proj.bias": DefaultPrimitiveTensor(
                 data=make_rand_torch((hidden_size,), dtype=dtype)
@@ -121,34 +119,34 @@ def make_mmdit_double_block_random_theta(
                 data=make_rand_torch((hidden_size, hidden_size), dtype=dtype)
             ),
             "img_attn.qkv.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size,), dtype=dtype)
+                data=make_rand_torch((qkv_out_size,), dtype=dtype)
             ),
             "img_attn.qkv.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size, hidden_size), dtype=dtype)
+                data=make_rand_torch((qkv_out_size, hidden_size), dtype=dtype)
             ),
             "img_mlp.0.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size2), dtype=dtype)
+                data=make_rand_torch((mlp_hidden_size), dtype=dtype)
             ),
             "img_mlp.0.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size2, hidden_size), dtype=dtype)
+                data=make_rand_torch((mlp_hidden_size, hidden_size), dtype=dtype)
             ),
             "img_mlp.2.bias": DefaultPrimitiveTensor(
                 data=make_rand_torch((hidden_size), dtype=dtype)
             ),
             "img_mlp.2.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((hidden_size, mlp_hidden_size2), dtype=dtype)
+                data=make_rand_torch((hidden_size, mlp_hidden_size), dtype=dtype)
             ),
             "img_mod.lin.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size3,), dtype=dtype)
+                data=make_rand_torch((modulation_size,), dtype=dtype)
             ),
             "img_mod.lin.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size3, hidden_size), dtype=dtype)
+                data=make_rand_torch((modulation_size, hidden_size), dtype=dtype)
             ),
             "txt_attn.norm.key_norm.scale": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((in_channels,), dtype=dtype)
+                data=make_rand_torch((head_dim,), dtype=dtype)
             ),
             "txt_attn.norm.query_norm.scale": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((in_channels,), dtype=dtype)
+                data=make_rand_torch((head_dim,), dtype=dtype)
             ),
             "txt_attn.proj.bias": DefaultPrimitiveTensor(
                 data=make_rand_torch((hidden_size,), dtype=dtype)
@@ -157,49 +155,50 @@ def make_mmdit_double_block_random_theta(
                 data=make_rand_torch((hidden_size, hidden_size), dtype=dtype)
             ),
             "txt_attn.qkv.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size,), dtype=dtype)
+                data=make_rand_torch((qkv_out_size,), dtype=dtype)
             ),
             "txt_attn.qkv.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size, hidden_size), dtype=dtype)
+                data=make_rand_torch((qkv_out_size, hidden_size), dtype=dtype)
             ),
             "txt_mlp.0.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size2), dtype=dtype)
+                data=make_rand_torch((mlp_hidden_size), dtype=dtype)
             ),
             "txt_mlp.0.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size2, hidden_size), dtype=dtype)
+                data=make_rand_torch((mlp_hidden_size, hidden_size), dtype=dtype)
             ),
             "txt_mlp.2.bias": DefaultPrimitiveTensor(
                 data=make_rand_torch((hidden_size), dtype=dtype)
             ),
             "txt_mlp.2.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((hidden_size, mlp_hidden_size2), dtype=dtype)
+                data=make_rand_torch((hidden_size, mlp_hidden_size), dtype=dtype)
             ),
             "txt_mod.lin.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size3,), dtype=dtype)
+                data=make_rand_torch((modulation_size,), dtype=dtype)
             ),
             "txt_mod.lin.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size3, hidden_size), dtype=dtype)
+                data=make_rand_torch((modulation_size, hidden_size), dtype=dtype)
             ),
         }
     )
 
 
 def make_mmdit_single_block_random_theta(
-    in_channels: int = 128,
     hidden_size: int = 3072,
+    num_heads: int = 24,
     mlp_ratio: float = 4.0,
     dtype: torch.dtype | None = None,
 ) -> Theta:
-    mlp_hidden_size = int((mlp_ratio - 1) * hidden_size)
-    mlp_hidden_size2 = int((mlp_ratio + 1) * hidden_size)
-    mlp_hidden_size3 = int((2 * mlp_ratio - 1) * hidden_size)
+    mlp_hidden_dim = int(hidden_size * mlp_ratio)
+    head_dim = hidden_size // num_heads
+    modulation_size = 3 * hidden_size
+    linear1_hidden_size = hidden_size * 3 + mlp_hidden_dim
     return Theta(
         {
             "norm.key_norm.scale": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((in_channels,), dtype=dtype)
+                data=make_rand_torch((head_dim,), dtype=dtype)
             ),
             "norm.query_norm.scale": DefaultPrimitiveTensor(  #
-                data=make_rand_torch((in_channels,), dtype=dtype)
+                data=make_rand_torch((head_dim,), dtype=dtype)
             ),
             "attn.proj.bias": DefaultPrimitiveTensor(
                 data=make_rand_torch((hidden_size,), dtype=dtype)
@@ -208,22 +207,24 @@ def make_mmdit_single_block_random_theta(
                 data=make_rand_torch((hidden_size, hidden_size), dtype=dtype)
             ),
             "linear1.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size3,), dtype=dtype)
+                data=make_rand_torch((linear1_hidden_size,), dtype=dtype)
             ),
             "linear1.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size3, hidden_size), dtype=dtype)
+                data=make_rand_torch((linear1_hidden_size, hidden_size), dtype=dtype)
             ),
             "linear2.bias": DefaultPrimitiveTensor(
                 data=make_rand_torch((hidden_size), dtype=dtype)
             ),
             "linear2.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((hidden_size, mlp_hidden_size2), dtype=dtype)
+                data=make_rand_torch(
+                    (hidden_size, hidden_size + mlp_hidden_dim), dtype=dtype
+                )
             ),
             "modulation.lin.bias": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size,), dtype=dtype)
+                data=make_rand_torch((modulation_size,), dtype=dtype)
             ),
             "modulation.lin.weight": DefaultPrimitiveTensor(
-                data=make_rand_torch((mlp_hidden_size, hidden_size), dtype=dtype)
+                data=make_rand_torch((modulation_size, hidden_size), dtype=dtype)
             ),
         }
     )

--- a/sharktank/sharktank/models/flux/export.py
+++ b/sharktank/sharktank/models/flux/export.py
@@ -16,6 +16,9 @@ from .flux import FluxModelV1, FluxParams
 from ...types import Dataset
 from ...utils.hf_datasets import get_dataset
 from sharktank.transforms.dataset import set_float_dtype
+from iree.turbine.aot import (
+    ExternalTensorTrait,
+)
 
 flux_transformer_default_batch_sizes = [1]
 
@@ -35,6 +38,8 @@ def export_flux_transformer_model_mlir(
     else:
         model = model_or_parameters_path
 
+    for t in model.theta.flatten().values():
+        ExternalTensorTrait(external_name=t.name, external_scope="").set(t.as_torch())
     export_static_model_mlir(model, output_path=output_path, batch_sizes=batch_sizes)
 
 
@@ -60,7 +65,7 @@ def export_flux_transformer(
 ):
     export_flux_transformer_iree_parameters(model, parameters_output_path)
     export_flux_transformer_model_mlir(
-        parameters_output_path, output_path=mlir_output_path, batch_sizes=batch_sizes
+        model, output_path=mlir_output_path, batch_sizes=batch_sizes
     )
 
 

--- a/sharktank/sharktank/utils/logging.py
+++ b/sharktank/sharktank/utils/logging.py
@@ -5,8 +5,13 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import logging
+import torch
 
 from iree.turbine.support.logging import get_logger
 
 
 transform_logger: logging.Logger = get_logger("sharktank.transforms")
+
+
+def format_tensor_statistics(tensor: torch.Tensor):
+    return f"mean = {tensor.mean()}, median = {tensor.median()}, std dev = {tensor.std()}, min = {tensor.min()}, max = {tensor.max()}"

--- a/sharktank/sharktank/utils/testing.py
+++ b/sharktank/sharktank/utils/testing.py
@@ -7,6 +7,7 @@
 from typing import Optional
 import contextlib
 from pathlib import Path
+import pytest
 from os import PathLike
 import os
 import shutil
@@ -20,6 +21,8 @@ import gc
 
 from ..types import *
 from .math import cosine_similarity
+
+is_mi300x = pytest.mark.skipif("config.getoption('iree_hip_target') != 'gfx942'")
 
 # Range of torch.rand() is [0,1)
 # Range of torch.rand() * 2 - 1 is [-1, 1), includes negative values

--- a/sharktank/tests/evaluate/perplexity_iree_test.py
+++ b/sharktank/tests/evaluate/perplexity_iree_test.py
@@ -10,8 +10,8 @@ import json
 import numpy as np
 
 from sharktank.evaluate import perplexity_iree
+from sharktank.utils.testing import is_mi300x
 
-is_mi300x = pytest.mark.skipif("config.getoption('iree_hip_target') != 'gfx942'")
 skipif_run_quick_llama_test = pytest.mark.skipif(
     'not config.getoption("run-nightly-llama-tests")',
     reason="Run large tests if --run-nightly-llama-tests is passed",

--- a/sharktank/tests/layers/mmdit_test.py
+++ b/sharktank/tests/layers/mmdit_test.py
@@ -56,10 +56,16 @@ class MMDITTest(TempDirTestBase):
         asm = str(output.mlir_module)
 
     def testSingleExport(self):
-        theta = make_mmdit_single_block_random_theta(hidden_size=self.hidden_size)
+        mlp_ratio = 4.0
+        theta = make_mmdit_single_block_random_theta(
+            hidden_size=self.hidden_size, num_heads=self.num_heads, mlp_ratio=mlp_ratio
+        )
         theta = self.save_load_theta(theta)
         mmdit = MMDITSingleBlock(
-            theta=theta, num_heads=self.num_heads, hidden_size=self.hidden_size
+            theta=theta,
+            num_heads=self.num_heads,
+            hidden_size=self.hidden_size,
+            mlp_ratio=mlp_ratio,
         )
 
         inp = torch.rand([self.batch_size, 1024, self.hidden_size])


### PR DESCRIPTION
We don't have proper tests for a toy size variant of the model, which is desirable for CI tests on every commit.

Some of the tests fail during IREE buffer destruction. Which is a known issue.