### PR TITLE
Bump semaphore count up

### DIFF
--- a/shortfin/src/shortfin/local/scheduler.cc
+++ b/shortfin/src/shortfin/local/scheduler.cc
@@ -196,7 +196,7 @@ void Scheduler::Initialize(
       throw std::logic_error("Duplicate device in Scheduler");
     }
     account.Initialize();
-    semaphore_count_ += account.semaphore_count();
+    semaphore_count_ += account.semaphore_count() + 8;
   }
 }
 


### PR DESCRIPTION
Number of timelines was fixed to one, bumped to 8 to support multiple fibers.