### PR TITLE
Replace `torch.aten.outer` with corresponding math

### DIFF
--- a/sharktank/sharktank/layers/rotary_embedding.py
+++ b/sharktank/sharktank/layers/rotary_embedding.py
@@ -276,7 +276,7 @@ class RotaryEmbeddingLayer(BaseLayer):
             freqs = torch.where(is_medium_freq, smoothed_inv_freq, inv_freq_llama)
 
             freqs = torch.cat((freqs, freqs), dim=-1)
-            emb = torch.outer(t.float(), freqs.float())
+            emb = t.unsqueeze(1).float() * freqs.unsqueeze(0).float()
             cos = torch.cos(emb).to(self.dtype)
             sin = torch.sin(emb).to(self.dtype)
             return (cos, sin)
@@ -284,7 +284,7 @@ class RotaryEmbeddingLayer(BaseLayer):
         freqs = 1.0 / (
             self.rope_freq_base ** ((torch.arange(0, dim) // 2).float() / dim * 2.0)
         )
-        freqs = torch.outer(t, freqs).float()
+        freqs = (t.unsqueeze(1) * freqs.unsqueeze(0)).float()
         return freqs
 
     def _create_rotary_embed_table(self):


### PR DESCRIPTION
Outer is missing lowerings in `torch-mlir` right now. To unblock we just explicitly do the unsqueeze and mul operators.