### PR TITLE
[sharktank] Ensure buffers are destroyed after devices

### DIFF
--- a/sharktank/tests/models/flux/flux_test.py
+++ b/sharktank/tests/models/flux/flux_test.py
@@ -259,12 +259,6 @@ class FluxTest(TempDirTestBase):
             reference_dtype=torch.float64, target_dtype=torch.float32, atol=1e-1
         )
 
-    @skip(
-        reason=(
-            "Sporadic segmentation fault during buffer destruction."
-            " See https://github.com/nod-ai/shark-ai/issues/1050"
-        )
-    )
     @is_mi300x
     def testCompareToyIreeBf16AgainstEagerF64(self):
         """atol is apparently high because the expected output range is large.
@@ -281,12 +275,6 @@ class FluxTest(TempDirTestBase):
             reference_dtype=torch.float32, target_dtype=torch.float32, atol=1e-2
         )
 
-    @skip(
-        reason=(
-            "Sporadic segmentation fault during buffer destruction."
-            " See https://github.com/nod-ai/shark-ai/issues/1050"
-        )
-    )
     @with_flux_data
     def testCompareDevIreeBf16AgainstEagerF32(self):
         self.runTestCompareDevIreeAgainstEager(

--- a/sharktank/tests/models/flux/flux_test.py
+++ b/sharktank/tests/models/flux/flux_test.py
@@ -27,6 +27,7 @@ from sharktank.models.flux.testing import (
 from sharktank.models.flux.flux import FluxModelV1, FluxParams
 from sharktank.utils.testing import TempDirTestBase, skip, is_mi300x
 from sharktank.utils.iree import (
+    with_iree_device_context,
     load_iree_module,
     run_iree_module_function,
     prepare_iree_module_function_args,
@@ -150,32 +151,38 @@ class FluxTest(TempDirTestBase):
         )
         expected_outputs = flatten_for_iree_signature(reference_result_dict)
 
-        iree_devices = [iree.runtime.get_device(self.iree_device)]
-        logger.info("Loading IREE module...")
-        iree_module, iree_vm_context, iree_vm_instance = load_iree_module(
-            module_path=iree_module_path,
-            devices=iree_devices,
-            parameters_path=parameters_path,
-        )
-        iree_args = prepare_iree_module_function_args(
-            args=flatten_for_iree_signature(target_input_kwargs),
-            devices=iree_devices,
-        )
+        iree_devices = [iree.runtime.get_device(self.iree_device, cache=False)]
 
-        logger.info("Invoking IREE function...")
-        iree_result = iree_to_torch(
-            *run_iree_module_function(
-                module=iree_module,
-                vm_context=iree_vm_context,
-                args=iree_args,
-                device=iree_devices[0],
-                function_name=f"forward_bs{batch_size}",
+        def run_iree_module(iree_devices: list[iree.runtime.HalDevice]):
+            logger.info("Loading IREE module...")
+            iree_module, iree_vm_context, iree_vm_instance = load_iree_module(
+                module_path=iree_module_path,
+                devices=iree_devices,
+                parameters_path=parameters_path,
             )
-        )
-        actual_outputs = [
-            ops.to(iree_result[i], dtype=expected_outputs[i].dtype)
-            for i in range(len(expected_outputs))
-        ]
+            iree_args = prepare_iree_module_function_args(
+                args=flatten_for_iree_signature(target_input_kwargs),
+                devices=iree_devices,
+            )
+
+            logger.info("Invoking IREE function...")
+            iree_result = iree_to_torch(
+                *run_iree_module_function(
+                    module=iree_module,
+                    vm_context=iree_vm_context,
+                    args=iree_args,
+                    device=iree_devices[0],
+                    function_name=f"forward_bs{batch_size}",
+                )
+            )
+            actual_outputs = [
+                ops.to(iree_result[i], dtype=expected_outputs[i].dtype)
+                for i in range(len(expected_outputs))
+            ]
+            return [t.clone() for t in actual_outputs]
+
+        actual_outputs = with_iree_device_context(run_iree_module, iree_devices)
+
         logger.info("Comparing outputs...")
         logger.info(f"Expected output {format_tensor_statistics(expected_outputs[0])}")
         abs_diff = (actual_outputs[0] - expected_outputs[0]).abs()

--- a/sharktank/tests/models/punet/sharded_resnet_block_with_iree_test.py
+++ b/sharktank/tests/models/punet/sharded_resnet_block_with_iree_test.py
@@ -19,6 +19,7 @@ from sharktank.models.punet.layers import ResnetBlock2D
 from sharktank.models.punet.sharding import ResnetBlock2DSplitOutputChannelsSharding
 from sharktank import ops
 from sharktank.types import *
+from sharktank.utils.iree import with_iree_device_context
 import iree.runtime
 from typing import List, Optional
 import os
@@ -60,54 +61,61 @@ def run_iree_module(
     devices = [
         hal_driver.create_device(available_devices[0]) for _ in range(shard_count)
     ]
-    hal_module = iree.runtime.create_hal_module(instance=vm_instance, devices=devices)
-    params_path = Path(parameters_path)
-    # TODO: make IREE able to load the parameters from the top parameter file
-    # without having to specify the parameter file for each shard separately.
-    parameter_index = iree.runtime.ParameterIndex()
-    for i in range(shard_count):
-        parameter_index.load(
-            file_path=str(
-                Path(params_path).with_suffix(f".rank{i}{params_path.suffix}")
+
+    def run_iree_module(devices: list[iree.runtime.HalDevice]):
+        hal_module = iree.runtime.create_hal_module(
+            instance=vm_instance, devices=devices
+        )
+        params_path = Path(parameters_path)
+        # TODO: make IREE able to load the parameters from the top parameter file
+        # without having to specify the parameter file for each shard separately.
+        parameter_index = iree.runtime.ParameterIndex()
+        for i in range(shard_count):
+            parameter_index.load(
+                file_path=str(
+                    Path(params_path).with_suffix(f".rank{i}{params_path.suffix}")
+                )
             )
+        parameter_provider = parameter_index.create_provider(scope="model")
+        parameters_module = iree.runtime.create_io_parameters_module(
+            vm_instance, parameter_provider
         )
-    parameter_provider = parameter_index.create_provider(scope="model")
-    parameters_module = iree.runtime.create_io_parameters_module(
-        vm_instance, parameter_provider
-    )
 
-    vm_module = iree.runtime.VmModule.mmap(vm_instance, str(module_path))
+        vm_module = iree.runtime.VmModule.mmap(vm_instance, str(module_path))
 
-    # The context needs to be destroyed after the buffers, although
-    # it is not associate with them on the API level.
-    global vm_context
-    vm_context = iree.runtime.VmContext(
-        instance=vm_instance, modules=(hal_module, parameters_module, vm_module)
-    )
-    module_input_args = [
-        iree.runtime.asdevicearray(
-            devices[i], sharded_input_image.shards[i].as_torch().to("cpu").numpy()
+        # The context needs to be destroyed after the buffers, although
+        # it is not associate with them on the API level.
+        global vm_context
+        vm_context = iree.runtime.VmContext(
+            instance=vm_instance, modules=(hal_module, parameters_module, vm_module)
         )
-        for i in range(shard_count)
-    ]
-    module_input_args += [
-        iree.runtime.asdevicearray(
-            devices[i], sharded_input_time_emb.shards[i].as_torch().to("cpu").numpy()
-        )
-        for i in range(shard_count)
-    ]
+        module_input_args = [
+            iree.runtime.asdevicearray(
+                devices[i], sharded_input_image.shards[i].as_torch().to("cpu").numpy()
+            )
+            for i in range(shard_count)
+        ]
+        module_input_args += [
+            iree.runtime.asdevicearray(
+                devices[i],
+                sharded_input_time_emb.shards[i].as_torch().to("cpu").numpy(),
+            )
+            for i in range(shard_count)
+        ]
 
-    vm_function = vm_module.lookup_function("main")
-    invoker = iree.runtime.FunctionInvoker(
-        vm_context=vm_context,
-        # TODO: rework iree.runtime.FunctionInvoker interface for multiple devices.
-        # This works, but does not look right.
-        device=devices[0],
-        vm_function=vm_function,
-    )
-    results = invoker(*module_input_args)
-    shards = [torch.tensor(tensor.to_host()) for tensor in results]
-    return SplitPrimitiveTensor(ts=shards, shard_dim=1)
+        vm_function = vm_module.lookup_function("main")
+        invoker = iree.runtime.FunctionInvoker(
+            vm_context=vm_context,
+            # TODO: rework iree.runtime.FunctionInvoker interface for multiple devices.
+            # This works, but does not look right.
+            device=devices[0],
+            vm_function=vm_function,
+        )
+        results = invoker(*module_input_args)
+        shards = [torch.tensor(tensor.to_host()).clone() for tensor in results]
+        return SplitPrimitiveTensor(ts=shards, shard_dim=1)
+
+    return with_iree_device_context(run_iree_module, devices)
 
 
 def run_test_sharded_resnet_block_with_iree(


### PR DESCRIPTION
There are sporadic occasions where a buffer is destroyed after its corresponding IREE device is destroyed.
See https://github.com/nod-ai/shark-ai/issues/1050

Here is introduced a construct that utilizes function scope to ensures devices outlive local objects.