### PR TITLE
Group system args and add device reuse

### DIFF
--- a/shortfin/python/shortfin/interop/support/device_setup.py
+++ b/shortfin/python/shortfin/interop/support/device_setup.py
@@ -5,10 +5,13 @@ def get_selected_devices(sb: sf.SystemBuilder, device_ids=None):
     available = sb.available_devices
     selected = []
     if device_ids is not None:
-        if len(device_ids) > len(available):
-            raise ValueError(
-                f"Requested more device ids ({device_ids}) than available ({available})."
-            )
+        for d in device_ids:
+            if not isinstance(d, int):
+                continue
+            if d >= len(available) or d < 0:
+                raise ValueError(
+                    f"Requested more device ids ({device_ids}) than available ({available})."
+                )
         for did in device_ids:
             if isinstance(did, str):
                 try:

--- a/shortfin/python/shortfin_apps/llm/cli.py
+++ b/shortfin/python/shortfin_apps/llm/cli.py
@@ -18,6 +18,7 @@ from shortfin.support.responder import AbstractResponder
 from .components.generate import ClientGenerateBatchProcess
 from .components.io_struct import GenerateReqInput
 from .components.lifecycle import ShortfinLlmLifecycleManager
+from ..utils import get_system_args
 
 
 logger = logging.getLogger(__name__)
@@ -31,6 +32,8 @@ def add_input_args(parser):
 
 
 def add_service_args(parser):
+    get_system_args(parser)
+
     parser.add_argument(
         "--tokenizer_json",
         type=Path,
@@ -63,35 +66,11 @@ def add_service_args(parser):
         metavar="FILE",
     )
     parser.add_argument(
-        "--device",
-        type=str,
-        required=True,
-        choices=["local-task", "hip", "amdgpu"],
-        help="Device to serve on; e.g. local-task, hip. Same options as `iree-run-module --device` ",
-    )
-    parser.add_argument(
-        "--device_ids",
-        type=str,
-        nargs="*",
-        default=None,
-        help="Device IDs visible to the system builder. Defaults to None (full visibility). Can be an index or a sf device id like amdgpu:0:0@0",
-    )
-    parser.add_argument(
         "--isolation",
         type=str,
         default="per_call",
         choices=[isolation.name.lower() for isolation in ProgramIsolation],
         help="Concurrency control -- How to isolate programs.",
-    )
-    parser.add_argument(
-        "--amdgpu_async_allocations",
-        action="store_true",
-        help="Enable asynchronous allocations for amdgpu device contexts.",
-    )
-    parser.add_argument(
-        "--amdgpu_allocators",
-        default=None,
-        help="Allocator to use during VMFB invocation.",
     )
     parser.add_argument(
         "--server_config",

--- a/shortfin/python/shortfin_apps/llm/components/config_struct.py
+++ b/shortfin/python/shortfin_apps/llm/components/config_struct.py
@@ -222,6 +222,7 @@ class ServerParams:
     device_ids: list[str] = field(default_factory=list)
     amdgpu_async_allocations: bool = False
     amdgpu_allocators: Optional[str] = None
+    amdgpu_allow_device_reuse: bool = False
 
     @staticmethod
     def load(config_path: Optional[Path] = None) -> "ServerParams":

--- a/shortfin/python/shortfin_apps/llm/components/lifecycle.py
+++ b/shortfin/python/shortfin_apps/llm/components/lifecycle.py
@@ -60,6 +60,7 @@ class ShortfinLlmLifecycleManager:
             device_ids=server_params.device_ids,
             async_allocs=server_params.amdgpu_async_allocations,
             amdgpu_allocators=server_params.amdgpu_allocators,
+            amdgpu_allow_device_reuse=server_params.amdgpu_allow_device_reuse,
         )
 
         # Setup each service we are hosting.

--- a/shortfin/python/shortfin_apps/llm/components/manager.py
+++ b/shortfin/python/shortfin_apps/llm/components/manager.py
@@ -14,12 +14,14 @@ class LlmSystemManager(SystemManager):
         device_ids=None,
         async_allocs=True,
         amdgpu_allocators=None,
+        amdgpu_allow_device_reuse=False,
     ):
         super().__init__(
             device=device,
             device_ids=device_ids,
             async_allocs=async_allocs,
             amdgpu_allocators=amdgpu_allocators,
+            amdgpu_allow_device_reuse=amdgpu_allow_device_reuse,
             logger_name=__name__,
             shutdown_system=False,
         )

--- a/shortfin/python/shortfin_apps/utils.py
+++ b/shortfin/python/shortfin_apps/utils.py
@@ -13,12 +13,45 @@ import shortfin as sf
 from shortfin.interop.support.device_setup import get_selected_devices
 
 
+def get_system_args(parser):
+    parser.add_argument(
+        "--device",
+        type=str,
+        required=True,
+        choices=["local-task", "hip", "amdgpu"],
+        help="Device to serve on; e.g. local-task, hip. Same options as `iree-run-module --device` ",
+    )
+    parser.add_argument(
+        "--device_ids",
+        type=str,
+        nargs="*",
+        default=None,
+        help="Device IDs visible to the system builder. Defaults to None (full visibility). Can be an index or a sf device id like amdgpu:0:0@0",
+    )
+    parser.add_argument(
+        "--amdgpu_async_allocations",
+        action="store_true",
+        help="Enable asynchronous allocations for amdgpu device contexts.",
+    )
+    parser.add_argument(
+        "--amdgpu_allow_device_reuse",
+        action="store_true",
+        help="Allows the same device to be used for each instance",
+    )
+    parser.add_argument(
+        "--amdgpu_allocators",
+        default=None,
+        help="Allocator to use during VMFB invocation.",
+    )
+
+
 class SystemManager:
     def __init__(
         self,
         device: str = "local-task",
         device_ids: list[Union[str, int]] = None,
         async_allocs: bool = True,
+        amdgpu_allow_device_reuse: bool = False,
         amdgpu_allocators: Optional[bool] = None,
         logger_name: str = __name__,
         shutdown_system: bool = True,
@@ -34,12 +67,14 @@ class SystemManager:
                 sb = sf.SystemBuilder(
                     system_type="amdgpu",
                     amdgpu_async_allocations=async_allocs,
+                    amdgpu_allow_device_reuse=amdgpu_allow_device_reuse,
                 )
             else:
                 sb = sf.SystemBuilder(
                     system_type="amdgpu",
                     amdgpu_async_allocations=async_allocs,
                     amdgpu_allocators=amdgpu_allocators,
+                    amdgpu_allow_device_reuse=amdgpu_allow_device_reuse,
                 )
             if device_ids:
                 sb.visible_devices = sb.available_devices

--- a/shortfin/src/shortfin/local/systems/amdgpu.cc
+++ b/shortfin/src/shortfin/local/systems/amdgpu.cc
@@ -55,6 +55,9 @@ void AMDGPUSystemBuilder::InitializeDefaultSettings() {
   default_device_params_.async_allocations =
       config_options().GetBool("amdgpu_async_allocations", true);
 
+  amdgpu_allow_device_reuse_ =
+      config_options().GetBool("amdgpu_allow_device_reuse", false);
+
   // HIP options.
   // "amdgpu_tracing_level": Matches IREE flag --hip_tracing:
   // Permissible values are:
@@ -177,7 +180,9 @@ SystemPtr AMDGPUSystemBuilder::CreateSystem() {
         if (hal_id) {
           found = true;
           used_device_ids.push_back(*hal_id);
-          hal_id.reset();
+          if (!amdgpu_allow_device_reuse_) {
+            hal_id.reset();
+          }
         }
       }
 

--- a/shortfin/src/shortfin/local/systems/amdgpu.h
+++ b/shortfin/src/shortfin/local/systems/amdgpu.h
@@ -24,10 +24,11 @@ class SHORTFIN_API AMDGPUDevice : public Device {
 };
 
 // System configuration for some subset of AMD GPUs connected to the local
-// system. Note that this inherits from HostCPUSystemBuilder, allowing joint
-// configuration of a heterogenous CPU/GPU system. Depending on the specific
-// system, this can involve more than simple starting CPU drivers: datacenter
-// GPU systems have specific NUMA configurations that need to be mated.
+// system. Note that this inherits from HostCPUSystemBuilder, amdgpu_allowing
+// joint configuration of a heterogenous CPU/GPU system. Depending on the
+// specific system, this can involve more than simple starting CPU drivers:
+// datacenter GPU systems have specific NUMA configurations that need to be
+// mated.
 class SHORTFIN_API AMDGPUSystemBuilder : public HostCPUSystemBuilder {
  public:
   AMDGPUSystemBuilder(iree_allocator_t host_allocator,
@@ -98,6 +99,7 @@ class SHORTFIN_API AMDGPUSystemBuilder : public HostCPUSystemBuilder {
 
   // Configuration.
   bool cpu_devices_enabled_ = false;
+  bool amdgpu_allow_device_reuse_ = false;
   std::vector<std::string> hip_lib_search_paths_;
   std::optional<std::vector<std::string>> visible_devices_;
   size_t logical_devices_per_physical_device_ = 1;


### PR DESCRIPTION
For testing sharding it can be useful to test reusing the same device multiple times. By default this should be set to false but for testing it can be enabled so sharding can be run without multiple devices.