### PR TITLE
[sharktank] Add toy VAE tests

### DIFF
--- a/sharktank/sharktank/models/vae/config.py
+++ b/sharktank/sharktank/models/vae/config.py
@@ -9,9 +9,9 @@
 # While much was a simple reverse engineering of the config.json and parameters,
 # code was taken where appropriate.
 
-from typing import List, Optional, Sequence, Tuple, Union
+from typing import Any, Sequence
 
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 import inspect
 import warnings
 
@@ -22,13 +22,10 @@ __all__ = [
 
 @dataclass
 class HParams:
-    # Per block sequences. These are normalized from either an int (dubplicated
-    # to the number of down_blocks or a list.
-    layers_per_block: Tuple[int]
-
     act_fn: str = "silu"
     block_out_channels: Sequence[int] = (128, 256, 512, 512)
     in_channels: int = 3
+    out_channels: int = 3
     up_block_types: Sequence[str] = (
         "UpDecoderBlock2D",
         "UpDecoderBlock2D",
@@ -36,10 +33,12 @@ class HParams:
         "UpDecoderBlock2D",
     )
     layers_per_block: int = 2
+    latent_channels: int = 4
     norm_num_groups: int = 32
     scaling_factor: float = 0.13025
     use_post_quant_conv: bool = True
     shift_factor: float = 0.0
+    sample_size: int | tuple[int, int] | list[int, int] = 1024
 
     def assert_default_values(self, attr_names: Sequence[str]):
         for name in attr_names:
@@ -61,3 +60,9 @@ class HParams:
         if extra_kwargs:
             warnings.warn(f"Unhandled vae.HParams: {extra_kwargs}")
         return cls(**declared_kwargs)
+
+    def asdict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def to_hugging_face_config(self) -> dict[str, Any]:
+        return self.asdict()

--- a/sharktank/sharktank/models/vae/testing.py
+++ b/sharktank/sharktank/models/vae/testing.py
@@ -1,0 +1,40 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import functools
+import torch
+
+from .config import HParams
+from ...types import Theta, torch_module_to_theta
+from ...transforms.dataset import set_float_dtype
+
+
+def get_toy_vae_decoder_config() -> HParams:
+    norm_num_groups = 3
+    return HParams(
+        block_out_channels=[norm_num_groups * 7, norm_num_groups * 11],
+        in_channels=5,
+        out_channels=17,
+        up_block_types=[
+            "UpDecoderBlock2D",
+            "UpDecoderBlock2D",
+        ],
+        norm_num_groups=norm_num_groups,
+        latent_channels=13,
+        layers_per_block=2,
+        shift_factor=0.1234,
+        use_post_quant_conv=False,
+        sample_size=[23, 29],
+    )
+
+
+def make_vae_decoder_random_theta(config: HParams, /, *, dtype: torch.dtype) -> Theta:
+    from diffusers.models.autoencoders.autoencoder_kl import AutoencoderKL
+
+    hf_config = config.to_hugging_face_config()
+    hf_model = AutoencoderKL(**hf_config)
+    theta = torch_module_to_theta(hf_model)
+    return theta.transform(functools.partial(set_float_dtype, dtype=dtype))

--- a/sharktank/sharktank/models/vae/tools/diffuser_ref.py
+++ b/sharktank/sharktank/models/vae/tools/diffuser_ref.py
@@ -10,11 +10,20 @@ from diffusers import AutoencoderKL
 from einops import rearrange
 import math
 
+from ..model import VaeDecoderModel
+
+
+def convert_vae_decoder_to_hugging_face(model: VaeDecoderModel) -> AutoencoderKL:
+    hf_model = AutoencoderKL(**model.hp.to_hugging_face_config())
+    state_dict = {k: v.as_torch() for k, v in model.theta.flatten().items()}
+    hf_model.load_state_dict(state_dict)
+    return hf_model
+
 
 class VaeModel(torch.nn.Module):
     def __init__(
         self,
-        hf_model_name,
+        hf_model: AutoencoderKL | str,
         custom_vae="",
         height=1024,
         width=1024,
@@ -25,16 +34,18 @@ class VaeModel(torch.nn.Module):
         self.height = height
         self.width = width
         self.flux = flux
-        if custom_vae in ["", None]:
+        if isinstance(hf_model, AutoencoderKL):
+            self.vae = hf_model
+        elif custom_vae in ["", None]:
             self.vae = AutoencoderKL.from_pretrained(
-                hf_model_name,
+                hf_model,
                 subfolder="vae",
             )
         elif "safetensors" in custom_vae:
             custom_vae = safetensors.torch.load_file(custom_vae)
             # custom vae as a HF state dict
             self.vae = AutoencoderKL.from_pretrained(
-                hf_model_name,
+                hf_model,
                 subfolder="vae",
             )
             self.vae.load_state_dict(custom_vae)
@@ -56,8 +67,10 @@ class VaeModel(torch.nn.Module):
             else self.vae.config.shift_factor
         )
 
-    def decode(self, inp):
+    def decode(self, inp: torch.Tensor) -> torch.Tensor:
+        inp = inp.to(dtype=self.dtype)
         if self.flux:
+            assert self.vae.post_quant_conv is None  # No post quant
             inp = rearrange(
                 inp,
                 "b (h w) (c ph pw) -> b c (h ph) (w pw)",
@@ -73,6 +86,10 @@ class VaeModel(torch.nn.Module):
         else:
             return (x / 2 + 0.5).clamp(0, 1)
 
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.vae.decoder.conv_out.weight.dtype
+
 
 def run_torch_vae(
     hf_model_name,
@@ -80,7 +97,9 @@ def run_torch_vae(
     height=1024,
     width=1024,
     flux=False,
-    dtype=torch.float32,
+    dtype: torch.dtype | None = None,
 ):
-    vae_model = VaeModel(hf_model_name, height=height, width=width, flux=flux).to(dtype)
+    vae_model = VaeModel(hf_model_name, height=height, width=width, flux=flux)
+    if dtype is not None:
+        vae_model = vae_model.to(dtype)
     return vae_model.decode(example_input)

--- a/sharktank/sharktank/models/vae/tools/run_vae.py
+++ b/sharktank/sharktank/models/vae/tools/run_vae.py
@@ -11,6 +11,7 @@ import torch
 
 from iree.turbine import aot
 
+from ..layers import ThetaLayer
 from ..model import VaeDecoderModel
 from ....utils.patching import SaveModuleResultTensorsPatch
 
@@ -24,7 +25,12 @@ from iree.turbine.dynamo.passes import (
 import numpy as np
 
 
-def export_vae(model, sample_inputs, decomp_attn):
+def export_vae(model: ThetaLayer, sample_inputs, decomp_attn: bool) -> aot.ExportOutput:
+    for t in model.theta.flatten().values():
+        aot.ExternalTensorTrait(external_name=t.name, external_scope="").set(
+            t.as_torch()
+        )
+
     decomp_list = []
     if decomp_attn:
         decomp_list = [

--- a/sharktank/sharktank/models/vae/tools/sample_data.py
+++ b/sharktank/sharktank/models/vae/tools/sample_data.py
@@ -6,20 +6,35 @@
 
 """Various utilities for deriving stable sample data for the model."""
 
-from pathlib import Path
-
+import math
 import torch
+import logging
+
+logger = logging.getLogger(__name__)
 
 
-def get_random_inputs(dtype, device, bs: int = 2, config: str = "sdxl"):
-    height = 1024
-    width = 1024
+def get_random_inputs(
+    *,
+    dtype: torch.dtype,
+    device: torch.device,
+    bs: int = 2,
+    config: str = "sdxl",
+    width: int = 1024,
+    height: int = 1024,
+    latent_channels: int = 16,
+):
     if config == "sdxl":
-        print("sdxl returning inputs")
+        logger.debug("sdxl returning inputs")
+        assert width % 8 == 0 and height % 8 == 0
         return torch.rand(bs, 4, width // 8, height // 8, dtype=dtype).to(device)
     elif config == "flux":
-        print("flux returning inputs")
-        return torch.rand(bs, int(width * height / 256), 64, dtype=dtype).to(device)
+        logger.debug("flux returning inputs")
+        return torch.rand(
+            bs,
+            math.ceil(height / 16) * math.ceil(width / 16),
+            4 * latent_channels,
+            dtype=dtype,
+        ).to(device)
     else:
-        print("config: ", config)
+        logger.debug("config: ", config)
         raise AssertionError(f"{config} config not implmented [sdxl, flux] implemented")

--- a/sharktank/tests/models/vae/vae_test.py
+++ b/sharktank/tests/models/vae/vae_test.py
@@ -4,42 +4,45 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from pathlib import Path
-import sys
-
+from collections import OrderedDict
+import logging
 import torch
-
-from iree.turbine import aot
+import unittest
+import pytest
 import iree.runtime
+import iree.compiler
+from huggingface_hub import hf_hub_download
+from diffusers.models.autoencoders.autoencoder_kl import AutoencoderKL
+import functools
+from parameterized import parameterized
+
 
 from sharktank.types import Dataset
 from sharktank.models.vae.model import VaeDecoderModel
-from sharktank.models.vae.tools.diffuser_ref import run_torch_vae
+from sharktank.models.vae.tools.diffuser_ref import (
+    run_torch_vae,
+    convert_vae_decoder_to_hugging_face,
+)
 from sharktank.models.vae.tools.run_vae import export_vae
 from sharktank.models.vae.tools.sample_data import get_random_inputs
-
-from sharktank.models.punet.tools.sample_data import load_inputs, save_outputs
 from sharktank.tools.import_hf_dataset import import_hf_dataset
-from iree.turbine.aot import FxProgramsBuilder, export, decompositions
-from sharktank.utils.hf_datasets import get_dataset
-import unittest
-import pytest
-from huggingface_hub import hf_hub_download
 from sharktank.utils.iree import (
     with_iree_device_context,
     get_iree_devices,
     load_iree_module,
     run_iree_module_function,
     prepare_iree_module_function_args,
-    call_torch_module_function,
     flatten_for_iree_signature,
-    iree_to_torch,
     device_array_to_host,
 )
-import iree.compiler
-from collections import OrderedDict
 from sharktank.utils.testing import TempDirTestBase
+from sharktank.models.vae.testing import (
+    get_toy_vae_decoder_config,
+    make_vae_decoder_random_theta,
+)
+from sharktank.transforms.dataset import set_float_dtype
 
+logger = logging.getLogger(__name__)
 
 with_vae_data = pytest.mark.skipif("not config.getoption('with_vae_data')")
 
@@ -75,12 +78,16 @@ class VaeSDXLDecoderTest(TempDirTestBase):
             f"{self._temp_dir}/vae/config.json",
             [f"{self._temp_dir}/vae/diffusion_pytorch_model.safetensors"],
         )
-        f32_dataset.save(f"{self._temp_dir}/vae_f32.irpa", io_report_callback=print)
+        f32_dataset.save(
+            f"{self._temp_dir}/vae_f32.irpa", io_report_callback=logger.info
+        )
         f16_dataset = import_hf_dataset(
             f"{self._temp_dir}/vae/config.json",
             [f"{self._temp_dir}/vae/vae.safetensors"],
         )
-        f16_dataset.save(f"{self._temp_dir}/vae_f16.irpa", io_report_callback=print)
+        f16_dataset.save(
+            f"{self._temp_dir}/vae_f16.irpa", io_report_callback=logger.info
+        )
 
     def testCompareF32EagerVsHuggingface(self):
         dtype = getattr(torch, "float32")
@@ -232,15 +239,32 @@ class VaeFluxDecoderTest(TempDirTestBase):
             f"{self._temp_dir}/flux_vae/vae/config.json",
             [f"{self._temp_dir}/flux_vae/vae/diffusion_pytorch_model.safetensors"],
         )
-        dataset.save(f"{self._temp_dir}/flux_vae_bf16.irpa", io_report_callback=print)
+        dataset.save(
+            f"{self._temp_dir}/flux_vae_bf16.irpa", io_report_callback=logger.info
+        )
         dataset_f32 = import_hf_dataset(
             f"{self._temp_dir}/flux_vae/vae/config.json",
             [f"{self._temp_dir}/flux_vae/vae/diffusion_pytorch_model.safetensors"],
             target_dtype=torch.float32,
         )
         dataset_f32.save(
-            f"{self._temp_dir}/flux_vae_f32.irpa", io_report_callback=print
+            f"{self._temp_dir}/flux_vae_f32.irpa", io_report_callback=logger.info
         )
+
+        self.extra_args = [
+            "--iree-hal-target-backends=rocm",
+            "--iree-hip-target=gfx942",
+            "--iree-opt-const-eval=false",
+            "--iree-opt-strip-assertions=true",
+            "--iree-global-opt-propagate-transposes=true",
+            "--iree-opt-outer-dim-concat=true",
+            "--iree-llvmgpu-enable-prefetch=true",
+            "--iree-hip-waves-per-eu=2",
+            "--iree-dispatch-creation-enable-aggressive-fusion=true",
+            "--iree-codegen-llvmgpu-use-vector-distribution=true",
+            "--iree-execution-model=async-external",
+            "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics)",
+        ]
 
     def testCompareBF16EagerVsHuggingface(self):
         dtype = torch.bfloat16
@@ -269,6 +293,46 @@ class VaeFluxDecoderTest(TempDirTestBase):
         results = model.forward(inputs)
         torch.testing.assert_close(ref_results, results)
 
+    @parameterized.expand(
+        [
+            (torch.float32, torch.float64, 1e-5),
+            (torch.bfloat16, torch.float64, 2e-2),
+        ],
+    )
+    def testCompareToyEagerVsHuggingFace(
+        self, target_dtype: torch.dtype, reference_dtype: torch.dtype, atol: float
+    ):
+        config = get_toy_vae_decoder_config()
+        theta = make_vae_decoder_random_theta(config, dtype=target_dtype)
+        model = VaeDecoderModel(config, theta)
+        hf_model = convert_vae_decoder_to_hugging_face(model).to(dtype=reference_dtype)
+
+        self.runTestCompareEagerVsHuggingFace(
+            target_model=model, reference_model=hf_model, atol=atol
+        )
+
+    @parameterized.expand(
+        [
+            (torch.float32, torch.float64, 1e-5),
+            (torch.bfloat16, torch.float64, 2e-2),
+        ],
+    )
+    @pytest.mark.xfail(
+        reason="See https://github.com/iree-org/iree/issues/20307",
+        strict=True,
+        raises=iree.compiler.CompilerToolError,
+    )
+    def testCompareToyIreeVsEager(
+        self, target_dtype: torch.dtype, reference_dtype: torch.dtype, atol: float
+    ):
+        config = get_toy_vae_decoder_config()
+        reference_theta = make_vae_decoder_random_theta(config, dtype=reference_dtype)
+        reference_model = VaeDecoderModel(config, reference_theta)
+
+        self.runTestCompareIreeVsEager(
+            target_dtype=target_dtype, reference_model=reference_model, atol=atol
+        )
+
     def testVaeIreeVsHuggingFace(self):
         dtype = torch.bfloat16
         inputs = get_random_inputs(
@@ -291,30 +355,15 @@ class VaeFluxDecoderTest(TempDirTestBase):
         module.save_mlir(f"{self._temp_dir}/flux_vae_bf16.mlir")
         module_f32.save_mlir(f"{self._temp_dir}/flux_vae_f32.mlir")
 
-        extra_args = [
-            "--iree-hal-target-backends=rocm",
-            "--iree-hip-target=gfx942",
-            "--iree-opt-const-eval=false",
-            "--iree-opt-strip-assertions=true",
-            "--iree-global-opt-propagate-transposes=true",
-            "--iree-opt-outer-dim-concat=true",
-            "--iree-llvmgpu-enable-prefetch=true",
-            "--iree-hip-waves-per-eu=2",
-            "--iree-dispatch-creation-enable-aggressive-fusion=true",
-            "--iree-codegen-llvmgpu-use-vector-distribution=true",
-            "--iree-execution-model=async-external",
-            "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics)",
-        ]
-
         iree.compiler.compile_file(
             f"{self._temp_dir}/flux_vae_bf16.mlir",
             output_file=f"{self._temp_dir}/flux_vae_bf16.vmfb",
-            extra_args=extra_args,
+            extra_args=self.extra_args,
         )
         iree.compiler.compile_file(
             f"{self._temp_dir}/flux_vae_f32.mlir",
             output_file=f"{self._temp_dir}/flux_vae_f32.vmfb",
-            extra_args=extra_args,
+            extra_args=self.extra_args,
         )
 
         iree_devices = get_iree_devices(driver="hip", device_count=1)
@@ -373,6 +422,96 @@ class VaeFluxDecoderTest(TempDirTestBase):
         iree_result_f32 = with_iree_device_context(run_iree_module, iree_devices)
 
         torch.testing.assert_close(ref_results, iree_result_f32)
+
+    def runTestCompareEagerVsHuggingFace(
+        self, target_model: VaeDecoderModel, reference_model: AutoencoderKL, atol: float
+    ):
+        inputs = get_random_inputs(
+            dtype=target_model.dtype,
+            device="cpu",
+            bs=1,
+            config="flux",
+            height=target_model.hp.sample_size[0],
+            width=target_model.hp.sample_size[1],
+            latent_channels=target_model.hp.latent_channels,
+        )
+        ref_results = run_torch_vae(
+            reference_model,
+            inputs,
+            height=target_model.hp.sample_size[0],
+            width=target_model.hp.sample_size[1],
+            flux=True,
+        )
+        results = target_model.forward(inputs)
+        torch.testing.assert_close(
+            results.to(dtype=ref_results.dtype), ref_results, atol=atol, rtol=0
+        )
+
+    def runTestCompareIreeVsEager(
+        self, target_dtype: torch.dtype, reference_model: VaeDecoderModel, atol: float
+    ):
+        target_theta = reference_model.theta.transform(
+            functools.partial(set_float_dtype, dtype=target_dtype)
+        )
+        target_model = VaeDecoderModel(reference_model.hp, theta=target_theta)
+
+        target_inputs = get_random_inputs(
+            dtype=target_model.dtype,
+            device="cpu",
+            bs=1,
+            config="flux",
+            height=target_model.hp.sample_size[0],
+            width=target_model.hp.sample_size[1],
+            latent_channels=target_model.hp.latent_channels,
+        )
+        reference_inputs = target_inputs.to(dtype=reference_model.dtype)
+
+        reference_results = reference_model(reference_inputs)
+
+        module = export_vae(target_model, target_inputs, True)
+        target_mlir_path = f"{self._temp_dir}/model.mlir"
+        target_module_path = f"{self._temp_dir}/model.vmfb"
+        module.save_mlir(f"{self._temp_dir}/model.mlir")
+        iree.compiler.compile_file(
+            target_mlir_path,
+            output_file=target_module_path,
+            extra_args=self.extra_args,
+        )
+        target_parameters_path = f"{self._temp_dir}/model.irpa"
+        target_dataset = Dataset(
+            properties=target_model.hp.asdict(), root_theta=target_model.theta
+        )
+        target_dataset.save(target_parameters_path)
+
+        iree_devices = get_iree_devices(driver="hip", device_count=1)
+
+        def run_iree_module(iree_devices: list[iree.runtime.HalDevice]):
+            iree_module, iree_vm_context, iree_vm_instance = load_iree_module(
+                module_path=target_module_path,
+                devices=iree_devices,
+                parameters_path=target_parameters_path,
+            )
+
+            iree_args = flatten_for_iree_signature(target_inputs)
+
+            iree_args = prepare_iree_module_function_args(
+                args=iree_args, devices=iree_devices
+            )
+            target_results = device_array_to_host(
+                run_iree_module_function(
+                    module=iree_module,
+                    vm_context=iree_vm_context,
+                    args=iree_args,
+                    device=iree_devices[0],
+                    function_name="decode",
+                )[0]
+            ).to(dtype=reference_results.dtype)
+
+            torch.testing.assert_close(
+                reference_results, target_results, atol=atol, rtol=0
+            )
+
+        with_iree_device_context(run_iree_module, iree_devices)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add eager and IREE tests for f32 and bf16.

The IREE test fails compilation for the particular model shape. See https://github.com/iree-org/iree/issues/20307