### PR TITLE
Doc fixes for llm server 3.3 release

### DIFF
--- a/docs/nightly_releases.md
+++ b/docs/nightly_releases.md
@@ -84,23 +84,6 @@ python -c "import shortfin as sf; print('Sanity check passed')"
 deactivate
 ```
 
-## Quickstart - shortfin apps
-
-```bash
-# Set up a virtual environment to isolate packages from other envs.
-python3.11 -m venv 3.11.venv
-source 3.11.venv/bin/activate
-
-# Install 'shortfin' package from nightly releases with the 'apps' requirement.
-pip install shortfin[apps] -f https://github.com/nod-ai/shark-ai/releases/expanded_assets/dev-wheels --pre
-
-# Test the installation.
-python -c "import shortfin as sf; print('Sanity check passed')"
-
-# Deactivate the virtual environment when done.
-deactivate
-```
-
 ## Installing newer versions of dependencies
 
 To install all IREE packages from nightly releases:

--- a/docs/nightly_releases.md
+++ b/docs/nightly_releases.md
@@ -84,6 +84,23 @@ python -c "import shortfin as sf; print('Sanity check passed')"
 deactivate
 ```
 
+## Quickstart - shortfin apps
+
+```bash
+# Set up a virtual environment to isolate packages from other envs.
+python3.11 -m venv 3.11.venv
+source 3.11.venv/bin/activate
+
+# Install 'shortfin' package from nightly releases with the 'apps' requirement.
+pip install shortfin[apps] -f https://github.com/nod-ai/shark-ai/releases/expanded_assets/dev-wheels --pre
+
+# Test the installation.
+python -c "import shortfin as sf; print('Sanity check passed')"
+
+# Deactivate the virtual environment when done.
+deactivate
+```
+
 ## Installing newer versions of dependencies
 
 To install all IREE packages from nightly releases:

--- a/docs/nightly_releases.md
+++ b/docs/nightly_releases.md
@@ -74,9 +74,6 @@ deactivate
 python3.11 -m venv 3.11.venv
 source 3.11.venv/bin/activate
 
-# Install 'shortfin' package from nightly releases.
-pip install shortfin -f https://github.com/nod-ai/shark-ai/releases/expanded_assets/dev-wheels --pre
-
 # Install 'shortfin' package from nightly releases, optionally with [apps] extra requirements.
 pip install shortfin[apps] -f https://github.com/nod-ai/shark-ai/releases/expanded_assets/dev-wheels --pre
 

--- a/docs/nightly_releases.md
+++ b/docs/nightly_releases.md
@@ -77,6 +77,9 @@ source 3.11.venv/bin/activate
 # Install 'shortfin' package from nightly releases.
 pip install shortfin -f https://github.com/nod-ai/shark-ai/releases/expanded_assets/dev-wheels --pre
 
+# Install 'shortfin' package from nightly releases, optionally with [apps] extra requirements.
+pip install shortfin[apps] -f https://github.com/nod-ai/shark-ai/releases/expanded_assets/dev-wheels --pre
+
 # Test the installation.
 python -c "import shortfin as sf; print('Sanity check passed')"
 

--- a/docs/shortfin/llm/user/llama_serving.md
+++ b/docs/shortfin/llm/user/llama_serving.md
@@ -177,7 +177,7 @@ tool for compiling our model.
 
 ```bash
 iree-compile $MLIR_PATH \
- --iree-hal-target-backends=rocm \
+ --iree-hal-target-device=hip \
  --iree-hip-target=gfx942 \
  -o $VMFB_PATH
 ```

--- a/docs/shortfin/llm/user/llama_serving.md
+++ b/docs/shortfin/llm/user/llama_serving.md
@@ -5,18 +5,18 @@
 The following models are supported for serving:
 
 <!-- TODO(https://github.com/iree-org/iree/issues/19832): Determine lower-bound of tp required for 405b -->
-| Model Name                   | HuggingFace Model                                                                                   | Tensor Parallelism Range | Limitations                                    |
-| ---------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------ | ---------------------------------------------- |
-| **Llama Models**             |                                                                                                     |                          |                                                |
-| `Llama-3.1-8B`               | [meta-llama/Llama-3.1-8B](https://huggingface.co/meta-llama/Llama-3.1-8B)                           | tp1-tp8                  | Lower accuracy compared to `instruct` variant. |
-| `Llama-3.1-8B-Instruct`      | [meta-llama/Llama-3.1-8B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct)         | tp1-tp8                  |                                                |
-| `Llama-3.1-70B`              | [meta-llama/Llama-3.1-70B](https://huggingface.co/meta-llama/Llama-3.1-70B)                         | tp1-tp8                  | Lower accuracy compared to `instruct` variant. |
-| `Llama-3.1-70B-Instruct`     | [meta-llama/Llama-3.1-70B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct)       | tp1-tp8                  |                                                |
-| `Llama-3.1-405b`             | [meta-llama/Llama-3.1-405B](https://huggingface.co/meta-llama/Llama-3.1-405B)                       | tp8                      | Lower accuracy compared to `instruct` variant. |
-| `Llama-3.1-405b-Instruct`    | [meta-llama/Llama-3.1-405B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-405B-Instruct)     | tp8                      |                                                |
-| **Llama-Like Models**        |                                                                                                     |                          |                                                |
-| `Mistral-Nemo-Base-2407`     | [mistralai/Mistral-Nemo-Base-2407](https://huggingface.co/mistralai/Mistral-Nemo-Base-2407)         | tp1                      | Lower accuracy compared to `instruct` variant. |
-| `Mistral-Nemo-Instruct-2407` | [mistralai/Mistral-Nemo-Instruct-2407](https://huggingface.co/mistralai/Mistral-Nemo-Instruct-2407) | tp1                      |                                                |
+| Model Name                   | HuggingFace Model                                                                                   | Tensor Parallelism Range |
+| ---------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------ |
+| **Llama Models**             |                                                                                                     |                          |
+| `Llama-3.1-8B`               | [meta-llama/Llama-3.1-8B](https://huggingface.co/meta-llama/Llama-3.1-8B)                           | tp1-tp8                  |
+| `Llama-3.1-8B-Instruct`      | [meta-llama/Llama-3.1-8B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct)         | tp1-tp8                  |
+| `Llama-3.1-70B`              | [meta-llama/Llama-3.1-70B](https://huggingface.co/meta-llama/Llama-3.1-70B)                         | tp1-tp8                  |
+| `Llama-3.1-70B-Instruct`     | [meta-llama/Llama-3.1-70B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct)       | tp1-tp8                  |
+| `Llama-3.1-405b`             | [meta-llama/Llama-3.1-405B](https://huggingface.co/meta-llama/Llama-3.1-405B)                       | tp8                      |
+| `Llama-3.1-405b-Instruct`    | [meta-llama/Llama-3.1-405B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-405B-Instruct)     | tp8                      |
+| **Llama-Like Models**        |                                                                                                     |                          |
+| `Mistral-Nemo-Base-2407`     | [mistralai/Mistral-Nemo-Base-2407](https://huggingface.co/mistralai/Mistral-Nemo-Base-2407)         | tp1                      |
+| `Mistral-Nemo-Instruct-2407` | [mistralai/Mistral-Nemo-Instruct-2407](https://huggingface.co/mistralai/Mistral-Nemo-Instruct-2407) | tp1                      |
 
 ## Introduction
 

--- a/docs/shortfin/llm/user/llama_serving.md
+++ b/docs/shortfin/llm/user/llama_serving.md
@@ -384,7 +384,8 @@ python -m sharktank.examples.export_paged_llm_v1 \
   --output-mlir /path/to/output/llama3.1-405b.mlir \
   --output-config /path/to/output/llama3.1-405b.config.json \
   --bs-prefill 4 \
-  --bs-decode 4
+  --bs-decode 4 \
+  --use-attention-mask
 ```
 
 ### Compiling to VMFB

--- a/docs/shortfin/llm/user/llama_serving.md
+++ b/docs/shortfin/llm/user/llama_serving.md
@@ -5,18 +5,18 @@
 The following models are supported for serving:
 
 <!-- TODO(https://github.com/iree-org/iree/issues/19832): Determine lower-bound of tp required for 405b -->
-| Model Name                   | HuggingFace Model                                                                                   | Tensor Parallelism Range |
-| ---------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------ |
-| **Llama Models**             |                                                                                                     |                          |
-| `Llama-3.1-8B`               | [meta-llama/Llama-3.1-8B](https://huggingface.co/meta-llama/Llama-3.1-8B)                           | tp1-tp8                  |
-| `Llama-3.1-8B-Instruct`      | [meta-llama/Llama-3.1-8B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct)         | tp1-tp8                  |
-| `Llama-3.1-70B`              | [meta-llama/Llama-3.1-70B](https://huggingface.co/meta-llama/Llama-3.1-70B)                         | tp1-tp8                  |
-| `Llama-3.1-70B-Instruct`     | [meta-llama/Llama-3.1-70B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct)       | tp1-tp8                  |
-| `Llama-3.1-405b`             | [meta-llama/Llama-3.1-405B](https://huggingface.co/meta-llama/Llama-3.1-405B)                       | tp8                      |
-| `Llama-3.1-405b-Instruct`    | [meta-llama/Llama-3.1-405B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-405B-Instruct)     | tp8                      |
-| **Llama-Like Models**        |                                                                                                     |                          |
-| `Mistral-Nemo-Base-2407`     | [mistralai/Mistral-Nemo-Base-2407](https://huggingface.co/mistralai/Mistral-Nemo-Base-2407)         | tp1                      |
-| `Mistral-Nemo-Instruct-2407` | [mistralai/Mistral-Nemo-Instruct-2407](https://huggingface.co/mistralai/Mistral-Nemo-Instruct-2407) | tp1                      |
+| Model Name                   | HuggingFace Model                                                                                   | Tensor Parallelism Range | Limitations                                    |
+| ---------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------ | ---------------------------------------------- |
+| **Llama Models**             |                                                                                                     |                          |                                                |
+| `Llama-3.1-8B`               | [meta-llama/Llama-3.1-8B](https://huggingface.co/meta-llama/Llama-3.1-8B)                           | tp1-tp8                  | Lower accuracy compared to `instruct` variant. |
+| `Llama-3.1-8B-Instruct`      | [meta-llama/Llama-3.1-8B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct)         | tp1-tp8                  |                                                |
+| `Llama-3.1-70B`              | [meta-llama/Llama-3.1-70B](https://huggingface.co/meta-llama/Llama-3.1-70B)                         | tp1-tp8                  | Lower accuracy compared to `instruct` variant. |
+| `Llama-3.1-70B-Instruct`     | [meta-llama/Llama-3.1-70B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct)       | tp1-tp8                  |                                                |
+| `Llama-3.1-405b`             | [meta-llama/Llama-3.1-405B](https://huggingface.co/meta-llama/Llama-3.1-405B)                       | tp8                      | Lower accuracy compared to `instruct` variant. |
+| `Llama-3.1-405b-Instruct`    | [meta-llama/Llama-3.1-405B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-405B-Instruct)     | tp8                      |                                                |
+| **Llama-Like Models**        |                                                                                                     |                          |                                                |
+| `Mistral-Nemo-Base-2407`     | [mistralai/Mistral-Nemo-Base-2407](https://huggingface.co/mistralai/Mistral-Nemo-Base-2407)         | tp1                      | Lower accuracy compared to `instruct` variant. |
+| `Mistral-Nemo-Instruct-2407` | [mistralai/Mistral-Nemo-Instruct-2407](https://huggingface.co/mistralai/Mistral-Nemo-Instruct-2407) | tp1                      |                                                |
 
 ## Introduction
 


### PR DESCRIPTION
There are three documentation related fixes that were identified through QA testing:

- Specify `use-attention-mask` when running with a sharded model
    - There's a special `--use-attention-mask` flag required to be able to run the sharded models. I had forgotten to add that flag to the sharded docs. This is what caused the compilation issue that Dhiraj had seen.
    - Context from Rob:
        - This is due to some affinity analysis and cloning work that still needs to be worked out. Its the main reason compilation work on iree presubmits. There are plans to get a proper fix in but it will be a while before someone can put hands on the issue.
- Removed deprecated `IREE` flag
    - The `--iree-hal-target-backends=rocm` flag has been deprecated for `--iree-hal-target-device=hip`. Removed the old flag in favor of the new one.
- Changed instructions in `nightlies` to use `shortfin[apps]` installation
    - Dhiraj was doing his testing this morning with the nightlies, and hit a bug due to `dataclasses_json` not being installed. The issue was that he was downloading the nightly `shortfin`, not `shortfin[apps]`.
    - Changed `nightly shortfin` instructions to install `shortfin[apps]`