### PR TITLE
[tuner] remove iree_input from the import list of dialects

### DIFF
--- a/tuner/tuner/libtuner_test.py
+++ b/tuner/tuner/libtuner_test.py
@@ -188,7 +188,7 @@ def test_get_compilation_success_rate():
 
 
 def test_enum_collision():
-    from iree.compiler.dialects import linalg, vector, iree_gpu, iree_codegen, iree_input  # type: ignore
+    from iree.compiler.dialects import linalg, vector, iree_gpu, iree_codegen  # type: ignore
 
 
 def test_baseline_result_handler_valid():


### PR DESCRIPTION
The `iree_input` dialect has been removed from IREE according to PR: https://github.com/iree-org/iree/pull/20256, so we update our tuner code and prevent related errors during pytest runs. 