### PR TITLE
Fix exporting of Flux pipeline artifacts

### DIFF
--- a/sharktank/sharktank/models/t5/export.py
+++ b/sharktank/sharktank/models/t5/export.py
@@ -103,14 +103,26 @@ def import_encoder_dataset_from_hugging_face(
     /,
     *,
     tokenizer_config: dict[str, Any] | None = None,
+    tokenizer_path_or_repo_id: str | None = None,
+    tokenizer_subfolder: str | None = None,
+    subfolder: str = "",
 ) -> Dataset:
     model = repo_id_or_model
     if not isinstance(repo_id_or_model, transformers.T5EncoderModel):
-        model = transformers.T5EncoderModel.from_pretrained(repo_id_or_model)
+        model = transformers.T5EncoderModel.from_pretrained(
+            repo_id_or_model, subfolder=subfolder, torch_dtype="auto"
+        )
         from transformers.models.auto.tokenization_auto import get_tokenizer_config
 
+        if tokenizer_path_or_repo_id is None:
+            assert not isinstance(repo_id_or_model, transformers.T5EncoderModel)
+            tokenizer_path_or_repo_id = repo_id_or_model
+        if tokenizer_subfolder is None:
+            tokenizer_subfolder = subfolder
         if tokenizer_config is None:
-            tokenizer_config = get_tokenizer_config(repo_id_or_model)
+            tokenizer_config = get_tokenizer_config(
+                tokenizer_path_or_repo_id, subfolder=tokenizer_subfolder
+            )
     else:
         if tokenizer_config is None:
             raise ValueError(

--- a/sharktank/sharktank/pipelines/flux/README.md
+++ b/sharktank/sharktank/pipelines/flux/README.md
@@ -4,7 +4,13 @@
 
 All the exports in this directory are done through `export.py`, with the CLI syntax as follows:
 ```shell
-python -m sharktank.pipelines.flux.export_parameters --dtype <fp32/fp16/bf16> --input-path <input-dir> --output-path <output-dir>
+python -m sharktank.pipelines.flux.export_parameters \
+  --dtype <fp32/fp16/bf16> \
+  --input-path <input-dir> \
+  --output-path <output-dir>
 
-python -m sharktank.pipelines.flux.export_components --model="flux-dev" --component=<clip/vae/t5xxl/mmdit/scheduler> --precision=<fp32/fp16/bf16>
+python -m sharktank.pipelines.flux.export_components \
+  --model="flux_dev" \
+  --component=<clip/vae/t5xxl/mmdit/scheduler> \
+  --precision=<fp32/fp16/bf16>
 ```

--- a/sharktank/sharktank/pipelines/flux/export_from_hf.sh
+++ b/sharktank/sharktank/pipelines/flux/export_from_hf.sh
@@ -18,8 +18,6 @@ python -m sharktank.pipelines.flux.export_parameters --dtype $export_dtype --inp
 # Move files to cache
 mkdir -p $destination
 # Copy VMFB files
-# Fallback to t5xxl irpa fetching during server startup
-rm ./exported_parameters_${export_dtype}/flux_dev_t5xxl_${export_dtype}.irpa # TODO: Modify T5 to enable initialization from the flux repo
 # Copy IRPA files from exported_parameters directory
 mv exported_parameters_${export_dtype}/* "$destination/"
 

--- a/sharktank/tests/models/t5/t5_test.py
+++ b/sharktank/tests/models/t5/t5_test.py
@@ -278,14 +278,24 @@ class T5EncoderIreeTest(TempDirTestBase):
         huggingface_repo_id: str,
         reference_dtype: torch.dtype,
         target_dtype: torch.dtype,
+        subfolder: str = "",
+        tokenizer_huggingface_repo_id: str | None = None,
+        tokenizer_subfolder: str | None = None,
     ):
-        get_dataset(
-            huggingface_repo_id,
-        ).download()
-        tokenizer = AutoTokenizer.from_pretrained(huggingface_repo_id)
+        if tokenizer_huggingface_repo_id is None:
+            tokenizer_huggingface_repo_id = huggingface_repo_id
+        if tokenizer_subfolder is None:
+            tokenizer_subfolder = subfolder
+        tokenizer = AutoTokenizer.from_pretrained(
+            tokenizer_huggingface_repo_id, subfolder=tokenizer_subfolder
+        )
 
         reference_dataset = import_encoder_dataset_from_hugging_face(
-            huggingface_repo_id
+            huggingface_repo_id,
+            subfolder=subfolder,
+            tokenizer_config=get_tokenizer_config(
+                tokenizer_huggingface_repo_id, subfolder=tokenizer_subfolder
+            ),
         )
         target_dataset = copy(reference_dataset)
 
@@ -410,6 +420,16 @@ class T5EncoderIreeTest(TempDirTestBase):
     def testCompareV1_1XxlIreeBf16AgainstTorchEagerF32(self):
         self.runTestV1_1CompareIreeAgainstTorchEager(
             "google/t5-v1_1-xxl",
+            reference_dtype=torch.float32,
+            target_dtype=torch.bfloat16,
+        )
+
+    @with_t5_data
+    def testCompareV1_1XxlFluxRepoIreeBf16AgainstTorchEagerF32(self):
+        self.runTestV1_1CompareIreeAgainstTorchEager(
+            "black-forest-labs/FLUX.1-dev",
+            subfolder="text_encoder_2",
+            tokenizer_subfolder="tokenizer_2",
             reference_dtype=torch.float32,
             target_dtype=torch.bfloat16,
         )

--- a/shortfin/python/shortfin_apps/flux/components/builders.py
+++ b/shortfin/python/shortfin_apps/flux/components/builders.py
@@ -17,7 +17,7 @@ this_dir = os.path.dirname(os.path.abspath(__file__))
 parent = os.path.dirname(this_dir)
 default_config_json = os.path.join(parent, "examples", "flux_dev_config_mixed.json")
 
-ARTIFACT_VERSION = "02102025"
+ARTIFACT_VERSION = "20250321"
 FLUX_BUCKET = (
     f"https://sharkpublic.blob.core.windows.net/sharkpublic/flux.1/{ARTIFACT_VERSION}/"
 )
@@ -100,7 +100,7 @@ def get_file_stems(model_params: ModelParams):
         for bs in getattr(model_params, f"{mod}_batch_sizes", [1]):
             bsizes.extend([f"bs{bs}"])
         ord_params.extend([bsizes])
-        if mod in ["sampler"]:
+        if mod in ["sampler", "t5xxl"]:
             ord_params.extend([[str(model_params.t5xxl_max_seq_len)]])
         elif mod == "clip":
             ord_params.extend([[str(model_params.clip_max_seq_len)]])
@@ -181,7 +181,10 @@ def flux(
     params_urls = get_url_map(params_filenames, FLUX_WEIGHTS_BUCKET)
     for f, url in params_urls.items():
         if needs_file_url(f, ctx, url):
-            fetch_http_check_size(name=f, url=url)
+            raise RuntimeError(
+                "Model parameters auto-downloading is disable."
+                " To obtain the weights please follow https://github.com/nod-ai/shark-ai/tree/main/shortfin/python/shortfin_apps/flux#prepare-artifacts"
+            )
     filenames = [*vmfb_filenames, *params_filenames, *mlir_filenames]
     return filenames
 


### PR DESCRIPTION
export_components.py and export_parameters.py had some artifact file
naming discrepancies.

Make T5 model exportable from Flux repo.
The T5 model needs to get loaded into the transformers.T5EncoderModel
before parameters can be exported.
There is a special function for that as the original parameters from
google/t5-v1_1-xxl are not in safetensors format. This is what the
original modeling work was based on.
It also populates some config options form the tokenizer like max
context length so that the MLIR model can get exported just from an
IRPA.