### PR TITLE
[tuner] merge default td specs

### DIFF
--- a/requirements-iree-unpinned.txt
+++ b/requirements-iree-unpinned.txt
@@ -2,6 +2,6 @@
 
 --pre
 --find-links https://iree.dev/pip-release-links.html
-iree-base-compiler
-iree-base-runtime
-iree-turbine
+iree-base-compiler==3.3.0rc20250324
+iree-base-runtime==3.3.0rc20250324
+iree-turbine==3.3.0rc20250324

--- a/requirements-iree-unpinned.txt
+++ b/requirements-iree-unpinned.txt
@@ -2,6 +2,6 @@
 
 --pre
 --find-links https://iree.dev/pip-release-links.html
-iree-base-compiler==3.3.0rc20250324
-iree-base-runtime==3.3.0rc20250324
-iree-turbine==3.3.0rc20250324
+iree-base-compiler
+iree-base-runtime
+iree-turbine

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -306,9 +306,6 @@ def link_tuning_specs(tuner_ctx: TunerContext, td_specs: list[ir.Module]) -> ir.
         input_path = os.path.join(tmpdir, "tmp_input.mlir")
         output_path = os.path.join(tmpdir, "tmp_output.mlir")
 
-        print(input_path)
-        print(output_path)
-
         with open(input_path, "w") as f:
             f.write(str(module))
 

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -206,3 +206,142 @@ def test_get_lowering_config(tuner_ctx: common.TunerContext) -> None:
 
     assert compilation_info.lowering_config.mma_kind is None
     assert compilation_info.lowering_config.subgroup_count_mn == (1, 1)
+
+
+def test_combine_tuning_specs(tuner_ctx: common.TunerContext) -> None:
+    context = tuner_ctx.mlir_ctx
+    first_module_str = """
+        module @inner_module_a
+            attributes { transform.with_named_sequence } {
+        }
+    """
+
+    second_module_str = """
+        module @inner_module_b
+            attributes { transform.with_named_sequence } {
+        }
+    """
+
+    first_ir_module = ir.Module.parse(first_module_str, context)
+    second_ir_module = ir.Module.parse(second_module_str, context)
+
+    module = common.combine_tuning_specs(tuner_ctx, [first_ir_module, second_ir_module])
+    assert module
+    assert "transform.with_named_sequence" in module.operation.attributes
+
+    inner_ops = list(module.body.operations)
+    assert all(
+        op.name == "builtin.module" for op in inner_ops
+    ), "Not all ops are builtin.module"
+    assert len(inner_ops) == 2, f"Expected 2 inner modules, got {len(inner_ops)}"
+    assert (
+        inner_ops[0].sym_name.value == "inner_module_a"
+    ), f"Expected 'inner_module_a', got '{inner_ops[0].sym_name.value}'"
+    assert (
+        inner_ops[1].sym_name.value == "inner_module_b"
+    ), f"Expected 'inner_module_b', got '{inner_ops[1].sym_name.value}'"
+
+
+def test_link_tuning_specs(tuner_ctx: common.TunerContext) -> None:
+    context = tuner_ctx.mlir_ctx
+    first_module_str = """
+        module @inner_module_a
+            attributes { transform.with_named_sequence, iree_codegen.tuning_spec_with_default_entrypoint } {
+            transform.named_sequence @match(%arg: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
+                transform.yield %arg : !transform.any_op
+            }
+
+            transform.named_sequence @apply_op_config(%op: !transform.any_op {transform.readonly}) {
+                transform.yield
+            }
+
+            transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
+            -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
+                %res = transform.foreach_match in %arg0 @match -> @apply_op_config
+                    : (!transform.any_op) -> (!transform.any_op)
+                transform.yield %res : !transform.any_op
+            }
+        }
+    """
+
+    second_module_str = """
+        module @inner_module_b
+            attributes { transform.with_named_sequence, iree_codegen.tuning_spec_with_default_entrypoint } {
+            transform.named_sequence @match(%arg: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
+                transform.yield %arg : !transform.any_op
+            }
+
+            transform.named_sequence @apply_op_config(%op: !transform.any_op {transform.readonly}) {
+                transform.yield
+            }
+
+            transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
+            -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
+                %res = transform.foreach_match in %arg0 @match -> @apply_op_config
+                    : (!transform.any_op) -> (!transform.any_op)
+                transform.yield %res : !transform.any_op
+            }
+        }
+    """
+
+    first_ir_module = ir.Module.parse(first_module_str, context)
+    second_ir_module = ir.Module.parse(second_module_str, context)
+    linked_module = common.link_tuning_specs(
+        tuner_ctx, [first_ir_module, second_ir_module]
+    )
+    assert linked_module
+
+    assert "transform.with_named_sequence" in linked_module.operation.attributes
+    assert (
+        "iree_codegen.tuning_spec_with_default_entrypoint"
+        in linked_module.operation.attributes
+    )
+
+    inner_ops = list(linked_module.body.operations)
+    # Check that inner modules have been merged into the top-level module and no inner modules remain.
+    assert all(
+        op.name != "builtin.module" for op in inner_ops
+    ), "Unexpected inner builtin.module ops found"
+
+    named_sequences = []
+    kernel_config_op = None
+    for op in linked_module.body.operations:
+        if op.name == "transform.named_sequence":
+            sym_name_attr = op.sym_name
+            assert sym_name_attr is not None
+            named_sequences.append(sym_name_attr.value)
+            if sym_name_attr.value == "__kernel_config":
+                kernel_config_op = op
+
+    assert kernel_config_op is not None, "Missing @__kernel_config"
+    expected_names = {
+        "match",
+        "apply_op_config",
+        "inner_module_b_match",
+        "inner_module_b_apply_op_config",
+        "__kernel_config",
+    }
+    assert (
+        set(named_sequences) == expected_names
+    ), f"Unexpected named sequence names: {named_sequences}"
+
+    foreach_match_op = kernel_config_op.body.operations[0]
+    assert (
+        foreach_match_op.name == "transform.foreach_match"
+    ), f"Expected op name 'transform.foreach_match', got '{foreach_match_op.name}'"
+    assert (
+        len(foreach_match_op.matchers) == len(foreach_match_op.actions)
+        and len(foreach_match_op.matchers) == 2
+    )
+    assert (
+        foreach_match_op.matchers[0].value == "match"
+    ), f"Expected first matcher to be 'match', got '{foreach_match_op.matchers[0].value}'"
+    assert (
+        foreach_match_op.matchers[1].value == "inner_module_b_match"
+    ), f"Expected second matcher to be 'inner_module_b_match', got '{foreach_match_op.matchers[1].value}'"
+    assert (
+        foreach_match_op.actions[0].value == "apply_op_config"
+    ), f"Expected first action to be 'apply_op_config', got '{foreach_match_op.actions[0].value}'"
+    assert (
+        foreach_match_op.actions[1].value == "inner_module_b_apply_op_config"
+    ), f"Expected second action to be 'inner_module_b_apply_op_config', got '{foreach_match_op.actions[1].value}'"

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -304,13 +304,6 @@ def test_link_tuning_specs_raises_error(tuner_ctx: common.TunerContext) -> None:
     module_str = """
         module @inner_module_a
             attributes { transform.with_named_sequence } {
-            transform.named_sequence @match(%arg: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
-                transform.yield %arg : !transform.any_op
-            }
-
-            transform.named_sequence @apply_op_config(%op: !transform.any_op {transform.readonly}) {
-                transform.yield
-            }
         }
     """
 
@@ -321,5 +314,5 @@ def test_link_tuning_specs_raises_error(tuner_ctx: common.TunerContext) -> None:
     with pytest.raises(RuntimeError) as exc_info:
         common.link_tuning_specs(tuner_ctx, [module])
         # iree-opt should fail due to missing named sequence @__kernel_config entrypoint required
-        # by `iree_codegen.tuning_spec_with_default_entrypoint` attribute.
+        # by the `iree_codegen.tuning_spec_with_default_entrypoint` attribute.
         assert "iree-opt failed" in str(exc_info.value)


### PR DESCRIPTION
This PR adds the utility functions on the tuner side, which call the LinkTuningSpecsPass (`--iree-codegen-link-tuning-specs`) to merge the default td specs. 

Two helper functions are added:
-  `combine_tuning_specs`:  put two modules in one outer module using Python bindings.
- `link_tuning_specs`: invokes linking/merging pass (`--iree-codegen-link-tuning-specs`) to merge td_specs inside the module.

Issue: #810 