### PR TITLE
Improving batching behavior for LLM inference

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/batcher.py
+++ b/shortfin/python/shortfin_apps/llm/components/batcher.py
@@ -72,6 +72,7 @@ class LlmBatcherProcess(BatcherProcess):
     async def board_flights(self):
         waiting_count = len(self.pending)
         if waiting_count == 0:
+            self.strobes = 0
             return
         if waiting_count < self.ideal_batch_size and self.strobes < 2:
             logger.info("Waiting a bit longer to fill flight")

--- a/shortfin/python/shortfin_apps/llm/components/generate.py
+++ b/shortfin/python/shortfin_apps/llm/components/generate.py
@@ -135,8 +135,9 @@ class ClientGenerateBatchProcess(sf.Process):
         service: LlmGenerateService,
         gen_req: GenerateReqInput,
         responder: FastAPIResponder,
+        fiber: sf.Fiber | None = None,
     ):
-        super().__init__(fiber=service.main_fiber)
+        super().__init__(fiber=service.main_fiber if fiber is None else fiber)
         self.gen_req = gen_req
         self.responder = responder
         self.tokenizer = service.tokenizer


### PR DESCRIPTION
Batching for LLM inference performed immediate dispatches on requests
before attempting to group. This meant that almost immediately things
were split into individual requests (instead of groups of requests).