### PR TITLE
Special case for all_reduce for single 1 shard

### DIFF
--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -153,6 +153,9 @@ def all_gather_split(
 def all_reduce_split_or_unreduced(
     input: Union[SplitPrimitiveTensor, UnreducedTensor],
 ) -> ReplicatedTensor:
+    if len(input.shards) == 1:
+        return ReplicatedTensor(ts=input.shards, devices=input.devices)
+
     reduced = functools.reduce(
         lambda x, y: elementwise(torch.add, x, y),
         [


### PR DESCRIPTION
Avoid creating redundant barriers when the ReplicatedTensor has a single shard.