### PR TITLE
Limit SplitTensors to >1 shards

### DIFF
--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -1027,13 +1027,18 @@ class SplitPrimitiveTensor(ShardedTensorBase):
             from ..ops import transfer_to_logical_device
 
             assert shard_count is not None
+            assert (
+                shard_count > 1
+            ), "SplitTensor must have at least 2 shards. Use ReplicatedTensor for 1 shard."
             ts = ts.split(ceildiv(ts.shape[shard_dim], shard_count), dim=shard_dim)
             ts = [transfer_to_logical_device(t, devices[i]) for i, t in enumerate(ts)]
             assert len(ts) == shard_count
             shard_count = None
 
         assert shard_count is None
-        assert len(ts) > 0
+        assert (
+            len(ts) > 1
+        ), "SplitTensor must have at least 2 shards. Use ReplicatedTensor for 1 shard."
         first_shape = ts[0].shape
         assert len(first_shape) > shard_dim
         expected_shape = list(first_shape)

--- a/sharktank/tests/export_test.py
+++ b/sharktank/tests/export_test.py
@@ -31,13 +31,13 @@ import torch
 
 class ExportTest(TestCase):
     def testFlattenSignature(self):
-        expected_a = [SplitPrimitiveTensor(ts=[torch.tensor([1])], shard_dim=0)]
+        expected_a = [ReplicatedTensor(ts=[torch.tensor([1])])]
         expected_b = {"element": DefaultPrimitiveTensor(data=torch.tensor([2]))}
         expected_c = torch.tensor([3])
 
         @flatten_signature(expected_a, expected_b, expected_c)
         def f(
-            a: list[SplitPrimitiveTensor],
+            a: list[ReplicatedTensor],
             b: dict[str, DefaultPrimitiveTensor],
             c: torch.Tensor,
         ):

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -608,9 +608,9 @@ class AttentionTest(unittest.TestCase):
         k = torch.rand(4, 32, 16, dtype=torch.float32)
         v = torch.rand(4, 32, 16, dtype=torch.float32)
 
-        qs = SplitPrimitiveTensor(shard_dim=0, ts=q.split(4, dim=0))
-        ks = SplitPrimitiveTensor(shard_dim=0, ts=k.split(4, dim=0))
-        vs = SplitPrimitiveTensor(shard_dim=0, ts=v.split(4, dim=0))
+        qs = SplitPrimitiveTensor(shard_dim=0, ts=q.split(2, dim=0))
+        ks = SplitPrimitiveTensor(shard_dim=0, ts=k.split(2, dim=0))
+        vs = SplitPrimitiveTensor(shard_dim=0, ts=v.split(2, dim=0))
 
         expected_result = ops.scaled_dot_product_attention(q, k, v, a=None)
         sharded_result = ops.scaled_dot_product_attention(qs, ks, vs, a=None)
@@ -622,9 +622,9 @@ class AttentionTest(unittest.TestCase):
         k = torch.rand(4, 32, 16, dtype=torch.float32)
         v = torch.rand(4, 32, 16, dtype=torch.float32)
 
-        qs = SplitPrimitiveTensor(shard_dim=0, ts=q.split(4, dim=0))
-        ks = SplitPrimitiveTensor(shard_dim=0, ts=k.split(4, dim=0))
-        vs = SplitPrimitiveTensor(shard_dim=0, ts=v.split(4, dim=0))
+        qs = SplitPrimitiveTensor(shard_dim=0, ts=q.split(2, dim=0))
+        ks = SplitPrimitiveTensor(shard_dim=0, ts=k.split(2, dim=0))
+        vs = SplitPrimitiveTensor(shard_dim=0, ts=v.split(2, dim=0))
 
         expected_result = ops.scaled_dot_product_attention(
             q, k, v, a=None, is_causal=True


### PR DESCRIPTION
SplitTensors should only be used for sharding across multiple devices.

This PR adds asserts to their `__init__` to ensure they are constructed with at least 2 shards.