### PR TITLE
Further pipeline parallelism support sharded functions

### DIFF
--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -6,7 +6,7 @@
 
 import torch
 from torch import Tensor
-from typing import List, Optional, Sequence, Union, Any, Tuple, Dict
+from typing import List, Optional, Sequence, Union, Any, Tuple, Dict, Iterable
 import itertools
 from numbers import Number
 import math
@@ -56,11 +56,16 @@ def sharded_wrap_override():
 
             If no ShardedTensors are present in the input, then no changes are made to input/output.
             """
-            sharded_tensors = [
-                value
-                for value in itertools.chain(args, kwargs.values())
-                if isinstance(value, ShardedTensor)
-            ]
+            sharded_tensors = []
+            for value in itertools.chain(args, kwargs.values()):
+                if isinstance(value, ShardedTensor):
+                    sharded_tensors.append(value)
+                    continue
+                if isinstance(value, Iterable):
+                    for val in value:
+                        if isinstance(val, ShardedTensor):
+                            sharded_tensors.append(val)
+
             assert_on_same_devices(*sharded_tensors)
             res = f(*args, **kwargs)
             if isinstance(res, ShardedTensor) and len(sharded_tensors) > 0:

--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -216,7 +216,12 @@ def cat_split(
         concatenated_unsharded = cat(
             [shard for t in tensors for shard in t.shards], dim
         )
-        return reshard_split(concatenated_unsharded, dim=shard_dim, count=shard_count)
+        return reshard_split(
+            concatenated_unsharded,
+            dim=shard_dim,
+            count=shard_count,
+            devices=tensors[0].devices,
+        )
 
 
 # conv2d
@@ -1172,14 +1177,18 @@ def reshard_all_to_replicated(
 
 
 @reshard_split.override(Tensor)
-def reshard_split_unsharded(input, *, dim: int, count: int) -> SplitPrimitiveTensor:
+def reshard_split_unsharded(
+    input, *, dim: int, count: int, devices: tuple[int, ...]
+) -> SplitPrimitiveTensor:
     torch_input = unbox_tensor(input)
-    return SplitPrimitiveTensor(ts=torch_input, shard_dim=dim, shard_count=count)
+    return SplitPrimitiveTensor(
+        ts=torch_input, shard_dim=dim, shard_count=count, devices=devices
+    )
 
 
 @reshard_split.override(SplitPrimitiveTensor)
 def reshard_split_split(
-    input: SplitPrimitiveTensor, *, dim: int, count: int
+    input: SplitPrimitiveTensor, *, dim: int, count: int, devices: None
 ) -> SplitPrimitiveTensor:
     if input.shard_count != count:
         raise ValueError(f"Number of shards not equal ({input.shard_count} != {count})")
@@ -1190,7 +1199,7 @@ def reshard_split_split(
 
 @reshard_split.override(ReplicatedTensor)
 def reshard_split_replicated(
-    input: ReplicatedTensor, *, dim: int, count: int
+    input: ReplicatedTensor, *, dim: int, count: int, devices: None
 ) -> SplitPrimitiveTensor:
     if input.shard_count != count:
         raise ValueError(f"Number of shards not equal ({input.shard_count} != {count})")
@@ -1211,7 +1220,7 @@ def reshard_split_replicated(
         ]
         for shard_idx, shard in enumerate(input.shards)
     ]
-    return SplitPrimitiveTensor(ts=shards, shard_dim=dim)
+    return SplitPrimitiveTensor(ts=shards, shard_dim=dim, devices=input.devices)
 
 
 @reshard_like.override(Tensor, SplitPrimitiveTensor)

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -824,7 +824,7 @@ def _repeat_trampoline(
 
 @overridable
 def replicate(
-    input: AnyTensor, count: int, devices: Tuple[int] | None
+    input: AnyTensor, count: int, devices: tuple[int, ...] | None
 ) -> ShardedTensor:
     """Replicate across devices.
 
@@ -837,13 +837,12 @@ def _replicate_trampoline(
     d: SignatureDispatcher,
     input: AnyTensor,
     count: int,
-    devices: Tuple[int] | None = None,
+    devices: tuple[int, ...] | None = None,
 ) -> ShardedTensor:
     tensors = (input,)
     if isinstance(input, (torch.Tensor, PrimitiveTensor)):
         devices = devices if devices is not None else tuple(range(count))
     else:
-        # TODO: Is this correct? Will use data on `input`.
         assert devices is None
 
     for override in d.find_overrides(tensors):
@@ -935,7 +934,9 @@ def _reshard_trampoline(d: SignatureDispatcher, input, spec) -> ShardedTensor:
 
 
 @overridable
-def reshard_split(input: AnyTensor, *, dim: int, count: int) -> ShardedTensor:
+def reshard_split(
+    input: AnyTensor, *, dim: int, count: int, devices: tuple[int, ...] | None
+) -> ShardedTensor:
     """Split `input` along `dim`.
     This does not mean that a sharded tensor is further sharded.
     It is not composition of sharding operations.
@@ -945,11 +946,20 @@ def reshard_split(input: AnyTensor, *, dim: int, count: int) -> ShardedTensor:
 
 @reshard_split.trampoline
 def _reshard_split_trampoline(
-    d: SignatureDispatcher, input: AnyTensor, dim: int, count: int
+    d: SignatureDispatcher,
+    input: AnyTensor,
+    dim: int,
+    count: int,
+    devices: tuple[int, ...] | None = None,
 ) -> ShardedTensor:
     tensors = (input,)
+    if isinstance(input, (torch.Tensor, PrimitiveTensor)):
+        devices = devices if devices is not None else tuple(range(count))
+    else:
+        assert devices is None
+
     for override in d.find_overrides(tensors):
-        result = override(input, dim=dim, count=count)
+        result = override(input, dim=dim, count=count, devices=devices)
         if result is not NotImplemented:
             return override, result
     else:


### PR DESCRIPTION
Follow up to https://github.com/nod-ai/shark-ai/pull/1149
- Add pipeline parallelism support to reshard_split and re-enable CatTest
- Fix an issue with func_wrapper exposed by reshard_split usage.