### PR TITLE
[sharktank] Fix T5 init of config parameters

### DIFF
--- a/sharktank/sharktank/models/t5/t5.py
+++ b/sharktank/sharktank/models/t5/t5.py
@@ -1056,7 +1056,10 @@ class T5Stack(BaseLayer):
 
 class T5Encoder(ThetaLayer):
     def __init__(self, theta: Theta, config: T5Config):
-        super().__init__(theta)
+        encoder_config = copy.deepcopy(config)
+        encoder_config.use_cache = False
+        encoder_config.is_encoder_decoder = False
+        super().__init__(theta, encoder_config)
         self.add_module(
             "token_embedding",
             TokenEmbeddingLayer(
@@ -1064,18 +1067,11 @@ class T5Encoder(ThetaLayer):
             ),
         )
 
-        encoder_config = copy.deepcopy(config)
-        encoder_config.use_cache = False
-        encoder_config.is_encoder_decoder = False
         self.encoder = T5Stack(
             theta=theta("encoder"),
             config=encoder_config,
             embed_tokens=self.token_embedding,
         )
-
-    @property
-    def config(self):
-        return self.encoder.config
 
     def sample_inputs(
         self, batch_size: int = 1, function: Optional[str] = None


### PR DESCRIPTION
Fix for test failure
```
FAILED sharktank/tests/models/t5/t5_test.py::T5EncoderIreeTest::testCompareToyIreeVsEager_1
AttributeError: property 'config' of 'T5Encoder' object has no setter
```

See https://github.com/nod-ai/shark-ai/actions/runs/14096001030/job/39483353268