### PR TITLE
[tuner] add the option of providing starter td spec

### DIFF
--- a/tuner/examples/simple/simple_tuner.py
+++ b/tuner/examples/simple/simple_tuner.py
@@ -70,12 +70,6 @@ def main():
         default="",
         help="Path to the flags file for iree-benchmark-module for model benchmarking.",
     )
-    client_args.add_argument(
-        "--simple-starter-td-spec",
-        type=str,
-        default="",
-        help="Path to a starter td spec file to merge with tuning spec files.",
-    )
     # Remaining arguments come from libtuner
     args = libtuner.parse_arguments(parser)
 

--- a/tuner/examples/simple/simple_tuner.py
+++ b/tuner/examples/simple/simple_tuner.py
@@ -70,9 +70,14 @@ def main():
         default="",
         help="Path to the flags file for iree-benchmark-module for model benchmarking.",
     )
+    client_args.add_argument(
+        "--simple-starter-td-spec",
+        type=str,
+        default="",
+        help="Path to a starter td spec file to merge with tuning spec files.",
+    )
     # Remaining arguments come from libtuner
     args = libtuner.parse_arguments(parser)
-
     path_config = libtuner.PathConfig()
     path_config.base_dir.mkdir(parents=True, exist_ok=True)
     # TODO(Max191): Make candidate_trackers internal to TuningClient.

--- a/tuner/examples/simple/simple_tuner.py
+++ b/tuner/examples/simple/simple_tuner.py
@@ -78,6 +78,7 @@ def main():
     )
     # Remaining arguments come from libtuner
     args = libtuner.parse_arguments(parser)
+
     path_config = libtuner.PathConfig()
     path_config.base_dir.mkdir(parents=True, exist_ok=True)
     # TODO(Max191): Make candidate_trackers internal to TuningClient.

--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -243,7 +243,7 @@ def generate_configs_and_td_specs(
         td_spec_module = dispatch_tuner.get_td_spec(input_module, config)
         assert td_spec_module, "Failed to generate transform dialect spec"
 
-        # if starter td spec is not provided, use the generated td spec directly.
+        # If starter td spec is not provided, use the generated td spec directly.
         if starter_td_spec is None:
             config_specs.append(td_spec_module)
             continue
@@ -264,7 +264,7 @@ def generate_configs_and_td_specs(
             log_duplicates=log_duplicates,
         )
 
-        td_spec_module = link_tuning_specs(tuner_context.mlir_ctx, td_specs_to_link)
+        td_spec_module = link_tuning_specs(tuner_context, td_specs_to_link)
         config_specs.append(td_spec_module)
 
     tune_logger.debug(f"Generated {len(config_specs)} tuning specs")

--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -147,6 +147,32 @@ def get_default_output_dir() -> str:
     return "tuning_" + datetime.now().strftime("%Y_%m_%d_%H_%M")
 
 
+def check_td_spec_matchers_overlap(
+    starter_matchers: set[str],
+    current_matchers: set[str],
+    warned_overlap_matchers: set[str],
+) -> tuple[bool, set[str]]:
+    """
+    Determines whether tuning specs should be linked and new overlapping matchers for warning.
+
+    Args:
+        starter_matchers: Matcher names from the starter tuning spec.
+        current_matchers: Matcher names from the current tuning spec.
+        warned_overlap_matchers: Set of matchers already warned about for overlaps.
+
+    Returns:
+        should_link: True if starter matchers contain any target operations not in the current spec.
+        new_warned_matchers: Set of oerlapping matchers that havenot' been warned about yet.
+    """
+
+    overlap_matchers = starter_matchers & current_matchers
+    unique_starter_matchers = starter_matchers - current_matchers
+    new_warned_matchers = overlap_matchers - warned_overlap_matchers
+
+    should_link = bool(unique_starter_matchers)
+    return should_link, new_warned_matchers
+
+
 def generate_configs_and_td_specs(
     input_module: ir.Module,  # Path to the mlir file to be tuned
     tuner_context: TunerContext,
@@ -182,7 +208,29 @@ def generate_configs_and_td_specs(
     assert len(variant_op_list) == 1, "Expect one executable variant op"
     variant_op = variant_op_list[0]
     mma_list = iree_codegen.query_mma_intrinsics(variant_op)
+    if starter_td_spec == None:
+        for i, config in enumerate(
+            generate_solutions(
+                tuner_context,
+                problem_size,
+                num_subgroups,
+                mma_list,
+                allowed_waves_per_eu,
+                pipeline_options_search_space,
+                codegen_pipeline,
+            )
+        ):
+            if i >= limit:
+                break
+            tune_logger.debug(f"Solution #{i+1}: {config}")
+            td_spec_module = dispatch_tuner.get_td_spec(input_module, config)
+            assert td_spec_module, "Failed to generate transform dialect spec"
+            config_specs.append(td_spec_module)
+            tune_logger.debug(f"Generated {len(config_specs)} tuning specs")
+            return config_specs
+
     warned_overlap_matchers: set[str] = set()
+    starter_matchers = get_matcher_names_from_td_spec(starter_td_spec)
     for i, config in enumerate(
         generate_solutions(
             tuner_context,
@@ -198,24 +246,25 @@ def generate_configs_and_td_specs(
             break
         tune_logger.debug(f"Solution #{i+1}: {config}")
         td_spec_module = dispatch_tuner.get_td_spec(input_module, config)
-        if starter_td_spec != None:
-            starter_matchers = get_matcher_names_from_td_spec(starter_td_spec)
-            current_matchers = get_matcher_names_from_td_spec(td_spec_module)
-            overlap_matchers = starter_matchers & current_matchers
-            unique_stater_matchers = starter_matchers - current_matchers
-            new_warnings = overlap_matchers - warned_overlap_matchers
+        current_matchers = get_matcher_names_from_td_spec(td_spec_module)
 
-            # Log warnings only for newly detected overlapping target operations.
-            if new_warnings:
-                logging.warning(
-                    f"Operations have been tuned in the starter tuning spec: {sorted(new_warnings)}"
-                )
-                warned_overlap_matchers.update(new_warnings)
-            # Only link td spec and starter spec if it adds unique target operations.
-            if unique_stater_matchers:
-                td_spec_module = link_tuning_specs(
-                    tuner_context.mlir_ctx, [starter_td_spec, td_spec_module]
-                )
+        should_link, new_warned_matchers = check_td_spec_matchers_overlap(
+            starter_matchers, current_matchers, warned_overlap_matchers
+        )
+
+        # Log warnings only for newly detected overlapping target operations.
+        if new_warned_matchers:
+            logging.warning(
+                f"Operations have been tuned in the starter tuning spec: {sorted(new_warned_matchers)}"
+            )
+            warned_overlap_matchers.update(new_warned_matchers)
+
+        # Only link td spec and starter spec if it adds unique target operations.
+        if should_link:
+            td_spec_module = link_tuning_specs(
+                tuner_context.mlir_ctx, [starter_td_spec, td_spec_module]
+            )
+
         assert td_spec_module, "Failed to generate transform dialect spec"
         config_specs.append(td_spec_module)
 

--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -263,11 +263,8 @@ def generate_configs_and_td_specs(
             td_specs,
             log_duplicates=log_duplicates,
         )
-        if len(td_specs_to_link) == 2:
-            td_spec_module = link_tuning_specs(tuner_context.mlir_ctx, td_specs_to_link)
-        else:
-            # avoid unnessary link overhead.
-            td_spec_module = td_specs_to_link[0]
+
+        td_spec_module = link_tuning_specs(tuner_context.mlir_ctx, td_specs_to_link)
         config_specs.append(td_spec_module)
 
     tune_logger.debug(f"Generated {len(config_specs)} tuning specs")

--- a/tuner/tuner/candidate_gen_test.py
+++ b/tuner/tuner/candidate_gen_test.py
@@ -240,7 +240,7 @@ def test_determine_td_specs_to_link(
     current_td_spec = ir.Module.parse(module_str, context)
 
     td_specs_to_link = candidate_gen.determine_td_specs_to_link(
-        [starter_td_spec, current_td_spec],
+        [current_td_spec, starter_td_spec],
         log_duplicates=True,
     )
 

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -301,6 +301,10 @@ def link_tuning_specs(context: ir.Context, td_specs: list[ir.Module]) -> ir.Modu
     module = combine_tuning_specs(context, td_specs)
     iree_opt = ireec.binaries.find_tool("iree-opt")
 
+    if len(td_specs) == 1:
+        # avoid unnessary link overhead.
+        return td_specs[0]
+
     with tempfile.TemporaryDirectory() as tmpdir:
         input_path = os.path.join(tmpdir, "tmp_input.mlir")
         output_path = os.path.join(tmpdir, "tmp_output.mlir")

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -342,3 +342,17 @@ def get_matcher_names_from_td_spec(td_spec: ir.Module) -> set[str]:
                     matcher_names.add(matcher.value)
 
     return matcher_names
+
+
+def get_matcher_overlap_info(
+    starter_matchers: set[str], current_matchers: set[str]
+) -> tuple[set[str], set[str]]:
+    """
+    Returns:
+        - overlapping_matchers: matchers shared by starter and current
+        - unique_starter_matchers: matchers only in the starter
+    """
+    overlapping_matchers = starter_matchers & current_matchers
+    unique_starter_matchers = starter_matchers - current_matchers
+
+    return overlapping_matchers, unique_starter_matchers

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -272,14 +272,12 @@ class MLIRTransformation:
     embeddable: str
 
 
-def combine_tuning_specs(
-    tuner_ctx: TunerContext, td_specs: list[ir.Module]
-) -> ir.Module:
+def combine_tuning_specs(context: ir.Context, td_specs: list[ir.Module]) -> ir.Module:
     """
     Puts multiple input modules `td_specs` into a single top-level container module.
     This function does *not* attempt to merge or link `td_specs` across modules.
     """
-    with tuner_ctx.mlir_ctx as ctx, ir.Location.unknown():
+    with context, ir.Location.unknown():
         top_module = ir.Module.create()
         top_module.operation.attributes[
             "transform.with_named_sequence"
@@ -290,7 +288,7 @@ def combine_tuning_specs(
         return top_module
 
 
-def link_tuning_specs(tuner_ctx: TunerContext, td_specs: list[ir.Module]) -> ir.Module:
+def link_tuning_specs(context: ir.Context, td_specs: list[ir.Module]) -> ir.Module:
     """
     Links multiple input modules (`td_specs`) into a single tuning specification module.
     First, the input modules are combined into a container module. Then, the external
@@ -299,7 +297,7 @@ def link_tuning_specs(tuner_ctx: TunerContext, td_specs: list[ir.Module]) -> ir.
     default attribute `iree_codegen.tuning_spec_with_default_entrypoint`, they are merged
     into one tuning spec.
     """
-    module = combine_tuning_specs(tuner_ctx, td_specs)
+    module = combine_tuning_specs(context, td_specs)
     iree_opt = ireec.binaries.find_tool("iree-opt")
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -326,4 +324,21 @@ def link_tuning_specs(tuner_ctx: TunerContext, td_specs: list[ir.Module]) -> ir.
 
         with open(output_path, "r") as f:
             output_mlir = f.read()
-            return ir.Module.parse(output_mlir, tuner_ctx.mlir_ctx)
+            return ir.Module.parse(output_mlir, context)
+
+
+def get_matcher_names_from_td_spec(td_spec: ir.Module) -> set[str]:
+    matcher_names = set()
+
+    for op in td_spec.body.operations:
+        if op.name != "transform.named_sequence":
+            continue
+        if op.sym_name.value != "__kernel_config":
+            continue
+
+        for inner_op in op.regions[0].blocks[0].operations:
+            if inner_op.name == "transform.foreach_match":
+                for matcher in inner_op.matchers:
+                    matcher_names.add(matcher.value)
+
+    return matcher_names

--- a/tuner/tuner/common.py
+++ b/tuner/tuner/common.py
@@ -17,6 +17,7 @@ import os
 from iree.compiler import ir  # type: ignore
 
 from iree.compiler.dialects import iree_gpu  # type: ignore
+from iree.compiler.dialects import transform  # type: ignore
 import iree.compiler as ireec  # type: ignore
 
 
@@ -331,13 +332,13 @@ def get_matcher_names_from_td_spec(td_spec: ir.Module) -> set[str]:
     matcher_names = set()
 
     for op in td_spec.body.operations:
-        if op.name != "transform.named_sequence":
+        if not isinstance(op, transform.NamedSequenceOp):
             continue
         if op.sym_name.value != "__kernel_config":
             continue
 
         for inner_op in op.regions[0].blocks[0].operations:
-            if inner_op.name == "transform.foreach_match":
+            if isinstance(inner_op, transform.ForeachMatchOp):
                 for matcher in inner_op.matchers:
                     matcher_names.add(matcher.value)
 

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -337,9 +337,8 @@ def test_get_matcher_names_from_td_spec(tuner_ctx: common.TunerContext) -> None:
             transform.named_sequence @__kernel_config(%arg0: !transform.any_op ) -> !transform.any_op
                 attributes { iree_codegen.tuning_spec_entrypoint } {
                 %0 = transform.foreach_match in %arg0
-                @match_foo -> @apply_op_config
-                , @match_bar -> @apply_op_config
-                : (!transform.any_op) -> !transform.any_op
+                    @match_foo -> @apply_op_config,
+                    @match_bar -> @apply_op_config : (!transform.any_op) -> !transform.any_op
                 transform.yield %0 : !transform.any_op
             }
         }
@@ -361,3 +360,25 @@ def test_get_matcher_names_from_td_spec(tuner_ctx: common.TunerContext) -> None:
     module = ir.Module.parse(module_str, context)
     matcher_names = common.get_matcher_names_from_td_spec(module)
     assert matcher_names == set()
+
+
+def test_get_matcher_overlap_info(tuner_ctx: common.TunerContext) -> None:
+    starter = {"match_a", "match_b", "match_c"}
+    current = {"match_b", "match_d"}
+
+    overlapping, unique = common.get_matcher_overlap_info(starter, current)
+
+    assert overlapping == {"match_b"}
+    assert unique == {"match_a", "match_c"}
+
+    starter = {"match_x", "match_y"}
+    current = {"match_a", "match_b"}
+    overlapping, unique = common.get_matcher_overlap_info(starter, current)
+    assert overlapping == set()
+    assert unique == {"match_x", "match_y"}
+
+    starter = {"match_a", "match_b"}
+    current = {"match_a", "match_b", "match_c"}
+    overlapping, unique = common.get_matcher_overlap_info(starter, current)
+    assert overlapping == {"match_a", "match_b"}
+    assert unique == set()

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -266,6 +266,12 @@ def test_link_tuning_specs(tuner_ctx: common.TunerContext) -> None:
         }
     """
 
+    ir_module = ir.Module.parse(module_str, context)
+    linked_module = common.link_tuning_specs(context, [ir_module])
+    assert (
+        linked_module is ir_module
+    ), "Expected single input module to be returned without modification"
+
     first_ir_module = ir.Module.parse(module_str, context)
     second_ir_module = ir.Module.parse(module_str, context)
     second_ir_module.operation.attributes["sym_name"] = ir.StringAttr.get(
@@ -314,7 +320,7 @@ def test_link_tuning_specs_raises_error(tuner_ctx: common.TunerContext) -> None:
         "iree_codegen.tuning_spec_with_default_entrypoint"
     ] = ir.UnitAttr.get()
     with pytest.raises(RuntimeError) as exc_info:
-        common.link_tuning_specs(context, [module])
+        common.link_tuning_specs(context, [module, module])
         # iree-opt should fail due to missing named sequence @__kernel_config entrypoint required
         # by the `iree_codegen.tuning_spec_with_default_entrypoint` attribute.
         assert "iree-opt failed" in str(exc_info.value)

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -322,26 +322,26 @@ def test_get_matcher_names_from_td_spec(tuner_ctx: common.TunerContext) -> None:
     context = tuner_ctx.mlir_ctx
     module_str = """
         module attributes { transform.with_named_sequence } {
-        transform.named_sequence @apply_op_config(%arg0: !transform.any_op {transform.readonly}) {
-            transform.yield
-        }
+            transform.named_sequence @apply_op_config(%arg0: !transform.any_op {transform.readonly}) {
+                transform.yield
+            }
 
-        transform.named_sequence @match_foo(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
-            transform.yield %arg0 : !transform.any_op
-        }
+            transform.named_sequence @match_foo(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
+                transform.yield %arg0 : !transform.any_op
+            }
 
-        transform.named_sequence @match_bar(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
-            transform.yield %arg0 : !transform.any_op
-        }
+            transform.named_sequence @match_bar(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
+                transform.yield %arg0 : !transform.any_op
+            }
 
-        transform.named_sequence @__kernel_config(%arg0: !transform.any_op ) -> !transform.any_op
-            attributes { iree_codegen.tuning_spec_entrypoint } {
-            %0 = transform.foreach_match in %arg0
-            @match_foo -> @apply_op_config
-            , @match_bar -> @apply_op_config
-            : (!transform.any_op) -> !transform.any_op
-            transform.yield %0 : !transform.any_op
-        }
+            transform.named_sequence @__kernel_config(%arg0: !transform.any_op ) -> !transform.any_op
+                attributes { iree_codegen.tuning_spec_entrypoint } {
+                %0 = transform.foreach_match in %arg0
+                @match_foo -> @apply_op_config
+                , @match_bar -> @apply_op_config
+                : (!transform.any_op) -> !transform.any_op
+                transform.yield %0 : !transform.any_op
+            }
         }
     """
 
@@ -349,3 +349,15 @@ def test_get_matcher_names_from_td_spec(tuner_ctx: common.TunerContext) -> None:
     matcher_names = common.get_matcher_names_from_td_spec(module)
 
     assert matcher_names == {"match_foo", "match_bar"}
+
+    module_str = """
+        module attributes { transform.with_named_sequence } {
+            transform.named_sequence @__kernel_config(%arg0: !transform.any_op) -> !transform.any_op
+                attributes { iree_codegen.tuning_spec_entrypoint } {
+                transform.yield %arg0 : !transform.any_op
+            }
+        }
+    """
+    module = ir.Module.parse(module_str, context)
+    matcher_names = common.get_matcher_names_from_td_spec(module)
+    assert matcher_names == set()

--- a/tuner/tuner/common_test.py
+++ b/tuner/tuner/common_test.py
@@ -267,7 +267,7 @@ def test_link_tuning_specs(tuner_ctx: common.TunerContext) -> None:
     """
 
     ir_module = ir.Module.parse(module_str, context)
-    linked_module = common.link_tuning_specs(context, [ir_module])
+    linked_module = common.link_tuning_specs(tuner_ctx, [ir_module])
     assert (
         linked_module is ir_module
     ), "Expected single input module to be returned without modification"
@@ -278,7 +278,7 @@ def test_link_tuning_specs(tuner_ctx: common.TunerContext) -> None:
         "inner_module_b"
     )
     linked_module = common.link_tuning_specs(
-        context, [first_ir_module, second_ir_module]
+        tuner_ctx, [first_ir_module, second_ir_module]
     )
     assert linked_module
 
@@ -320,7 +320,7 @@ def test_link_tuning_specs_raises_error(tuner_ctx: common.TunerContext) -> None:
         "iree_codegen.tuning_spec_with_default_entrypoint"
     ] = ir.UnitAttr.get()
     with pytest.raises(RuntimeError) as exc_info:
-        common.link_tuning_specs(context, [module, module])
+        common.link_tuning_specs(tuner_ctx, [module, module])
         # iree-opt should fail due to missing named sequence @__kernel_config entrypoint required
         # by the `iree_codegen.tuning_spec_with_default_entrypoint` attribute.
         assert "iree-opt failed" in str(exc_info.value)

--- a/tuner/tuner/libtuner.py
+++ b/tuner/tuner/libtuner.py
@@ -338,6 +338,21 @@ def parse_arguments(
         help="Codegen pipeline to tune for",
     )
 
+    """
+    Providing a starter td spec enables incremental merging of TD specs across different dispatches
+    when tuning real models.
+
+    If there are conflicts on target operations (e.g., duplicate matchers), the candidate spec takes
+    precedence, and a warning will be issued to notify the user. If the candidate spec fully covers all
+    operations from the starter spec, the starter td spec will be excluded from linking.
+    """
+    general_args.add_argument(
+        "--simple-starter-td-spec",
+        type=str,
+        default="",
+        help="Path to a starter td spec file to merge with tuning spec files.",
+    )
+
     return parser.parse_args()
 
 

--- a/tuner/tuner/libtuner.py
+++ b/tuner/tuner/libtuner.py
@@ -683,7 +683,6 @@ def generate_candidate_specs(
             no_reduce_shared_memory_bank_conflicts=args.no_reduce_shared_memory_bank_conflicts_options,
         )
         starter_td_spec: Optional[ir.Module] = None
-        print(args.simple_starter_td_spec)
         if args.simple_starter_td_spec:
             with open(args.simple_starter_td_spec, "r") as f:
                 starter_td_spec = ir.Module.parse(f.read())

--- a/tuner/tuner/libtuner.py
+++ b/tuner/tuner/libtuner.py
@@ -337,20 +337,16 @@ def parse_arguments(
         default=CodegenPipelines.llvmgpu_vector_distribute,
         help="Codegen pipeline to tune for",
     )
-
-    """
-    Providing a starter td spec enables incremental merging of TD specs across different dispatches
-    when tuning real models.
-
-    If there are conflicts on target operations (e.g., duplicate matchers), the candidate spec takes
-    precedence, and a warning will be issued to notify the user. If the candidate spec fully covers all
-    operations from the starter spec, the starter td spec will be excluded from linking.
-    """
     general_args.add_argument(
-        "--simple-starter-td-spec",
-        type=str,
+        "--starter-td-spec",
+        type=Path,
         default="",
-        help="Path to a starter td spec file to merge with tuning spec files.",
+        help=(
+            "Path to a starter TD spec file to merge with tuning spec files. "
+            "Enables incremental merging of td specs across dispatches when tuning real models. "
+            "Candidate specs take precedence in case of conflicts; the starter spec is excluded "
+            "if fully covered."
+        ),
     )
 
     return parser.parse_args()
@@ -698,8 +694,8 @@ def generate_candidate_specs(
             no_reduce_shared_memory_bank_conflicts=args.no_reduce_shared_memory_bank_conflicts_options,
         )
         starter_td_spec: Optional[ir.Module] = None
-        if args.simple_starter_td_spec:
-            with open(args.simple_starter_td_spec, "r") as f:
+        if args.starter_td_spec:
+            with open(args.starter_td_spec, "r") as f:
                 starter_td_spec = ir.Module.parse(f.read())
         config_specs: list[ir.Module] = candidate_gen.generate_configs_and_td_specs(
             input_module=mlir_module,

--- a/tuner/tuner/libtuner.py
+++ b/tuner/tuner/libtuner.py
@@ -682,6 +682,11 @@ def generate_candidate_specs(
             prefetch_shared_memory=args.prefetch_shared_memory_options,
             no_reduce_shared_memory_bank_conflicts=args.no_reduce_shared_memory_bank_conflicts_options,
         )
+        starter_td_spec: Optional[ir.Module] = None
+        print(args.simple_starter_td_spec)
+        if args.simple_starter_td_spec:
+            with open(args.simple_starter_td_spec, "r") as f:
+                starter_td_spec = ir.Module.parse(f.read())
         config_specs: list[ir.Module] = candidate_gen.generate_configs_and_td_specs(
             input_module=mlir_module,
             tuner_context=tuning_client.tuner_context,
@@ -690,6 +695,7 @@ def generate_candidate_specs(
             allowed_waves_per_eu=args.waves_per_eu_options,
             pipeline_options_search_space=pipeline_options_search_space,
             codegen_pipeline=get_iree_codegen_pipeline(args.codegen_pipeline),
+            starter_td_spec=starter_td_spec,
         )
         logging.debug("candidate_gen.py ends")
         handle_error(


### PR DESCRIPTION
This PR adds implementation for providing a starter td spec, enabling incremental merging of tuning specs when tuning across different dispatches in a real model. 

Testing has been done from my end and verified that it works by supplying td specs that include matchers for attention ops or identical matmul ops, demonstrating that merging behaves correctly based on matcher overlap.

Issue: #810