### PR TITLE
[sharktank] Move expensive VAE tests to nightly

### DIFF
--- a/.github/workflows/ci-sharktank-nightly.yml
+++ b/.github/workflows/ci-sharktank-nightly.yml
@@ -77,6 +77,7 @@ jobs:
             --with-clip-data \
             --with-flux-data \
             --with-t5-data \
+            --with-vae-data \
             --iree-hal-target-device=hip \
             --iree-hip-target=gfx942 \
             --iree-device=hip://0 \

--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -140,12 +140,10 @@ jobs:
           pytest \
             -v \
             --log-cli-level=info \
-            --with-vae-data \
             --with-quark-data \
             --iree-hal-target-device=hip \
             --iree-hip-target=gfx942 \
             --iree-device=hip://0 \
-            sharktank/tests/models/vae/vae_test.py \
             sharktank/tests/models/llama/quark_parity_test.py \
             --durations=0 \
             --timeout=800

--- a/sharktank/sharktank/models/vae/testing.py
+++ b/sharktank/sharktank/models/vae/testing.py
@@ -13,21 +13,40 @@ from ...transforms.dataset import set_float_dtype
 
 
 def get_toy_vae_decoder_config() -> HParams:
-    norm_num_groups = 3
+    # This config causes compiler error
+    # https://github.com/iree-org/iree/issues/20307
+    # norm_num_groups = 3
+    # return HParams(
+    #     block_out_channels=[norm_num_groups * 7, norm_num_groups * 11],
+    #     in_channels=5,
+    #     out_channels=17,
+    #     up_block_types=[
+    #         "UpDecoderBlock2D",
+    #         "UpDecoderBlock2D",
+    #     ],
+    #     norm_num_groups=norm_num_groups,
+    #     latent_channels=13,
+    #     layers_per_block=2,
+    #     shift_factor=0.1234,
+    #     use_post_quant_conv=False,
+    #     sample_size=[23, 29],
+    # )
+
+    norm_num_groups = 2
     return HParams(
-        block_out_channels=[norm_num_groups * 7, norm_num_groups * 11],
+        block_out_channels=[norm_num_groups * 3, norm_num_groups * 4],
         in_channels=5,
-        out_channels=17,
+        out_channels=6,
         up_block_types=[
             "UpDecoderBlock2D",
             "UpDecoderBlock2D",
         ],
         norm_num_groups=norm_num_groups,
-        latent_channels=13,
-        layers_per_block=2,
+        latent_channels=7,
+        layers_per_block=8,
         shift_factor=0.1234,
         use_post_quant_conv=False,
-        sample_size=[23, 29],
+        sample_size=[128, 128],
     )
 
 


### PR DESCRIPTION
Change toy-size model config to circumvent compiler error for HIP. CPU still fails in another way.