### PR TITLE
Change ShardedTensor.clone to error out on wrong args

### DIFF
--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -1068,14 +1068,18 @@ class SplitPrimitiveTensor(ShardedTensorBase):
         )
 
     def clone(self, **kwargs) -> "SplitPrimitiveTensor":
-        new_kwargs = {
-            "shard_dim": kwargs.get("shard_dim", self.shard_dim),
-            "ts": kwargs.get("ts", self.shards),
-            "name": kwargs.get("name", self.name),
-            "shape": kwargs.get("shape", self.shape),
-            "devices": kwargs.get("devices", self.devices),
-        }
-        return SplitPrimitiveTensor(**new_kwargs)
+        kwargs["name"] = kwargs.get("name", self.name)
+        kwargs["devices"] = kwargs.get("devices", self.devices)
+        kwargs["shape"] = kwargs.get("shape", self.shape)
+        kwargs["shard_dim"] = kwargs.get("shard_dim", self.shard_dim)
+
+        if "ts" in kwargs:
+            # Only override shard_count if ts is a tensor.
+            if isinstance(kwargs["ts"], torch.Tensor):
+                kwargs["shard_count"] = kwargs.get("shard_count", self.shard_dim)
+        else:
+            kwargs["ts"] = self.shards
+        return SplitPrimitiveTensor(**kwargs)
 
     def _is_slicing_split_dim(self, key):
         if isinstance(
@@ -1206,17 +1210,17 @@ class ReplicatedTensor(ShardedTensor):
         )
 
     def clone(self, **kwargs) -> "ReplicatedTensor":
-        new_kwargs = {
-            "ts": kwargs.get("ts", self.shards),
-            "name": kwargs.get("name", self.name),
-            "devices": kwargs.get("devices", self.devices),
-        }
-        if "shard_count" in kwargs:
-            assert isinstance(new_kwargs["ts"], torch.Tensor)
-            new_kwargs["shard_count"] = kwargs["shard_count"]
+        kwargs["ts"] = kwargs.get("ts", self.shards)
+        kwargs["name"] = kwargs.get("name", self.name)
+        kwargs["devices"] = kwargs.get("devices", self.devices)
+
+        if "ts" in kwargs:
+            # Only override shard_count if ts is a tensor.
+            if isinstance(kwargs["ts"], torch.Tensor):
+                kwargs["shard_count"] = kwargs.get("shard_count", self.shard_dim)
         else:
-            assert not isinstance(new_kwargs["ts"], torch.Tensor)
-        return ReplicatedTensor(**new_kwargs)
+            kwargs["ts"] = self.shards
+        return ReplicatedTensor(**kwargs)
 
     @property
     def is_replicated(self) -> bool:
@@ -1340,13 +1344,11 @@ class UnreducedTensor(ShardedTensorBase):
         )
 
     def clone(self, **kwargs) -> "UnreducedTensor":
-        new_kwargs = {
-            "ts": kwargs.get("ts", self.shards),
-            "name": kwargs.get("name", self.name),
-            "shape": kwargs.get("shape", self.shape),
-            "devices": kwargs.get("devices", self.devices),
-        }
-        return UnreducedTensor(**new_kwargs)
+        kwargs["ts"] = kwargs.get("ts", self.shards)
+        kwargs["name"] = kwargs.get("name", self.name)
+        kwargs["shape"] = kwargs.get("shape", self.shape)
+        kwargs["devices"] = kwargs.get("devices", self.devices)
+        return UnreducedTensor(**kwargs)
 
 
 def flatten_tensor_tree(

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -1076,7 +1076,7 @@ class SplitPrimitiveTensor(ShardedTensorBase):
         if "ts" in kwargs:
             # Only override shard_count if ts is a tensor.
             if isinstance(kwargs["ts"], torch.Tensor):
-                kwargs["shard_count"] = kwargs.get("shard_count", self.shard_dim)
+                kwargs["shard_count"] = kwargs.get("shard_count", self.shard_count)
         else:
             kwargs["ts"] = self.shards
         return SplitPrimitiveTensor(**kwargs)
@@ -1217,7 +1217,7 @@ class ReplicatedTensor(ShardedTensor):
         if "ts" in kwargs:
             # Only override shard_count if ts is a tensor.
             if isinstance(kwargs["ts"], torch.Tensor):
-                kwargs["shard_count"] = kwargs.get("shard_count", self.shard_dim)
+                kwargs["shard_count"] = kwargs.get("shard_count", self.shard_count)
         else:
             kwargs["ts"] = self.shards
         return ReplicatedTensor(**kwargs)

--- a/sharktank/tests/ops/pipeline_parallelized_test.py
+++ b/sharktank/tests/ops/pipeline_parallelized_test.py
@@ -152,6 +152,42 @@ class CatTest(unittest.TestCase):
         assert iterables_equal(expected_result.devices, actual_result.devices)
 
 
+class CloneTest(unittest.TestCase):
+    def testCloneReplicatedFail(self):
+        original = ReplicatedTensor(
+            ts=torch.rand(5, 4, dtype=torch.float32), shard_count=4
+        )
+        try:
+            original.clone(shards=None)
+        except:
+            return
+        assert (
+            False
+        ), "Should have thrown an error when passing incorrect keywords to clone"
+
+    def testCloneSplitFail(self):
+        original = SplitPrimitiveTensor(
+            ts=torch.rand(5, 4, dtype=torch.float32), shard_dim=1, shard_count=4
+        )
+        try:
+            original.clone(shards=None)
+        except:
+            return
+        assert (
+            False
+        ), "Should have thrown an error when passing incorrect keywords to clone"
+
+    def testCloneUnreducedFail(self):
+        original = UnreducedTensor(ts=[torch.rand(5, 4, dtype=torch.float32)])
+        try:
+            original.clone(shards=None)
+        except:
+            return
+        assert (
+            False
+        ), "Should have thrown an error when passing incorrect keywords to clone"
+
+
 class IndexSelectTest(unittest.TestCase):
     def testIndexReplicatedPinned(self):
         shard_count = 5


### PR DESCRIPTION
- Change how defaults are loaded into kwargs by .clone() so that incorrectly specified kwargs will error out.
  - Previously it silently used defaults and not the specified values. E.g. if you provided `shards=...` instead of `ts=...` it would use the tensor's existing shards rather than error out.
- Added tests to verify this behaviour