### PR TITLE
Expand_split fix

### DIFF
--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -537,26 +537,13 @@ def expand_split(
     tensor: SplitPrimitiveTensor, shape: List[int]
 ) -> SplitPrimitiveTensor:
     assert len(shape) == len(tensor.shape)
-    expanded_dims = [
-        i
-        for i, (old_dim, new_dim) in enumerate(zip(tensor.shape, shape))
-        if old_dim == 1 and new_dim != 1
-    ]
-    assert (
-        tensor.shard_dim not in expanded_dims
-    ), "Expanding a split dimension is not supported"
+    shard_dim = tensor.shard_dim
+    not_expanding_split_dim = (
+        shape[shard_dim] == -1 or shape[shard_dim] == tensor.shards[0].shape[shard_dim]
+    )
+    assert not_expanding_split_dim, "Expanding a split dimension is not supported"
 
-    def set_element(l: List, idx: int, el: Any) -> List:
-        l[idx] = el
-        return l
-
-    shards = [
-        expand(
-            shard,
-            set_element(list(shape), tensor.shard_dim, shard.shape[tensor.shard_dim]),
-        )
-        for shard in tensor.shards
-    ]
+    shards = [expand(shard, shape) for shard in tensor.shards]
     return SplitPrimitiveTensor(ts=shards, shard_dim=tensor.shard_dim)
 
 

--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -539,10 +539,12 @@ def expand_split(
     assert len(shape) == len(tensor.shape)
     shard_dim = tensor.shard_dim
     not_expanding_split_dim = (
-        shape[shard_dim] == -1 or shape[shard_dim] == tensor.shards[0].shape[shard_dim]
+        shape[shard_dim] == -1 or shape[shard_dim] == tensor.shape[shard_dim]
     )
     assert not_expanding_split_dim, "Expanding a split dimension is not supported"
 
+    shape = list(shape)
+    shape[shard_dim] = -1
     shards = [expand(shard, shape) for shard in tensor.shards]
     return SplitPrimitiveTensor(ts=shards, shard_dim=tensor.shard_dim)
 

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -383,6 +383,31 @@ class FlattenTest(unittest.TestCase):
 
 
 class ExpandTest(unittest.TestCase):
+    def testExpandSplit(self):
+        sizes = [4, -1, -1]
+        a = torch.rand(1, 2, 5)
+        b = SplitPrimitiveTensor(ts=a.split(1, dim=1), shard_dim=1)
+
+        expected = [torch.Tensor.expand(shard, sizes) for shard in a.split(1, dim=1)]
+        actual = ops.expand(b, sizes)
+
+        for expected_shard, actual_shard in zip(expected, actual.shards):
+            torch.testing.assert_close(actual_shard.as_torch(), expected_shard)
+
+    def testExpandSplitAlongSplit(self):
+        sizes = [-1, 4, -1]
+        a = torch.rand(4, 2, 5)
+        b = SplitPrimitiveTensor(ts=a.split(1, dim=1), shard_dim=1)
+
+        try:
+            ops.expand(b, sizes)
+        except:
+            return
+
+        assert (
+            False
+        ), "Expanding SplitTensor along split dimension should have thrown an error"
+
     def testExpandReplicated(self):
         sizes = [4, 4, 5]
         shard_count = 2

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -408,6 +408,17 @@ class ExpandTest(unittest.TestCase):
             False
         ), "Expanding SplitTensor along split dimension should have thrown an error"
 
+    def testExpandSplitAlongSplitNoExand(self):
+        sizes = [-1, 3, -1]
+        a = torch.rand(4, 2, 5)
+        b = torch.rand(4, 1, 5)
+        split = SplitPrimitiveTensor(ts=[a, b], shard_dim=1)
+
+        actual = ops.expand(split, sizes)
+
+        for pre_shard, post_shard in zip(split.shards, actual.shards):
+            torch.testing.assert_close(pre_shard.as_torch(), post_shard.as_torch())
+
     def testExpandReplicated(self):
         sizes = [4, 4, 5]
         shard_count = 2


### PR DESCRIPTION
Current behaviour of ops.split for SplitPrimitiveTensor is not consistent with either torch.split nor with its own documentation.

See the added tests, specifically `testExpandSplitAlongSplit` should error since it's splitting along `shard_dim`, but it does not error out. Instead it silently does nothing.

This change attempts to 'fix' the behaviour to be in line with torch.split (i.e. not allow splitting along a non-singular dimension) and with its own doc (i.e. don't allow expanding along the `shard_dim`).