### PR TITLE
Check output paths before performing computation

### DIFF
--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -27,6 +27,7 @@ from .. import ops
 
 def main():
     from ..utils import cli
+    import os
 
     parser = cli.create_parser()
     cli.add_input_dataset_options(parser)
@@ -71,6 +72,14 @@ def main():
     cli.add_quantization_options(parser)
     cli.add_model_options(parser)
     args = cli.parse(parser)
+
+    if args.output_mlir and args.output_mlir != "-":
+        mlir_dir = os.path.dirname(args.output_mlir)
+        if mlir_dir and not os.path.exists(mlir_dir):
+            raise ValueError(
+                f"Parent directory for output MLIR file does not exist: {mlir_dir}"
+            )
+
     if args.attention_kernel == "sharktank":
         ops.attention_impls.register_attention_override_by_name(
             "masked_flash_attention"

--- a/sharktank/sharktank/examples/pipeline/export_ppffn_net.py
+++ b/sharktank/sharktank/examples/pipeline/export_ppffn_net.py
@@ -70,6 +70,7 @@ class PPFFN(ThetaLayer):
 
 def main(raw_args=None):
     from ...utils import cli
+    import os
 
     parser = cli.create_parser()
     parser.add_argument(
@@ -81,6 +82,19 @@ def main(raw_args=None):
     )
     cli.add_output_dataset_options(parser)
     args = cli.parse(parser, args=raw_args)
+
+    if args.output_irpa_file and args.output_irpa_file != "-":
+        irpa_dir = os.path.dirname(args.output_irpa_file)
+        if irpa_dir and not os.path.exists(irpa_dir):
+            raise ValueError(
+                f"Parent directory for output IRPA file does not exist: {irpa_dir}"
+            )
+    if args.output_file and args.output_file != "-":
+        output_dir = os.path.dirname(args.output_file)
+        if output_dir and not os.path.exists(output_dir):
+            raise ValueError(
+                f"Parent directory for output file does not exist: {output_dir}"
+            )
 
     bs = 16
     sl = 128

--- a/sharktank/sharktank/examples/sharding/export_ffn_net.py
+++ b/sharktank/sharktank/examples/sharding/export_ffn_net.py
@@ -64,6 +64,7 @@ class ShardedFFN(ThetaLayer):
 
 def main(raw_args=None):
     from ...utils import cli
+    import os
 
     parser = cli.create_parser()
     parser.add_argument(
@@ -75,6 +76,19 @@ def main(raw_args=None):
     )
     cli.add_output_dataset_options(parser)
     args = cli.parse(parser, args=raw_args)
+
+    if args.output_irpa_file and args.output_irpa_file != "-":
+        irpa_dir = os.path.dirname(args.output_irpa_file)
+        if irpa_dir and not os.path.exists(irpa_dir):
+            raise ValueError(
+                f"Parent directory for output IRPA file does not exist: {irpa_dir}"
+            )
+    if args.output_file and args.output_file != "-":
+        output_dir = os.path.dirname(args.output_file)
+        if output_dir and not os.path.exists(output_dir):
+            raise ValueError(
+                f"Parent directory for output file does not exist: {output_dir}"
+            )
 
     bs = 4
     sl = 32


### PR DESCRIPTION
These scripts, especially `export_paged_llm_v1` can take several minutes to complete, and to have to have it fail right at the end because of an incorrectly specified path is a bad user experience.