### PR TITLE
Rework batcher for a reservation system

### DIFF
--- a/shortfin/python/shortfin_apps/llm/cli.py
+++ b/shortfin/python/shortfin_apps/llm/cli.py
@@ -153,6 +153,8 @@ class Timer:
         self._end = time.perf_counter()
 
     def elapsed(self):
+        if self._end is None:
+            return time.perf_counter() - self._start
         return self._end - self._start
 
 

--- a/shortfin/python/shortfin_apps/llm/components/batcher.py
+++ b/shortfin/python/shortfin_apps/llm/components/batcher.py
@@ -104,7 +104,10 @@ class LlmBatcherProcess(BatcherProcess):
             self.strobes = 0
             return
         target_size = min(self._current_workitems, self.ideal_batch_size)
-        if waiting_count < target_size and self.strobes < 2:
+        if waiting_count < target_size:
+            logger.info("Pending workitems to be enqueued")
+            return
+        if waiting_count < self.ideal_batch_size and self.strobes < 2:
             logger.info("Waiting a bit longer to fill flight")
             return
 

--- a/shortfin/python/shortfin_apps/llm/components/batcher.py
+++ b/shortfin/python/shortfin_apps/llm/components/batcher.py
@@ -35,6 +35,14 @@ logger = logging.getLogger(__name__)
 import math
 
 
+class NewWorkItem(sf.Message):
+    ...
+
+
+class DoneWorkItem(sf.Message):
+    ...
+
+
 class LlmBatcherProcess(BatcherProcess):
     """This batcher provides a high-level mechanism for dispatching LLM tasks."""
 
@@ -60,6 +68,7 @@ class LlmBatcherProcess(BatcherProcess):
         # batching in the scheduling algo.
         self.ideal_batch_size: int = ideal_batch_size
         self.page_seq_stride = self.model_params.paged_kv_cache.block_seq_stride
+        self._current_workitems = 0
 
     def handle_inference_request(self, request):
         """Handle an inference request."""
@@ -69,10 +78,32 @@ class LlmBatcherProcess(BatcherProcess):
         """Process batches of requests."""
         await self.board_flights()
 
+    def reserve_workitem(self):
+        self.submit(NewWorkItem())
+
+    def complete_workitem(self):
+        self.submit(DoneWorkItem())
+
+    def custom_message(self, msg):
+        if isinstance(msg, NewWorkItem):
+            self._current_workitems = self._current_workitems + 1
+            return
+
+        if isinstance(msg, DoneWorkItem):
+            self._current_workitems = self._current_workitems - 1
+            return
+
+        super().custom_message(msg)
+
+    async def board_flights(self):
+        await super().board_flights()
+
     async def board_flights(self):
         waiting_count = len(self.pending)
         if waiting_count == 0:
             self.strobes = 0
+            return
+        if self._current_workitems > waiting_count:
             return
         if waiting_count < self.ideal_batch_size and self.strobes < 2:
             logger.info("Waiting a bit longer to fill flight")
@@ -174,8 +205,8 @@ class DecodeBatcherProcess(LlmBatcherProcess):
     committed cache state).
     """
 
-    STROBE_SHORT_DELAY = 0.010
-    STROBE_LONG_DELAY = 0.010
+    STROBE_SHORT_DELAY = 0.0001
+    STROBE_LONG_DELAY = 0.0001
 
     def __init__(
         self,

--- a/shortfin/python/shortfin_apps/llm/components/batcher.py
+++ b/shortfin/python/shortfin_apps/llm/components/batcher.py
@@ -103,9 +103,8 @@ class LlmBatcherProcess(BatcherProcess):
         if waiting_count == 0:
             self.strobes = 0
             return
-        if self._current_workitems > waiting_count:
-            return
-        if waiting_count < self.ideal_batch_size and self.strobes < 2:
+        target_size = min(self._current_workitems, self.ideal_batch_size)
+        if waiting_count < target_size and self.strobes < 2:
             logger.info("Waiting a bit longer to fill flight")
             return
 

--- a/shortfin/python/shortfin_apps/llm/components/generate.py
+++ b/shortfin/python/shortfin_apps/llm/components/generate.py
@@ -23,7 +23,6 @@ from .service import LlmGenerateService
 from .token_selection_strategy import (
     BaseTokenSelectionStrategy,
     TokenSelectionStrategyConfig,
-    TokenSelectionStrategy,
     build_token_selector,
     build_token_selector_config,
     is_multi_beam,
@@ -63,8 +62,8 @@ class GenerateItemProcess(sf.Process):
         self.token_selector_config: TokenSelectionStrategyConfig = (
             build_token_selector_config(
                 decode_config,
-                prefill_callback=self.client.prefill_batcher.submit,
-                decode_callback=self.client.decode_batcher.submit,
+                prefill_batcher=self.client.prefill_batcher,
+                decode_batcher=self.client.decode_batcher,
                 results_callback=self.results_callback,
                 eos_token_id=self.eos_token_id,
                 max_completion_tokens=self.max_completion_tokens,

--- a/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/__init__.py
+++ b/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/__init__.py
@@ -22,8 +22,8 @@ from ..messages import LlmInferenceExecRequest
 
 def build_token_selector_config(
     decode_config: DecodeConfig,
-    prefill_callback: Callable[[LlmInferenceExecRequest], None],
-    decode_callback: Callable[[LlmInferenceExecRequest], None],
+    prefill_batcher,
+    decode_batcher,
     results_callback: Callable[[Union[int, List[int]]], None],
     eos_token_id: int,
     max_completion_tokens: int,
@@ -49,8 +49,10 @@ def build_token_selector_config(
         case TokenSelectionStrategy.GREEDY | TokenSelectionStrategy.MULTI_GREEDY:
             config = TokenSelectionStrategyConfig(
                 decode_config,
-                prefill_callback=prefill_callback,
-                decode_callback=decode_callback,
+                prefill_callback=prefill_batcher.submit,
+                decode_callback=decode_batcher.submit,
+                decode_begin_callback=decode_batcher.reserve_workitem,
+                decode_end_callback=decode_batcher.complete_workitem,
                 results_callback=results_callback,
                 eos_token_id=eos_token_id,
                 max_completion_tokens=max_completion_tokens,

--- a/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/base_token_selection_strategy.py
+++ b/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/base_token_selection_strategy.py
@@ -62,6 +62,8 @@ class TokenSelectionStrategyConfig:
     decode_config: DecodeConfig
     prefill_callback: Callable[[LlmInferenceExecRequest], None]
     decode_callback: Callable[[LlmInferenceExecRequest], None]
+    decode_begin_callback: Callable[[], None]
+    decode_end_callback: Callable[[], None]
     results_callback: Callable[[Union[int, List[int]]], None]
     eos_token_id: int
     max_completion_tokens: int

--- a/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/greedy_token_selection_strategy.py
+++ b/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/greedy_token_selection_strategy.py
@@ -39,6 +39,7 @@ class GreedyTokenSelectionStrategy(BaseTokenSelectionStrategy):
             exec_req (LlmInferenceExecRequest): Execution request that has had prefill invoked on it.
         """
         config = self.token_selection_strategy_config
+        config.decode_begin_callback()
         for _ in range(config.max_completion_tokens):
             exec_req.reset(InferencePhase.DECODE)
             config.decode_callback(exec_req)
@@ -50,3 +51,4 @@ class GreedyTokenSelectionStrategy(BaseTokenSelectionStrategy):
                 break
             exec_req.input_token_ids.append(token_int)
             exec_req.start_position += 1
+        config.decode_end_callback()

--- a/shortfin/python/shortfin_apps/utils.py
+++ b/shortfin/python/shortfin_apps/utils.py
@@ -478,6 +478,7 @@ class BatcherProcess(sf.Process):
         self.strobe_enabled = True
         self.strobes = 0
         self.pending_requests = set()
+        self.logger = logging.getLogger("batcher")
 
     def shutdown(self):
         """Shutdown the batcher process."""
@@ -498,6 +499,10 @@ class BatcherProcess(sf.Process):
             if self.strobe_enabled:
                 self.submit(StrobeMessage())
 
+    def custom_message(self, msg):
+        self.logger.error("Illegal message received by batcher: %r", msg)
+        exit(1)
+
     async def run(self):
         """Main run loop for the batcher process."""
         strober_task = asyncio.create_task(self._background_strober())
@@ -509,9 +514,7 @@ class BatcherProcess(sf.Process):
             elif isinstance(item, StrobeMessage):
                 self.strobes += 1
             else:
-                logger.error("Illegal message received by batcher: %r", item)
-                exit(1)
-
+                self.custom_message(item)
             await self.process_batches()
 
             self.strobe_enabled = True

--- a/shortfin/tests/apps/llm/components/token_selection_strategy/multi_greedy_token_selection_strategy_test.py
+++ b/shortfin/tests/apps/llm/components/token_selection_strategy/multi_greedy_token_selection_strategy_test.py
@@ -50,6 +50,17 @@ def multi_greedy_token_selection_strategy():
     )
 
 
+class FakeBatcher:
+    def __init__(self, submit_cb, workitem_cb):
+        self.submit = submit_cb
+        self.reserve_workitem = workitem_cb
+        self.complete_workitem = workitem_cb
+
+
+def _batcher_workitem_callback():
+    pass
+
+
 @pytest.mark.asyncio
 async def test_multi_greedy_decode_single(
     cache,
@@ -76,8 +87,8 @@ async def test_multi_greedy_decode_single(
     )
     config = build_token_selector_config(
         decode_config,
-        prefill_callback=_batcher_callback,
-        decode_callback=_batcher_callback,
+        prefill_batcher=FakeBatcher(_batcher_callback, _batcher_workitem_callback),
+        decode_batcher=FakeBatcher(_batcher_callback, _batcher_workitem_callback),
         results_callback=_results_callback,
         eos_token_id=-1,
         max_completion_tokens=1,
@@ -148,8 +159,12 @@ async def test_multi_greedy_decode_multiple_completions(
     )
     config = build_token_selector_config(
         decode_config,
-        prefill_callback=_batcher_callback_multiple_completions,
-        decode_callback=_batcher_callback_multiple_completions,
+        prefill_batcher=FakeBatcher(
+            _batcher_callback_multiple_completions, _batcher_workitem_callback
+        ),
+        decode_batcher=FakeBatcher(
+            _batcher_callback_multiple_completions, _batcher_workitem_callback
+        ),
         results_callback=_results_callback,
         eos_token_id=-1,
         max_completion_tokens=5,
@@ -220,8 +235,12 @@ async def test_multi_greedy_decode_eos_token(
     )
     config = build_token_selector_config(
         decode_config,
-        prefill_callback=_batcher_callback_multiple_completions,
-        decode_callback=_batcher_callback_multiple_completions,
+        prefill_batcher=FakeBatcher(
+            _batcher_callback_multiple_completions, _batcher_workitem_callback
+        ),
+        decode_batcher=FakeBatcher(
+            _batcher_callback_multiple_completions, _batcher_workitem_callback
+        ),
         results_callback=_results_callback,
         eos_token_id=-1,
         max_completion_tokens=5,

--- a/shortfin/tests/apps/llm/components/token_selection_strategy/token_selection_strategy_test.py
+++ b/shortfin/tests/apps/llm/components/token_selection_strategy/token_selection_strategy_test.py
@@ -16,6 +16,17 @@ from shortfin_apps.llm.components.messages import (
 from shortfin_apps.llm.components import token_selection_strategy
 
 
+class FakeBatcher:
+    def __init__(self, submit_cb, workitem_cb):
+        self.submit = submit_cb
+        self.reserve_workitem = workitem_cb
+        self.complete_workitem = workitem_cb
+
+
+def _batcher_workitem_callback():
+    pass
+
+
 def test_imports():
     for attr in token_selection_strategy.__all__:
         assert hasattr(token_selection_strategy, attr)
@@ -37,8 +48,8 @@ def test_build_token_selector_config():
 
     config = token_selection_strategy.build_token_selector_config(
         decode_config,
-        prefill_callback=_batcher_callback,
-        decode_callback=_batcher_callback,
+        prefill_batcher=FakeBatcher(_batcher_callback, _batcher_workitem_callback),
+        decode_batcher=FakeBatcher(_batcher_callback, _batcher_workitem_callback),
         results_callback=_results_callback,
         eos_token_id=0,
         max_completion_tokens=42,
@@ -54,8 +65,8 @@ def test_build_token_selector_config():
         decode_config.token_selection_strategy = "NotImplemented"
         config = token_selection_strategy.build_token_selector_config(
             decode_config,
-            prefill_callback=_batcher_callback,
-            decode_callback=_batcher_callback,
+            prefill_batcher=FakeBatcher(_batcher_callback, _batcher_workitem_callback),
+            decode_batcher=FakeBatcher(_batcher_callback, _batcher_workitem_callback),
             results_callback=_results_callback,
             eos_token_id=0,
             max_completion_tokens=42,
@@ -70,8 +81,8 @@ def test_build_token_selector():
     )
     config = token_selection_strategy.build_token_selector_config(
         decode_config,
-        prefill_callback=_batcher_callback,
-        decode_callback=_batcher_callback,
+        prefill_batcher=FakeBatcher(_batcher_callback, _batcher_workitem_callback),
+        decode_batcher=FakeBatcher(_batcher_callback, _batcher_workitem_callback),
         results_callback=_results_callback,
         eos_token_id=0,
         max_completion_tokens=42,
@@ -120,8 +131,8 @@ async def test_prefill(
 
     config = token_selection_strategy.build_token_selector_config(
         decode_config,
-        prefill_callback=_batcher_callback,
-        decode_callback=_batcher_callback,
+        prefill_batcher=FakeBatcher(_batcher_callback, _batcher_workitem_callback),
+        decode_batcher=FakeBatcher(_batcher_callback, _batcher_workitem_callback),
         results_callback=_results_callback,
         eos_token_id=0,
         max_completion_tokens=1,


### PR DESCRIPTION
With decode the majority of future steps are known a groupable. Created a basic reservation system so that steps can be reserved and the continuous batcher knows that a future groupable request is coming.

This should be adapted to include grouping multiple responses, and having a "grouping" exist. E.g. multiple parallel requests in flight and grouped together for the multiple hypothesis case.