### PR TITLE
Add --use-attention-mask for tp8 as workaround for sharded compilation

### DIFF
--- a/.github/workflows/ci-llama-large-tests.yaml
+++ b/.github/workflows/ci-llama-large-tests.yaml
@@ -8,6 +8,7 @@ name: Llama Benchmarking Tests
 
 on:
   workflow_dispatch:
+  on: pull_request
   schedule:
     # Weekdays at 11:00 AM UTC = 03:00 AM PST / 04:00 AM PDT
     - cron: "0 11 * * 0-6"

--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -49,15 +49,10 @@ class BaseBenchmarkTest(unittest.TestCase):
 
     def setUp(self):
         self.compile_args = [
-            "--iree-dispatch-creation-enable-aggressive-fusion=true",
-            "--iree-global-opt-propagate-transposes=true",
-            "--iree-opt-aggressively-propagate-transposes=true",
-            "--iree-opt-data-tiling=false",
-            "--iree-preprocessing-pass-pipeline='builtin.module(util.func(iree-preprocessing-generalize-linalg-matmul-experimental))'",
+            "--iree-opt-level=O3",
             "--iree-stream-resource-memory-model=discrete",
             "--iree-hal-indirect-command-buffers=true",
             "--iree-hal-memoization=true",
-            "--iree-opt-strip-assertions",
         ]
 
     def save_benchmarks(
@@ -356,6 +351,7 @@ class BenchmarkLlama3_1_70B(BaseBenchmarkTest):
             attention_kernel="torch",
             tensor_parallelism_size=self.tensor_parallelism_size,
             block_seq_stride=32,
+            use_attention_mask=True,
         )
         self.llama70b_fp8_torch_sdpa_artifacts_tp1 = ExportArtifacts(
             irpa_path=str(self.irpa_path_fp8),
@@ -704,6 +700,7 @@ class BenchmarkLlama3_1_405B(BaseBenchmarkTest):
             attention_kernel="torch",
             tensor_parallelism_size=self.tensor_parallelism_size,
             block_seq_stride=32,
+            use_attention_mask=True,
         )
         self.llama405b_fp8_torch_sdpa_artifacts = ExportArtifacts(
             irpa_path=str(self.irpa_path_fp8),
@@ -716,6 +713,7 @@ class BenchmarkLlama3_1_405B(BaseBenchmarkTest):
             activation_dtype="bfloat16",
             attention_dtype="bfloat16",
             kv_cache_dtype="float8_e4m3fnuz",
+            use_attention_mask=True,
         )
         self.prefill_args_bs4_128_stride_32_tp8_f16 = (
             self.artifacts_dir / "prefill_args_bs4_128_stride_32_tp8"


### PR DESCRIPTION
We need to have a small tweak to how we export for sharding, specifically when exporting we need to include `--use-attention-mask`. This is due to some affinity analysis and cloning work that still needs to be worked out. Its the main reason compilation work on iree presubmits. There are plans to get a proper fix in but it will be a while before someone can put hands on the issue.