### PR TITLE
[sharktank] Refactor Flux transformer export and compile to use the common ModelConfig

### DIFF
--- a/sharktank/sharktank/export.py
+++ b/sharktank/sharktank/export.py
@@ -182,7 +182,7 @@ def export_model_mlir(
     model: BaseLayer,
     output_path: PathLike,
     *,
-    function_batch_size_pairs: Optional[dict[Optional[str], list[int]]] = None,
+    function_batch_sizes_map: Optional[dict[Optional[str], list[int]]] = None,
     batch_sizes: Optional[list[int]] = None,
 ):
     """Export a model with no dynamic dimensions.
@@ -199,20 +199,20 @@ def export_model_mlir(
     The model is required to implement method `sample_inputs`.
     """
 
-    assert not (function_batch_size_pairs is not None and batch_sizes is not None)
+    assert not (function_batch_sizes_map is not None and batch_sizes is not None)
 
     if isinstance(model, ThetaLayer):
         mark_export_external_theta(model.theta)
 
     if batch_sizes is not None:
-        function_batch_size_pairs = {None: batch_sizes}
+        function_batch_sizes_map = {None: batch_sizes}
 
-    if function_batch_size_pairs is None and batch_sizes is None:
-        function_batch_size_pairs = {None: batch_sizes}
+    if function_batch_sizes_map is None and batch_sizes is None:
+        function_batch_sizes_map = {None: batch_sizes}
 
     fxb = FxProgramsBuilder(model)
 
-    for function, batch_sizes in function_batch_size_pairs.items():
+    for function, batch_sizes in function_batch_sizes_map.items():
         for batch_size in batch_sizes:
             args, kwargs = model.sample_inputs(batch_size, function)
             dynamic_shapes = model.dynamic_shapes_for_export(

--- a/sharktank/sharktank/layers/base.py
+++ b/sharktank/sharktank/layers/base.py
@@ -12,10 +12,13 @@ import torch
 import torch.nn as nn
 from os import PathLike
 import logging
+from pathlib import Path
 
 from ..types import InferenceTensor, Theta, AnyTensor, Dataset
-from ..utils import debugging
+from ..utils import debugging, chdir
 from .configs import ModelConfig, ExportFunctionConfig, DynamicBatchSize
+from ..utils.iree import flatten_for_iree_signature
+from iree.turbine.support.tools import iree_tool_prepare_input_args
 
 __all__ = [
     "BaseLayer",
@@ -218,21 +221,7 @@ class BaseLayer(nn.Module, metaclass=BaseLayerMetaClass):
         if path is None:
             raise ValueError("Missing MLIR export path.")
 
-        export_functions = [
-            ExportFunctionConfig(
-                function=self.default_export_function,
-                batch_sizes=self.default_export_batch_sizes,
-            )
-        ]
-        if self.config.export_functions is not None:
-            export_functions = self.config.export_functions
-
-        function_batch_size_pairs = {
-            export_function.function
-            or self.default_export_function: export_function.batch_sizes
-            or self.default_export_batch_sizes
-            for export_function in export_functions
-        }
+        function_batch_size_pairs = self._get_function_batch_sizes_map()
         from ..export import export_model_mlir
 
         export_model_mlir(
@@ -244,7 +233,41 @@ class BaseLayer(nn.Module, metaclass=BaseLayerMetaClass):
     def export(self, mlir_path: PathLike | None = None, /, *args, **kwargs):
         """Export MLIR and any other artifacts required for compilation.
         Can be overridden in derived classes."""
+        if self.config.export_sample_inputs_enabled:
+            path_prefix = mlir_path
+            if path_prefix is not None:
+                path_prefix = Path(path_prefix)
+                path_prefix = path_prefix.parent / path_prefix.stem
+            self.export_sample_inputs()
+
         self.export_mlir(mlir_path)
+
+    def export_sample_inputs(self, path_prefix: PathLike | None = None):
+        if path_prefix is None:
+            path_prefix = self.config.mlir_path.parent / self.config.mlir_path.stem
+        if path_prefix is None:
+            raise ValueError("Can't export sample inputs. No path prefix specified.")
+        path_prefix = Path(path_prefix)
+
+        function_batch_size_pairs = self._get_function_batch_sizes_map()
+
+        with chdir(str(path_prefix.parent)):
+            for function, batch_sizes in function_batch_size_pairs.items():
+                for batch_size in batch_sizes:
+                    sample_args, sample_kwargs = self.sample_inputs(
+                        function=function, batch_size=batch_size
+                    )
+                    flat_args = flatten_for_iree_signature((sample_args, sample_kwargs))
+                    file_path_prefix = (
+                        f"{path_prefix.name}-{function}_bs{batch_size}-arg"
+                    )
+                    arg_descriptors = iree_tool_prepare_input_args(
+                        flat_args, file_path_prefix=file_path_prefix
+                    )
+                    arg_descriptor_path = f"{file_path_prefix}-desc"
+                    with open(arg_descriptor_path, "w") as f:
+                        for desc in arg_descriptors:
+                            print(desc, file=f)
 
     def compile(self, output_path: PathLike | None = None, /):
         """Compile the model.
@@ -261,6 +284,22 @@ class BaseLayer(nn.Module, metaclass=BaseLayerMetaClass):
             output_file=str(output_path),
             extra_args=self.config.get_compile_args(),
         )
+
+    def _get_function_batch_sizes_map(self) -> dict[str, list[int]]:
+        export_functions = [
+            ExportFunctionConfig(
+                function=self.default_export_function,
+                batch_sizes=self.default_export_batch_sizes,
+            )
+        ]
+        if self.config.export_functions is not None:
+            export_functions = self.config.export_functions
+        return {
+            export_function.function
+            or self.default_export_function: export_function.batch_sizes
+            or self.default_export_batch_sizes
+            for export_function in export_functions
+        }
 
 
 class ThetaLayer(BaseLayer):

--- a/sharktank/sharktank/layers/base.py
+++ b/sharktank/sharktank/layers/base.py
@@ -221,13 +221,13 @@ class BaseLayer(nn.Module, metaclass=BaseLayerMetaClass):
         if path is None:
             raise ValueError("Missing MLIR export path.")
 
-        function_batch_size_pairs = self._get_function_batch_sizes_map()
+        function_batch_sizes_map = self._get_function_batch_sizes_map()
         from ..export import export_model_mlir
 
         export_model_mlir(
             model=self,
             output_path=path,
-            function_batch_size_pairs=function_batch_size_pairs,
+            function_batch_sizes_map=function_batch_sizes_map,
         )
 
     def export(self, mlir_path: PathLike | None = None, /, *args, **kwargs):
@@ -249,10 +249,10 @@ class BaseLayer(nn.Module, metaclass=BaseLayerMetaClass):
             raise ValueError("Can't export sample inputs. No path prefix specified.")
         path_prefix = Path(path_prefix)
 
-        function_batch_size_pairs = self._get_function_batch_sizes_map()
+        function_batch_sizes_map = self._get_function_batch_sizes_map()
 
         with chdir(str(path_prefix.parent)):
-            for function, batch_sizes in function_batch_size_pairs.items():
+            for function, batch_sizes in function_batch_sizes_map.items():
                 for batch_size in batch_sizes:
                     sample_args, sample_kwargs = self.sample_inputs(
                         function=function, batch_size=batch_size

--- a/sharktank/sharktank/layers/configs/config.py
+++ b/sharktank/sharktank/layers/configs/config.py
@@ -20,6 +20,8 @@ __all__ = [
     "ExportFunctionConfig",
     "DynamicBatchSize",
     "ModelConfig",
+    "model_config_presets",
+    "register_model_config_preset",
 ]
 
 
@@ -73,6 +75,7 @@ class ModelConfig:
 
     export_functions: list[ExportFunctionConfig] | None = None
     """function, batch size pairs that are to be exported."""
+    export_sample_inputs_enabled: bool = False
 
     tensor_parallelism: int | None = None
     """If specified exported model parameters will be shard."""
@@ -274,6 +277,16 @@ class ModelConfig:
         if path is None or path.is_absolute() or config_dir is None:
             return path
         return Path(os.path.normpath(os.path.relpath(path, config_dir)))
+
+
+model_config_presets: dict[str, ModelConfig] = {}
+"""Presets of named model configurations."""
+
+
+def register_model_config_preset(name: str, config: ModelConfig):
+    if name in model_config_presets:
+        raise ValueError(f'Model config preset with name "{name}" already registered.')
+    model_config_presets[name] = config
 
 
 def _make_optional_path(path: PathLike | None = None) -> Path | None:

--- a/sharktank/sharktank/models/flux/__init__.py
+++ b/sharktank/sharktank/models/flux/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from .flux import *

--- a/sharktank/sharktank/models/flux/compile.py
+++ b/sharktank/sharktank/models/flux/compile.py
@@ -1,0 +1,25 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+iree_compile_flags = [
+    "--iree-opt-const-eval=false",
+    "--iree-opt-strip-assertions=true",
+    "--iree-global-opt-propagate-transposes=true",
+    # TODO: We want the following flag to be enable eventually, but there's
+    # a bug in iree that's causing a failure right now.
+    "--iree-dispatch-creation-enable-fuse-horizontal-contractions=false",
+    "--iree-dispatch-creation-enable-aggressive-fusion=true",
+    "--iree-opt-aggressively-propagate-transposes=true",
+    "--iree-opt-outer-dim-concat=true",
+    "--iree-vm-target-truncate-unsupported-floats",
+    "--iree-llvmgpu-enable-prefetch=true",
+    "--iree-opt-data-tiling=false",
+    "--iree-codegen-gpu-native-math-precision=true",
+    "--iree-codegen-llvmgpu-use-vector-distribution=1",
+    "--iree-hip-waves-per-eu=2",
+    "--iree-execution-model=async-external",
+    "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics,util.func(iree-preprocessing-generalize-linalg-matmul-experimental))",
+]

--- a/sharktank/sharktank/models/flux/export.py
+++ b/sharktank/sharktank/models/flux/export.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import torch
 
 from ...export import export_model_mlir
-from ...tools.import_hf_dataset import import_hf_dataset
+from ...utils.hf import import_hf_dataset_from_hub
 from .flux import FluxModelV1, FluxParams
 from ...types import Dataset
 from ...utils.hf_datasets import get_dataset
@@ -70,15 +70,16 @@ def export_flux_transformer(
 
 
 def import_flux_transformer_dataset_from_hugging_face(
-    repo_id: str, parameters_output_path: PathLike
-):
-    hf_dataset = get_dataset(
-        repo_id,
-    ).download()
-
-    import_hf_dataset(
-        config_json_path=hf_dataset["config"][0],
-        param_paths=hf_dataset["parameters"],
+    repo_id: str,
+    revision: str | None = None,
+    subfolder: str | None = None,
+    parameters_output_path: PathLike | None = None,
+) -> Dataset | None:
+    return import_hf_dataset_from_hub(
+        repo_id=repo_id,
+        revision=revision,
+        subfolder=subfolder,
+        config_subpath="transformer/config.json",
         output_irpa_file=parameters_output_path,
     )
 

--- a/sharktank/sharktank/utils/hf.py
+++ b/sharktank/sharktank/utils/hf.py
@@ -1,0 +1,82 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Optional
+from os import PathLike
+import os
+import json
+import logging
+from pathlib import Path
+
+from huggingface_hub import snapshot_download
+from ..types import *
+
+logger = logging.getLogger(__name__)
+
+
+def import_hf_dataset(
+    config_json_path: PathLike,
+    param_paths: list[PathLike],
+    output_irpa_file: Optional[PathLike] = None,
+    target_dtype=None,
+) -> Optional[Dataset]:
+    import safetensors
+
+    with open(config_json_path, "rb") as f:
+        config_json = json.load(f)
+    # Separate meta parameters (prefixed with _) from hparams.
+    meta_params = {k: v for k, v in config_json.items() if k.startswith("_")}
+    hparams = {k: v for k, v in config_json.items() if not k.startswith("_")}
+
+    tensors = []
+    for params_path in param_paths:
+        with safetensors.safe_open(params_path, framework="pt", device="cpu") as st:
+            tensors += [
+                DefaultPrimitiveTensor(
+                    name=name, data=st.get_tensor(name).to(target_dtype)
+                )
+                for name in st.keys()
+            ]
+
+    theta = Theta(tensors)
+    props = {
+        "meta": meta_params,
+        "hparams": hparams,
+    }
+    dataset = Dataset(props, theta)
+
+    if output_irpa_file is None:
+        return dataset
+
+    dataset.save(output_irpa_file, io_report_callback=logger.debug)
+
+
+def import_hf_dataset_from_hub(
+    repo_id: str,
+    revision: str | None = None,
+    subfolder: str | None = None,
+    config_subpath: str | None = None,
+    output_irpa_file: PathLike | None = None,
+) -> Dataset | None:
+    model_dir = Path(snapshot_download(repo_id=repo_id, revision=revision))
+    if subfolder is not None:
+        model_dir /= subfolder
+    if config_subpath is None:
+        config_json_path = model_dir / "config.json"
+    else:
+        config_json_path = model_dir / config_subpath
+    file_paths = [
+        model_dir / file_name
+        for file_name in os.listdir(model_dir)
+        if (model_dir / file_name).is_file()
+    ]
+    param_paths = [p for p in file_paths if p.is_file() and p.suffix == ".safetensors"]
+
+    return import_hf_dataset(
+        config_json_path=config_json_path,
+        param_paths=param_paths,
+        output_irpa_file=output_irpa_file,
+    )


### PR DESCRIPTION
With the goal of unifying model export and compile under one interface, here the Flux transformer refactored.

Add model config preset registry.