### PR TITLE
[sharktank] Make common test prompts initialize lazily to avoid spamming the HF server

### DIFF
--- a/sharktank/sharktank/utils/testing.py
+++ b/sharktank/sharktank/utils/testing.py
@@ -394,4 +394,13 @@ def get_frozen_test_text_prompts(
         random.setstate(orig_rng_state)
 
 
-test_prompts = get_frozen_test_text_prompts(num_prompts=16, min_prompt_length=50)
+_test_prompts = None
+
+
+def get_test_prompts():
+    global _test_prompts
+    if _test_prompts is None:
+        _test_prompts = get_frozen_test_text_prompts(
+            num_prompts=16, min_prompt_length=50
+        )
+    return _test_prompts

--- a/sharktank/tests/models/clip/clip_test.py
+++ b/sharktank/tests/models/clip/clip_test.py
@@ -47,7 +47,7 @@ from sharktank.utils.testing import (
     make_rand_torch,
     make_random_mask,
     TempDirTestBase,
-    test_prompts,
+    get_test_prompts,
 )
 from sharktank.models.clip.export import (
     hugging_face_clip_attention_to_theta,
@@ -316,7 +316,7 @@ class ClipTextIreeTest(TempDirTestBase):
 
         tokenizer: CLIPTokenizer = CLIPTokenizer.from_pretrained(huggingface_repo_id)
         input_ids = tokenizer(
-            test_prompts,
+            get_test_prompts(),
             truncation=True,
             max_length=reference_model.config.max_position_embeddings,
             padding="max_length",
@@ -368,7 +368,7 @@ class ClipTextEagerTest(TestCase):
             max_length=reference_model.config.max_position_embeddings,
         )
         input_ids = tokenizer(
-            test_prompts,
+            get_test_prompts(),
             truncation=True,
             max_length=reference_model.config.max_position_embeddings,
             padding="max_length",

--- a/sharktank/tests/models/t5/t5_test.py
+++ b/sharktank/tests/models/t5/t5_test.py
@@ -54,7 +54,7 @@ from sharktank.utils.testing import (
     make_random_mask,
     skip,
     TempDirTestBase,
-    test_prompts,
+    get_test_prompts,
 )
 from sharktank.utils.hf_datasets import get_dataset
 from sharktank.utils.iree import (
@@ -157,7 +157,7 @@ class T5EncoderEagerTest(TestCase):
         )
 
         input_ids = tokenizer(
-            test_prompts,
+            get_test_prompts(),
             truncation=True,
             return_length=False,
             return_overflowing_tokens=False,
@@ -202,7 +202,7 @@ class T5EncoderEagerTest(TestCase):
         )
 
         input_ids = tokenizer(
-            test_prompts,
+            get_test_prompts(),
             truncation=True,
             return_length=False,
             return_overflowing_tokens=False,
@@ -464,7 +464,7 @@ class T5EncoderIreeTest(TempDirTestBase):
         reference_model = T5Encoder(theta=reference_dataset.root_theta, config=config)
 
         input_ids = tokenizer(
-            test_prompts,
+            get_test_prompts(),
             truncation=True,
             return_length=False,
             return_overflowing_tokens=False,


### PR DESCRIPTION
The test prompts in sharktank.utils.testing got initialized on every import of the module, which caused excessive downloading/checking of Hugging Face site for the prompt dataset.

Now they get initialized only when used.