### PR TITLE
Export with log-softmax and softmax of logits

### DIFF
--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -19,7 +19,6 @@ from sharktank import ops
 
 # TODO: Should be using a base class with the protocol supported.
 from ..models.llama.llama import LlamaModelConfig, PagedLlamaModelV1
-from ..models.llama.sharding import shard_theta
 from ..models.mixtral.mixtral import *
 from ..models.grok.grok import *
 from .. import ops
@@ -67,6 +66,12 @@ def main():
         help="Generates attention mask during export",
         action="store_true",
     )
+    parser.add_argument(
+        "--logits-normalization",
+        default="none",
+        help="Return the log softmax of the logits",
+        choices=["none", "softmax", "log_softmax"],
+    )
 
     cli.add_quantization_options(parser)
     cli.add_model_options(parser)
@@ -106,7 +111,10 @@ def main():
         model = PagedLlamaModelV1(dataset.root_theta, llama_config)
 
     def generate_params_json(
-        hp: LlamaHParams, prefill_bs: list[int], decode_bs: list[int]
+        hp: LlamaHParams,
+        prefill_bs: list[int],
+        decode_bs: list[int],
+        logits_normalization: str,
     ) -> Dict[str, Any]:
         """
         Generate config.json for shortfin.
@@ -123,6 +131,7 @@ def main():
             "prefill_batch_sizes": prefill_bs,
             "decode_batch_sizes": decode_bs,
             "transformer_block_count": hp.block_count,
+            "logits_normalization": logits_normalization,
             "paged_kv_cache": {
                 "attention_head_count_kv": hp.attention_head_count_kv,
                 "block_seq_stride": llama_config.block_seq_stride,
@@ -255,6 +264,12 @@ def main():
             if llama_config.tensor_parallelism_size != 1:
                 logits = ops.unshard(logits)
 
+            if args.logits_normalization == "softmax":
+                logits = ops.softmax(logits, dim=-1)
+
+            if args.logits_normalization == "log_softmax":
+                logits = ops.elementwise(torch.log, ops.softmax(logits, dim=-1))
+
             return logits
 
     def generate_batch_decode(bs: int):
@@ -343,9 +358,14 @@ def main():
             if llama_config.tensor_parallelism_size != 1:
                 logits = ops.unshard(logits)
 
+            if args.logits_normalization == "softmax":
+                logits = ops.softmax(logits, dim=-1)
+
+            if args.logits_normalization == "log_softmax":
+                logits = ops.elementwise(torch.log, ops.softmax(logits, dim=-1))
+
             return logits
 
-    bsizes = []
     if not args.skip_prefill:
         for bs in args.bs_prefill:
             generate_batch_prefill(bs)
@@ -353,7 +373,9 @@ def main():
         for bs in args.bs_decode:
             generate_batch_decode(bs)
 
-    config = generate_params_json(hp, args.bs_prefill, args.bs_decode)
+    config = generate_params_json(
+        hp, args.bs_prefill, args.bs_decode, args.logits_normalization
+    )
     print("GENERATED!")
 
     if args.verbose:

--- a/shortfin/python/shortfin_apps/llm/components/config_struct.py
+++ b/shortfin/python/shortfin_apps/llm/components/config_struct.py
@@ -137,6 +137,8 @@ class ModelParams:
     # ABI of the module.
     module_abi_version: int = 1
 
+    logits_normalization: str = "none"
+
     # The element type of the attention caches.
     attn_dtype: sfnp.DType = sfnp.float16
 


### PR DESCRIPTION
For some searches (sampling, beamsearch) it is beneficial to return either the softmax or log softmax of the values.