### PR TITLE
[sharktank] Add Tracy utils

### DIFF
--- a/sharktank/sharktank/layers/base.py
+++ b/sharktank/sharktank/layers/base.py
@@ -80,6 +80,7 @@ def create_model(config: PathLike | ModelConfig | Mapping[str, Any], /) -> "Base
     model.compile()
     ```
     """
+    register_all_models()
     if isinstance(config, Mapping):
         config = ModelConfig.create(**config)
     elif not isinstance(config, ModelConfig):
@@ -91,6 +92,10 @@ def create_model(config: PathLike | ModelConfig | Mapping[str, Any], /) -> "Base
 model_registry: dict[str, type["BaseLayer"]] = {}
 """Registry of all model types.
 This is used to dispatch when construction a model form a config."""
+
+
+def register_all_models():
+    from .. import models
 
 
 class BaseLayerMetaClass(ABCMeta):

--- a/sharktank/sharktank/models/__init__.py
+++ b/sharktank/sharktank/models/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from . import clip
+from . import deepseek
+from . import dummy
+from . import flux
+from . import grok
+from . import llama
+from . import mixtral
+from . import punet
+from . import t5
+from . import vae

--- a/sharktank/sharktank/models/dummy/__init__.py
+++ b/sharktank/sharktank/models/dummy/__init__.py
@@ -1,0 +1,1 @@
+from .dummy import *

--- a/sharktank/sharktank/models/dummy/dummy.py
+++ b/sharktank/sharktank/models/dummy/dummy.py
@@ -1,0 +1,96 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from dataclasses import dataclass
+import torch
+from collections import OrderedDict
+
+from ...layers import (
+    ThetaLayer,
+    ModelConfig,
+    LinearLayer,
+    register_model_config_preset,
+    configure_default_export_compile,
+)
+from ...types import Theta, AnyTensor, DefaultPrimitiveTensor
+from ...utils.testing import make_rand_torch
+
+__all__ = [
+    "DummyModel",
+    "DummyModelConfig",
+]
+
+
+@dataclass(kw_only=True)
+class DummyModelConfig(ModelConfig):
+    def __post_init__(self):
+        self.model_type = DummyModel
+        super().__post_init__()
+
+    linear_input_size: int = 2
+    linear_output_size: int = 3
+
+
+class DummyModel(ThetaLayer):
+    """A simple model for testing."""
+
+    def __init__(self, *, config: DummyModelConfig, theta: Theta | None = None):
+        super().__init__(theta, config=config)
+        self.linear = LinearLayer(theta=self.theta("linear"))
+
+    @classmethod
+    def config_type(cls) -> type[ModelConfig]:
+        """Return the type of the config for this model."""
+        return DummyModelConfig
+
+    def generate_random_theta(self) -> Theta:
+        rng_seed = self.config.rng_seed
+        if rng_seed is None:
+            rng_seed = 12345
+        with torch.random.fork_rng():
+            torch.random.manual_seed(rng_seed)
+            return Theta(
+                {
+                    "linear.weight": DefaultPrimitiveTensor(
+                        data=make_rand_torch(
+                            shape=[
+                                self.config.linear_output_size,
+                                self.config.linear_input_size,
+                            ]
+                        )
+                    )
+                }
+            )
+
+    def forward(self, x: AnyTensor) -> AnyTensor:
+        return self.linear(x)
+
+    def sample_inputs(
+        self, batch_size: int | None = 1, function: str | None = None
+    ) -> tuple[tuple[AnyTensor, ...], OrderedDict[str, AnyTensor]]:
+        assert batch_size is not None
+        assert function == "forward" or function is None
+
+        return tuple(), OrderedDict(
+            [
+                (
+                    "x",
+                    make_rand_torch(shape=[batch_size, self.config.linear_input_size]),
+                )
+            ]
+        )
+
+
+def _register_dummy_model_config_presets():
+    config = DummyModelConfig()
+    configure_default_export_compile(config)
+    register_model_config_preset(
+        name="dummy-model-local-llvm-cpu",
+        config=config,
+    )
+
+
+_register_dummy_model_config_presets()

--- a/sharktank/sharktank/tools/trace_model_with_tracy.py
+++ b/sharktank/sharktank/tools/trace_model_with_tracy.py
@@ -1,0 +1,47 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import argparse
+import sys
+import json
+import os
+import subprocess
+from copy import copy
+
+from ..layers import ModelConfig
+from ..utils.iree import run_model_with_iree_run_module
+
+
+def main(args: list[str] | None = None):
+    if args is None:
+        args = sys.argv[1:]
+
+    parser = argparse.ArgumentParser(
+        description="Trace an already exported and compiled model from a model config."
+    )
+    parser.add_argument(
+        "--config", type=str, default="-", help="Path to the model config."
+    )
+    parser.add_argument(
+        "--function", type=str, required=True, help="The function to trace."
+    )
+    args = parser.parse_args(args)
+
+    if args.config == "-":
+        config = json.load(sys.stdin)
+    else:
+        with open(args.config, "r") as f:
+            config = json.load(f)
+
+    env = copy(os.environ)
+    env["IREE_PY_RUNTIME"] = "tracy"
+    run_model_with_iree_run_module(
+        ModelConfig.create(**config), function=args.function, env=env
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/sharktank/tests/utils/iree_test.py
+++ b/sharktank/tests/utils/iree_test.py
@@ -1,0 +1,49 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from pathlib import Path
+import pytest
+import platform
+
+from sharktank.layers import create_model, model_config_presets
+from sharktank.utils import chdir
+from sharktank.utils.iree import trace_model_with_tracy, run_model_with_iree_run_module
+from sharktank.models.dummy import DummyModel
+
+
+@pytest.fixture(scope="session")
+def dummy_model_path(tmp_path_factory) -> Path:
+    return tmp_path_factory.mktemp("dummy_model")
+
+
+@pytest.fixture(scope="session")
+def dummy_model(dummy_model_path: Path) -> DummyModel:
+    with chdir(dummy_model_path):
+        model = create_model(model_config_presets["dummy-model-local-llvm-cpu"])
+        model.export()
+        model.compile()
+        return model
+
+
+def test_run_model_with_iree_run_module(
+    dummy_model: DummyModel, dummy_model_path: Path
+):
+    with chdir(dummy_model_path):
+        run_model_with_iree_run_module(dummy_model.config, function="forward_bs1")
+
+
+@pytest.mark.xfail(
+    platform.system() == "Windows",
+    raises=FileNotFoundError,
+    strict=True,
+    reason="The Python package for Windows does not include iree-tracy-capture.",
+)
+def test_trace_model_with_tracy(dummy_model: DummyModel, dummy_model_path: Path):
+    with chdir(dummy_model_path):
+        trace_path = Path(f"{dummy_model.config.iree_module_path}.tracy")
+        assert not trace_path.exists()
+        trace_model_with_tracy(dummy_model.config, function="forward_bs1")
+        assert trace_path.exists()


### PR DESCRIPTION
Add functions for more convenient tracing of models.

E.g.
```
model = ...
model.export()
model.compile()
trace_model_with_tracy(model.config, function="forward_bs1")
```

```
def my_fn():
   ...

trace_with_tracy(my_fn, output_trace_path="capture.tracy")
```

Add a dummy model to the registry to server for testing.