### PR TITLE
[sharktank] Fix nightly Flux transformer tests wrong HF repo id

### DIFF
--- a/sharktank/sharktank/models/flux/export.py
+++ b/sharktank/sharktank/models/flux/export.py
@@ -108,7 +108,7 @@ def export_flux_transformer_models(dir: Path):
     mlir_path = base_dir / f"{file_name_base}.mlir"
     parameters_output_path = base_dir / f"{file_name_base}.irpa"
     export_flux_transformer_from_hugging_face(
-        "black-forest-labs/FLUX.1-dev/black-forest-labs-transformer",
+        "black-forest-labs/FLUX.1-dev",
         mlir_output_path=mlir_path,
         parameters_output_path=parameters_output_path,
     )
@@ -119,7 +119,7 @@ def export_flux_transformer_models(dir: Path):
     mlir_path = base_dir / f"{file_name_base}.mlir"
     parameters_output_path = base_dir / f"{file_name_base}.irpa"
     export_flux_transformer_from_hugging_face(
-        "black-forest-labs/FLUX.1-schnell/black-forest-labs-transformer",
+        "black-forest-labs/FLUX.1-schnell",
         mlir_output_path=mlir_path,
         parameters_output_path=parameters_output_path,
     )

--- a/sharktank/sharktank/models/flux/flux.py
+++ b/sharktank/sharktank/models/flux/flux.py
@@ -124,7 +124,7 @@ class FluxParams(ModelConfig):
             repo_id, revision, subfolder
         )
 
-    @staticmethod
+    @classmethod
     def from_hugging_face_properties(
         cls: type["FluxParams"], properties: dict[str, Any]
     ) -> "FluxParams":

--- a/sharktank/tests/models/flux/flux_test.py
+++ b/sharktank/tests/models/flux/flux_test.py
@@ -187,7 +187,7 @@ class FluxTest(TempDirTestBase):
         parameters_output_path = self._temp_dir / "parameters.irpa"
 
         import_flux_transformer_dataset_from_hugging_face(
-            repo_id="black-forest-labs/FLUX.1-dev/black-forest-labs-transformer",
+            repo_id="black-forest-labs/FLUX.1-dev",
             parameters_output_path=parameters_output_path,
         )
         refrence_dataset = Dataset.load(parameters_output_path)
@@ -296,7 +296,7 @@ class FluxTest(TempDirTestBase):
         )
 
         import_flux_transformer_dataset_from_hugging_face(
-            repo_id="black-forest-labs/FLUX.1-dev/black-forest-labs-transformer",
+            repo_id="black-forest-labs/FLUX.1-dev",
             parameters_output_path=parameters_output_path,
         )
         target_dataset = Dataset.load(parameters_output_path)
@@ -326,7 +326,7 @@ class FluxTest(TempDirTestBase):
         )
 
         import_flux_transformer_dataset_from_hugging_face(
-            repo_id="black-forest-labs/FLUX.1-dev/black-forest-labs-transformer",
+            repo_id="black-forest-labs/FLUX.1-dev",
             parameters_output_path=parameters_output_path,
         )
         target_dataset = Dataset.load(parameters_output_path)
@@ -352,7 +352,7 @@ class FluxTest(TempDirTestBase):
     @pytest.mark.expensive
     def testExportSchnellTransformerFromHuggingFace(self):
         export_flux_transformer_from_hugging_face(
-            "black-forest-labs/FLUX.1-schnell/black-forest-labs-transformer",
+            "black-forest-labs/FLUX.1-schnell",
             mlir_output_path=self._temp_dir / "model.mlir",
             parameters_output_path=self._temp_dir / "parameters.irpa",
         )
@@ -361,7 +361,7 @@ class FluxTest(TempDirTestBase):
     @pytest.mark.expensive
     def testExportDevTransformerFromHuggingFace(self):
         export_flux_transformer_from_hugging_face(
-            "black-forest-labs/FLUX.1-dev/black-forest-labs-transformer",
+            "black-forest-labs/FLUX.1-dev",
             mlir_output_path=self._temp_dir / "model.mlir",
             parameters_output_path=self._temp_dir / "parameters.irpa",
         )


### PR DESCRIPTION
We do not import with a shartank dataset name anymore. The repo_id needs to be an actual repo_id in Hugging Face.