### PR TITLE
Add llama tool to randomize weights in irpa file

### DIFF
--- a/sharktank/sharktank/models/llama/testing.py
+++ b/sharktank/sharktank/models/llama/testing.py
@@ -8,6 +8,7 @@ from typing import List
 
 import torch
 
+from ...types import Dataset
 from ...types.tensors import *
 from ...types.theta import Theta
 from typing import Optional
@@ -162,4 +163,23 @@ def make_random_llama_theta(
         data=make_rand_torch((1, config.hp.embedding_length), dtype=dtype),
     )
 
+    return Theta(res)
+
+
+def make_random_theta_from_dataset(dataset: Dataset) -> Theta:
+    res = {}
+    for key, value in dataset.root_theta.flatten().items():
+        shape = value.shape
+        min_val = torch.min(value.flatten())
+        max_val = torch.max(value.flatten())
+        import pdb
+
+        pdb.set_trace()
+        random_tensor = torch.normal(
+            mean=value.as_torch().mean(),
+            std=value.as_torch().std(),
+            size=shape,
+            dtype=value.dtype,
+        )
+        res[key] = DefaultPrimitiveTensor(name=key, data=random_tensor)
     return Theta(res)

--- a/sharktank/sharktank/models/llama/tools/randomize_llama_weights.py
+++ b/sharktank/sharktank/models/llama/tools/randomize_llama_weights.py
@@ -1,0 +1,59 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from ..testing import make_random_theta_from_dataset
+
+from sharktank.layers.configs import LlamaHParams
+from sharktank.models.llama.llama import LlamaModelConfig
+from sharktank.types import Dataset
+
+import argparse
+import torch
+from ....types.tensors import *
+from ....utils import cli
+
+parser = cli.create_parser()
+cli.add_input_dataset_options(parser)
+cli.add_model_options(parser)
+parser.add_argument("-s", "--seed", default=12345)
+parser.add_argument("-o", "--output", default="/tmp/toy_llama.irpa")
+args = cli.parse(parser)
+
+
+def generate(seed):
+    torch.manual_seed(seed)
+    dtype = torch.float16
+
+    device = torch.device(args.device) if args.device else None
+    dataset = cli.get_input_dataset(args)
+    config = LlamaModelConfig(
+        hp=LlamaHParams.from_gguf_props(dataset.properties),
+        block_seq_stride=args.block_seq_stride,
+        device=device,
+        activation_dtype=args.activation_dtype,
+        attention_dtype=args.attention_dtype,
+        attention_kernel=args.attention_kernel,
+        kv_cache_dtype=args.kv_cache_dtype,
+        use_hf=args.use_hf,
+        tensor_parallelism_size=args.tensor_parallelism_size,
+    )
+
+    theta = make_random_theta_from_dataset(dataset)
+    return theta, config
+
+
+def main():
+    args = parser.parse_args()
+    theta, config = generate(args.seed)
+
+    config_dict = config.hp.to_gguf_props()
+
+    dataset = Dataset(config_dict, theta)
+    dataset.save(args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a tool that takes in a llama irpa file, randomizes the weights using a normal distribution in order to maintain the same mean and standard deviation as the original weights, and outputs the new irpa file.