### PR TITLE
[sharktank] Fix and enable sharded toy llama IREE test

### DIFF
--- a/sharktank/sharktank/export.py
+++ b/sharktank/sharktank/export.py
@@ -170,7 +170,7 @@ def export(
         return fx_builder.export_program(
             module_fn_with_flat_signature,
             *transitive_args,
-            args=flat_args,
+            args=tuple(flat_args),
             arg_device=arg_device,
             **amended_kwargs,
         )

--- a/sharktank/sharktank/utils/iree.py
+++ b/sharktank/sharktank/utils/iree.py
@@ -65,7 +65,9 @@ def with_iree_device_context(
 
 
 @overload
-def get_iree_devices(*, driver: str, device_count: int) -> List[iree.runtime.HalDevice]:
+def get_iree_devices(
+    *, driver: str, device_count: int, allow_repeat: bool
+) -> List[iree.runtime.HalDevice]:
     """Gets a list of IREE HAL devices for the given driver.
 
     The first available device_count devices will be created,
@@ -82,15 +84,18 @@ def get_iree_devices(*, driver: str, device_count: int) -> List[iree.runtime.Hal
 
 
 @overload
-def get_iree_devices(*, device: str) -> List[iree.runtime.HalDevice]:
+def get_iree_devices(
+    *, device: str | list[str], device_count: int, allow_repeating: bool
+) -> List[iree.runtime.HalDevice]:
     ...
 
 
 def get_iree_devices(
     *,
-    device: str | None = None,
+    device: str | list[str] | None = None,
     driver: str | None = None,
     device_count: int | None = None,
+    allow_repeating: bool = True,
 ) -> List[iree.runtime.HalDevice]:
     has_device_arg = device is not None
     has_driver_arg = driver is not None
@@ -99,17 +104,17 @@ def get_iree_devices(
         raise ValueError(
             "Could not select overload. Please, provide at least one argument"
         )
-    if has_driver_arg != has_device_count_arg:
-        raise ValueError("driver and device_count args must be provided simultaneously")
-    if has_device_arg and (has_driver_arg or has_device_count_arg):
+    if has_device_arg and has_driver_arg:
         raise ValueError(
             "device arg is mutually exclusive with driver and device_count args"
         )
+    if has_driver_arg and not has_device_count_arg:
+        raise ValueError("When driver is provided, device_count must also be provided")
 
     if has_device_arg:
-        return [iree.runtime.get_device(device, cache=False)]
-
-    if "IREE_DEVICE" in os.environ:
+        if isinstance(device, str):
+            device = [device]
+    elif "IREE_DEVICE" in os.environ:
         device_uris = [d.strip() for d in os.environ["IREE_DEVICE"].split(",")]
         driver_names = [n.split("://")[0] for n in device_uris]
         if driver is not None:
@@ -117,28 +122,27 @@ def get_iree_devices(
                 ValueError(
                     f'Inconsistent IREE driver, expected "{driver}" for all devices f{device_uris}'
                 )
-        if device_count > len(device_uris):
-            raise ValueError(
-                "Environment variable IREE_DEVICE provides less devices than requested."
-            )
-        return [
-            iree.runtime.get_driver(driver_names[i]).create_device_by_uri(
-                device_uris[i]
-            )
-            for i in range(device_count)
+        device = device_uris
+
+    if device is not None:
+        if not has_device_count_arg:
+            device_count = len(device)
+        if device_count < len(device):
+            device = device[:device_count]
+        hal_devices = [iree.runtime.get_device(d, cache=False) for d in device]
+    else:
+        hal_driver = iree.runtime.get_driver(driver)
+        device_infos = hal_driver.query_available_devices()
+        if device_count < len(device_infos):
+            device_infos = device_infos[:device_count]
+        hal_devices = [
+            hal_driver.create_device(device_info) for device_info in device_infos
         ]
 
-    hal_driver = iree.runtime.get_driver(driver)
-    available_devices = hal_driver.query_available_devices()
-    if driver in ["local-task", "local-sync"]:
-        # Use the same actual device for all devices.
-        return [
-            hal_driver.create_device(available_devices[0]) for _ in range(device_count)
-        ]
-    else:
-        return [
-            hal_driver.create_device(available_devices[i]) for i in range(device_count)
-        ]
+    if not allow_repeating and len(hal_devices) < device_count:
+        ValueError("Requested more devices than available or specified")
+
+    return [hal_devices[i % len(hal_devices)] for i in range(device_count)]
 
 
 def load_iree_module(

--- a/sharktank/tests/models/llama/sharded_llama_test.py
+++ b/sharktank/tests/models/llama/sharded_llama_test.py
@@ -11,12 +11,17 @@ from sharktank.models.llama.llama import LlamaModelConfig, PagedLlamaModelV1
 import sharktank.ops as ops
 from sharktank.types import unbox_tensor, Dataset, UnreducedTensor, SplitPrimitiveTensor
 from sharktank.models.llama.testing import make_random_llama_theta
-from sharktank.utils.testing import skip
+from sharktank.utils.testing import (
+    assert_cosine_similarity_close,
+    get_iree_compiler_flags,
+    is_hip_condition,
+)
 from sharktank.models.llama.sharding import shard_theta
 from sharktank.layers.configs import LlamaHParams
 from sharktank.utils.math import round_up_to_multiple_of
 from sharktank.utils import iterables_equal
 from sharktank.utils.iree import (
+    with_iree_device_context,
     get_iree_devices,
     load_iree_module,
     run_iree_module_function,
@@ -34,7 +39,7 @@ import numpy as np
 import os
 
 
-@pytest.mark.usefixtures("caching", "path_prefix")
+@pytest.mark.usefixtures("caching", "path_prefix", "get_iree_flags")
 class ShardedLlamaTest(unittest.TestCase):
     def setUp(self):
         torch.random.manual_seed(123456)
@@ -235,11 +240,12 @@ class ShardedLlamaTest(unittest.TestCase):
             actual_decode_cache_state, expected_decode_cache_state, atol=1e-4, rtol=1e-4
         )
 
-    @skip(
-        (
-            "Before this does not crash at all we need "
-            "https://github.com/iree-org/iree/pull/18663 merged."
-        )
+    @pytest.mark.xfail(
+        is_hip_condition,
+        raises=RuntimeError,
+        match="Compilation failed",
+        strict=True,
+        reason="IREE regression https://github.com/iree-org/iree/issues/20365",
     )
     def testExportAndRunToySizedModelWithIree(self):
         """Test exporting to MLIR and compiling with IREE the sharded Llama model.
@@ -264,7 +270,6 @@ class ShardedLlamaTest(unittest.TestCase):
         sharded_parameters_path = f"{path_prefix}parameters.irpa"
         sharded_dataset.save(sharded_parameters_path)
         sharded_dataset = Dataset.load(sharded_parameters_path, mmap=False)
-        iree_driver = "local-task"
 
         model = PagedLlamaModelV1(self.theta, self.config)
         sharded_model = PagedLlamaModelV1(
@@ -309,99 +314,137 @@ class ShardedLlamaTest(unittest.TestCase):
             if dump_enabled:
                 output.save_mlir(f"{path_prefix}program.mlir")
             output.session.set_flags(
-                "--iree-hal-local-target-device-backends=llvm-cpu",
-                *[
-                    f"--iree-hal-target-device=local[{i}]"
-                    for i in range(self.sharded_config.tensor_parallelism_size)
-                ],
+                *get_iree_compiler_flags(
+                    self, self.sharded_config.tensor_parallelism_size
+                )
             )
             output.compile(
                 save_to=iree_module_path,
                 target_backends=None,
             )
 
-        iree_devices = get_iree_devices(
-            driver=iree_driver,
-            device_count=self.sharded_config.tensor_parallelism_size,
-        )
-        iree_module, vm_context, vm_instance = load_iree_module(
-            module_path=iree_module_path,
-            devices=iree_devices,
-            parameters_path=sharded_parameters_path,
-        )
-
-        # Run prefill step.
-        prefill_iree_args = prepare_iree_module_function_args(
-            args=deepcopy(sharded_prefill_kwargs).values(), devices=iree_devices
-        )
-        for i, arg in enumerate(prefill_iree_args):
-            np.save(f"{path_prefix}prefill_arg{i}.npy", arg.to_host())
-        prefill_iree_result = run_iree_module_function(
-            args=prefill_iree_args,
-            function_name="prefill",
-            module=iree_module,
-            vm_context=vm_context,
-            device=iree_devices[0],
-            trace_path_prefix=path_prefix if dump_enabled else None,
-        )
-        prefill_iree_result = UnreducedTensor(ts=iree_to_torch(*prefill_iree_result))
         expected_prefill_result = call_torch_module_function(
             module=sharded_model,
             function_name="prefill",
             kwargs=sharded_prefill_kwargs,
             trace_path_prefix=f"{path_prefix}expected_" if dump_enabled else None,
         )
-        prefill_iree_cache_state_shards = prefill_iree_args[
-            -self.config.tensor_parallelism_size - 1 :
-        ]
-        prefill_iree_cache_state = SplitPrimitiveTensor(
-            ts=iree_to_torch(*prefill_iree_cache_state_shards),
-            shard_dim=sharded_prefill_kwargs["cache_state"][0].shard_dim,
-        )
-
-        # Run decode step.
-        decode_iree_args = prepare_iree_module_function_args(
-            args=deepcopy(sharded_decode_kwargs).values(), devices=iree_devices
-        )
-        decode_iree_result = run_iree_module_function(
-            args=decode_iree_args,
-            function_name="decode",
-            module=iree_module,
-            vm_context=vm_context,
-            device=iree_devices[0],
-            trace_path_prefix=path_prefix if dump_enabled else None,
-        )
-        decode_iree_result = UnreducedTensor(ts=iree_to_torch(*decode_iree_result))
         expected_decode_result = call_torch_module_function(
             module=sharded_model,
             function_name="decode",
             kwargs=sharded_decode_kwargs,
             trace_path_prefix=f"{path_prefix}expected_" if dump_enabled else None,
         )
-        decode_iree_cache_state_shards = decode_iree_args[
-            -self.config.tensor_parallelism_size - 1 :
-        ]
-        decode_iree_cache_state = SplitPrimitiveTensor(
-            ts=iree_to_torch(*decode_iree_cache_state_shards),
-            shard_dim=sharded_decode_kwargs["cache_state"][0].shard_dim,
+
+        iree_devices = get_iree_devices(
+            device=self.iree_device,
+            device_count=self.sharded_config.tensor_parallelism_size,
         )
 
-        # Check IREE's numerical correctness against PyTorch.
-        # TODO: Although, not entirely wrong, investigate why this accuracy is that
-        # low for fp32 (atol=0.0011, rtol=0.013).
-        torch.testing.assert_close(
+        def run_iree_module(iree_devices: list[iree.runtime.HalDevice]):
+            iree_module, vm_context, vm_instance = load_iree_module(
+                module_path=iree_module_path,
+                devices=iree_devices,
+                parameters_path=sharded_parameters_path,
+            )
+
+            # Run prefill step.
+            prefill_iree_args = prepare_iree_module_function_args(
+                args=deepcopy(sharded_prefill_kwargs).values(), devices=iree_devices
+            )
+            for i, arg in enumerate(prefill_iree_args):
+                np.save(f"{path_prefix}prefill_arg{i}.npy", arg.to_host())
+            prefill_iree_result = run_iree_module_function(
+                args=prefill_iree_args,
+                function_name="prefill",
+                module=iree_module,
+                vm_context=vm_context,
+                device=iree_devices[0],
+                trace_path_prefix=path_prefix if dump_enabled else None,
+            )
+            prefill_iree_result = UnreducedTensor(
+                ts=[t.clone() for t in iree_to_torch(*prefill_iree_result)]
+            )
+            prefill_iree_cache_state_shards = prefill_iree_args[
+                -self.config.tensor_parallelism_size - 1 :
+            ]
+            prefill_iree_cache_state = SplitPrimitiveTensor(
+                ts=[t.clone() for t in iree_to_torch(*prefill_iree_cache_state_shards)],
+                shard_dim=sharded_prefill_kwargs["cache_state"][0].shard_dim,
+            )
+
+            # Run decode step.
+            decode_iree_args = prepare_iree_module_function_args(
+                args=deepcopy(sharded_decode_kwargs).values(), devices=iree_devices
+            )
+            decode_iree_result = run_iree_module_function(
+                args=decode_iree_args,
+                function_name="decode",
+                module=iree_module,
+                vm_context=vm_context,
+                device=iree_devices[0],
+                trace_path_prefix=path_prefix if dump_enabled else None,
+            )
+            decode_iree_result = UnreducedTensor(
+                ts=[t.clone() for t in iree_to_torch(*decode_iree_result)]
+            )
+            decode_iree_cache_state_shards = decode_iree_args[
+                -self.config.tensor_parallelism_size - 1 :
+            ]
+            decode_iree_cache_state = SplitPrimitiveTensor(
+                ts=[t.clone() for t in iree_to_torch(*decode_iree_cache_state_shards)],
+                shard_dim=sharded_decode_kwargs["cache_state"][0].shard_dim,
+            )
+
+            return (
+                prefill_iree_result,
+                prefill_iree_cache_state,
+                decode_iree_result,
+                decode_iree_cache_state,
+            )
+
+        (
+            prefill_iree_result,
+            prefill_iree_cache_state,
+            decode_iree_result,
+            decode_iree_cache_state,
+        ) = with_iree_device_context(run_iree_module, iree_devices)
+
+        atol = 1e-5
+        assert_cosine_similarity_close(
             ops.unshard(prefill_iree_result),
             ops.unshard(expected_prefill_result),
+            dim=-1,
+            atol=atol,
         )
-        torch.testing.assert_close(
-            ops.unshard(prefill_iree_cache_state),
-            ops.unshard(sharded_prefill_kwargs["cache_state"][0]),
+
+        actual_prefill_cache_state = ops.unshard(
+            sharded_model.cache.unflatten_page_table([prefill_iree_cache_state])
         )
-        torch.testing.assert_close(
+        expected_prefill_cache_state = ops.unshard(
+            sharded_model.cache.unflatten_page_table(
+                sharded_prefill_kwargs["cache_state"]
+            )
+        )
+        assert_cosine_similarity_close(
+            actual_prefill_cache_state, expected_prefill_cache_state, dim=-1, atol=atol
+        )
+
+        assert_cosine_similarity_close(
             ops.unshard(decode_iree_result),
             ops.unshard(expected_decode_result),
+            dim=-1,
+            atol=atol,
         )
-        torch.testing.assert_close(
-            ops.unshard(decode_iree_cache_state),
-            ops.unshard(sharded_decode_kwargs["cache_state"][0]),
+
+        actual_decode_cache_state = ops.unshard(
+            sharded_model.cache.unflatten_page_table([decode_iree_cache_state])
+        )
+        expected_decode_cache_state = ops.unshard(
+            sharded_model.cache.unflatten_page_table(
+                sharded_decode_kwargs["cache_state"]
+            )
+        )
+        assert_cosine_similarity_close(
+            actual_decode_cache_state, expected_decode_cache_state, dim=-1, atol=atol
         )


### PR DESCRIPTION
Check cosine similarity for the logits and the cache state instead of element-wise comparison.

Make the test respect IREE target test args, allowing it to run not just on CPU.

Make the test CLI accept multiple IREE devices.

Refactor get_iree_devices to accept multiple devices and to allow for repeating devices even when not using "local-task". It will repeat the devices to get to the desired device count. This is useful when you want a test to run on a machine with fewer devices than required.
Allow for specifying device_count even when specifying a list of devices.