### PR TITLE
[sharktank] Add CLI tool for operations on models

### DIFF
--- a/sharktank/pyproject.toml
+++ b/sharktank/pyproject.toml
@@ -22,7 +22,7 @@ dynamic = ["version", "dependencies", "optional-dependencies"]
 Repository = "https://github.com/nod-ai/shark-ai"
 
 [project.scripts]
-sharktank = "sharktank.tools.sharktank:main"
+shark = "sharktank.tools.sharktank:main"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/sharktank/pyproject.toml
+++ b/sharktank/pyproject.toml
@@ -21,6 +21,9 @@ dynamic = ["version", "dependencies", "optional-dependencies"]
 [project.urls]
 Repository = "https://github.com/nod-ai/shark-ai"
 
+[project.scripts]
+sharktank = "sharktank.tools.sharktank:main"
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["sharktank*"]

--- a/sharktank/requirements.txt
+++ b/sharktank/requirements.txt
@@ -1,6 +1,7 @@
 iree-turbine
 
 # Runtime deps.
+fire
 gguf>=0.11.0
 numpy
 

--- a/sharktank/requirements.txt
+++ b/sharktank/requirements.txt
@@ -1,7 +1,7 @@
 iree-turbine
 
 # Runtime deps.
-fire
+fire>=0.7
 gguf>=0.11.0
 numpy
 

--- a/sharktank/sharktank/layers/base.py
+++ b/sharktank/sharktank/layers/base.py
@@ -28,6 +28,7 @@ __all__ = [
     "create_model",
     "get_model_type_id",
     "model_registry",
+    "register_all_models",
 ]
 
 logger = logging.getLogger(__name__)

--- a/sharktank/sharktank/layers/configs/config.py
+++ b/sharktank/sharktank/layers/configs/config.py
@@ -95,6 +95,9 @@ class ModelConfig:
         self.parameters_path = self._config_relative_to_cwd_relative_path(
             self.parameters_path
         )
+        self.export_parameters_path = self._config_relative_to_cwd_relative_path(
+            self.export_parameters_path
+        )
         self.iree_module_path = self._config_relative_to_cwd_relative_path(
             self.iree_module_path
         )

--- a/sharktank/sharktank/layers/configs/config.py
+++ b/sharktank/sharktank/layers/configs/config.py
@@ -135,7 +135,9 @@ class ModelConfig:
         if config_path is None:
             raise ValueError("Could not save config, missing save path")
         with open(config_path, "w") as f:
-            json.dump(self.asdict_for_saving(config_path), f)
+            json.dump(
+                self.asdict_for_saving(config_path), fp=f, indent=2, sort_keys=True
+            )
 
     def asdict_for_saving(
         self, config_path: PathLike | None = None, /

--- a/sharktank/sharktank/tools/sharktank.py
+++ b/sharktank/sharktank/tools/sharktank.py
@@ -51,9 +51,7 @@ class Model:
     def show(self, config: str):
         """Show model config."""
         model_config = self._resolve_config(config)
-        json.dump(
-            model_config.asdict_for_saving(), fp=sys.stdout, indent=2, sort_keys=True
-        )
+        json.dump(model_config, fp=sys.stdout, indent=2, sort_keys=True)
         print()
 
     def tracy_trace(self, config: str, /, function: str | None = None):

--- a/sharktank/sharktank/tools/sharktank.py
+++ b/sharktank/sharktank/tools/sharktank.py
@@ -1,0 +1,81 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from pathlib import Path
+import fire
+import json
+import sys
+
+from ..layers import (
+    model_config_presets,
+    ModelConfig,
+    create_model,
+    BaseLayer,
+    register_all_models,
+)
+from ..utils import chdir
+
+
+class Cli:
+    """Command line tool for performing operations on Sharktank models.
+
+    Common parameters:
+
+    config
+      Path to a config file or name of a config preset. The file takes precedence if it
+      exists.
+
+    out_dir
+      Path to the output directory where generated artifacts are placed.
+    """
+
+    def export(self, config: str, /):
+        """Export a model. This includes MLIR and optionally sample input arguments."""
+        model = self._resolve_model(config)
+        model.export()
+
+    def compile(self, config: str, /):
+        """Compile a model.
+        The model needs to be exported before compiling."""
+        model = self._resolve_model(config)
+        model.compile()
+
+    def list(self):
+        """List all model config preset names."""
+        register_all_models()
+        for name in model_config_presets.keys():
+            print(name)
+
+    def show(self, config: str):
+        """Show model config."""
+        model_config = self._resolve_config(config)
+        json.dump(
+            model_config.asdict_for_saving(), fp=sys.stdout, indent=2, sort_keys=True
+        )
+        print()
+
+    def tracy_trace(self, config: str, /, function: str | None = None):
+        """Trace model with tracy.
+        If function is not given all model functions are traced."""
+        raise NotImplementedError("TODO")
+
+    def _resolve_config(self, config: str) -> ModelConfig:
+        register_all_models()
+        if Path(config).exists():
+            return ModelConfig.load(config)
+        return model_config_presets[config]
+
+    def _resolve_model(self, config: str) -> BaseLayer:
+        config = self._resolve_config(config)
+        return create_model(config)
+
+
+def main():
+    fire.Fire(Cli())
+
+
+if __name__ == "__main__":
+    main()

--- a/sharktank/sharktank/tools/sharktank.py
+++ b/sharktank/sharktank/tools/sharktank.py
@@ -16,10 +16,9 @@ from ..layers import (
     BaseLayer,
     register_all_models,
 )
-from ..utils import chdir
 
 
-class Cli:
+class Model:
     """Command line tool for performing operations on Sharktank models.
 
     Common parameters:
@@ -71,6 +70,11 @@ class Cli:
     def _resolve_model(self, config: str) -> BaseLayer:
         config = self._resolve_config(config)
         return create_model(config)
+
+
+class Cli:
+    def __init__(self):
+        self.model = Model()
 
 
 def main():

--- a/sharktank/tests/tools/sharktank_test.py
+++ b/sharktank/tests/tools/sharktank_test.py
@@ -1,0 +1,36 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from subprocess import check_call
+from pathlib import Path
+import pytest
+
+from sharktank.layers import model_config_presets
+from sharktank.utils import chdir
+
+
+@pytest.fixture(scope="module")
+def dummy_model_path(tmp_path_factory) -> Path:
+    return tmp_path_factory.mktemp("dummy_model")
+
+
+def test_list():
+    check_call(["sharktank", "list"])
+
+
+def test_show():
+    check_call(["sharktank", "show", "dummy-model-local-llvm-cpu"])
+
+
+def test_export_compile(dummy_model_path: Path):
+    with chdir(dummy_model_path):
+        check_call(["sharktank", "export", "dummy-model-local-llvm-cpu"])
+        check_call(["sharktank", "compile", "dummy-model-local-llvm-cpu"])
+        from .. import models
+
+        assert model_config_presets[
+            "dummy-model-local-llvm-cpu"
+        ].export_parameters_path.exists()

--- a/sharktank/tests/tools/sharktank_test.py
+++ b/sharktank/tests/tools/sharktank_test.py
@@ -18,17 +18,17 @@ def dummy_model_path(tmp_path_factory) -> Path:
 
 
 def test_list():
-    check_call(["sharktank", "list"])
+    check_call(["shark", "model", "list"])
 
 
 def test_show():
-    check_call(["sharktank", "show", "dummy-model-local-llvm-cpu"])
+    check_call(["shark", "model", "show", "dummy-model-local-llvm-cpu"])
 
 
 def test_export_compile(dummy_model_path: Path):
     with chdir(dummy_model_path):
-        check_call(["sharktank", "export", "dummy-model-local-llvm-cpu"])
-        check_call(["sharktank", "compile", "dummy-model-local-llvm-cpu"])
+        check_call(["shark", "model", "export", "dummy-model-local-llvm-cpu"])
+        check_call(["shark", "model", "compile", "dummy-model-local-llvm-cpu"])
         from .. import models
 
         assert model_config_presets[

--- a/sharktank/tests/tools/sharktank_test.py
+++ b/sharktank/tests/tools/sharktank_test.py
@@ -8,7 +8,7 @@ from subprocess import check_call
 from pathlib import Path
 import pytest
 
-from sharktank.layers import model_config_presets
+from sharktank.layers import model_config_presets, register_all_models, ModelConfig
 from sharktank.utils import chdir
 
 
@@ -31,6 +31,8 @@ def test_export_compile(dummy_model_path: Path):
         check_call(["shark", "model", "compile", "dummy-model-local-llvm-cpu"])
         from .. import models
 
-        assert model_config_presets[
-            "dummy-model-local-llvm-cpu"
-        ].export_parameters_path.exists()
+        register_all_models()
+        config = ModelConfig.create(
+            **model_config_presets["dummy-model-local-llvm-cpu"]
+        )
+        assert config.export_parameters_path.exists()


### PR DESCRIPTION
To have a convenient generation of model artifacts we would benefit from a CLI tool. The tool here could be used for model, export, compile, tracy_trace. E.g.

```
sharktank list
```

```
sharktank export some-model-config-preset-name
sharktank compile some-model-config-preset-name
```

```
sharktank export /path/to/model/config.json
```