### PR TITLE
[sharktank] Add Tracy tracing to Flux transformer artifact exporting

### DIFF
--- a/sharktank/sharktank/layers/configs/config.py
+++ b/sharktank/sharktank/layers/configs/config.py
@@ -299,11 +299,11 @@ def configure_default_export_compile(config: ModelConfig):
     config.export_sample_inputs_enabled = True
 
 
-model_config_presets: dict[str, ModelConfig] = {}
+model_config_presets: dict[str, dict[str, Any]] = {}
 """Presets of named model configurations."""
 
 
-def register_model_config_preset(name: str, config: ModelConfig):
+def register_model_config_preset(name: str, config: dict[str, Any]):
     if name in model_config_presets:
         raise ValueError(f'Model config preset with name "{name}" already registered.')
     model_config_presets[name] = config

--- a/sharktank/sharktank/models/dummy/dummy.py
+++ b/sharktank/sharktank/models/dummy/dummy.py
@@ -89,7 +89,7 @@ def _register_dummy_model_config_presets():
     configure_default_export_compile(config)
     register_model_config_preset(
         name="dummy-model-local-llvm-cpu",
-        config=config,
+        config=config.asdict_for_saving(),
     )
 
 

--- a/sharktank/tests/models/flux/flux_test.py
+++ b/sharktank/tests/models/flux/flux_test.py
@@ -370,7 +370,7 @@ class FluxTest(TempDirTestBase):
     @pytest.mark.expensive
     def testExportAndCompileFromPreset(self):
         with chdir(self._temp_dir):
-            name = "black-forest-labs--FLUX.1-dev-bf16-1024x1024-hip-gfx942"
+            name = "black-forest-labs--FLUX.1-dev-bf16-1024x1024-hip-gfx942-release"
             config = model_config_presets[name]
             logger.info("Creating model...")
             model = create_model(config)


### PR DESCRIPTION
Add debug and release presets for the model.
Tracing requires some debug info to be inserted into the module.