### PR TITLE
[sharktank] Add ops.clone and implement for DefaultPrimitiveTensor

### DIFF
--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -30,6 +30,7 @@ __all__ = [
     "all_reduce",
     "barrier_on_logical_device",
     "cat",
+    "clone",
     "conv2d",
     "einsum_2args",
     "elementwise",
@@ -128,6 +129,26 @@ def _cat_trampoline(
 ):
     for override in d.find_overrides(tensors):
         result = override(tensors, dim)
+        if result is not NotImplemented:
+            return override, result
+    else:
+        d.fail(tensors)
+
+
+@overridable
+def clone(tensor: AnyTensor) -> AnyTensor:
+    """Insert a tensor copy in the graph. The resulting tensor has a new copy of the data.
+    No name cloning to avoid name aliasing, etc. Cloning should thought as equivalent
+    to `b = a + 0`.
+    For more info see torch.clone."""
+    ...
+
+
+@clone.trampoline
+def _clone_trampoline(d: SignatureDispatcher, tensor: AnyTensor):
+    tensors = [tensor]
+    for override in d.find_overrides(tensors):
+        result = override(tensor)
         if result is not NotImplemented:
             return override, result
     else:

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -288,6 +288,11 @@ class InferenceTensor(ABC):
             lambda d: {k: t.to(device=device) for k, t in d.items()}
         )
 
+    def clone(self) -> "InferenceTensor":
+        raise NotImplementedError(
+            f"InferenceTensor {type(self)} does not implement clone."
+        )
+
     def _clone_with_globals(
         self, new_globals: dict[str, torch.Tensor]
     ) -> "InferenceTensor":
@@ -522,6 +527,12 @@ class DefaultPrimitiveTensor(PrimitiveTensor):
     ):
         super().__init__(name=name, shape=list(data.shape))
         self._data = data
+
+    def clone(self) -> "InferenceTensor":
+        from .. import ops
+
+        # We don't clone due the name to not introduce name aliasing.
+        return DefaultPrimitiveTensor(data=ops.clone(self._data))
 
     @classmethod
     def serialized_name(cls) -> str:
@@ -1075,7 +1086,7 @@ class SplitPrimitiveTensor(ShardedTensorBase):
         )
 
     def clone(self, **kwargs) -> "SplitPrimitiveTensor":
-        kwargs["name"] = kwargs.get("name", self.name)
+        # We don't copy the name to not introduce name aliasing.
         kwargs["devices"] = kwargs.get("devices", self.devices)
         kwargs["shape"] = kwargs.get("shape", self.shape)
         kwargs["shard_dim"] = kwargs.get("shard_dim", self.shard_dim)
@@ -1085,7 +1096,7 @@ class SplitPrimitiveTensor(ShardedTensorBase):
             if isinstance(kwargs["ts"], torch.Tensor):
                 kwargs["shard_count"] = kwargs.get("shard_count", self.shard_count)
         else:
-            kwargs["ts"] = self.shards
+            kwargs["ts"] = [shard.clone() for shard in self.shards]
         return SplitPrimitiveTensor(**kwargs)
 
     def _is_slicing_split_dim(self, key):
@@ -1217,8 +1228,8 @@ class ReplicatedTensor(ShardedTensor):
         )
 
     def clone(self, **kwargs) -> "ReplicatedTensor":
+        # We don't copy the name to not introduce name aliasing.
         kwargs["ts"] = kwargs.get("ts", self.shards)
-        kwargs["name"] = kwargs.get("name", self.name)
         kwargs["devices"] = kwargs.get("devices", self.devices)
 
         if "ts" in kwargs:
@@ -1226,7 +1237,7 @@ class ReplicatedTensor(ShardedTensor):
             if isinstance(kwargs["ts"], torch.Tensor):
                 kwargs["shard_count"] = kwargs.get("shard_count", self.shard_count)
         else:
-            kwargs["ts"] = self.shards
+            kwargs["ts"] = [shard.clone() for shard in self.shards]
         return ReplicatedTensor(**kwargs)
 
     @property

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -12,6 +12,7 @@ import iree.turbine.aot as aot
 from iree.turbine.aot import FxProgramsBuilder
 import iree.runtime
 import iree.compiler
+from iree.turbine.aot import DeviceTensorTrait
 import safetensors
 from sharktank import ops
 from sharktank.types import *
@@ -47,6 +48,20 @@ class BroadcastDimsTest(unittest.TestCase):
         res = ops.broadcast_dims(dims, tensors)
         assert res[0] == 0
         assert res[1] == 2
+
+
+class CloneTest(unittest.TestCase):
+    def testDefaultPrimitiveTensor(self):
+        data = torch.tensor([1, 2, 3], dtype=int)
+        DeviceTensorTrait(1).set(data)
+        a = DefaultPrimitiveTensor(data=data, name="a")
+        b = ops.clone(a)
+        assert isinstance(b, DefaultPrimitiveTensor)
+        torch.testing.assert_close(a.as_torch(), b.as_torch())
+        assert a.name != b.name
+        assert DeviceTensorTrait.get(a.as_torch()) == DeviceTensorTrait.get(
+            b.as_torch()
+        )
 
 
 class EqualTest(unittest.TestCase):

--- a/sharktank/tests/types/tensors_test.py
+++ b/sharktank/tests/types/tensors_test.py
@@ -169,22 +169,32 @@ class ShardedTensorTest(unittest.TestCase):
 
     def testCloneUnreducedTensor(self):
         tensors = [torch.rand([4, 3, 4], dtype=torch.float32) for _ in range(4)]
-        sharded_tensor = UnreducedTensor(ts=tensors)
+        sharded_tensor = UnreducedTensor(ts=tensors, name="sharded_tensor")
         cloned_tensor = sharded_tensor.clone()
+        assert cloned_tensor.name != sharded_tensor.name
+        cloned_tensor.name = sharded_tensor.name
         assert sharded_tensor.is_deep_equal(cloned_tensor)
         assert iterables_equal(sharded_tensor.devices, cloned_tensor.devices)
 
     def testCloneSplitPrimitiveTensor(self):
         tensor = torch.rand([4, 3, 4], dtype=torch.float32)
-        sharded_tensor = SplitPrimitiveTensor(ts=tensor, shard_dim=0, shard_count=4)
+        sharded_tensor = SplitPrimitiveTensor(
+            ts=tensor, shard_dim=0, shard_count=4, name="sharded_tensor"
+        )
         cloned_tensor = sharded_tensor.clone()
+        assert cloned_tensor.name != sharded_tensor.name
+        cloned_tensor.name = sharded_tensor.name
         assert sharded_tensor.is_deep_equal(cloned_tensor)
         assert iterables_equal(sharded_tensor.devices, cloned_tensor.devices)
 
     def testCloneReplicatedTensor(self):
         tensor = torch.rand([4, 3, 4], dtype=torch.float32)
-        sharded_tensor = ReplicatedTensor(ts=tensor, shard_count=4)
+        sharded_tensor = ReplicatedTensor(
+            ts=tensor, shard_count=4, name="sharded_tensor"
+        )
         cloned_tensor = sharded_tensor.clone()
+        assert cloned_tensor.name != sharded_tensor.name
+        cloned_tensor.name = sharded_tensor.name
         assert sharded_tensor.is_deep_equal(cloned_tensor)
         assert iterables_equal(sharded_tensor.devices, cloned_tensor.devices)
 


### PR DESCRIPTION
Change sharded tensors to clone their data, but not the name to avoid name aliasing. Cloning should thought as equivalent to `b = a + 0`.