### PR TITLE
[tuner] deferring the link phase to multi-threaded compilation phase

### DIFF
--- a/tuner/tuner/libtuner.py
+++ b/tuner/tuner/libtuner.py
@@ -67,6 +67,7 @@ class CandidateTracker:
     mlir_path: Optional[Path] = None
     compiled_vmfb_path: Optional[Path] = None
     spec_path: Optional[Path] = None
+    starter_td_spec_str: Optional[str] = None
 
 
 @dataclass()
@@ -458,9 +459,30 @@ def create_worker_context_queue(device_ids: list[str]) -> queue.Queue[tuple[int,
 
 def run_iree_compile_command(compile_pack: CompilePack) -> Optional[int]:
     candidate_tracker = compile_pack.candidate_tracker
+    assert candidate_tracker.spec_path, "expected candidate spec path"
+
+    if candidate_tracker.starter_td_spec_str is not None:
+        iree_opt = ireec.binaries.find_tool("iree-opt")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = os.path.join(tmpdir, "tmp_input.mlir")
+            with open(input_path, "w") as f:
+                f.write(candidate_tracker.starter_td_spec_str)
+            link_result = subprocess.run(
+                [
+                    iree_opt,
+                    "--iree-codegen-link-tuning-specs",
+                    input_path,
+                    "-o",
+                    candidate_tracker.spec_path,
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            if link_result.returncode != 0:
+                raise RuntimeError(f"iree-opt failed: {link_result.stderr}")
 
     # Compile to vmfb.
-    assert candidate_tracker.spec_path, "expected candidate spec path"
     td_spec_path = candidate_tracker.spec_path.as_posix()
     logging.debug(
         f"Compiling candidate {candidate_tracker.candidate_id} with spec: {td_spec_path}"
@@ -705,7 +727,6 @@ def generate_candidate_specs(
             allowed_waves_per_eu=args.waves_per_eu_options,
             pipeline_options_search_space=pipeline_options_search_space,
             codegen_pipeline=get_iree_codegen_pipeline(args.codegen_pipeline),
-            starter_td_spec=starter_td_spec,
         )
         logging.debug("candidate_gen.py ends")
         handle_error(
@@ -720,6 +741,26 @@ def generate_candidate_specs(
             spec_path = path_config.specs_dir / path_config.get_candidate_spec_filename(
                 candidate_num
             )
+
+            starter_td_spec_str: Optional[str] = None
+            if starter_td_spec is not None:
+                td_specs: list[ir.Module] = []
+                td_specs.append(spec)
+                td_specs.append(starter_td_spec)
+                # Only log duplicate matchers during the first iteration.
+                log_duplicates = candidate_num == 0
+                td_specs_to_link = determine_td_specs_to_link(
+                    td_specs,
+                    log_duplicates=log_duplicates,
+                )
+
+                if len(td_specs_to_link) != 1:
+                    starter_td_spec_str = str(
+                        combine_tuning_specs(
+                            tuning_client.tuner_context, td_specs_to_link
+                        )
+                    )
+
             with open(spec_path, "w") as f:
                 # Write the module with local scope so that compilation info
                 # attributes are inlined. This makes it easier to split up the
@@ -730,6 +771,7 @@ def generate_candidate_specs(
                 mlir_path=path_config.template_mlir,
                 candidate_id=candidate_num,
                 spec_path=spec_path,
+                starter_td_spec_str=starter_td_spec_str,
             )
             candidate_trackers.append(new_candidate)
     except Exception as e:


### PR DESCRIPTION
This PR moves the linking phase, which links the starter transform td spec with candidate specs, to the candidate compilation phase. Since candidate compilation is multithreaded, this change reduces the linking overhead.

Below are the overhead results I observed (the time unit is seconds):

| Number of candidates| Candidate generation  + link       | Candidate compilation  | Total  |
|------------------------|-------------------------------|--------------------|------------ |
|              50                 |        4.85                              |    13.78                 |    18.63      |
|              100               |        5.31                              |    16.31                 |    21.62      |

After deferring the link phase from candidate generation to the compilation phase
| Number of candidates| Candidate generation         | Candidate link + Compilation  | Total |
|------------------------|-------------------------------|--------------------|------------ |
|              50                 |        1.62                              |    14.20                 |    15.82      |
|              100               |        1.94                              |    16.49                 |    18.44      |

The total overhead is reduced through deferring link phase, as shown by the table above.

fixes #1200 