### PR TITLE
[sharktank] Align the meaning of ops.equal to that of torch.equal

### DIFF
--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -171,8 +171,8 @@ def embedding_lookup_Tensor_QuantizedTensor(
     return F.embedding(unbox_tensor(input), dequant)
 
 
-@equal.override(Tensor, Tensor)
-def equal_default(a, b) -> bool:
+@equal.override(AllOfType(Tensor, InferenceTensor))
+def equal_default(a: Tensor | InferenceTensor, b: Tensor | InferenceTensor) -> bool:
     return torch.equal(unbox_tensor(a), unbox_tensor(b))
 
 

--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -526,16 +526,6 @@ def embedding_lookup_default(
     return ReplicatedTensor(ts=shards)
 
 
-@equal.override(ReplicatedTensor)
-def equal_replicated(a: ReplicatedTensor, b: AnyTensor) -> bool:
-    return a.is_deep_equal(b)
-
-
-@equal.override(SplitPrimitiveTensor)
-def equal_split(a: SplitPrimitiveTensor, b: AnyTensor) -> bool:
-    return a.is_deep_equal(b)
-
-
 @expand.override(ReplicatedTensor)
 def expand_replicated(tensor: ReplicatedTensor, shape: List[int]) -> ReplicatedTensor:
     shards = [expand(shard, shape) for shard in tensor.shards]

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -270,16 +270,12 @@ def _embedding_lookup_trampoline(
 
 @overridable
 def equal(a: AnyTensor, b: AnyTensor) -> bool:
-    """Compares 2 tensors for equality, such that if one is substituted with the other
-    in sharktank polymorphic calls, the results will be essentially the same.
-    Meaning, they would also compare equal.
+    """Compares 2 tensors for equality, such that they elements and dtype are equal.
 
     Overrides are matched first against both tensor types and failing that,
     then on just the first.
     Therefore, each first-only argument override must internally decide whether
     it can handle an equality check with an arbitrary b tensor.
-
-    torch.Tensor and DefaultPrimitiveTensor with the same contents would compare equal.
     """
     ...
 

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -241,7 +241,7 @@ class InferenceTensor(ABC):
         """Adds this tensor to the global archive."""
         ...
 
-    def is_deep_equal(self, other: Any) -> bool:
+    def is_deep_equal(self, other: Any, *, compare_name: bool = True) -> bool:
         """Deep equality including metadata and exact equality of tensor elements.
         It is a representational equality."""
         raise NotImplementedError()
@@ -459,6 +459,13 @@ class InferenceTensor(ABC):
 
         return get_index(self, key)
 
+    def _is_deep_equal(self, other: Any, compare_name: bool = True) -> bool:
+        if self.shape != other.shape:
+            return False
+        if compare_name and self.name != other.name:
+            return False
+        return True
+
 
 REGISTERED_INFERENCE_TENSOR_CLASSES: dict[str, Type[InferenceTensor]] = {}
 
@@ -575,10 +582,10 @@ class DefaultPrimitiveTensor(PrimitiveTensor):
     def __repr__(self):
         return f"PrimitiveTensor({self.name}, {self.shape}, {self._data.dtype})"
 
-    def is_deep_equal(self, other: Any) -> bool:
+    def is_deep_equal(self, other: Any, *, compare_name: bool = True) -> bool:
         if not isinstance(other, DefaultPrimitiveTensor):
             return False
-        if self.shape != other.shape or self.name != other.name:
+        if not self._is_deep_equal(other, compare_name=compare_name):
             return False
         return torch.equal(self.as_torch(), other.as_torch())
 
@@ -942,15 +949,12 @@ class ShardedTensorBase(ShardedTensor):
             f"of {self.shards[0].shape})"
         )
 
-    def is_deep_equal(self, other: Any) -> bool:
+    def is_deep_equal(self, other: Any, compare_name: bool = True) -> bool:
         if type(self) != type(other):
             return False
-        if (
-            self.shard_count != other.shard_count
-            or self.shard_dim != other.shard_dim
-            or self.name != other.name
-            or self.shape != other.shape
-        ):
+        if self.shard_count != other.shard_count or self.shard_dim != other.shard_dim:
+            return False
+        if not self._is_deep_equal(other, compare_name=compare_name):
             return False
         return all(a.is_deep_equal(b) for a, b in zip(self.shards, other.shards))
 
@@ -1311,17 +1315,13 @@ class ReplicatedTensor(ShardedTensor):
             f"of {self.shards[0].shape})"
         )
 
-    def is_deep_equal(self, other: Any) -> bool:
+    def is_deep_equal(self, other: Any, *, compare_name: bool = True) -> bool:
         if not isinstance(other, ReplicatedTensor):
             return False
-        if (
-            self.shard_count != other.shard_count
-            or self.name != other.name
-            or self.shape != other.shape
-        ):
+        if self.shard_count != other.shard_count:
             return False
-        if self.shard_count == 0:
-            return True
+        if not self._is_deep_equal(other, compare_name=compare_name):
+            return False
         return self.shards[0].is_deep_equal(other.shards[0])
 
 
@@ -1382,6 +1382,10 @@ def unbox_tensor(t: Any) -> Tensor:
         return t.as_torch()
     elif isinstance(t, QuantizedTensor):
         return t.unpack().dequant()
+    elif isinstance(t, ShardedTensor):
+        from .. import ops
+
+        return unbox_tensor(ops.unshard(t))
     raise ValueError(f"Expected a Tensor or PrimitiveTensor but got {type(t)}")
 
 

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -64,7 +64,7 @@ class CatTest(unittest.TestCase):
         sharded_a = ops.reshard_split(a, count=shard_count, dim=shard_dim)
         sharded_b = ops.reshard_split(b, count=shard_count, dim=shard_dim)
         actual_result = ops.cat([sharded_a, sharded_b], dim=cat_dim)
-        assert ops.equal(expected_result, actual_result)
+        assert expected_result.is_deep_equal(actual_result, compare_name=False)
 
     def testCatNonSplitDim(self):
         """Concatenation along a non-split dimension."""
@@ -80,7 +80,7 @@ class CatTest(unittest.TestCase):
         sharded_a = ops.reshard_split(a, count=shard_count, dim=shard_dim)
         sharded_b = ops.reshard_split(b, count=shard_count, dim=shard_dim)
         actual_result = ops.cat([sharded_a, sharded_b], dim=cat_dim)
-        assert ops.equal(expected_result, actual_result)
+        assert expected_result.is_deep_equal(actual_result, compare_name=False)
 
 
 class ConvTest(unittest.TestCase):
@@ -363,7 +363,7 @@ class FlattenTest(unittest.TestCase):
         expected_result = ops.replicate(unsharded_expected_result, count=2)
         sharded_tensor = ops.replicate(tensor, count=2)
         actual_result = ops.flatten(sharded_tensor, start_dim=1, end_dim=2)
-        assert expected_result.is_deep_equal(actual_result)
+        assert expected_result.is_deep_equal(actual_result, compare_name=False)
 
     def testSplitTensorFlattenNonSplitDim(self):
         tensor = torch.rand(2, 3, 4, 5)
@@ -371,7 +371,7 @@ class FlattenTest(unittest.TestCase):
         expected_result = ops.reshard_split(unsharded_expected_result, dim=2, count=2)
         sharded_tensor = ops.reshard_split(tensor, dim=3, count=2)
         actual_result = ops.flatten(sharded_tensor, start_dim=1, end_dim=2)
-        assert expected_result.is_deep_equal(actual_result)
+        assert expected_result.is_deep_equal(actual_result, compare_name=False)
 
     def testSplitTensorSplitDimIsLeadingFlattenDim(self):
         tensor = torch.rand(3, 4, 5, 6)
@@ -379,7 +379,7 @@ class FlattenTest(unittest.TestCase):
         expected_result = ops.reshard_split(unsharded_expected_result, dim=1, count=2)
         sharded_tensor = ops.reshard_split(tensor, dim=1, count=2)
         actual_result = ops.flatten(sharded_tensor, start_dim=1, end_dim=2)
-        assert expected_result.is_deep_equal(actual_result)
+        assert expected_result.is_deep_equal(actual_result, compare_name=False)
 
 
 class ExpandTest(unittest.TestCase):
@@ -721,7 +721,7 @@ class MatmulTest(unittest.TestCase):
         b_sharded = ops.reshard_split(b, dim=1, count=shard_count)
         a_sharded = ops.replicate(a, count=shard_count)
         actual_result = ops.matmul(a_sharded, b_sharded)
-        assert ops.equal(expected_result, actual_result)
+        assert expected_result.is_deep_equal(actual_result, compare_name=False)
 
     def testShardedChainMatmulX2Transposed(self):
         # Computes Z = (XA)B (sharded by 8).
@@ -1024,7 +1024,7 @@ class ReshardSplitTest(unittest.TestCase):
         # Test that is a copy.
         tensor[...] = torch.rand_like(tensor)
         result_split2 = ops.reshard_split(tensor, dim=shard_dim, count=shard_count)
-        assert not ops.equal(actual_result, result_split2)
+        assert not result_split2.is_deep_equal(actual_result, compare_name=False)
 
     def testReshardSharded(self):
         tensor = torch.rand(4, 5, 6, dtype=torch.float32)
@@ -1036,7 +1036,7 @@ class ReshardSplitTest(unittest.TestCase):
         actual_result = ops.reshard_split(
             expected_result, dim=shard_dim, count=shard_count
         )
-        assert expected_result.is_deep_equal(actual_result)
+        assert expected_result.is_deep_equal(actual_result, compare_name=False)
 
 
 class ReshardTest(unittest.TestCase):
@@ -1047,7 +1047,7 @@ class ReshardTest(unittest.TestCase):
         expected_result = ops.reshard_split(tensor, count=shard_count, dim=shard_dim)
         split_sharding = sharding.Split(shard_count=shard_count, shard_dim=shard_dim)
         actual_result = ops.reshard(tensor, split_sharding)
-        assert ops.equal(expected_result, actual_result)
+        assert expected_result.is_deep_equal(actual_result, compare_name=False)
 
     def testGroupNormSplitChannelSharding(self):
         channels = 12
@@ -1064,8 +1064,10 @@ class ReshardTest(unittest.TestCase):
         sharded_theta = ops.reshard(theta, sharding_spec)
         expected_weight = ops.reshard_split(weight, dim=0, count=shard_count)
         expected_bias = ops.reshard_split(bias, dim=0, count=shard_count)
-        assert ops.equal(expected_weight, sharded_theta("weight"))
-        assert ops.equal(expected_bias, sharded_theta("bias"))
+        assert expected_weight.is_deep_equal(
+            sharded_theta("weight"), compare_name=False
+        )
+        assert expected_bias.is_deep_equal(sharded_theta("bias"), compare_name=False)
 
 
 class ShardLikeTest(unittest.TestCase):
@@ -1074,7 +1076,7 @@ class ShardLikeTest(unittest.TestCase):
         shard_count = 2
         expected_result = ops.replicate(tensor, count=shard_count)
         actual_result = ops.reshard_like(expected_result, expected_result)
-        assert expected_result.is_deep_equal(actual_result)
+        assert expected_result.is_deep_equal(actual_result, compare_name=False)
 
     def testReshardLikeReplicatedToSharded(self):
         tensor = torch.rand(4, 5, 6, dtype=torch.float32)
@@ -1083,7 +1085,7 @@ class ShardLikeTest(unittest.TestCase):
         expected_result = ops.reshard_split(tensor, dim=shard_dim, count=shard_count)
         replicated_tensor = ops.replicate(tensor, count=shard_count)
         actual_result = ops.reshard_like(replicated_tensor, expected_result)
-        assert expected_result.is_deep_equal(actual_result)
+        assert expected_result.is_deep_equal(actual_result, compare_name=False)
 
     def testReshardLikeReplicatedToUnsharded(self):
         tensor = torch.rand(4, 5, 6, dtype=torch.float32)
@@ -1107,7 +1109,7 @@ class ShardLikeTest(unittest.TestCase):
         shard_count = 3
         expected_result = ops.replicate(tensor, count=shard_count)
         actual_result = ops.reshard_like(tensor, expected_result)
-        assert expected_result.is_deep_equal(actual_result)
+        assert expected_result.is_deep_equal(actual_result, compare_name=False)
 
     def testReshardLikeUnshardedToSharded(self):
         tensor = torch.rand(4, 5, 6, dtype=torch.float32)
@@ -1115,7 +1117,7 @@ class ShardLikeTest(unittest.TestCase):
         shard_count = 3
         expected_result = ops.reshard_split(tensor, dim=shard_dim, count=shard_count)
         actual_result = ops.reshard_like(tensor, expected_result)
-        assert expected_result.is_deep_equal(actual_result)
+        assert expected_result.is_deep_equal(actual_result, compare_name=False)
 
     def testReshardLikeShardedToShared(self):
         tensor = torch.rand(5, 6, dtype=torch.float32)
@@ -1123,7 +1125,7 @@ class ShardLikeTest(unittest.TestCase):
         shard_count = 3
         expected_result = ops.reshard_split(tensor, dim=shard_dim, count=shard_count)
         actual_result = ops.reshard_like(expected_result, expected_result)
-        assert expected_result.is_deep_equal(actual_result)
+        assert expected_result.is_deep_equal(actual_result, compare_name=False)
 
 
 class TransposeTest(unittest.TestCase):


### PR DESCRIPTION
The previous meaning was not precise and diverged from that of torch:
Compares 2 tensors for equality, such that if one is substituted with the other in sharktank polymorphic calls, the results will be essentially the same. Meaning, they would also compare equal.

We should try to not change the meaning of ops compared to torch. Now the meaning is the same as in torch. They are equal if their dtypes is equal and their elements.
For that we utilize unboxing.

Add parameter to is_deep_equal to not require name equality.