### PR TITLE
[sharktank] make tests optionally more verbose to log start/finish

### DIFF
--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -85,7 +85,11 @@ jobs:
       - name: Run sharktank tests
         if: ${{ !cancelled() }}
         run: |
-          pytest -n 4 sharktank/ --durations=10
+          pytest -n 4 sharktank/ \
+            --durations=10 \
+            --capture=no \
+            --log-cli-level=info \
+            -v
 
 
   test_with_data:

--- a/sharktank/conftest.py
+++ b/sharktank/conftest.py
@@ -4,10 +4,13 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import logging
 from pathlib import Path
 import pytest
 from pytest import FixtureRequest
 from typing import Optional, Any
+
+logger = logging.getLogger(__name__)
 
 
 # Tests under each top-level directory will get a mark.
@@ -269,6 +272,13 @@ def set_fixture_from_cli_option(
     if class_attribute_name is None:
         class_attribute_name = cli_option_name
     return set_fixture(request, class_attribute_name, value)
+
+
+@pytest.fixture(autouse=True, scope="function")
+def log_test_start_finish(request: FixtureRequest):
+    logger.info(f"Test started:  {request.node.name}")
+    yield
+    logger.info(f"Test finished: {request.node.name}")
 
 
 @pytest.fixture(scope="class")

--- a/sharktank/sharktank/utils/testing.py
+++ b/sharktank/sharktank/utils/testing.py
@@ -74,7 +74,12 @@ def make_random_mask(shape: tuple[int], dtype: Optional[torch.dtype] = None):
     return mask
 
 
-class TempDirTestBase(unittest.TestCase):
+@pytest.mark.usefixtures("log_test_start_finish")
+class TestCase(unittest.TestCase):
+    pass
+
+
+class TempDirTestBase(TestCase):
     def setUp(self):
         self._temp_dir = Path(tempfile.mkdtemp(type(self).__qualname__))
 

--- a/sharktank/tests/evaluate/perplexity_iree_test.py
+++ b/sharktank/tests/evaluate/perplexity_iree_test.py
@@ -10,7 +10,7 @@ import json
 import numpy as np
 
 from sharktank.evaluate import perplexity_iree
-from sharktank.utils.testing import is_mi300x
+from sharktank.utils.testing import is_mi300x, TestCase
 
 skipif_run_quick_llama_test = pytest.mark.skipif(
     'not config.getoption("run-nightly-llama-tests")',
@@ -26,7 +26,7 @@ skipif_run_quick_llama_test = pytest.mark.skipif(
     "batch_size",
 )
 @is_mi300x
-class PerplexityTest(unittest.TestCase):
+class PerplexityTest(TestCase):
     def setUp(self):
         self.current_perplexity_all = {}
         self.delta = 5e-1

--- a/sharktank/tests/evaluate/perplexity_torch_test.py
+++ b/sharktank/tests/evaluate/perplexity_torch_test.py
@@ -11,6 +11,7 @@ import numpy as np
 import gc
 
 from sharktank.evaluate import perplexity_torch
+from sharktank.utils.testing import TestCase
 
 skipif_run_quick_llama_test = pytest.mark.skipif(
     'not config.getoption("run-nightly-llama-tests")',
@@ -25,7 +26,7 @@ skipif_run_quick_llama_test = pytest.mark.skipif(
     "batch_size",
     "device",
 )
-class PerplexityTest(unittest.TestCase):
+class PerplexityTest(TestCase):
     def setUp(self):
         self.current_perplexity_all = {}
         self.delta = 5e-1

--- a/sharktank/tests/export_test.py
+++ b/sharktank/tests/export_test.py
@@ -19,13 +19,13 @@ from sharktank.export import (
 )
 from sharktank import ops
 from sharktank.utils.testing import (
+    TestCase,
     assert_equal,
     assert_iterables_equal,
     assert_dicts_equal,
 )
 from iree.turbine.aot import DeviceAffinity, FxProgramsBuilder
 from iree.turbine import aot
-from unittest import TestCase
 import torch
 
 

--- a/sharktank/tests/kernels/attention_template_test.py
+++ b/sharktank/tests/kernels/attention_template_test.py
@@ -17,11 +17,12 @@ from iree.turbine import aot
 from sharktank import kernels
 from sharktank.types import layout_utils
 from sharktank.utils import debugging
+from sharktank.utils.testing import TestCase
 from sharktank import ops
 from sharktank.ops.signatures import scaled_dot_product_attention
 
 
-class custom_attention(unittest.TestCase):
+class custom_attention(TestCase):
     def setUp(self):
         torch.manual_seed(420)
 

--- a/sharktank/tests/kernels/batch_matmul_transpose_b_test.py
+++ b/sharktank/tests/kernels/batch_matmul_transpose_b_test.py
@@ -16,10 +16,10 @@ import torch
 from iree.turbine import aot
 from iree.turbine.support.conversions import TORCH_DTYPE_TO_IREE_TYPE_ASM
 from sharktank import kernels
-from sharktank.utils.testing import skip
+from sharktank.utils.testing import TestCase
 
 
-class batch_matmul_transpose_b_test(unittest.TestCase):
+class batch_matmul_transpose_b_test(TestCase):
     def setUp(self):
         torch.manual_seed(42)
 

--- a/sharktank/tests/kernels/conv_2d_nchw_fchw_test.py
+++ b/sharktank/tests/kernels/conv_2d_nchw_fchw_test.py
@@ -16,9 +16,10 @@ import torch.nn.functional as F
 
 from iree.turbine import aot
 from sharktank import kernels
+from sharktank.utils.testing import TestCase
 
 
-class conv_2d_nchw_fchw_test(unittest.TestCase):
+class conv_2d_nchw_fchw_test(TestCase):
     def setUp(self):
         torch.manual_seed(42)
 

--- a/sharktank/tests/kernels/einsum_q4_test.py
+++ b/sharktank/tests/kernels/einsum_q4_test.py
@@ -16,9 +16,10 @@ import torch
 from iree.turbine import aot
 from sharktank import kernels
 from sharktank.types import layout_utils
+from sharktank.utils.testing import TestCase
 
 
-class einsum_2args_q4_test(unittest.TestCase):
+class einsum_2args_q4_test(TestCase):
     def setUp(self):
         torch.manual_seed(42)
 

--- a/sharktank/tests/kernels/mmt_block_scaled_offset_q4_test.py
+++ b/sharktank/tests/kernels/mmt_block_scaled_offset_q4_test.py
@@ -16,9 +16,10 @@ import torch
 from iree.turbine import aot
 from sharktank import kernels
 from sharktank.types import layout_utils
+from sharktank.utils.testing import TestCase
 
 
-class mmt_block_scaled_offset_q4_unsigned_test(unittest.TestCase):
+class mmt_block_scaled_offset_q4_unsigned_test(TestCase):
     def setUp(self):
         torch.manual_seed(42)
 

--- a/sharktank/tests/kernels/mmt_block_scaled_q8_test.py
+++ b/sharktank/tests/kernels/mmt_block_scaled_q8_test.py
@@ -15,9 +15,10 @@ import torch
 
 from iree.turbine import aot
 from sharktank import kernels
+from sharktank.utils.testing import TestCase
 
 
-class mmt_block_scaled_q8_test(unittest.TestCase):
+class mmt_block_scaled_q8_test(TestCase):
     def setUp(self):
         torch.manual_seed(42)
 

--- a/sharktank/tests/kernels/mmt_super_block_scaled_offset_q4_test.py
+++ b/sharktank/tests/kernels/mmt_super_block_scaled_offset_q4_test.py
@@ -16,9 +16,10 @@ import torch
 from iree.turbine import aot
 from sharktank import kernels
 from sharktank.types import layout_utils
+from sharktank.utils.testing import TestCase
 
 
-class mmt_super_block_scaled_offset_q4_unsigned(unittest.TestCase):
+class mmt_super_block_scaled_offset_q4_unsigned(TestCase):
     def setUp(self):
         torch.manual_seed(42)
 

--- a/sharktank/tests/kernels/mmtfp_test.py
+++ b/sharktank/tests/kernels/mmtfp_test.py
@@ -15,9 +15,10 @@ import torch
 
 from iree.turbine import aot
 from sharktank import kernels
+from sharktank.utils.testing import TestCase
 
 
-class mmtfp_test(unittest.TestCase):
+class mmtfp_test(TestCase):
     def setUp(self):
         torch.manual_seed(42)
 

--- a/sharktank/tests/kernels/pooling_nchw_sum_test.py
+++ b/sharktank/tests/kernels/pooling_nchw_sum_test.py
@@ -16,9 +16,10 @@ import torch.nn.functional as F
 
 from iree.turbine import aot
 from sharktank import kernels
+from sharktank.utils.testing import TestCase
 
 
-class pooling_nchw_sum_test(unittest.TestCase):
+class pooling_nchw_sum_test(TestCase):
     def setUp(self):
         torch.manual_seed(42)
 

--- a/sharktank/tests/kernels/rotary.py
+++ b/sharktank/tests/kernels/rotary.py
@@ -13,9 +13,10 @@ import unittest
 
 from sharktank import kernels
 from sharktank import ops
+from sharktank.utils.testing import TestCase
 
 
-class rotary_test(unittest.TestCase):
+class rotary_test(TestCase):
     def setUp(self):
         torch.manual_seed(42)
 

--- a/sharktank/tests/layers/linear_test.py
+++ b/sharktank/tests/layers/linear_test.py
@@ -11,7 +11,7 @@ from parameterized import parameterized
 
 from sharktank.layers import *
 from sharktank.types import *
-from sharktank.utils.testing import make_rand_torch
+from sharktank.utils.testing import make_rand_torch, TestCase
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ def _scale_per_tensor_i8(t: torch.Tensor):
     return scale
 
 
-class LinearQuantTest(unittest.TestCase):
+class LinearQuantTest(TestCase):
     def setUp(self):
         torch.manual_seed(12345)
 

--- a/sharktank/tests/layers/paged_llama_attention_block_test.py
+++ b/sharktank/tests/layers/paged_llama_attention_block_test.py
@@ -22,9 +22,10 @@ from sharktank.layers import (
 )
 from sharktank.layers.testing import make_llama_attention_block_theta
 from sharktank.types.tensors import DefaultPrimitiveTensor
+from sharktank.utils.testing import TestCase
 
 
-class PagedLlamaAttentionBlockTest(unittest.TestCase):
+class PagedLlamaAttentionBlockTest(TestCase):
     def setUp(self):
         torch.manual_seed(12345)
         self.transformer_block_count = 13

--- a/sharktank/tests/layers/sharded_paged_kv_cache_test.py
+++ b/sharktank/tests/layers/sharded_paged_kv_cache_test.py
@@ -12,9 +12,10 @@ from copy import deepcopy
 from typing import List, Tuple
 from sharktank import ops
 from sharktank.types import SplitPrimitiveTensor
+from sharktank.utils.testing import TestCase
 
 
-class ShardedPagedKVCacheTest(unittest.TestCase):
+class ShardedPagedKVCacheTest(TestCase):
     """Verify that the sharded paged KV cache behaves as the unsharded variant."""
 
     def setUp(self):

--- a/sharktank/tests/layers/sharded_paged_llama_attention_block.py
+++ b/sharktank/tests/layers/sharded_paged_llama_attention_block.py
@@ -15,11 +15,12 @@ from sharktank.models.llama.sharding import PagedLlamaAttentionBlockSharding
 from sharktank.types import SplitPrimitiveTensor, unbox_tensor
 import torch
 from sharktank import ops
+from sharktank.utils.testing import TestCase
 from copy import deepcopy
 import pytest
 
 
-class ShardedPagedLlamaAttentionBlockTest(unittest.TestCase):
+class ShardedPagedLlamaAttentionBlockTest(TestCase):
     """Verify that the sharded Llama paged attention block behaves in PyTorch as the
     unsharded variant."""
 

--- a/sharktank/tests/models/clip/clip_test.py
+++ b/sharktank/tests/models/clip/clip_test.py
@@ -16,7 +16,6 @@ import pytest
 import torch
 from torch.utils._pytree import tree_map
 from typing import Optional
-from unittest import TestCase
 from transformers import CLIPTextModel as HfCLIPTextModel, CLIPTokenizer
 from transformers.models.clip.modeling_clip import (
     CLIPAttention as HfCLIPAttention,
@@ -46,6 +45,7 @@ from sharktank.utils.testing import (
     assert_text_encoder_state_close,
     make_rand_torch,
     make_random_mask,
+    TestCase,
     TempDirTestBase,
     get_test_prompts,
 )

--- a/sharktank/tests/models/llama/attention_test.py
+++ b/sharktank/tests/models/llama/attention_test.py
@@ -13,6 +13,7 @@ from sharktank.models.llama.testing import *
 from sharktank.layers.rotary_embedding import RotaryEmbeddingLayer
 from sharktank.models.llama.llama import AttentionFFNBlock, PagedAttention
 from sharktank import ops
+from sharktank.utils.testing import TestCase
 
 from transformers.models.llama.modeling_llama import (
     LlamaAttention,
@@ -23,7 +24,7 @@ from transformers.models.llama.modeling_llama import (
 from transformers.models.llama.configuration_llama import LlamaConfig
 
 
-class AttentionBlockTest(unittest.TestCase):
+class AttentionBlockTest(TestCase):
     def test(self):
         torch.manual_seed(1234567)
         torch.set_default_dtype(torch.float32)

--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -19,6 +19,7 @@ from sharktank.utils.export_artifacts import (
     IreeBenchmarkException,
     IreeCompileException,
 )
+from sharktank.utils.testing import TestCase
 
 is_mi300x = pytest.mark.skipif("config.getoption('iree_hip_target') != 'gfx942'")
 skipif_run_quick_llama_test = pytest.mark.skipif(
@@ -28,7 +29,7 @@ skipif_run_quick_llama_test = pytest.mark.skipif(
 
 
 @pytest.mark.usefixtures("get_iree_flags")
-class BaseBenchmarkTest(unittest.TestCase):
+class BaseBenchmarkTest(TestCase):
     directory_created = False
     current_date = datetime.now()
     dir_path_suffix = current_date.strftime("%Y-%m-%d")

--- a/sharktank/tests/models/llama/kv_cache_test.py
+++ b/sharktank/tests/models/llama/kv_cache_test.py
@@ -16,9 +16,10 @@ from sharktank.models.llama.llama import (
 from sharktank.models.llama.testing import *
 from sharktank.layers.rotary_embedding import RotaryEmbeddingLayer
 from sharktank.layers import causal_llm
+from sharktank.utils.testing import TestCase
 
 
-class KVCacheTest(unittest.TestCase):
+class KVCacheTest(TestCase):
     def setUp(self):
         torch.set_default_dtype(torch.float32)
         self.block_count = 5

--- a/sharktank/tests/models/llama/moe_block_test.py
+++ b/sharktank/tests/models/llama/moe_block_test.py
@@ -12,9 +12,10 @@ from iree.turbine.aot import *
 from sharktank.models.llama.testing import make_moe_block_theta, make_rand_torch
 from sharktank.layers.mixture_of_experts_block import MoeBlock
 from sharktank import ops
+from sharktank.utils.testing import TestCase
 
 
-class MoeBlockTest(unittest.TestCase):
+class MoeBlockTest(TestCase):
     def test(self):
         model = MoeBlock(
             theta=make_moe_block_theta()("blk.0"),

--- a/sharktank/tests/models/llama/prefill_tests.py
+++ b/sharktank/tests/models/llama/prefill_tests.py
@@ -8,11 +8,12 @@ import torch
 from sharktank.examples.paged_llm_v1 import *
 from sharktank.utils import tokenizer
 from sharktank.utils import hf_datasets
+from sharktank.utils.testing import TestCase
 import unittest
 from pathlib import Path
 
 
-class BaseLlamaTest(unittest.TestCase):
+class BaseLlamaTest(TestCase):
     def setUp(self):
         raise NotImplementedError("Subclasses should implement this method.")
 

--- a/sharktank/tests/models/llama/rot_emb_test.py
+++ b/sharktank/tests/models/llama/rot_emb_test.py
@@ -7,6 +7,7 @@
 import torch
 
 from sharktank.layers.rotary_embedding import RotaryEmbeddingLayer
+from sharktank.utils.testing import TestCase
 from transformers.models.llama.modeling_llama import (
     LlamaRotaryEmbedding,
     apply_rotary_pos_emb,
@@ -15,7 +16,7 @@ from transformers import LlamaConfig
 import unittest
 
 
-class HFRotaryComparisonTest(unittest.TestCase):
+class HFRotaryComparisonTest(TestCase):
     def test(self):
         test_dtype = torch.bfloat16
         bs = 2

--- a/sharktank/tests/models/llama/sharded_llama_test.py
+++ b/sharktank/tests/models/llama/sharded_llama_test.py
@@ -12,6 +12,7 @@ import sharktank.ops as ops
 from sharktank.types import unbox_tensor, Dataset, UnreducedTensor, SplitPrimitiveTensor
 from sharktank.models.llama.testing import make_random_llama_theta
 from sharktank.utils.testing import (
+    TestCase,
     assert_cosine_similarity_close,
     get_iree_compiler_flags,
     is_hip_condition,
@@ -40,7 +41,7 @@ import os
 
 
 @pytest.mark.usefixtures("caching", "path_prefix", "get_iree_flags")
-class ShardedLlamaTest(unittest.TestCase):
+class ShardedLlamaTest(TestCase):
     def setUp(self):
         torch.random.manual_seed(123456)
         self.dtype = torch.float32

--- a/sharktank/tests/models/punet/resnet_test.py
+++ b/sharktank/tests/models/punet/resnet_test.py
@@ -14,9 +14,10 @@ from sharktank.models.punet.layers import ResnetBlock2D
 from sharktank.types import *
 from sharktank.models.punet.sharding import ResnetBlock2DSplitOutputChannelsSharding
 from sharktank import ops
+from sharktank.utils.testing import TestCase
 
 
-class ResnetBlockTest(unittest.TestCase):
+class ResnetBlockTest(TestCase):
     def testResnetBlock2DSplitInputAndOutputChannelsSharding(self):
         torch.set_default_dtype(torch.float32)
         batches = 2

--- a/sharktank/tests/models/punet/up_down_block_test.py
+++ b/sharktank/tests/models/punet/up_down_block_test.py
@@ -16,9 +16,10 @@ from sharktank.models.punet.sharding import UpDownBlock2DSplitChannelsSharing
 from sharktank.types import *
 from sharktank import ops
 from sharktank.types.tensors import flatten_tensor_tree
+from sharktank.utils.testing import TestCase
 
 
-class UpBlock2DTest(unittest.TestCase):
+class UpBlock2DTest(TestCase):
     @parameterized.expand(
         [
             (True,),

--- a/sharktank/tests/models/t5/t5_test.py
+++ b/sharktank/tests/models/t5/t5_test.py
@@ -25,7 +25,6 @@ import logging
 import pytest
 import torch
 from torch.utils._pytree import tree_map
-from unittest import TestCase
 from parameterized import parameterized
 from sharktank.types import (
     Theta,
@@ -53,6 +52,7 @@ from sharktank.utils.testing import (
     make_rand_torch,
     make_random_mask,
     skip,
+    TestCase,
     TempDirTestBase,
     get_test_prompts,
 )

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -17,7 +17,7 @@ from sharktank import ops
 from sharktank.types import *
 from sharktank.layers import BaseLayer
 from sharktank.utils import debugging
-from sharktank.utils.testing import TempDirTestBase
+from sharktank.utils.testing import TestCase, TempDirTestBase
 from sharktank.utils.iree import (
     with_iree_device_context,
     get_iree_devices,
@@ -28,7 +28,7 @@ from sharktank.utils.iree import (
 )
 
 
-class BroadcastDimsTest(unittest.TestCase):
+class BroadcastDimsTest(TestCase):
     def testBroadcastDimForSmallerRankTensor(self):
         a = torch.empty(2, 5, 1)
         b = torch.empty(4, 2, 5, 1)
@@ -49,7 +49,7 @@ class BroadcastDimsTest(unittest.TestCase):
         assert res[1] == 2
 
 
-class EqualTest(unittest.TestCase):
+class EqualTest(TestCase):
     def testEqualTorchTensors(self):
         a = torch.rand(2, 3, dtype=torch.float32)
         b = torch.clone(a)
@@ -77,7 +77,7 @@ class EqualTest(unittest.TestCase):
         assert not ops.equal(b, a)
 
 
-class EmbeddingLookupTest(unittest.TestCase):
+class EmbeddingLookupTest(TestCase):
     def testTorchImplNoCast(self):
         t1 = torch.tensor([[1, 2, 4, 5], [4, 3, 2, 9]])
         t2 = torch.rand(10, 3, dtype=torch.float32)
@@ -105,7 +105,7 @@ class EmbeddingLookupTest(unittest.TestCase):
         ...
 
 
-class GemmTest(unittest.TestCase):
+class GemmTest(TestCase):
     def testGemm(self):
         a = torch.tensor([[1, 2], [3, 4]])
         b = torch.tensor([[5, 6], [7, 8]])
@@ -117,7 +117,7 @@ class GemmTest(unittest.TestCase):
         torch.testing.assert_close(result, expected)
 
 
-class MatmulTest(unittest.TestCase):
+class MatmulTest(TestCase):
     def tearDown(self):
         ops._registry._test_enable_last_op_dispatch(False)
 
@@ -220,7 +220,7 @@ class MatmulTest(unittest.TestCase):
     # TODO: mmt_super_block_scaled_offset_q4_unsigned
 
 
-class PermuteTest(unittest.TestCase):
+class PermuteTest(TestCase):
     def testPermute(self):
         torch_tensor = torch.rand(3, 4, 5, dtype=torch.float32)
         permutation = [1, 0, 2]
@@ -239,7 +239,7 @@ class PermuteTest(unittest.TestCase):
         assert torch.equal(torch_tensor.T, primitive_tensor.T)
 
 
-class RmsNormTest(unittest.TestCase):
+class RmsNormTest(TestCase):
     def _ref(self, x, weight, epsilon):
         variance = x.pow(2).mean(-1, keepdim=True)
         output = x * torch.rsqrt(variance + epsilon)
@@ -264,7 +264,7 @@ class RmsNormTest(unittest.TestCase):
     # TODO: Quantized tensor
 
 
-class TestOpExport(unittest.TestCase):
+class TestOpExport(TestCase):
     """Tests that the machinery holds up under dynamo torch.export.
 
     Dynamo can be finicky with dynamism, and we've had trouble, so verify.

--- a/sharktank/tests/ops/pipeline_parallelized_test.py
+++ b/sharktank/tests/ops/pipeline_parallelized_test.py
@@ -13,9 +13,10 @@ from sharktank.ops.sharded_impls import assert_on_same_devices
 from sharktank import ops
 from sharktank.types import *
 from sharktank.utils import iterables_equal
+from sharktank.utils.testing import TestCase
 
 
-class CheckThatOnSameDevicesTest(unittest.TestCase):
+class CheckThatOnSameDevicesTest(TestCase):
     def testOnSameDevices(self):
         tensor_count = 5
         shard_count = 4
@@ -56,7 +57,7 @@ class CheckThatOnSameDevicesTest(unittest.TestCase):
         assert False  # Should throw and error since the first two tensors are on different devices
 
 
-class AllGatherTest(unittest.TestCase):
+class AllGatherTest(TestCase):
     def testAllGather(self):
         shard_count = 3
         shard_shape = [3, 4]
@@ -77,7 +78,7 @@ class AllGatherTest(unittest.TestCase):
             assert actual_result.devices[i] == devices[i]
 
 
-class AllReduceTest(unittest.TestCase):
+class AllReduceTest(TestCase):
     def testAllReduce(self):
         shard_count = 3
         shard_shape = [3, 4]
@@ -98,7 +99,7 @@ class AllReduceTest(unittest.TestCase):
             assert actual_result.devices[i] == devices[i]
 
 
-class CatTest(unittest.TestCase):
+class CatTest(TestCase):
     def testCatSplitDim(self):
         """Concatenation along the sharded split dimension."""
         shard_dim = 1
@@ -152,7 +153,7 @@ class CatTest(unittest.TestCase):
         assert iterables_equal(expected_result.devices, actual_result.devices)
 
 
-class CloneTest(unittest.TestCase):
+class CloneTest(TestCase):
     def testCloneReplicatedFail(self):
         original = ReplicatedTensor(
             ts=torch.rand(5, 4, dtype=torch.float32), shard_count=4
@@ -188,7 +189,7 @@ class CloneTest(unittest.TestCase):
         ), "Should have thrown an error when passing incorrect keywords to clone"
 
 
-class IndexSelectTest(unittest.TestCase):
+class IndexSelectTest(TestCase):
     def testIndexReplicatedPinned(self):
         shard_count = 5
         shards = [torch.rand(5, 4, dtype=torch.float32) for _ in range(shard_count)]
@@ -209,7 +210,7 @@ class IndexSelectTest(unittest.TestCase):
             assert expected_shard.equal(actual_shards.as_torch())
 
 
-class MatmulTest(unittest.TestCase):
+class MatmulTest(TestCase):
     def testShardedParallelAxesInLhsAndRhs(self):  # matmul_split
         a = torch.rand(2, 12, 5, dtype=torch.float32)
         b = torch.rand(5, 9, dtype=torch.float32)
@@ -239,7 +240,7 @@ class MatmulTest(unittest.TestCase):
         torch.testing.assert_close(actual_result, expected_result)
 
 
-class TransposeTest(unittest.TestCase):
+class TransposeTest(TestCase):
     def testTranspose(self):
         shard_count = 4
         shard_shape = [3, 4]

--- a/sharktank/tests/ops/qconv_test.py
+++ b/sharktank/tests/ops/qconv_test.py
@@ -11,6 +11,7 @@ import torch.nn.functional as F
 
 from sharktank import ops
 from sharktank.types import *
+from sharktank.utils.testing import TestCase
 
 
 def _randomize_per_axis(t: torch.Tensor, axis: int, offset_range: float = 0.0):
@@ -38,7 +39,7 @@ def _scale_per_tensor_i8(t: torch.Tensor):
     return scale
 
 
-class QConvTest(unittest.TestCase):
+class QConvTest(TestCase):
     def setUp(self):
         torch.manual_seed(12345)
 

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -13,9 +13,10 @@ from sharktank import ops
 from sharktank.types import *
 from sharktank.types import sharding
 from sharktank.layers import Conv2DLayer
+from sharktank.utils.testing import TestCase
 
 
-class AllGatherTest(unittest.TestCase):
+class AllGatherTest(TestCase):
     def testAllGather(self):
         shard_count = 3
         shard_shape = [3, 4]
@@ -32,7 +33,7 @@ class AllGatherTest(unittest.TestCase):
             torch.testing.assert_close(shard.as_torch(), expected_result)
 
 
-class AllReduceTest(unittest.TestCase):
+class AllReduceTest(TestCase):
     def testAllReduce(self):
         shard_count = 3
         shard_shape = [3, 4]
@@ -49,7 +50,7 @@ class AllReduceTest(unittest.TestCase):
             torch.testing.assert_close(shard.as_torch(), expected_result)
 
 
-class CatTest(unittest.TestCase):
+class CatTest(TestCase):
     def testCatSplitDim(self):
         """Concatenation along the sharded split dimension."""
         shard_dim = 1
@@ -83,7 +84,7 @@ class CatTest(unittest.TestCase):
         assert ops.equal(expected_result, actual_result)
 
 
-class ConvTest(unittest.TestCase):
+class ConvTest(TestCase):
     def testConv2dShardedInputAndOutputChannelsOneGroup(self):
         batches = 2
         in_channels = 6
@@ -233,7 +234,7 @@ class ConvTest(unittest.TestCase):
         assert ops.equal(expected_result, actual_result)
 
 
-class ElementwiseTest(unittest.TestCase):
+class ElementwiseTest(TestCase):
     def testRhsAndLhsShardedAdd(self):
         a = torch.rand(4, 5, 6, dtype=torch.float32)
         b = torch.rand(4, 5, 6, dtype=torch.float32)
@@ -314,7 +315,7 @@ class ElementwiseTest(unittest.TestCase):
         torch.testing.assert_close(actual_result, expected_result)
 
 
-class EqualTest(unittest.TestCase):
+class EqualTest(TestCase):
     def testNotEqualReplicated(self):
         a = torch.rand(3, 4, 5, dtype=torch.float32)
         b = torch.clone(a)
@@ -356,7 +357,7 @@ class EqualTest(unittest.TestCase):
         assert not ops.equal(b_sharded, a_sharded)
 
 
-class FlattenTest(unittest.TestCase):
+class FlattenTest(TestCase):
     def testReplicated(self):
         tensor = torch.rand(2, 3, 4, 5)
         unsharded_expected_result = torch.flatten(tensor, start_dim=1, end_dim=2)
@@ -382,7 +383,7 @@ class FlattenTest(unittest.TestCase):
         assert expected_result.is_deep_equal(actual_result)
 
 
-class ExpandTest(unittest.TestCase):
+class ExpandTest(TestCase):
     def testExpandSplit(self):
         sizes = [4, -1, -1]
         a = torch.rand(1, 2, 5)
@@ -432,7 +433,7 @@ class ExpandTest(unittest.TestCase):
             torch.testing.assert_close(shard.as_torch(), expected)
 
 
-class GemmTest(unittest.TestCase):
+class GemmTest(TestCase):
     def testShardedParallelDim(self):
         a = torch.rand(4, 3)
         b = torch.rand(5, 3)
@@ -451,7 +452,7 @@ class GemmTest(unittest.TestCase):
         torch.testing.assert_close(actual, expected)
 
 
-class IndexCopyTest(unittest.TestCase):
+class IndexCopyTest(TestCase):
     def testSplitInPlace(self):
         torch.set_default_dtype(torch.float32)
         tensor = torch.rand(3, 4, 5, 6)
@@ -473,7 +474,7 @@ class IndexCopyTest(unittest.TestCase):
         assert ops.equal(actual_result, expected_result)
 
 
-class IndexPutTest(unittest.TestCase):
+class IndexPutTest(TestCase):
     def testSplitNonIndexDimInPlace(self):
         torch.set_default_dtype(torch.float32)
         tensor = torch.rand(3, 4, 5, 6)
@@ -492,7 +493,7 @@ class IndexPutTest(unittest.TestCase):
         assert ops.equal(actual_result, expected_result)
 
 
-class InterpolateTest(unittest.TestCase):
+class InterpolateTest(TestCase):
     def testInterpolateSplitChannelDim(self):
         batches = 2
         channels = 6
@@ -563,7 +564,7 @@ class InterpolateTest(unittest.TestCase):
         torch.testing.assert_close(actual_result, expected_result)
 
 
-class NormalizationTest(unittest.TestCase):
+class NormalizationTest(TestCase):
     def testGroupNormShardedGroups(self):
         """Shard the channel dimension such that the group count is multiple of the
         shard count."""
@@ -623,7 +624,7 @@ class NormalizationTest(unittest.TestCase):
         torch.testing.assert_close(actual_result, expected_result)
 
 
-class PermuteTest(unittest.TestCase):
+class PermuteTest(TestCase):
     def testShardedPrimitiveTensorPermute(self):
         torch_tensor = torch.rand(3, 8, 5, dtype=torch.float32)
         permutation = [1, 0, 2]
@@ -638,7 +639,7 @@ class PermuteTest(unittest.TestCase):
         assert ops.equal(expected_result, result)
 
 
-class AttentionTest(unittest.TestCase):
+class AttentionTest(TestCase):
     def testAttentionShardedBatch(self):
         q = torch.rand(4, 32, 16, dtype=torch.float32)
         k = torch.rand(4, 32, 16, dtype=torch.float32)
@@ -692,7 +693,7 @@ class AttentionTest(unittest.TestCase):
         torch.testing.assert_close(unsharded_result, expected_result)
 
 
-class MatmulTest(unittest.TestCase):
+class MatmulTest(TestCase):
     def testTorchRHSColumnShardedTransposed(self):
         t1 = torch.rand(4, 32, 16, dtype=torch.float32)
         t2 = torch.rand(48, 16, dtype=torch.float16)
@@ -887,7 +888,7 @@ class MatmulTest(unittest.TestCase):
             assert ops.equal(shard, unsharded_result)
 
 
-class ReplicateTest(unittest.TestCase):
+class ReplicateTest(TestCase):
     def testReplicateReplicated(self):
         tensor = torch.rand(4, 5, dtype=torch.float32)
         shard_count = 3
@@ -907,7 +908,7 @@ class ReplicateTest(unittest.TestCase):
         assert all(not ops.equal(tensor, shard) for shard in actual_result.shards)
 
 
-class ReshapeTest(unittest.TestCase):
+class ReshapeTest(TestCase):
     def testSplitTensorFlattenNonSplitDim(self):
         tensor = torch.rand(2, 3, 4, 5)
         new_shape = [2, 12, 5]
@@ -999,7 +1000,7 @@ class ReshapeTest(unittest.TestCase):
         assert expected_result.is_deep_equal(actual_result)
 
 
-class ReshardSplitTest(unittest.TestCase):
+class ReshardSplitTest(TestCase):
     def testReshardReplicated(self):
         tensor = torch.rand(4, 5, 6, dtype=torch.float32)
         shard_dim = 2
@@ -1039,7 +1040,7 @@ class ReshardSplitTest(unittest.TestCase):
         assert expected_result.is_deep_equal(actual_result)
 
 
-class ReshardTest(unittest.TestCase):
+class ReshardTest(TestCase):
     def testTensorSplit(self):
         tensor = torch.rand(5, 6, dtype=torch.float32)
         shard_count = 3
@@ -1068,7 +1069,7 @@ class ReshardTest(unittest.TestCase):
         assert ops.equal(expected_bias, sharded_theta("bias"))
 
 
-class ShardLikeTest(unittest.TestCase):
+class ShardLikeTest(TestCase):
     def testReshardLikeReplicatedToReplicated(self):
         tensor = torch.rand(4, 5, 6, dtype=torch.float32)
         shard_count = 2
@@ -1126,7 +1127,7 @@ class ShardLikeTest(unittest.TestCase):
         assert expected_result.is_deep_equal(actual_result)
 
 
-class TransposeTest(unittest.TestCase):
+class TransposeTest(TestCase):
     def testTransposeReplicated(self):
         a = torch.randn(3, 4, 1)
         expected = torch.transpose(a, 1, 2)
@@ -1138,7 +1139,7 @@ class TransposeTest(unittest.TestCase):
             assert ops.equal(shard, expected)
 
 
-class UnflattenTest(unittest.TestCase):
+class UnflattenTest(TestCase):
     def testUnflattenReplicated(self):
         a = torch.randn(3, 4, 1)
         expected = torch.unflatten(a, 1, [2, 2])
@@ -1150,7 +1151,7 @@ class UnflattenTest(unittest.TestCase):
             assert ops.equal(shard, expected)
 
 
-class UnshardTest(unittest.TestCase):
+class UnshardTest(TestCase):
     def testUnshardSplitTensor(self):
         tensor = torch.rand(4, 5, 6, dtype=torch.float32)
         shard_dim = 0

--- a/sharktank/tests/pipelines/flux/flux_pipeline_test.py
+++ b/sharktank/tests/pipelines/flux/flux_pipeline_test.py
@@ -9,11 +9,11 @@
 from typing import Optional
 import pytest
 import torch
-from unittest import TestCase
 import numpy
 
 from diffusers import FluxPipeline as ReferenceFluxPipeline
 
+from sharktank.utils.testing import TestCase
 from sharktank.pipelines.flux import FluxPipeline
 
 with_flux_data = pytest.mark.skipif("not config.getoption('with_flux_data')")

--- a/sharktank/tests/types/dataset_test.py
+++ b/sharktank/tests/types/dataset_test.py
@@ -13,6 +13,7 @@ import torch
 
 from iree.turbine.aot import ExternalTensorTrait
 from sharktank.types import *
+from sharktank.utils.testing import TestCase
 
 
 def _t(name: str, *dims: int):
@@ -23,7 +24,7 @@ def _flat_t_dict(*ts):
     return {t.name: t for t in ts}
 
 
-class ThetaTest(unittest.TestCase):
+class ThetaTest(TestCase):
     def testThetaAccess(self):
         # TODO: Make construction of a Theta programatically more natural.
         theta = Theta(
@@ -94,7 +95,7 @@ class ThetaTest(unittest.TestCase):
         self.assertIn("a.b.3", popped.keys())
 
 
-class DatasetTest(unittest.TestCase):
+class DatasetTest(TestCase):
     def setUp(self):
         self.temp_dir = Path(tempfile.mkdtemp("_dstest"))
 

--- a/sharktank/tests/types/layout_utils_test.py
+++ b/sharktank/tests/types/layout_utils_test.py
@@ -9,9 +9,10 @@ import unittest
 import torch
 
 from sharktank.types.layout_utils import *
+from sharktank.utils.testing import TestCase
 
 
-class I4Shuffle(unittest.TestCase):
+class I4Shuffle(TestCase):
     def test_linearize_interleaved_i4_block(self):
         # Linearize.
         input_data = torch.tensor(

--- a/sharktank/tests/types/layouts_test.py
+++ b/sharktank/tests/types/layouts_test.py
@@ -10,9 +10,10 @@ import torch
 
 from sharktank.types import *
 from sharktank.types.tensors import REGISTERED_LAYOUT_CLASSES
+from sharktank.utils.testing import TestCase
 
 
-class BlockScaledLayoutTest(unittest.TestCase):
+class BlockScaledLayoutTest(TestCase):
     def testRegistered(self):
         self.assertIs(
             BlockScaledLayout,
@@ -37,7 +38,7 @@ class BlockScaledLayoutTest(unittest.TestCase):
         self.assertEqual(l.metadata, l_new.metadata)
 
 
-class BlockScaledI4LayoutTest(unittest.TestCase):
+class BlockScaledI4LayoutTest(TestCase):
     def testRegistered(self):
         self.assertIs(
             BlockScaledI4Layout,
@@ -64,7 +65,7 @@ class BlockScaledI4LayoutTest(unittest.TestCase):
         self.assertEqual(l.signed, l_new.signed)
 
 
-class SuperBlockOffsetScaled_4_6_LayoutTest(unittest.TestCase):
+class SuperBlockOffsetScaled_4_6_LayoutTest(TestCase):
     def testRegistered(self):
         self.assertIs(
             SuperBlockOffsetScaled_4_6_Layout,
@@ -97,7 +98,7 @@ class SuperBlockOffsetScaled_4_6_LayoutTest(unittest.TestCase):
         self.assertEqual(l.metadata, l_new.metadata)
 
 
-class TensorScaledLayoutTest(unittest.TestCase):
+class TensorScaledLayoutTest(TestCase):
     def testRegistered(self):
         self.assertIs(
             TensorScaledLayout,

--- a/sharktank/tests/types/tensors_test.py
+++ b/sharktank/tests/types/tensors_test.py
@@ -13,6 +13,7 @@ import os
 from sharktank.types import *
 from sharktank import ops
 from sharktank.utils import iterables_equal
+from sharktank.utils.testing import TestCase
 
 
 def _createTestLayout():
@@ -28,7 +29,7 @@ def _createTestLayout():
     )
 
 
-class PlanarQuantizedTensorTest(unittest.TestCase):
+class PlanarQuantizedTensorTest(TestCase):
     def testTransform(self):
         pqt1 = PlanarQuantizedTensor(
             name="t1", shape=[128, 1024], layout=_createTestLayout()
@@ -61,7 +62,7 @@ class PlanarQuantizedTensorTest(unittest.TestCase):
         self.assertEqual(new_planes["d"].dtype, torch.float16)
 
 
-class ShardedTensorTest(unittest.TestCase):
+class ShardedTensorTest(TestCase):
     def testReplicatedTensorSaveLoad(self):
         tensor = [torch.rand([2, 3, 4], dtype=torch.float32)] * 3
         replicated_tensor = ReplicatedTensor(ts=tensor, name="the_tensor")


### PR DESCRIPTION
Occasionally have hanging tests in CI and it would be nice to know which test is the culprit.

Here all tests are made to inherit from
`sharktank.utils.testing.TestCase`, which has a test fixture to log the start and end of all each tests.
This will enable use to see which test started and did not finish even when running multiple tests in parallel.

The fixture is required to be imported even when defining the derived class so we import with
```
from sharktank.utils.testing import *
```
This will allow us to add more fixtures to the base class if required without changing all import statements.