### PR TITLE
Pipeline Parallelism Support for KVCache

### DIFF
--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -66,6 +66,7 @@ def main():
     llama_config = LlamaModelConfig(
         hp,
         tensor_parallelism_size=tensor_parallelism_size,
+        pipeline_parallelism_size=args.pipeline_parallelism_size,
         use_hf=args.use_hf,
         static_tables=False,  # Rely on the compiler for hoisting tables.
         attention_kernel=args.attention_kernel,

--- a/sharktank/sharktank/utils/cli.py
+++ b/sharktank/sharktank/utils/cli.py
@@ -114,6 +114,12 @@ def add_model_options(parser: argparse.ArgumentParser):
         help="Number of devices for tensor parallel sharding. Will be overridden by dataset.properties if present",
     )
     parser.add_argument(
+        "--pipeline-parallelism-size",
+        type=int,
+        default=1,
+        help="Number of (roughly) uniform groups of layers to split the model for pipeline parallelism.",
+    )
+    parser.add_argument(
         "--block-seq-stride",
         help="Block sequence stride for paged KV cache, must divide evenly into the context length",
         type=int,

--- a/sharktank/sharktank/utils/create_cache.py
+++ b/sharktank/sharktank/utils/create_cache.py
@@ -15,6 +15,7 @@ def create_paged_kv_cache(config: LlamaModelConfig) -> PagedAttention:
     dtype = config.kv_cache_dtype or config.attention_dtype
     return PagedAttention(
         transformer_block_count=hp.block_count,
+        block_to_device_lookup=config.block_to_device_lookup,
         attn_head_count=hp.attention_head_count_kv,
         attn_head_dim=hp.attn_head_dim,
         cache_partition_count=2,  # One for each of K/V.

--- a/sharktank/tests/layers/pipelined_paged_attention_test.py
+++ b/sharktank/tests/layers/pipelined_paged_attention_test.py
@@ -1,0 +1,242 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import unittest
+from sharktank.layers import PagedAttention
+import torch
+from sharktank.utils import iterables_equal
+from copy import deepcopy
+from typing import List, Tuple
+from sharktank import ops
+from sharktank.types import SplitPrimitiveTensor
+
+
+class PipelinedPagedAttentionTest(unittest.TestCase):
+    """Verify that the pipelined paged attention behaves the same as the unpipelined variant."""
+
+    def setUp(self):
+        torch.manual_seed(12345)
+        self.dtype = torch.float32
+        torch.set_default_dtype(self.dtype)
+        self.shard_count = 1
+        self.pipeline_count = 2
+        self.transformer_block_count = 5
+        self.attn_head_count = self.shard_count * 7
+        self.block_seq_stride = 19
+        self.attn_head_dim = 17
+        self.cache_partition_count = 2
+        self.page_count = 23
+        self.batch_size = 11
+        self.block_seq_len = 2
+        self.max_seq_len = self.block_seq_len * self.block_seq_stride
+
+        block_to_device_lookup = []
+        for block in range(self.transformer_block_count):
+            pp_group = int(block * self.pipeline_count / self.transformer_block_count)
+            zero_4_group = self.shard_count * pp_group
+            block_to_device_lookup.append(
+                tuple(i + zero_4_group for i in range(self.shard_count))
+            )
+        self.block_to_device_lookup = tuple(block_to_device_lookup)
+
+        self.cache = PagedAttention(
+            transformer_block_count=self.transformer_block_count,
+            attn_head_count=self.attn_head_count,
+            block_seq_stride=self.block_seq_stride,
+            attn_head_dim=self.attn_head_dim,
+            cache_partition_count=self.cache_partition_count,
+            dtype=self.dtype,
+        )
+        self.pipelined_cache = PagedAttention(
+            shard_count=self.shard_count,
+            block_to_device_lookup=self.block_to_device_lookup,
+            transformer_block_count=self.transformer_block_count,
+            attn_head_count=self.attn_head_count,
+            block_seq_stride=self.block_seq_stride,
+            attn_head_dim=self.attn_head_dim,
+            cache_partition_count=self.cache_partition_count,
+            dtype=self.dtype,
+        )
+
+    def make_unpipelined_and_pipelined_equal_cache_states(
+        self,
+    ) -> Tuple[List[torch.Tensor], List[SplitPrimitiveTensor]]:
+        cache_state = self.cache.allocate(self.page_count)
+        cache_state[0] = torch.rand_like(cache_state[0])
+        pipelined_cache_state = self.pipelined_cache.shard_state(deepcopy(cache_state))
+        self.assert_equal_unpipelined_and_pipelined_cache_states(
+            cache_state, pipelined_cache_state
+        )
+        return cache_state, pipelined_cache_state
+
+    def assert_equal_unpipelined_and_pipelined_cache_states(
+        self,
+        cache_state: List[torch.Tensor],
+        pipelined_cache_state: List[SplitPrimitiveTensor],
+    ):
+        pipelined_states_as_unreplicated = [
+            ops.unshard(unflatted_page).flatten(start_dim=1)
+            for unflatted_page in self.pipelined_cache.unflatten_page_tables(
+                pipelined_cache_state
+            )
+        ]
+        pipelined_states_as_single = (
+            torch.cat(  # TODO cat isn't what we should be doing
+                pipelined_states_as_unreplicated, dim=1
+            )
+        )
+        assert iterables_equal(cache_state[0].shape, pipelined_states_as_single.shape)
+        assert ops.equal(
+            cache_state[0],
+            pipelined_states_as_single,
+        )
+
+    def testAllocate(self):
+        cache_state = self.cache.allocate(self.page_count)
+        pipelined_cache_allocation = self.pipelined_cache.allocate(self.page_count)
+        assert len(cache_state) == 1
+        assert len(pipelined_cache_allocation) == self.pipeline_count
+        assert all(t.shape[0] == self.page_count for t in cache_state)
+        assert cache_state[0].shape[1] == sum(
+            t.shape[1] for t in pipelined_cache_allocation
+        )
+
+    def testUnflattenPageTable(self):
+        cache_state = self.cache.allocate(self.page_count)
+        assert len(cache_state) == 1
+        pipelined_cache_state = self.pipelined_cache.allocate(self.page_count)
+
+        unflattened_state = self.cache.unflatten_page_tables(cache_state)
+        pipelined_unflattened_state = self.pipelined_cache.unflatten_page_tables(
+            pipelined_cache_state
+        )
+        # [0] is page count
+        assert all(
+            pipelined_page_slab.shape[0] == self.page_count
+            for pipelined_page_slab in pipelined_unflattened_state
+        )
+        # [1] is for block count, and split across pipelines
+        assert unflattened_state[0].shape[1] == self.transformer_block_count
+        assert (
+            sum(page_slab.shape[1] for page_slab in pipelined_unflattened_state)
+            == self.transformer_block_count
+        )
+        # [2:] should be the same
+        assert all(
+            iterables_equal(page_slab.shape[2:], unflattened_state[0].shape[2:])
+            for page_slab in pipelined_unflattened_state
+        )
+
+    def testRead(self):
+        (
+            cache_state,
+            pipelined_cache_state,
+        ) = self.make_unpipelined_and_pipelined_equal_cache_states()
+
+        transformer_block_index = 1
+        page_ids = torch.randint(
+            low=0, high=self.page_count, size=[self.batch_size, self.block_seq_len]
+        ).reshape([self.batch_size, self.block_seq_len])
+        unpipelined_read = self.cache.read(
+            state=cache_state,
+            transformer_block_index=transformer_block_index,
+            page_ids=page_ids,
+            seq_len=self.block_seq_len * self.block_seq_stride,
+        )
+        pipelined_page_ids = ops.replicate(page_ids, count=self.shard_count)
+        pipelined_read = self.pipelined_cache.read(
+            state=pipelined_cache_state,
+            transformer_block_index=transformer_block_index,
+            page_ids=pipelined_page_ids,
+            seq_len=self.block_seq_len * self.block_seq_stride,
+        )
+        for unpipelined, pipelined in zip(unpipelined_read, pipelined_read):
+            assert ops.equal(unpipelined, ops.unshard(pipelined))
+
+    def testWriteTimestep(self):
+        (
+            cache_state,
+            pipelined_cache_state,
+        ) = self.make_unpipelined_and_pipelined_equal_cache_states()
+
+        cache_partitions = [
+            torch.rand(
+                self.batch_size,
+                1,
+                self.attn_head_count,
+                self.attn_head_dim,
+            )
+            for _ in range(self.cache_partition_count)
+        ]
+        transformer_block_index = 1
+        seq_positions = torch.randint(
+            low=0, high=self.max_seq_len, size=[self.batch_size]
+        )
+        page_ids = torch.randperm(self.batch_size * self.block_seq_len).reshape(
+            [self.batch_size, self.block_seq_len]
+        )
+        self.cache.write_timestep(
+            state=cache_state,
+            cache_partitions=cache_partitions,
+            transformer_block_index=transformer_block_index,
+            seq_positions=seq_positions,
+            page_ids=page_ids,
+        )
+        pipelined_cache_partitions = deepcopy(
+            [ops.replicate(t, count=self.shard_count) for t in cache_partitions]
+        )
+        pipelined_seq_positions = ops.replicate(seq_positions, count=self.shard_count)
+        pipelined_page_ids = ops.replicate(page_ids, count=self.shard_count)
+        self.pipelined_cache.write_timestep(
+            state=pipelined_cache_state,
+            cache_partitions=pipelined_cache_partitions,
+            transformer_block_index=transformer_block_index,
+            seq_positions=pipelined_seq_positions,
+            page_ids=pipelined_page_ids,
+        )
+        self.assert_equal_unpipelined_and_pipelined_cache_states(
+            cache_state, pipelined_cache_state
+        )
+
+    def testWrite(self):
+        (
+            cache_state,
+            pipelined_cache_state,
+        ) = self.make_unpipelined_and_pipelined_equal_cache_states()
+
+        cache_partitions = [
+            torch.rand(
+                self.batch_size,
+                self.block_seq_len * self.block_seq_stride,
+                self.attn_head_count,
+                self.attn_head_dim,
+            )
+            for _ in range(self.cache_partition_count)
+        ]
+        transformer_block_index = 1
+        assert self.batch_size * self.block_seq_len <= self.page_count
+        page_ids = torch.randperm(self.batch_size * self.block_seq_len).reshape(
+            [self.batch_size, self.block_seq_len]
+        )
+        self.cache.write(
+            state=cache_state,
+            cache_partitions=cache_partitions,
+            transformer_block_index=transformer_block_index,
+            page_ids=page_ids,
+        )
+        pipelined_cache_partitions = deepcopy(
+            [ops.replicate(t, count=self.shard_count) for t in cache_partitions]
+        )
+        pipelined_page_ids = ops.replicate(page_ids, count=self.shard_count)
+        self.pipelined_cache.write(
+            state=pipelined_cache_state,
+            cache_partitions=pipelined_cache_partitions,
+            transformer_block_index=transformer_block_index,
+            page_ids=pipelined_page_ids,
+        )
+        self.assert_equal_unpipelined_and_pipelined_cache_states(
+            cache_state, pipelined_cache_state
+        )

--- a/sharktank/tests/layers/pipelined_paged_attention_test.py
+++ b/sharktank/tests/layers/pipelined_paged_attention_test.py
@@ -48,7 +48,8 @@ class PipelinedPagedAttentionTest(unittest.TestCase):
             block_seq_stride=self.block_seq_stride,
             attn_head_dim=self.attn_head_dim,
             cache_partition_count=self.cache_partition_count,
-            dtype=self.dtype,
+            cache_dtype=self.dtype,
+            attn_dtype=self.dtype,
         )
         self.pipelined_cache = PagedAttention(
             shard_count=self.shard_count,
@@ -58,7 +59,8 @@ class PipelinedPagedAttentionTest(unittest.TestCase):
             block_seq_stride=self.block_seq_stride,
             attn_head_dim=self.attn_head_dim,
             cache_partition_count=self.cache_partition_count,
-            dtype=self.dtype,
+            cache_dtype=self.dtype,
+            attn_dtype=self.dtype,
         )
 
     def make_unpipelined_and_pipelined_equal_cache_states(

--- a/sharktank/tests/layers/pipelined_paged_attention_test.py
+++ b/sharktank/tests/layers/pipelined_paged_attention_test.py
@@ -77,17 +77,13 @@ class PipelinedPagedAttentionTest(unittest.TestCase):
         cache_state: List[torch.Tensor],
         pipelined_cache_state: List[SplitPrimitiveTensor],
     ):
-        pipelined_states_as_unreplicated = [
+        pipelined_states_unreplicated = [
             ops.unshard(unflatted_page).flatten(start_dim=1)
             for unflatted_page in self.pipelined_cache.unflatten_page_tables(
                 pipelined_cache_state
             )
         ]
-        pipelined_states_as_single = (
-            torch.cat(  # TODO cat isn't what we should be doing
-                pipelined_states_as_unreplicated, dim=1
-            )
-        )
+        pipelined_states_as_single = ops.cat(pipelined_states_unreplicated, dim=1)
         assert iterables_equal(cache_state[0].shape, pipelined_states_as_single.shape)
         assert ops.equal(
             cache_state[0],

--- a/sharktank/tests/layers/pipelined_sharded_paged_attention_test.py
+++ b/sharktank/tests/layers/pipelined_sharded_paged_attention_test.py
@@ -85,7 +85,7 @@ class PipelinedShardedPagedAttentionTest(unittest.TestCase):
                 pipelined_sharded_cache_state
             )
         ]
-        pipelined_sharded_states_as_single = torch.cat(
+        pipelined_sharded_states_as_single = ops.cat(
             pipelined_sharded_states_as_unsharded, dim=1
         )
         assert iterables_equal(

--- a/sharktank/tests/layers/pipelined_sharded_paged_attention_test.py
+++ b/sharktank/tests/layers/pipelined_sharded_paged_attention_test.py
@@ -14,14 +14,15 @@ from sharktank import ops
 from sharktank.types import SplitPrimitiveTensor
 
 
-class ShardedPagedKVCacheTest(unittest.TestCase):
-    """Verify that the sharded paged KV cache behaves as the unsharded variant."""
+class PipelinedShardedPagedAttentionTest(unittest.TestCase):
+    """Verify that the pipelined sharded paged attention behaves the same as the unpipelined unsharded variant."""
 
     def setUp(self):
         torch.manual_seed(12345)
         self.dtype = torch.float32
         torch.set_default_dtype(self.dtype)
-        self.shard_count = 3
+        self.shard_count = 2
+        self.pipeline_count = 2
         self.transformer_block_count = 5
         self.attn_head_count = self.shard_count * 7
         self.block_seq_stride = 19
@@ -32,24 +33,32 @@ class ShardedPagedKVCacheTest(unittest.TestCase):
         self.block_seq_len = 2
         self.max_seq_len = self.block_seq_len * self.block_seq_stride
 
+        block_to_device_lookup = []
+        for block in range(self.transformer_block_count):
+            pp_group = int(block * self.pipeline_count / self.transformer_block_count)
+            zero_4_group = self.shard_count * pp_group
+            block_to_device_lookup.append(
+                tuple(i + zero_4_group for i in range(self.shard_count))
+            )
+        self.block_to_device_lookup = tuple(block_to_device_lookup)
+
         self.cache = PagedAttention(
             transformer_block_count=self.transformer_block_count,
             attn_head_count=self.attn_head_count,
             block_seq_stride=self.block_seq_stride,
             attn_head_dim=self.attn_head_dim,
             cache_partition_count=self.cache_partition_count,
-            cache_dtype=self.dtype,
-            attn_dtype=self.dtype,
+            dtype=self.dtype,
         )
-        self.sharded_cache = PagedAttention(
+        self.pipelined_sharded_cache = PagedAttention(
             shard_count=self.shard_count,
+            block_to_device_lookup=self.block_to_device_lookup,
             transformer_block_count=self.transformer_block_count,
             attn_head_count=self.attn_head_count,
             block_seq_stride=self.block_seq_stride,
             attn_head_dim=self.attn_head_dim,
             cache_partition_count=self.cache_partition_count,
-            cache_dtype=self.dtype,
-            attn_dtype=self.dtype,
+            dtype=self.dtype,
         )
 
     def make_unsharded_and_sharded_equal_cache_states(
@@ -57,7 +66,9 @@ class ShardedPagedKVCacheTest(unittest.TestCase):
     ) -> Tuple[List[torch.Tensor], List[SplitPrimitiveTensor]]:
         cache_state = self.cache.allocate(self.page_count)
         cache_state[0] = torch.rand_like(cache_state[0])
-        sharded_cache_state = self.sharded_cache.shard_state(deepcopy(cache_state))
+        sharded_cache_state = self.pipelined_sharded_cache.shard_state(
+            deepcopy(cache_state)
+        )
         self.assert_equal_unsharded_and_sharded_cache_states(
             cache_state, sharded_cache_state
         )
@@ -66,39 +77,79 @@ class ShardedPagedKVCacheTest(unittest.TestCase):
     def assert_equal_unsharded_and_sharded_cache_states(
         self,
         cache_state: List[torch.Tensor],
-        sharded_cache_state: List[SplitPrimitiveTensor],
+        pipelined_sharded_cache_state: List[SplitPrimitiveTensor],
     ):
-        sharded_state_as_unsharded = ops.unshard(
-            self.sharded_cache.unflatten_page_tables(sharded_cache_state)[0]
-        ).flatten(start_dim=1)
+        pipelined_sharded_states_as_unsharded = [
+            ops.unshard(unflatted_page).flatten(start_dim=1)
+            for unflatted_page in self.pipelined_sharded_cache.unflatten_page_tables(
+                pipelined_sharded_cache_state
+            )
+        ]
+        pipelined_sharded_states_as_single = torch.cat(
+            pipelined_sharded_states_as_unsharded, dim=1
+        )
+        assert iterables_equal(
+            cache_state[0].shape, pipelined_sharded_states_as_single.shape
+        )
         assert ops.equal(
             cache_state[0],
-            sharded_state_as_unsharded,
+            pipelined_sharded_states_as_single,
         )
 
     def testAllocate(self):
         cache_state = self.cache.allocate(self.page_count)
-        sharded_cache_state = self.sharded_cache.allocate(self.page_count)
+        pipelined_sharded_cache_allocation = self.pipelined_sharded_cache.allocate(
+            self.page_count
+        )
         assert len(cache_state) == 1
-        assert len(sharded_cache_state) == 1
-        assert iterables_equal(cache_state[0].shape, sharded_cache_state[0].shape)
-        assert sharded_cache_state[0].shard_dim == 1
-        assert sharded_cache_state[0].shard_count == self.shard_count
+        assert len(pipelined_sharded_cache_allocation) == self.pipeline_count
+        assert all(t.shape[0] == self.page_count for t in cache_state)
+        assert cache_state[0].shape[1] == sum(
+            t.shape[1] for t in pipelined_sharded_cache_allocation
+        )
+        assert all(t.shard_dim == 1 for t in pipelined_sharded_cache_allocation)
+        assert all(
+            t.shard_count == self.shard_count
+            for t in pipelined_sharded_cache_allocation
+        )
 
     def testUnflattenPageTable(self):
         cache_state = self.cache.allocate(self.page_count)
-        sharded_cache_state = self.sharded_cache.allocate(self.page_count)
-
-        unflattened_cache_state = self.cache.unflatten_page_tables(cache_state)[0]
-        sharded_unflattened_cache_state = self.sharded_cache.unflatten_page_tables(
-            sharded_cache_state
-        )[0]
-        assert iterables_equal(
-            unflattened_cache_state.shape, sharded_unflattened_cache_state.shape
+        assert len(cache_state) == 1
+        pipelined_sharded_cache_state = self.pipelined_sharded_cache.allocate(
+            self.page_count
         )
-        assert sharded_unflattened_cache_state.shard_dim == 4
-        assert sharded_unflattened_cache_state.shard_count == self.shard_count
-        assert sharded_unflattened_cache_state.shape[0] == self.page_count
+
+        unflattened_state = self.cache.unflatten_page_tables(cache_state)
+        pipelined_sharded_unflattened_state = (
+            self.pipelined_sharded_cache.unflatten_page_tables(
+                pipelined_sharded_cache_state
+            )
+        )
+        # [0] is page count
+        assert all(
+            sharded_page_slab.shape[0] == self.page_count
+            for sharded_page_slab in pipelined_sharded_unflattened_state
+        )
+        # [1] is for block count, and split across pipelines
+        assert unflattened_state[0].shape[1] == self.transformer_block_count
+        assert (
+            sum(page_slab.shape[1] for page_slab in pipelined_sharded_unflattened_state)
+            == self.transformer_block_count
+        )
+        # [2:] should be the same
+        assert all(
+            iterables_equal(page_slab.shape[2:], unflattened_state[0].shape[2:])
+            for page_slab in pipelined_sharded_unflattened_state
+        )
+        assert all(
+            sharded_page_slab.shard_dim == 4
+            for sharded_page_slab in pipelined_sharded_unflattened_state
+        )
+        assert all(
+            sharded_page_slab.shard_count == self.shard_count
+            for sharded_page_slab in pipelined_sharded_unflattened_state
+        )
 
     def testRead(self):
         (
@@ -117,7 +168,7 @@ class ShardedPagedKVCacheTest(unittest.TestCase):
             seq_len=self.block_seq_len * self.block_seq_stride,
         )
         sharded_page_ids = ops.replicate(page_ids, count=self.shard_count)
-        sharded_read = self.sharded_cache.read(
+        sharded_read = self.pipelined_sharded_cache.read(
             state=sharded_cache_state,
             transformer_block_index=transformer_block_index,
             page_ids=sharded_page_ids,
@@ -163,7 +214,7 @@ class ShardedPagedKVCacheTest(unittest.TestCase):
         )
         sharded_seq_positions = ops.replicate(seq_positions, count=self.shard_count)
         sharded_page_ids = ops.replicate(page_ids, count=self.shard_count)
-        self.sharded_cache.write_timestep(
+        self.pipelined_sharded_cache.write_timestep(
             state=sharded_cache_state,
             cache_partitions=sharded_cache_partitions,
             transformer_block_index=transformer_block_index,
@@ -207,7 +258,7 @@ class ShardedPagedKVCacheTest(unittest.TestCase):
             ]
         )
         sharded_page_ids = ops.replicate(page_ids, count=self.shard_count)
-        self.sharded_cache.write(
+        self.pipelined_sharded_cache.write(
             state=sharded_cache_state,
             cache_partitions=sharded_cache_partitions,
             transformer_block_index=transformer_block_index,

--- a/sharktank/tests/layers/pipelined_sharded_paged_attention_test.py
+++ b/sharktank/tests/layers/pipelined_sharded_paged_attention_test.py
@@ -48,7 +48,8 @@ class PipelinedShardedPagedAttentionTest(unittest.TestCase):
             block_seq_stride=self.block_seq_stride,
             attn_head_dim=self.attn_head_dim,
             cache_partition_count=self.cache_partition_count,
-            dtype=self.dtype,
+            cache_dtype=self.dtype,
+            attn_dtype=self.dtype,
         )
         self.pipelined_sharded_cache = PagedAttention(
             shard_count=self.shard_count,
@@ -58,7 +59,8 @@ class PipelinedShardedPagedAttentionTest(unittest.TestCase):
             block_seq_stride=self.block_seq_stride,
             attn_head_dim=self.attn_head_dim,
             cache_partition_count=self.cache_partition_count,
-            dtype=self.dtype,
+            cache_dtype=self.dtype,
+            attn_dtype=self.dtype,
         )
 
     def make_unsharded_and_sharded_equal_cache_states(

--- a/sharktank/tests/layers/sharded_paged_llama_attention_block.py
+++ b/sharktank/tests/layers/sharded_paged_llama_attention_block.py
@@ -157,7 +157,7 @@ class ShardedPagedLlamaAttentionBlockTest(unittest.TestCase):
         actual_result = unbox_tensor(ops.unshard(sharded_result))
         actual_cache_state = unbox_tensor(
             ops.unshard(
-                sharded_cache.unflatten_page_table(sharded_cache_state)
+                sharded_cache.unflatten_page_tables(sharded_cache_state)
             ).flatten(start_dim=1)
         )
 


### PR DESCRIPTION
Implementation and tests for pipeline parallelism support in KVCache. Instead of one tensor (torch or split) for the whole model, there is now a list of tensors (replicated for TP=1 and split for TP>1) one for each stage of the pipeline.

#1238 must be merged immediately afterwards.