### PR TITLE
Pipeline Parallellism for LLama

### DIFF
--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -9,84 +9,20 @@
 import os
 import logging
 import json
-from typing import Any, Dict, Tuple
+from typing import Any, Dict
 import torch
 
 from iree.turbine.aot import *
 
 from sharktank.layers import *
 from sharktank.types import *
+from sharktank.types.pipelining import pipeline_parallelize_theta
 from sharktank.utils.math import ceildiv
 from sharktank import ops
 from sharktank.utils import cli
 
 # TODO: Should be using a base class with the protocol supported.
 from sharktank.models.llm import *
-
-
-def pipeline_parallelize_theta(
-    theta: Theta, pipeline_parallelism_size: int
-) -> tuple[tuple[int, ...], ...]:
-    """Pipeline parallelize theta."""
-    # TODO: Still modifies the shards, but the signature doesn't imply this
-    def parallelize_weight(
-        weight: ShardedTensor, new_devices: Tuple[int, ...]
-    ) -> ShardedTensor:
-        (old_shards, old_devices) = (
-            ([weight], (0,))
-            if isinstance(weight, PrimitiveTensor)
-            else (weight.shards, weight.devices)
-        )
-        new_shards = ShardedTensor.move_shards_to_new_devices(
-            old_shards, old_devices=old_devices, new_devices=new_devices
-        )
-
-        for i, (old_shard, new_shard) in enumerate(zip(old_shards, new_shards)):
-            DeviceTensorTrait(new_devices[i]).set(new_shard._data)
-            if old_tensor_trait := ExternalTensorTrait.get(old_shard._data):
-                ExternalTensorTrait(
-                    old_tensor_trait.external_scope,
-                    old_tensor_trait.external_name,
-                ).set(new_shard._data)
-
-        return (
-            ReplicatedTensor(ts=new_shards, name=weight.name, devices=new_devices)
-            if isinstance(weight, PrimitiveTensor)
-            else weight.clone(ts=new_shards, devices=new_devices)
-        )
-
-    _t = theta.tensor("token_embd")["weight"]
-    shard_count = 1 if isinstance(_t, DefaultPrimitiveTensor) else _t.shard_count
-    num_blocks = len(theta.tensor("blk"))
-
-    block_to_device_lookup = []
-    block_indices = sorted(theta.tensor("blk").keys(), key=lambda item: int(item))
-    assert (
-        bi == i for i, bi in enumerate(block_indices)
-    ), "Blocks assumed to be numbered contiguously from [0, N-1]"
-    for blk_idx in block_indices:
-        pp_group = int(int(blk_idx) * pipeline_parallelism_size / num_blocks)
-        zero_4_group = shard_count * pp_group
-        devices = tuple(i + zero_4_group for i in range(shard_count))
-        block_to_device_lookup.append(devices)
-
-        block_data = theta.tensor("blk", blk_idx)
-        for t_name in block_data.keys():
-            block_data[t_name]["weight"] = parallelize_weight(
-                block_data[t_name]["weight"], devices
-            )
-
-    theta.tensor("token_embd")["weight"] = parallelize_weight(
-        theta.tensor("token_embd")["weight"], block_to_device_lookup[0]
-    )
-    theta.tensor("output_norm")["weight"] = parallelize_weight(
-        theta.tensor("output_norm")["weight"], block_to_device_lookup[-1]
-    )
-    theta.tensor("output")["weight"] = parallelize_weight(
-        theta.tensor("output")["weight"], block_to_device_lookup[-1]
-    )
-
-    return tuple(block_to_device_lookup)
 
 
 def main():

--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -66,6 +66,7 @@ def main():
     llama_config = LlamaModelConfig(
         hp,
         tensor_parallelism_size=tensor_parallelism_size,
+        pipeline_parallelism_size=args.pipeline_parallelism_size,
         use_hf=args.use_hf,
         static_tables=False,  # Rely on the compiler for hoisting tables.
         attention_kernel=args.attention_kernel,

--- a/sharktank/sharktank/examples/paged_llm_v1.py
+++ b/sharktank/sharktank/examples/paged_llm_v1.py
@@ -40,11 +40,6 @@ def main():
 
     args = cli.parse(parser)
 
-    prompt_seq_len = args.prompt_seq_len
-    assert (
-        args.prompt or prompt_seq_len
-    ), "Pass --prompt for custom prompts or --prompt-seq-len and --bs to generate random token ids"
-
     device = torch.device(args.device) if args.device else None
     dataset = cli.get_input_dataset(args)
     tokenizer = cli.get_tokenizer(args)
@@ -79,7 +74,6 @@ def main():
     batch = generator.begin_batch(
         token_ids=token_ids,
         seq_lens=seq_lens,
-        prompt_seq_len=prompt_seq_len,
         dump_path=args.dump_path,
         dump_decode_steps=args.dump_decode_steps,
     )

--- a/sharktank/sharktank/examples/paged_llm_v1.py
+++ b/sharktank/sharktank/examples/paged_llm_v1.py
@@ -18,6 +18,16 @@ from sharktank.utils import cli
 
 
 def main():
+    """
+    Run LLM inference in torch/eager mode. Use --device='cuda:0' to run on AMD GPU
+    Args:
+        --prompt: list[str] - Custom space separated prompts
+        --prompt-seq-len: int - Generate random token ids for given seq len and bs and save prefill & first decode step input args as npy files
+        --dump-path: str - Path to save prefill and decode input args as npy files
+        --dump-decode-steps: int - Number of decode steps to dump decode args (defaults to 1 decode step)
+        --bs: int - batch size, for custom prompts, bs is number of given prompts (defaults to 4)
+        --save_intermediates_path: str - save module forward outputs to safetensors, ex: run_0 will save to run_0_prefill.savetensors"
+    """
     from ..utils import cli
 
     parser = cli.create_parser()
@@ -29,6 +39,12 @@ def main():
     cli.add_save_tensor_options(parser)
 
     args = cli.parse(parser)
+
+    prompt_seq_len = args.prompt_seq_len
+    assert (
+        args.prompt or prompt_seq_len
+    ), "Pass --prompt for custom prompts or --prompt-seq-len and --bs to generate random token ids"
+
     device = torch.device(args.device) if args.device else None
     dataset = cli.get_input_dataset(args)
     tokenizer = cli.get_tokenizer(args)
@@ -63,7 +79,9 @@ def main():
     batch = generator.begin_batch(
         token_ids=token_ids,
         seq_lens=seq_lens,
-        dump_bins=args.dump_bins,
+        prompt_seq_len=prompt_seq_len,
+        dump_path=args.dump_path,
+        dump_decode_steps=args.dump_decode_steps,
     )
     results = batch.prefill()
     batch.print_current_results()

--- a/sharktank/sharktank/examples/paged_llm_v1.py
+++ b/sharktank/sharktank/examples/paged_llm_v1.py
@@ -43,6 +43,7 @@ def main():
         kv_cache_dtype=args.kv_cache_dtype,
         use_hf=args.use_hf,
         tensor_parallelism_size=args.tensor_parallelism_size,
+        pipeline_parallelism_size=args.pipeline_parallelism_size,
         fake_quant=args.fake_quant,
     )
     if config.tensor_parallelism_size > 1:

--- a/sharktank/sharktank/layers/paged_llama_attention_block.py
+++ b/sharktank/sharktank/layers/paged_llama_attention_block.py
@@ -8,7 +8,13 @@ from typing import Optional
 
 
 import torch
-from sharktank.types import QuantizerTensor, StaticScaledQuantizer, Theta
+
+from sharktank.types import (
+    QuantizerTensor,
+    ReplicatedTensor,
+    StaticScaledQuantizer,
+    Theta,
+)
 from sharktank.layers import *
 
 
@@ -35,11 +41,13 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         attention_scale: Optional[float] = None,
         softcap: Optional[float] = None,
         fake_quant: Optional[bool] = True,
+        block_to_device_lookup: tuple[tuple[int, ...], ...] | None = None,
     ):
         super().__init__(theta)
 
         self.paged_attention = PagedAttention(
             transformer_block_count=cache.transformer_block_count,
+            block_to_device_lookup=block_to_device_lookup,
             attn_head_count=head_count_kv,
             attn_head_dim=head_dim,
             block_seq_stride=cache.block_seq_stride,
@@ -106,8 +114,8 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         # [bs, batch_seq_len // block_seq_stride]
         seq_block_ids: torch.Tensor,
         start_index: Optional[int] = None,
-        start_positions: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
+        start_positions: Optional[torch.Tensor | ReplicatedTensor] = None,
+        attention_mask: Optional[torch.Tensor | ReplicatedTensor] = None,
         embedding_batch_mask: Optional[torch.Tensor] = None,
         cache_state: list[torch.Tensor] = None,
     ):

--- a/sharktank/sharktank/types/pipelining.py
+++ b/sharktank/sharktank/types/pipelining.py
@@ -1,0 +1,86 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+Specifications describing how
+"""
+
+from iree.turbine.aot import DeviceTensorTrait, ExternalTensorTrait
+from sharktank.types import (
+    DefaultPrimitiveTensor,
+    PrimitiveTensor,
+    ReplicatedTensor,
+    ShardedTensor,
+    Theta,
+)
+
+
+from typing import Tuple
+
+
+def pipeline_parallelize_theta(
+    theta: Theta, pipeline_parallelism_size: int
+) -> tuple[tuple[int, ...], ...]:
+    """Pipeline parallelize theta for Llama."""
+    # TODO: Still modifies the shards, but the signature doesn't imply this
+    def parallelize_weight(
+        weight: ShardedTensor, new_devices: Tuple[int, ...]
+    ) -> ShardedTensor:
+        (old_shards, old_devices) = (
+            ([weight], (0,))
+            if isinstance(weight, PrimitiveTensor)
+            else (weight.shards, weight.devices)
+        )
+        new_shards = ShardedTensor.move_shards_to_new_devices(
+            old_shards, old_devices=old_devices, new_devices=new_devices
+        )
+
+        for i, (old_shard, new_shard) in enumerate(zip(old_shards, new_shards)):
+            DeviceTensorTrait(new_devices[i]).set(new_shard._data)
+            if old_tensor_trait := ExternalTensorTrait.get(old_shard._data):
+                ExternalTensorTrait(
+                    old_tensor_trait.external_scope,
+                    old_tensor_trait.external_name,
+                ).set(new_shard._data)
+
+        return (
+            ReplicatedTensor(ts=new_shards, name=weight.name, devices=new_devices)
+            if isinstance(weight, PrimitiveTensor)
+            else weight.clone(ts=new_shards, devices=new_devices)
+        )
+
+    _t = theta.tensor("token_embd")["weight"]
+    shard_count = 1 if isinstance(_t, DefaultPrimitiveTensor) else _t.shard_count
+    num_blocks = len(theta.tensor("blk"))
+
+    block_to_device_lookup = []
+    block_indices = sorted(theta.tensor("blk").keys(), key=lambda item: int(item))
+    assert (
+        bi == i for i, bi in enumerate(block_indices)
+    ), "Blocks assumed to be numbered contiguously from [0, N-1]"
+    for blk_idx in block_indices:
+        pp_group = int(int(blk_idx) * pipeline_parallelism_size / num_blocks)
+        zero_4_group = shard_count * pp_group
+        devices = tuple(i + zero_4_group for i in range(shard_count))
+        block_to_device_lookup.append(devices)
+
+        block_data = theta.tensor("blk", blk_idx)
+        for t_name in block_data.keys():
+            block_data[t_name]["weight"] = parallelize_weight(
+                block_data[t_name]["weight"], devices
+            )
+
+    theta.tensor("token_embd")["weight"] = parallelize_weight(
+        theta.tensor("token_embd")["weight"], block_to_device_lookup[0]
+    )
+    theta.tensor("output_norm")["weight"] = parallelize_weight(
+        theta.tensor("output_norm")["weight"], block_to_device_lookup[-1]
+    )
+    theta.tensor("output")["weight"] = parallelize_weight(
+        theta.tensor("output")["weight"], block_to_device_lookup[-1]
+    )
+
+    return tuple(block_to_device_lookup)

--- a/sharktank/sharktank/utils/cli.py
+++ b/sharktank/sharktank/utils/cli.py
@@ -211,9 +211,27 @@ def add_save_tensor_options(parser: argparse.ArgumentParser):
         help="save module forward outputs to safetensors, ex: run_0 will save to run_0_prefill.savetensors",
     )
     parser.add_argument(
-        "--dump-bins",
-        help="dump input tensors to bin files",
-        action="store_true",
+        "--dump-path",
+        help="Path to dump prefill/decode input tensors to npy files",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--dump-decode-steps",
+        help="Number of decode steps to dump decode input tensors",
+        type=int,
+        default=1,
+    )
+    parser.add_argument(
+        "--prompt-seq-len",
+        help="Seq len to generate input prompts for prefill",
+        type=int,
+    )
+    parser.add_argument(
+        "--bs",
+        help="Batch size",
+        type=int,
+        default="4",
     )
 
 

--- a/sharktank/sharktank/utils/cli.py
+++ b/sharktank/sharktank/utils/cli.py
@@ -114,6 +114,12 @@ def add_model_options(parser: argparse.ArgumentParser):
         help="Number of devices for tensor parallel sharding. Will be overridden by dataset.properties if present",
     )
     parser.add_argument(
+        "--pipeline-parallelism-size",
+        type=int,
+        default=1,
+        help="Number of (roughly) uniform groups of layers to split the model for pipeline parallelism.",
+    )
+    parser.add_argument(
         "--block-seq-stride",
         help="Block sequence stride for paged KV cache, must divide evenly into the context length",
         type=int,

--- a/sharktank/sharktank/utils/create_cache.py
+++ b/sharktank/sharktank/utils/create_cache.py
@@ -15,6 +15,7 @@ def create_paged_kv_cache(config: LlamaModelConfig) -> PagedAttention:
     dtype = config.kv_cache_dtype or config.attention_dtype
     return PagedAttention(
         transformer_block_count=hp.block_count,
+        block_to_device_lookup=config.block_to_device_lookup,
         attn_head_count=hp.attention_head_count_kv,
         attn_head_dim=hp.attn_head_dim,
         cache_partition_count=2,  # One for each of K/V.

--- a/sharktank/sharktank/utils/load_llm.py
+++ b/sharktank/sharktank/utils/load_llm.py
@@ -4,10 +4,13 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import collections
 import math
+from pathlib import Path
 
 import numpy as np
 import torch
+import numpy as np
 
 from sharktank.layers import *
 from sharktank.types import *
@@ -61,9 +64,15 @@ class TorchGenerator:
         token_ids: torch.tensor,
         seq_lens: torch.tensor,
         page_cache_size: int = None,
-        dump_bins: bool = False,
+        prompt_seq_len: int = None,
+        dump_path: Path = None,
+        dump_decode_steps: int = None,
     ):
         bs = token_ids.shape[0]
+
+        self.prompt_seq_len = prompt_seq_len
+        if self.prompt_seq_len and not dump_path:
+            dump_path = ""
 
         self.page_cache_size = (
             page_cache_size
@@ -80,7 +89,8 @@ class TorchGenerator:
             seq_lens=seq_lens,
             cache_state=cache_state,
             bs=bs,
-            dump_bins=dump_bins,
+            dump_path=dump_path,
+            dump_decode_steps=dump_decode_steps,
         )
 
     def alloc_page(self) -> int:
@@ -98,7 +108,8 @@ class Batch:
         seq_lens: torch.Tensor,
         cache_state: list[torch.Tensor | SplitPrimitiveTensor | ReplicatedTensor],
         bs: int,
-        dump_bins: bool = False,
+        dump_path: Path,
+        dump_decode_steps: int,
     ):
         self.bs = bs
         assert seq_lens.shape[0] == self.bs
@@ -109,7 +120,9 @@ class Batch:
         self.cache_state = cache_state
         self.results: list[list[int]] = [[] for _ in range(self.bs)]
         self.done_result_indices: set[int] = set()
-        self.dump_bins = dump_bins
+        self.dump_path = dump_path
+        self.dump_decode_steps = dump_decode_steps
+        self.decode_step = 0
 
         # Assemble the batch.
         seq_stride = self.parent.block_seq_stride
@@ -169,6 +182,33 @@ class Batch:
                     break
                 block_ids_row.append(self.parent.alloc_page())
 
+    def dump_args(
+        self,
+        phase: str,
+        arg_name: str,
+        arg: torch.Tensor | ShardedTensor | list[torch.Tensor | ShardedTensor],
+        decode_step: int | None = None,
+        rank: int | None = None,
+    ):
+        if isinstance(arg, collections.abc.Sequence):
+            for i, a in enumerate(arg):
+                subarg_name = arg_name if len(arg) == 1 else f"{arg_name}_{i}"
+                self.dump_args(phase, subarg_name, a, decode_step, rank)
+        elif isinstance(arg, ShardedTensor):
+            for rank in range(arg.shard_count):
+                self.dump_args(
+                    phase, arg_name, arg.shards[rank]._data, decode_step, rank
+                )
+        else:
+            if arg.dtype in [torch.float8_e4m3fnuz, torch.bfloat16]:
+                arg = arg.to(torch.uint8)
+            if phase == "decode":
+                arg_name = f"{arg_name}_{decode_step}"
+            rank_str = "" if (rank is None) else f".rank{rank}"
+
+            file_path = Path(self.dump_path, f"{phase}_{arg_name}{rank_str}.npy")
+            np.save(file_path, arg.cpu().numpy())
+
     def prefill(self):
         model = self.parent.model
         attention_mask = model.attention_mask(
@@ -207,22 +247,14 @@ class Batch:
                 )
             attention_mask, seq_block_ids = _attention_mask, _seq_block_ids
 
-        if self.dump_bins:
-            write_ndarray_to_bin(
-                token_ids.numpy(),
-                f"prefill_token_ids_{'x'.join([str(x) for x in token_ids.shape])}xi64.bin",
-            )
-            write_ndarray_to_bin(
-                np.array(token_ids.shape[0], dtype=np.int64),
-                f"prefill_seq_lens_1xi64.bin",
-            )
-            write_ndarray_to_bin(
-                seq_block_ids.numpy(),
-                f"prefill_seq_block_ids_{'x'.join([str(x) for x in seq_block_ids.shape])}xi64.bin",
-            )
-            write_ndarray_to_bin(
-                self.cache_state[0].to(torch.float8_e4m3fnuz).to(torch.uint8).numpy(),
-                f"prefill_cache_state_{'x'.join([str(x) for x in self.cache_state[0].shape])}xf8E4M3FNUZ.bin",
+        if self.dump_path:
+            print(f"\nSaving prefill args to {Path(self.dump_path)}\n")
+
+            self.dump_args(phase="prefill", arg_name="token_ids", arg=token_ids)
+            self.dump_args(phase="prefill", arg_name="seq_lens", arg=self.seq_lens)
+            self.dump_args(phase="prefill", arg_name="seq_block_ids", arg=seq_block_ids)
+            self.dump_args(
+                phase="prefill", arg_name="cache_state", arg=self.cache_state
             )
 
         self.prefill_logits = model.prefill(
@@ -301,10 +333,14 @@ class Batch:
                 _decode_attention_mask,
             )
 
-        if self.dump_bins:
-            write_ndarray_to_bin(
-                token_batch.numpy(),
-                f"decode_next_tokens_{'x'.join([str(x)for x in token_batch.shape])}xi64.bin",
+        if self.dump_path is not None:
+            print(f"\nSaving decode args to {Path(self.dump_path)}\n")
+
+            self.dump_args(
+                phase="decode",
+                arg_name="next_tokens",
+                arg=token_batch,
+                decode_step=self.decode_step,
             )
             self.dump_args(
                 phase="decode",
@@ -312,17 +348,23 @@ class Batch:
                 arg=start_positions,
                 decode_step=self.decode_step,
             )
-            write_ndarray_to_bin(
-                seq_block_ids_tensor.numpy(),
-                f"decode_seq_block_ids_tensor_{'x'.join([str(x)for x in seq_block_ids_tensor.shape])}xi64.bin",
+            self.dump_args(
+                phase="decode",
+                arg_name="seq_lens",
+                arg=self.seq_lens,
+                decode_step=self.decode_step,
             )
-            write_ndarray_to_bin(
-                torch.tensor(token_batch.shape[0]).to(torch.int64).numpy(),
-                f"decode_seq_lens_1xi64.bin",
+            self.dump_args(
+                phase="decode",
+                arg_name="seq_block_ids",
+                arg=seq_block_ids,
+                decode_step=self.decode_step,
             )
-            write_ndarray_to_bin(
-                self.cache_state[0].to(torch.float8_e4m3fnuz).to(torch.uint8).numpy(),
-                f"decode_cache_state_{'x'.join([str(x) for x in self.cache_state[0].shape])}xf8E4M3FNUZ.bin",
+            self.dump_args(
+                phase="decode",
+                arg_name="cache_state",
+                arg=self.cache_state,
+                decode_step=self.decode_step,
             )
 
         self.decode_logits = model.decode(
@@ -343,6 +385,7 @@ class Batch:
             device=self.parent.model.device,
         ).unsqueeze(1)
         self.add_result_token(tokens)
+        self.decode_step += 1
         return tokens
 
     def pad_block_ids(self) -> torch.Tensor:

--- a/sharktank/sharktank/utils/load_llm.py
+++ b/sharktank/sharktank/utils/load_llm.py
@@ -64,15 +64,10 @@ class TorchGenerator:
         token_ids: torch.tensor,
         seq_lens: torch.tensor,
         page_cache_size: int = None,
-        prompt_seq_len: int = None,
         dump_path: Path = None,
         dump_decode_steps: int = None,
     ):
         bs = token_ids.shape[0]
-
-        self.prompt_seq_len = prompt_seq_len
-        if self.prompt_seq_len and not dump_path:
-            dump_path = ""
 
         self.page_cache_size = (
             page_cache_size

--- a/sharktank/tests/layers/pipelined_paged_attention_test.py
+++ b/sharktank/tests/layers/pipelined_paged_attention_test.py
@@ -1,0 +1,242 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import unittest
+from sharktank.layers import PagedAttention
+import torch
+from sharktank.utils import iterables_equal
+from copy import deepcopy
+from typing import List, Tuple
+from sharktank import ops
+from sharktank.types import SplitPrimitiveTensor
+
+
+class PipelinedPagedAttentionTest(unittest.TestCase):
+    """Verify that the pipelined paged attention behaves the same as the unpipelined variant."""
+
+    def setUp(self):
+        torch.manual_seed(12345)
+        self.dtype = torch.float32
+        torch.set_default_dtype(self.dtype)
+        self.shard_count = 1
+        self.pipeline_count = 2
+        self.transformer_block_count = 5
+        self.attn_head_count = self.shard_count * 7
+        self.block_seq_stride = 19
+        self.attn_head_dim = 17
+        self.cache_partition_count = 2
+        self.page_count = 23
+        self.batch_size = 11
+        self.block_seq_len = 2
+        self.max_seq_len = self.block_seq_len * self.block_seq_stride
+
+        block_to_device_lookup = []
+        for block in range(self.transformer_block_count):
+            pp_group = int(block * self.pipeline_count / self.transformer_block_count)
+            zero_4_group = self.shard_count * pp_group
+            block_to_device_lookup.append(
+                tuple(i + zero_4_group for i in range(self.shard_count))
+            )
+        self.block_to_device_lookup = tuple(block_to_device_lookup)
+
+        self.cache = PagedAttention(
+            transformer_block_count=self.transformer_block_count,
+            attn_head_count=self.attn_head_count,
+            block_seq_stride=self.block_seq_stride,
+            attn_head_dim=self.attn_head_dim,
+            cache_partition_count=self.cache_partition_count,
+            dtype=self.dtype,
+        )
+        self.pipelined_cache = PagedAttention(
+            shard_count=self.shard_count,
+            block_to_device_lookup=self.block_to_device_lookup,
+            transformer_block_count=self.transformer_block_count,
+            attn_head_count=self.attn_head_count,
+            block_seq_stride=self.block_seq_stride,
+            attn_head_dim=self.attn_head_dim,
+            cache_partition_count=self.cache_partition_count,
+            dtype=self.dtype,
+        )
+
+    def make_unpipelined_and_pipelined_equal_cache_states(
+        self,
+    ) -> Tuple[List[torch.Tensor], List[SplitPrimitiveTensor]]:
+        cache_state = self.cache.allocate(self.page_count)
+        cache_state[0] = torch.rand_like(cache_state[0])
+        pipelined_cache_state = self.pipelined_cache.shard_state(deepcopy(cache_state))
+        self.assert_equal_unpipelined_and_pipelined_cache_states(
+            cache_state, pipelined_cache_state
+        )
+        return cache_state, pipelined_cache_state
+
+    def assert_equal_unpipelined_and_pipelined_cache_states(
+        self,
+        cache_state: List[torch.Tensor],
+        pipelined_cache_state: List[SplitPrimitiveTensor],
+    ):
+        pipelined_states_as_unreplicated = [
+            ops.unshard(unflatted_page).flatten(start_dim=1)
+            for unflatted_page in self.pipelined_cache.unflatten_page_tables(
+                pipelined_cache_state
+            )
+        ]
+        pipelined_states_as_single = (
+            torch.cat(  # TODO cat isn't what we should be doing
+                pipelined_states_as_unreplicated, dim=1
+            )
+        )
+        assert iterables_equal(cache_state[0].shape, pipelined_states_as_single.shape)
+        assert ops.equal(
+            cache_state[0],
+            pipelined_states_as_single,
+        )
+
+    def testAllocate(self):
+        cache_state = self.cache.allocate(self.page_count)
+        pipelined_cache_allocation = self.pipelined_cache.allocate(self.page_count)
+        assert len(cache_state) == 1
+        assert len(pipelined_cache_allocation) == self.pipeline_count
+        assert all(t.shape[0] == self.page_count for t in cache_state)
+        assert cache_state[0].shape[1] == sum(
+            t.shape[1] for t in pipelined_cache_allocation
+        )
+
+    def testUnflattenPageTable(self):
+        cache_state = self.cache.allocate(self.page_count)
+        assert len(cache_state) == 1
+        pipelined_cache_state = self.pipelined_cache.allocate(self.page_count)
+
+        unflattened_state = self.cache.unflatten_page_tables(cache_state)
+        pipelined_unflattened_state = self.pipelined_cache.unflatten_page_tables(
+            pipelined_cache_state
+        )
+        # [0] is page count
+        assert all(
+            pipelined_page_slab.shape[0] == self.page_count
+            for pipelined_page_slab in pipelined_unflattened_state
+        )
+        # [1] is for block count, and split across pipelines
+        assert unflattened_state[0].shape[1] == self.transformer_block_count
+        assert (
+            sum(page_slab.shape[1] for page_slab in pipelined_unflattened_state)
+            == self.transformer_block_count
+        )
+        # [2:] should be the same
+        assert all(
+            iterables_equal(page_slab.shape[2:], unflattened_state[0].shape[2:])
+            for page_slab in pipelined_unflattened_state
+        )
+
+    def testRead(self):
+        (
+            cache_state,
+            pipelined_cache_state,
+        ) = self.make_unpipelined_and_pipelined_equal_cache_states()
+
+        transformer_block_index = 1
+        page_ids = torch.randint(
+            low=0, high=self.page_count, size=[self.batch_size, self.block_seq_len]
+        ).reshape([self.batch_size, self.block_seq_len])
+        unpipelined_read = self.cache.read(
+            state=cache_state,
+            transformer_block_index=transformer_block_index,
+            page_ids=page_ids,
+            seq_len=self.block_seq_len * self.block_seq_stride,
+        )
+        pipelined_page_ids = ops.replicate(page_ids, count=self.shard_count)
+        pipelined_read = self.pipelined_cache.read(
+            state=pipelined_cache_state,
+            transformer_block_index=transformer_block_index,
+            page_ids=pipelined_page_ids,
+            seq_len=self.block_seq_len * self.block_seq_stride,
+        )
+        for unpipelined, pipelined in zip(unpipelined_read, pipelined_read):
+            assert ops.equal(unpipelined, ops.unshard(pipelined))
+
+    def testWriteTimestep(self):
+        (
+            cache_state,
+            pipelined_cache_state,
+        ) = self.make_unpipelined_and_pipelined_equal_cache_states()
+
+        cache_partitions = [
+            torch.rand(
+                self.batch_size,
+                1,
+                self.attn_head_count,
+                self.attn_head_dim,
+            )
+            for _ in range(self.cache_partition_count)
+        ]
+        transformer_block_index = 1
+        seq_positions = torch.randint(
+            low=0, high=self.max_seq_len, size=[self.batch_size]
+        )
+        page_ids = torch.randperm(self.batch_size * self.block_seq_len).reshape(
+            [self.batch_size, self.block_seq_len]
+        )
+        self.cache.write_timestep(
+            state=cache_state,
+            cache_partitions=cache_partitions,
+            transformer_block_index=transformer_block_index,
+            seq_positions=seq_positions,
+            page_ids=page_ids,
+        )
+        pipelined_cache_partitions = deepcopy(
+            [ops.replicate(t, count=self.shard_count) for t in cache_partitions]
+        )
+        pipelined_seq_positions = ops.replicate(seq_positions, count=self.shard_count)
+        pipelined_page_ids = ops.replicate(page_ids, count=self.shard_count)
+        self.pipelined_cache.write_timestep(
+            state=pipelined_cache_state,
+            cache_partitions=pipelined_cache_partitions,
+            transformer_block_index=transformer_block_index,
+            seq_positions=pipelined_seq_positions,
+            page_ids=pipelined_page_ids,
+        )
+        self.assert_equal_unpipelined_and_pipelined_cache_states(
+            cache_state, pipelined_cache_state
+        )
+
+    def testWrite(self):
+        (
+            cache_state,
+            pipelined_cache_state,
+        ) = self.make_unpipelined_and_pipelined_equal_cache_states()
+
+        cache_partitions = [
+            torch.rand(
+                self.batch_size,
+                self.block_seq_len * self.block_seq_stride,
+                self.attn_head_count,
+                self.attn_head_dim,
+            )
+            for _ in range(self.cache_partition_count)
+        ]
+        transformer_block_index = 1
+        assert self.batch_size * self.block_seq_len <= self.page_count
+        page_ids = torch.randperm(self.batch_size * self.block_seq_len).reshape(
+            [self.batch_size, self.block_seq_len]
+        )
+        self.cache.write(
+            state=cache_state,
+            cache_partitions=cache_partitions,
+            transformer_block_index=transformer_block_index,
+            page_ids=page_ids,
+        )
+        pipelined_cache_partitions = deepcopy(
+            [ops.replicate(t, count=self.shard_count) for t in cache_partitions]
+        )
+        pipelined_page_ids = ops.replicate(page_ids, count=self.shard_count)
+        self.pipelined_cache.write(
+            state=pipelined_cache_state,
+            cache_partitions=pipelined_cache_partitions,
+            transformer_block_index=transformer_block_index,
+            page_ids=pipelined_page_ids,
+        )
+        self.assert_equal_unpipelined_and_pipelined_cache_states(
+            cache_state, pipelined_cache_state
+        )

--- a/sharktank/tests/layers/pipelined_paged_attention_test.py
+++ b/sharktank/tests/layers/pipelined_paged_attention_test.py
@@ -48,7 +48,8 @@ class PipelinedPagedAttentionTest(unittest.TestCase):
             block_seq_stride=self.block_seq_stride,
             attn_head_dim=self.attn_head_dim,
             cache_partition_count=self.cache_partition_count,
-            dtype=self.dtype,
+            cache_dtype=self.dtype,
+            attn_dtype=self.dtype,
         )
         self.pipelined_cache = PagedAttention(
             shard_count=self.shard_count,
@@ -58,7 +59,8 @@ class PipelinedPagedAttentionTest(unittest.TestCase):
             block_seq_stride=self.block_seq_stride,
             attn_head_dim=self.attn_head_dim,
             cache_partition_count=self.cache_partition_count,
-            dtype=self.dtype,
+            cache_dtype=self.dtype,
+            attn_dtype=self.dtype,
         )
 
     def make_unpipelined_and_pipelined_equal_cache_states(

--- a/sharktank/tests/layers/pipelined_paged_attention_test.py
+++ b/sharktank/tests/layers/pipelined_paged_attention_test.py
@@ -77,17 +77,13 @@ class PipelinedPagedAttentionTest(unittest.TestCase):
         cache_state: List[torch.Tensor],
         pipelined_cache_state: List[SplitPrimitiveTensor],
     ):
-        pipelined_states_as_unreplicated = [
+        pipelined_states_unreplicated = [
             ops.unshard(unflatted_page).flatten(start_dim=1)
             for unflatted_page in self.pipelined_cache.unflatten_page_tables(
                 pipelined_cache_state
             )
         ]
-        pipelined_states_as_single = (
-            torch.cat(  # TODO cat isn't what we should be doing
-                pipelined_states_as_unreplicated, dim=1
-            )
-        )
+        pipelined_states_as_single = ops.cat(pipelined_states_unreplicated, dim=1)
         assert iterables_equal(cache_state[0].shape, pipelined_states_as_single.shape)
         assert ops.equal(
             cache_state[0],

--- a/sharktank/tests/layers/pipelined_sharded_paged_attention_test.py
+++ b/sharktank/tests/layers/pipelined_sharded_paged_attention_test.py
@@ -85,7 +85,7 @@ class PipelinedShardedPagedAttentionTest(unittest.TestCase):
                 pipelined_sharded_cache_state
             )
         ]
-        pipelined_sharded_states_as_single = torch.cat(
+        pipelined_sharded_states_as_single = ops.cat(
             pipelined_sharded_states_as_unsharded, dim=1
         )
         assert iterables_equal(

--- a/sharktank/tests/layers/pipelined_sharded_paged_attention_test.py
+++ b/sharktank/tests/layers/pipelined_sharded_paged_attention_test.py
@@ -14,14 +14,15 @@ from sharktank import ops
 from sharktank.types import SplitPrimitiveTensor
 
 
-class ShardedPagedKVCacheTest(unittest.TestCase):
-    """Verify that the sharded paged KV cache behaves as the unsharded variant."""
+class PipelinedShardedPagedAttentionTest(unittest.TestCase):
+    """Verify that the pipelined sharded paged attention behaves the same as the unpipelined unsharded variant."""
 
     def setUp(self):
         torch.manual_seed(12345)
         self.dtype = torch.float32
         torch.set_default_dtype(self.dtype)
-        self.shard_count = 3
+        self.shard_count = 2
+        self.pipeline_count = 2
         self.transformer_block_count = 5
         self.attn_head_count = self.shard_count * 7
         self.block_seq_stride = 19
@@ -32,24 +33,32 @@ class ShardedPagedKVCacheTest(unittest.TestCase):
         self.block_seq_len = 2
         self.max_seq_len = self.block_seq_len * self.block_seq_stride
 
+        block_to_device_lookup = []
+        for block in range(self.transformer_block_count):
+            pp_group = int(block * self.pipeline_count / self.transformer_block_count)
+            zero_4_group = self.shard_count * pp_group
+            block_to_device_lookup.append(
+                tuple(i + zero_4_group for i in range(self.shard_count))
+            )
+        self.block_to_device_lookup = tuple(block_to_device_lookup)
+
         self.cache = PagedAttention(
             transformer_block_count=self.transformer_block_count,
             attn_head_count=self.attn_head_count,
             block_seq_stride=self.block_seq_stride,
             attn_head_dim=self.attn_head_dim,
             cache_partition_count=self.cache_partition_count,
-            cache_dtype=self.dtype,
-            attn_dtype=self.dtype,
+            dtype=self.dtype,
         )
-        self.sharded_cache = PagedAttention(
+        self.pipelined_sharded_cache = PagedAttention(
             shard_count=self.shard_count,
+            block_to_device_lookup=self.block_to_device_lookup,
             transformer_block_count=self.transformer_block_count,
             attn_head_count=self.attn_head_count,
             block_seq_stride=self.block_seq_stride,
             attn_head_dim=self.attn_head_dim,
             cache_partition_count=self.cache_partition_count,
-            cache_dtype=self.dtype,
-            attn_dtype=self.dtype,
+            dtype=self.dtype,
         )
 
     def make_unsharded_and_sharded_equal_cache_states(
@@ -57,7 +66,9 @@ class ShardedPagedKVCacheTest(unittest.TestCase):
     ) -> Tuple[List[torch.Tensor], List[SplitPrimitiveTensor]]:
         cache_state = self.cache.allocate(self.page_count)
         cache_state[0] = torch.rand_like(cache_state[0])
-        sharded_cache_state = self.sharded_cache.shard_state(deepcopy(cache_state))
+        sharded_cache_state = self.pipelined_sharded_cache.shard_state(
+            deepcopy(cache_state)
+        )
         self.assert_equal_unsharded_and_sharded_cache_states(
             cache_state, sharded_cache_state
         )
@@ -66,39 +77,79 @@ class ShardedPagedKVCacheTest(unittest.TestCase):
     def assert_equal_unsharded_and_sharded_cache_states(
         self,
         cache_state: List[torch.Tensor],
-        sharded_cache_state: List[SplitPrimitiveTensor],
+        pipelined_sharded_cache_state: List[SplitPrimitiveTensor],
     ):
-        sharded_state_as_unsharded = ops.unshard(
-            self.sharded_cache.unflatten_page_tables(sharded_cache_state)[0]
-        ).flatten(start_dim=1)
+        pipelined_sharded_states_as_unsharded = [
+            ops.unshard(unflatted_page).flatten(start_dim=1)
+            for unflatted_page in self.pipelined_sharded_cache.unflatten_page_tables(
+                pipelined_sharded_cache_state
+            )
+        ]
+        pipelined_sharded_states_as_single = torch.cat(
+            pipelined_sharded_states_as_unsharded, dim=1
+        )
+        assert iterables_equal(
+            cache_state[0].shape, pipelined_sharded_states_as_single.shape
+        )
         assert ops.equal(
             cache_state[0],
-            sharded_state_as_unsharded,
+            pipelined_sharded_states_as_single,
         )
 
     def testAllocate(self):
         cache_state = self.cache.allocate(self.page_count)
-        sharded_cache_state = self.sharded_cache.allocate(self.page_count)
+        pipelined_sharded_cache_allocation = self.pipelined_sharded_cache.allocate(
+            self.page_count
+        )
         assert len(cache_state) == 1
-        assert len(sharded_cache_state) == 1
-        assert iterables_equal(cache_state[0].shape, sharded_cache_state[0].shape)
-        assert sharded_cache_state[0].shard_dim == 1
-        assert sharded_cache_state[0].shard_count == self.shard_count
+        assert len(pipelined_sharded_cache_allocation) == self.pipeline_count
+        assert all(t.shape[0] == self.page_count for t in cache_state)
+        assert cache_state[0].shape[1] == sum(
+            t.shape[1] for t in pipelined_sharded_cache_allocation
+        )
+        assert all(t.shard_dim == 1 for t in pipelined_sharded_cache_allocation)
+        assert all(
+            t.shard_count == self.shard_count
+            for t in pipelined_sharded_cache_allocation
+        )
 
     def testUnflattenPageTable(self):
         cache_state = self.cache.allocate(self.page_count)
-        sharded_cache_state = self.sharded_cache.allocate(self.page_count)
-
-        unflattened_cache_state = self.cache.unflatten_page_tables(cache_state)[0]
-        sharded_unflattened_cache_state = self.sharded_cache.unflatten_page_tables(
-            sharded_cache_state
-        )[0]
-        assert iterables_equal(
-            unflattened_cache_state.shape, sharded_unflattened_cache_state.shape
+        assert len(cache_state) == 1
+        pipelined_sharded_cache_state = self.pipelined_sharded_cache.allocate(
+            self.page_count
         )
-        assert sharded_unflattened_cache_state.shard_dim == 4
-        assert sharded_unflattened_cache_state.shard_count == self.shard_count
-        assert sharded_unflattened_cache_state.shape[0] == self.page_count
+
+        unflattened_state = self.cache.unflatten_page_tables(cache_state)
+        pipelined_sharded_unflattened_state = (
+            self.pipelined_sharded_cache.unflatten_page_tables(
+                pipelined_sharded_cache_state
+            )
+        )
+        # [0] is page count
+        assert all(
+            sharded_page_slab.shape[0] == self.page_count
+            for sharded_page_slab in pipelined_sharded_unflattened_state
+        )
+        # [1] is for block count, and split across pipelines
+        assert unflattened_state[0].shape[1] == self.transformer_block_count
+        assert (
+            sum(page_slab.shape[1] for page_slab in pipelined_sharded_unflattened_state)
+            == self.transformer_block_count
+        )
+        # [2:] should be the same
+        assert all(
+            iterables_equal(page_slab.shape[2:], unflattened_state[0].shape[2:])
+            for page_slab in pipelined_sharded_unflattened_state
+        )
+        assert all(
+            sharded_page_slab.shard_dim == 4
+            for sharded_page_slab in pipelined_sharded_unflattened_state
+        )
+        assert all(
+            sharded_page_slab.shard_count == self.shard_count
+            for sharded_page_slab in pipelined_sharded_unflattened_state
+        )
 
     def testRead(self):
         (
@@ -117,7 +168,7 @@ class ShardedPagedKVCacheTest(unittest.TestCase):
             seq_len=self.block_seq_len * self.block_seq_stride,
         )
         sharded_page_ids = ops.replicate(page_ids, count=self.shard_count)
-        sharded_read = self.sharded_cache.read(
+        sharded_read = self.pipelined_sharded_cache.read(
             state=sharded_cache_state,
             transformer_block_index=transformer_block_index,
             page_ids=sharded_page_ids,
@@ -163,7 +214,7 @@ class ShardedPagedKVCacheTest(unittest.TestCase):
         )
         sharded_seq_positions = ops.replicate(seq_positions, count=self.shard_count)
         sharded_page_ids = ops.replicate(page_ids, count=self.shard_count)
-        self.sharded_cache.write_timestep(
+        self.pipelined_sharded_cache.write_timestep(
             state=sharded_cache_state,
             cache_partitions=sharded_cache_partitions,
             transformer_block_index=transformer_block_index,
@@ -207,7 +258,7 @@ class ShardedPagedKVCacheTest(unittest.TestCase):
             ]
         )
         sharded_page_ids = ops.replicate(page_ids, count=self.shard_count)
-        self.sharded_cache.write(
+        self.pipelined_sharded_cache.write(
             state=sharded_cache_state,
             cache_partitions=sharded_cache_partitions,
             transformer_block_index=transformer_block_index,

--- a/sharktank/tests/layers/pipelined_sharded_paged_attention_test.py
+++ b/sharktank/tests/layers/pipelined_sharded_paged_attention_test.py
@@ -48,7 +48,8 @@ class PipelinedShardedPagedAttentionTest(unittest.TestCase):
             block_seq_stride=self.block_seq_stride,
             attn_head_dim=self.attn_head_dim,
             cache_partition_count=self.cache_partition_count,
-            dtype=self.dtype,
+            cache_dtype=self.dtype,
+            attn_dtype=self.dtype,
         )
         self.pipelined_sharded_cache = PagedAttention(
             shard_count=self.shard_count,
@@ -58,7 +59,8 @@ class PipelinedShardedPagedAttentionTest(unittest.TestCase):
             block_seq_stride=self.block_seq_stride,
             attn_head_dim=self.attn_head_dim,
             cache_partition_count=self.cache_partition_count,
-            dtype=self.dtype,
+            cache_dtype=self.dtype,
+            attn_dtype=self.dtype,
         )
 
     def make_unsharded_and_sharded_equal_cache_states(

--- a/sharktank/tests/layers/sharded_paged_llama_attention_block.py
+++ b/sharktank/tests/layers/sharded_paged_llama_attention_block.py
@@ -157,7 +157,7 @@ class ShardedPagedLlamaAttentionBlockTest(unittest.TestCase):
         actual_result = unbox_tensor(ops.unshard(sharded_result))
         actual_cache_state = unbox_tensor(
             ops.unshard(
-                sharded_cache.unflatten_page_table(sharded_cache_state)
+                sharded_cache.unflatten_page_tables(sharded_cache_state)
             ).flatten(start_dim=1)
         )
 

--- a/sharktank/tests/models/llama/test_llama.py
+++ b/sharktank/tests/models/llama/test_llama.py
@@ -27,7 +27,7 @@ def test_llama():
     ids = ids + [0] * padding
 
     ids = torch.asarray([ids], dtype=torch.int64)
-    block_ids = torch.asarray([[i for i in range(blocks)]]).to(torch.int64)
+    block_ids = [torch.asarray([[i for i in range(blocks)]]).to(torch.int64)]
 
     cache_state = model.cache.allocate(
         page_count=config.hp.context_length // config.block_seq_stride
@@ -35,7 +35,7 @@ def test_llama():
 
     logits = model.prefill(
         tokens=ids,
-        attention_mask=None,
+        attention_mask=[None],
         cache_state=cache_state,
         seq_block_ids=block_ids,
     )


### PR DESCRIPTION
Requires #1237, developed together, split up to make reviewing easier. They **must** be merged together as both PRs change interfaces for models and the KVCache (PagedAttention).

Parallelism is implemented with an inter-layer callback which checks if transfers are required and performs them there.
Model weights are not changed or tagged when written out, instead they are modified in-place before tracing is performed by `pipeline_parallelize_theta`.

Decode for PP>1 currently does not work, blocked by https://github.com/iree-org/iree/issues/20551