### PR TITLE
sharktank: fixes attention overrides for SDXL punet export

### DIFF
--- a/sharktank/sharktank/ops/attention_impls.py
+++ b/sharktank/sharktank/ops/attention_impls.py
@@ -49,7 +49,7 @@ def _extract_linear_scale(t):
 
 
 # TODO: apply similar thing to masked_flash_attention
-def flash_attention(q, k, v, scale):
+def flash_attention(q, k, v, a=None, is_causal=False, scale=1.0):
     scale = torch.scalar_tensor(1.0 / math.sqrt(q.shape[-1]), dtype=torch.float32)
 
     q, qscale = _extract_linear_scale(q)

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -872,12 +872,13 @@ def _scaled_dot_product_attention(
     q: AnyTensor,
     k: AnyTensor,
     v: AnyTensor,
-    a: Optional[AnyTensor],
+    a: Optional[AnyTensor] = None,
     is_causal: bool = False,
     scale: Optional[float] = None,
 ):
     tensors = (q, k, v, a)
     for override in d.find_overrides(tensors):
+
         if is_causal is not None:
             result = override(q, k, v, a, is_causal=is_causal, scale=scale)
         else:

--- a/shortfin/python/shortfin_apps/sd/examples/sdxl_flagfile_gfx1201.txt
+++ b/shortfin/python/shortfin_apps/sd/examples/sdxl_flagfile_gfx1201.txt
@@ -1,6 +1,6 @@
 all
---iree-hal-target-device=hip
---iree-hip-target=gfx942
+--iree-hal-target-backends=rocm
+--iree-hip-target=gfx1201
 --iree-execution-model=async-external
 --iree-preprocessing-pass-pipeline='builtin.module(util.func(iree-global-opt-raise-special-ops, iree-flow-canonicalize), iree-preprocessing-transpose-convolution-pipeline, iree-preprocessing-pad-to-intrinsics, util.func(iree-preprocessing-generalize-linalg-matmul-experimental))'
 --iree-global-opt-propagate-transposes=1
@@ -11,6 +11,7 @@ all
 --iree-hal-force-indirect-command-buffers
 --iree-codegen-llvmgpu-use-vector-distribution=1
 --iree-llvmgpu-enable-prefetch=1
+--iree-codegen-gpu-native-math-precision=1
 --iree-opt-data-tiling=0
 --iree-vm-target-truncate-unsupported-floats
 clip


### PR DESCRIPTION
Aligns signature of sharktank attention op overload with torch attention op overload.

fp8 SDXL was not able to export without this change after https://github.com/nod-ai/shark-ai/commit/bb3be684446ef9313294e484b7432aaf03d02ed7 (what I could tell from rough bisecting)