### PR TITLE
Ensure that all beams are cleared from the `kvcache` when running decode

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/beam_search_token_selection_strategy.py
+++ b/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/beam_search_token_selection_strategy.py
@@ -224,6 +224,7 @@ class BeamSearchTokenSelectionStrategy(BaseTokenSelectionStrategy):
             beam_group.process_beams()
 
         config.decode_end_callback(reservations)
+        beam_group.clean_up()
         self.get_results(beam_group)
 
     def get_results(self, beam_group: BeamGroup):

--- a/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/greedy_token_selection_strategy.py
+++ b/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/greedy_token_selection_strategy.py
@@ -87,3 +87,4 @@ class GreedyTokenSelectionStrategy(BaseTokenSelectionStrategy):
                 break
             beam.update_exec_req()
         config.decode_end_callback(1)
+        beam.exec_req.free_cache_pages()

--- a/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/multi_greedy_token_selection_strategy.py
+++ b/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/multi_greedy_token_selection_strategy.py
@@ -96,6 +96,7 @@ class MultiGreedyTokenSelectionStrategy(GreedyTokenSelectionStrategy):
             beam_group.process_beams()
 
         config.decode_end_callback(reservations)
+        beam_group.clean_up()
 
         results = [
             beam.exec_req.input_token_ids[exec_req.prompt_length :]

--- a/shortfin/tests/apps/llm/components/token_selection_strategy/greedy_token_selection_strategy_test.py
+++ b/shortfin/tests/apps/llm/components/token_selection_strategy/greedy_token_selection_strategy_test.py
@@ -153,11 +153,16 @@ async def test_greedy_decode_single(
         "_token_selection_strategy_config",
         new=config,
     ):
-        await greedy_token_selection_strategy.decode(exec_req)
+        with patch.object(
+            exec_req,
+            "free_cache_pages",
+        ) as mock_clean_up:
+            await greedy_token_selection_strategy.decode(exec_req)
 
-        assert results_array[0] == 15
-        assert exec_req.input_token_ids[-1] == 15
-        assert exec_req.start_position == 6
+            assert results_array[0] == 15
+            assert exec_req.input_token_ids[-1] == 15
+            assert exec_req.start_position == 6
+            mock_clean_up.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -215,11 +220,16 @@ async def test_greedy_decode_multiple_completions(
         "_token_selection_strategy_config",
         new=config,
     ):
-        await greedy_token_selection_strategy.decode(exec_req)
+        with patch.object(
+            exec_req,
+            "free_cache_pages",
+        ) as mock_clean_up:
+            await greedy_token_selection_strategy.decode(exec_req)
 
-        assert results_array == [0, 1, 2, 3, 4]
-        assert len(exec_req.input_token_ids) == 11
-        assert exec_req.start_position == 10
+            assert results_array == [0, 1, 2, 3, 4]
+            assert len(exec_req.input_token_ids) == 11
+            assert exec_req.start_position == 10
+            mock_clean_up.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -277,8 +287,13 @@ async def test_greedy_decode_eos_token(
         "_token_selection_strategy_config",
         new=config,
     ):
-        await greedy_token_selection_strategy.decode(exec_req)
+        with patch.object(
+            exec_req,
+            "free_cache_pages",
+        ) as mock_clean_up:
+            await greedy_token_selection_strategy.decode(exec_req)
 
-        assert results_array == [0, 1, 2, 3, 4, 5]
-        assert len(exec_req.input_token_ids) == 11
-        assert exec_req.start_position == 10
+            assert results_array == [0, 1, 2, 3, 4, 5]
+            assert len(exec_req.input_token_ids) == 11
+            assert exec_req.start_position == 10
+            mock_clean_up.assert_called_once()

--- a/shortfin/tests/apps/llm/components/token_selection_strategy/multi_greedy_token_selection_strategy_test.py
+++ b/shortfin/tests/apps/llm/components/token_selection_strategy/multi_greedy_token_selection_strategy_test.py
@@ -16,6 +16,9 @@ import shortfin.array as sfnp
 from shortfin_apps.llm.components.kvcache.base_attention_cache import (
     BasePagedAttentionCacheAllocation,
 )
+from shortfin_apps.llm.components.token_selection_strategy.beam_group import (
+    BeamGroup,
+)
 from shortfin_apps.llm.components.messages import (
     LlmInferenceExecRequest,
 )
@@ -122,7 +125,6 @@ async def test_multi_greedy_decode_single(
         eos_token_id=-1,
     )
 
-    allocation = BasePagedAttentionCacheAllocation(dummy_pages, cache=cache)
     exec_req._cache = cache
     allocation = BasePagedAttentionCacheAllocation(dummy_pages, cache=cache)
     exec_req.allocation = allocation
@@ -134,14 +136,19 @@ async def test_multi_greedy_decode_single(
         with patch.object(
             exec_req._cache, "fork_pages", return_value=allocation
         ) as fork_pages_mock:
-            await multi_greedy_token_selection_strategy.decode(exec_req)
-            logger.info(f"results_array: {results_array}")
-            assert len(results_array) == 2
-            for result in results_array:
-                assert len(result) == 1
-                assert result[0] == 15
+            with patch.object(
+                BeamGroup,
+                "clean_up",
+            ) as mock_clean_up:
+                await multi_greedy_token_selection_strategy.decode(exec_req)
+                logger.info(f"results_array: {results_array}")
+                assert len(results_array) == 2
+                for result in results_array:
+                    assert len(result) == 1
+                    assert result[0] == 15
 
-            fork_pages_mock.assert_called_once()
+                fork_pages_mock.assert_called_once()
+                mock_clean_up.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -198,7 +205,6 @@ async def test_multi_greedy_decode_multiple_completions(
         eos_token_id=-1,
     )
 
-    allocation = BasePagedAttentionCacheAllocation(dummy_pages, cache=cache)
     exec_req._cache = cache
     allocation = BasePagedAttentionCacheAllocation(dummy_pages, cache=cache)
     exec_req.allocation = allocation
@@ -210,13 +216,18 @@ async def test_multi_greedy_decode_multiple_completions(
         with patch.object(
             exec_req._cache, "fork_pages", return_value=allocation
         ) as fork_pages_mock:
-            await multi_greedy_token_selection_strategy.decode(exec_req)
-            assert len(results_array) == 2
-            for result in results_array:
-                assert len(result) == 5
-                assert result == [0, 1, 2, 3, 4]
+            with patch.object(
+                BeamGroup,
+                "clean_up",
+            ) as mock_clean_up:
+                await multi_greedy_token_selection_strategy.decode(exec_req)
+                assert len(results_array) == 2
+                for result in results_array:
+                    assert len(result) == 5
+                    assert result == [0, 1, 2, 3, 4]
 
-            fork_pages_mock.assert_called_once()
+                fork_pages_mock.assert_called_once()
+                mock_clean_up.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -273,7 +284,6 @@ async def test_multi_greedy_decode_eos_token(
         eos_token_id=-1,
     )
 
-    allocation = BasePagedAttentionCacheAllocation(dummy_pages, cache=cache)
     exec_req._cache = cache
     allocation = BasePagedAttentionCacheAllocation(dummy_pages, cache=cache)
     exec_req.allocation = allocation
@@ -285,11 +295,16 @@ async def test_multi_greedy_decode_eos_token(
         with patch.object(
             exec_req._cache, "fork_pages", return_value=allocation
         ) as fork_pages_mock:
-            await multi_greedy_token_selection_strategy.decode(exec_req)
-            logger.info(f"results_array: {results_array}")
-            assert len(results_array) == 2
-            for result in results_array:
-                assert len(result) == 5
-                assert result == [0, 1, 2, 3, 4]
+            with patch.object(
+                BeamGroup,
+                "clean_up",
+            ) as mock_clean_up:
+                await multi_greedy_token_selection_strategy.decode(exec_req)
+                logger.info(f"results_array: {results_array}")
+                assert len(results_array) == 2
+                for result in results_array:
+                    assert len(result) == 5
+                    assert result == [0, 1, 2, 3, 4]
 
-            fork_pages_mock.assert_called_once()
+                fork_pages_mock.assert_called_once()
+                mock_clean_up.assert_called_once()


### PR DESCRIPTION
Based on reporting this morning from cache running out, I created a quick test script that spams the server with requests of 1024 tokens, followed by normal prompts.

I was seeing the heavy requests getting processed fine, but eventually the cache being exhausted with a simple request. This means that there must have been stuff left over in the cache from previous requests.

Found this hole, where if a beam `collapses` it gets cleaned up, and if a beam `completes` (eos_token) it gets cleaned up, but if a beam hits `max_completion_tokens`, without outputting `eos_token`, it wasn't.

After adding this patch, my stress test was able to run to completion.