### PR TITLE
Fix export_atifcats usage in benchmark test

### DIFF
--- a/.github/workflows/ci-llama-large-tests.yaml
+++ b/.github/workflows/ci-llama-large-tests.yaml
@@ -7,6 +7,7 @@
 name: Llama Benchmarking Tests
 
 on:
+  pull_request:
   workflow_dispatch:
   schedule:
     # Weekdays at 11:00 AM UTC = 03:00 AM PST / 04:00 AM PDT

--- a/.github/workflows/ci-llama-large-tests.yaml
+++ b/.github/workflows/ci-llama-large-tests.yaml
@@ -7,7 +7,6 @@
 name: Llama Benchmarking Tests
 
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     # Weekdays at 11:00 AM UTC = 03:00 AM PST / 04:00 AM PDT

--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -378,12 +378,12 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
             suffix=".txt", prefix=output_file_name
         )
         export_return_code = self.llama8b_fp8_attnf8_sdpa_artifacts.export_to_mlir(
-            mlir_path=output_mlir,
-            json_path=output_json,
+            output_mlir=output_mlir,
+            output_config=output_json,
         )
         self.llama8b_fp8_attnf8_sdpa_artifacts.compile_to_vmfb(
-            mlir_path=str(output_mlir),
-            vmfb_path=output_vmfb,
+            output_mlir=str(output_mlir),
+            output_vmfb=output_vmfb,
             hal_dump_path=output_file_name,
             cwd=self.repo_root,
             args=self.compile_args,
@@ -423,12 +423,12 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
             suffix=".txt", prefix=output_file_name
         )
         export_return_code = self.llama8b_fp8_attnf8_sdpa_artifacts.export_to_mlir(
-            mlir_path=output_mlir,
-            json_path=output_json,
+            output_mlir=output_mlir,
+            output_config=output_json,
         )
         self.llama8b_fp8_attnf8_sdpa_artifacts.compile_to_vmfb(
-            mlir_path=str(output_mlir),
-            vmfb_path=output_vmfb,
+            output_mlir=str(output_mlir),
+            output_vmfb=output_vmfb,
             hal_dump_path=output_file_name,
             cwd=self.repo_root,
             args=self.compile_args,

--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -666,7 +666,9 @@ class BenchmarkLlama3_1_70B(BaseBenchmarkTest):
         )
 
     @pytest.mark.xfail(
-        reason="Benchmarking Error", strict=True, raises=IreeBenchmarkException
+        run=False,
+        reason="https://github.com/iree-org/iree/issues/20581",
+        raises=IreeCompileException,
     )
     def testBenchmark70B_f16_TP8_Non_Decomposed_Input_Len_128(self):
         output_file_name = self.dir_path_70b / "f16_torch_128_tp8"
@@ -716,7 +718,9 @@ class BenchmarkLlama3_1_70B(BaseBenchmarkTest):
         )
 
     @pytest.mark.xfail(
-        reason="Benchmarking Error", strict=True, raises=IreeBenchmarkException
+        run=False,
+        reason="https://github.com/iree-org/iree/issues/20581",
+        raises=IreeCompileException,
     )
     def testBenchmark70B_f16_TP8_Non_Decomposed_Input_Len_2048(self):
         output_file_name = self.dir_path_70b / "f16_torch_2048_tp8"


### PR DESCRIPTION
- Fix issue in 0418 llama nightly benchmark test https://github.com/nod-ai/shark-ai/actions/runs/14534130397/job/40779266661#step:7:1036 bring from https://github.com/nod-ai/shark-ai/pull/1172#pullrequestreview-2780139231
- Xfail llama70B codegen issue in 0419 llama70b nightly benchmark test https://github.com/nod-ai/shark-ai/actions/runs/14548496681/job/40816909348#step:7:386534