### PR TITLE
[tuner] get the function name from the func.func in the input module

### DIFF
--- a/tuner/tuner/candidate_gen.py
+++ b/tuner/tuner/candidate_gen.py
@@ -69,14 +69,7 @@ class ContractionOpInterfaceTuner(DispatchTuner, ContractionOpInterfaceParser):
         compilation_info: iree_codegen.CompilationInfoAttr,
     ) -> ir.Module:
         contraction_op = self.get_root_op()
-        lhs_type = ir.ShapedType(contraction_op.operands[0].type)
-        rhs_type = ir.ShapedType(contraction_op.operands[1].type)
-        acc_type = ir.ShapedType(contraction_op.operands[2].type)
-        M = acc_type.get_dim_size(0)
-        N = acc_type.get_dim_size(1)
-        K = lhs_type.get_dim_size(1)
-        # TODO(Max191): Get the function name from the func.func in the input module.
-        func_name = f"match_contraction_{M}x{N}x{K}_{lhs_type.element_type}x{rhs_type.element_type}x{acc_type.element_type}"
+        func_name = self.get_root_op_func_name()
         return build_td_spec(
             contraction_op.context, contraction_op, compilation_info, func_name
         )
@@ -91,19 +84,7 @@ class ConvolutionOpInterfaceTuner(DispatchTuner, ConvolutionOpInterfaceParser):
         assert (
             conv_op.name == "linalg.conv_2d_nhwc_hwcf"
         ), "expected linalg.conv_2d_nhwc_hwcf"
-        lhs_type = ir.ShapedType(conv_op.operands[0].type)
-        rhs_type = ir.ShapedType(conv_op.operands[1].type)
-        acc_type = ir.ShapedType(conv_op.operands[2].type)
-        N = acc_type.get_dim_size(0)
-        H = acc_type.get_dim_size(1)
-        W = acc_type.get_dim_size(2)
-        C = rhs_type.get_dim_size(2)
-        P = rhs_type.get_dim_size(0)
-        Q = rhs_type.get_dim_size(1)
-        F = rhs_type.get_dim_size(3)
-        conv_type = conv_op.name.split(".")[-1]
-        # TODO(Max191): Get the function name from the func.func in the input module.
-        func_name = f"match_{conv_type}_{N}x{H}x{W}x{C}x{P}x{Q}x{F}_{lhs_type.element_type}x{rhs_type.element_type}x{acc_type.element_type}"
+        func_name = self.get_root_op_func_name()
         return build_td_spec(conv_op.context, conv_op, compilation_info, func_name)
 
 

--- a/tuner/tuner/dispatch_parser.py
+++ b/tuner/tuner/dispatch_parser.py
@@ -29,9 +29,16 @@ def parse_mlir(mlir_text: str, ctx: TunerContext) -> ir.Module:
 class DispatchParser(metaclass=ABCMeta):
     def __init__(self, root_op: ir.Operation):
         self._root_op = root_op
+        func_op = self._root_op.parent
+        assert func_op.name == "func.func", f"Expected func.func, got {func_op.name}"
+        func_name_attr = func_op.attributes["sym_name"]
+        self._func_name = f"match_{ir.StringAttr(func_name_attr).value}"
 
     def get_root_op(self) -> ir.Operation:
         return self._root_op
+
+    def get_root_op_func_name(self) -> str:
+        return self._func_name
 
     @abstractmethod
     def has_valid_root_op(self) -> bool:

--- a/tuner/tuner/dispatch_parser.py
+++ b/tuner/tuner/dispatch_parser.py
@@ -9,7 +9,7 @@
 
 from abc import ABCMeta, abstractmethod
 
-from iree.compiler.dialects import linalg  # type: ignore
+from iree.compiler.dialects import linalg, func  # type: ignore
 
 from .common import *
 
@@ -29,9 +29,11 @@ def parse_mlir(mlir_text: str, ctx: TunerContext) -> ir.Module:
 class DispatchParser(metaclass=ABCMeta):
     def __init__(self, root_op: ir.Operation):
         self._root_op = root_op
-        func_op = self._root_op.parent
-        assert func_op.name == "func.func", f"Expected func.func, got {func_op.name}"
-        func_name_attr = func_op.attributes["sym_name"]
+        func_op = self._root_op.parent.opview
+        assert isinstance(
+            func_op, func.FuncOp
+        ), f"Expected func.func, got {func_op.name}"
+        func_name_attr = func_op.name
         self._func_name = f"match_{ir.StringAttr(func_name_attr).value}"
 
     def get_root_op(self) -> ir.Operation:

--- a/tuner/tuner/dispatch_parser_test.py
+++ b/tuner/tuner/dispatch_parser_test.py
@@ -16,7 +16,7 @@ from iree.compiler import ir  # type: ignore
 from iree.compiler.dialects import func  # type: ignore
 from iree.compiler.dialects import iree_gpu  # type: ignore
 from iree.compiler.dialects import iree_codegen  # type: ignore
-from iree.compiler.dialects import linalg, arith, tensor, func  # type: ignore
+from iree.compiler.dialects import linalg, func  # type: ignore
 
 from . import common
 from . import dispatch_parser
@@ -121,6 +121,7 @@ def test_get_contraction_operation(tuner_ctx: common.TunerContext) -> None:
     assert len(root_op_list) == 1
     root_op = root_op_list[0]
     parser = dispatch_parser.ContractionOpInterfaceParser(root_op)
+    assert parser.get_root_op_func_name() == "match_test"
     shapes = parser.get_problem_size()
     assert shapes.matmul_size.B == [16, 16]
     assert shapes.matmul_size.M == [8, 64]
@@ -162,6 +163,7 @@ def test_get_matmul_named_op(tuner_ctx: common.TunerContext) -> None:
         root_op = root_op_list[0]
 
         parser = dispatch_parser.ContractionOpInterfaceParser(root_op)
+        assert parser.get_root_op_func_name() == "match_named_matmul"
         shapes = parser.get_problem_size()
 
         assert shapes.matmul_size.B == []
@@ -209,6 +211,7 @@ def test_get_named_contraction_op():
         root_op = root_op_list[0]
 
         parser = dispatch_parser.ContractionOpInterfaceParser(root_op)
+        assert parser.get_root_op_func_name() == "match_named_contraction"
         shape = parser.get_problem_size()
 
         assert shape.matmul_size.B == []
@@ -239,6 +242,7 @@ def test_get_conv_operation(tuner_ctx: common.TunerContext) -> None:
     assert len(root_op_list) == 1
     root_op = root_op_list[0]
     parser = dispatch_parser.ConvolutionOpInterfaceParser(root_op)
+    assert parser.get_root_op_func_name() == "match_test"
     assert (
         parser.has_valid_root_op()
     ), f"ConvolutionOpInterfaceParser does not support the op: {root_op.name}"


### PR DESCRIPTION
This PR mainly gets the function name from the func.func, which contains the root op in the input module.

Issue: https://github.com/nod-ai/shark-ai/issues/1303