### PR TITLE
Add ops.mean for SplitPrimitiveTensor

### DIFF
--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -1051,7 +1051,7 @@ def mean_replicated(
     keepdim: bool,
     *,
     dtype: torch.dtype,
-) -> None:
+) -> ReplicatedTensor:
     shards = [mean(shard, dim=dim, keepdim=keepdim, dtype=dtype) for shard in x.shards]
     return ReplicatedTensor(ts=shards)
 

--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -1066,6 +1066,8 @@ def mean_split(
 ) -> SplitPrimitiveTensor | ReplicatedTensor:
     if not isinstance(dim, (list, tuple)):
         dim = [dim]
+    dim = [d + len(x.shape) if d < 0 else d for d in dim]
+
     if x.shard_dim not in dim:
         # If keepdim == False and any entry in dim is smaller than shard_dim
         # we need to offset shard_dim_new to have it point to the same dimension.

--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -1085,7 +1085,7 @@ def mean_split(
                 )
                 for i, shard in enumerate(x.shards)
             ],
-            dim=dim,
+            dim=x.shard_dim,
         )
         meaned = mean(gathered, dim=dim, keepdim=keepdim, dtype=dtype)
         return ReplicatedTensor(ts=meaned, shard_count=x.shard_count, devices=x.devices)

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -887,6 +887,31 @@ class MatmulTest(unittest.TestCase):
             assert ops.equal(shard, unsharded_result)
 
 
+class MeanTest(unittest.TestCase):
+    def testMeanReplicated(self):
+        tensor = torch.rand(4, 5, dtype=torch.float32)
+        shard_count = 3
+        expected_result = ops.mean(tensor, dim=0)
+        actual_result = ops.mean(ops.replicate(tensor, count=shard_count), dim=0)
+        assert ops.equal(expected_result, actual_result)
+
+    def testMeanSplitNotSplitDim(self):
+        tensor = torch.rand(4, 5, dtype=torch.float32)
+        shard_count = 3
+        expected_result = ops.mean(tensor, dim=0)
+        sharded_tensor = ops.reshard_split(tensor, dim=1, count=shard_count)
+        actual_result = ops.mean(sharded_tensor, dim=0)
+        assert ops.equal(expected_result, actual_result)
+
+    def testMeanSplitSplitDim(self):
+        tensor = torch.rand(4, 5, dtype=torch.float32)
+        shard_count = 3
+        expected_result = ops.mean(tensor, dim=1)
+        sharded_tensor = ops.reshard_split(tensor, dim=1, count=shard_count)
+        actual_result = ops.mean(sharded_tensor, dim=1)
+        assert ops.equal(expected_result, actual_result)
+
+
 class ReplicateTest(unittest.TestCase):
     def testReplicateReplicated(self):
         tensor = torch.rand(4, 5, dtype=torch.float32)

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -898,6 +898,7 @@ class MeanTest(unittest.TestCase):
         self.mean_dim = self.shard_dim + self.mean_dim_delta
         self.mean_dims_multi = tuple(self.mean_dim + i for i in [-1, 0, +1])
         self.shard_count = 2
+        torch.random.manual_seed(sum(self.mean_dims_multi) + 13 * self.keepdim)
 
     def testMeanReplicated(self):
         tensor = torch.rand(self.shape, dtype=torch.float32)

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -921,6 +921,20 @@ class MeanTest(unittest.TestCase):
         )
         torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
 
+    def testMeanSplitNegativeDims(self):
+        if self.mean_dim_delta != -1:
+            self.skipTest(
+                "Using a specifc negative dim, so only running for different versions of 'keepdim'."
+            )
+        mean_dim = [-5, -1, -4]
+        tensor = torch.rand(self.shape, dtype=torch.float32)
+        expected_result = ops.mean(tensor, dim=mean_dim, keepdim=self.keepdim)
+        sharded_tensor = ops.reshard_split(
+            tensor, dim=self.shard_dim, count=self.shard_count
+        )
+        actual_result = ops.mean(sharded_tensor, dim=mean_dim, keepdim=self.keepdim)
+        torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
+
     def testMeanSplitMultiDim(self):
         tensor = torch.rand(self.shape, dtype=torch.float32)
         expected_result = ops.mean(

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -906,7 +906,7 @@ class MeanTest(unittest.TestCase):
             dim=self.mean_dim,
             keepdim=self.keepdim,
         )
-        assert ops.equal(expected_result, actual_result)
+        torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
 
     def testMeanSplit(self):
         tensor = torch.rand(self.shape, dtype=torch.float32)
@@ -917,7 +917,7 @@ class MeanTest(unittest.TestCase):
         actual_result = ops.mean(
             sharded_tensor, dim=self.mean_dim, keepdim=self.keepdim
         )
-        assert ops.equal(expected_result, actual_result)
+        torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
 
 
 class ReplicateTest(unittest.TestCase):


### PR DESCRIPTION
Only strange thing about this op that I haven't seen in others is that doing the mean across the `shard_dim` requires us to return a `ReplicatedTensor` rather than a `SplitPrimitiveTensor`, especially when `keepdim == False` since the `shard_dim` stops existing. 