### PR TITLE
[tuner] padding support along TileAndFuse pipeline

### DIFF
--- a/sharktuner/sharktuner/common.py
+++ b/sharktuner/sharktuner/common.py
@@ -5,7 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import logging
-from dataclasses import astuple, dataclass, field
+from collections.abc import Sequence
+from dataclasses import dataclass, field
 from enum import Enum
 from types import TracebackType
 from typing import Optional
@@ -187,8 +188,8 @@ def get_lowering_config(
         # A local variable to hold the transformed value.
         promoted_value = value
         match key:
-            case "workgroup" | "reduction" | "subgroup" | "promote_operands":
-                if isinstance(value, list):
+            case "workgroup" | "reduction" | "subgroup" | "promote_operands" | "padding":
+                if isinstance(value, Sequence):
                     promoted_value = ir.ArrayAttr.get(
                         [tuner_ctx.type.getI64(x) for x in value]
                     )

--- a/sharktuner/sharktuner/dispatch_constraints.py
+++ b/sharktuner/sharktuner/dispatch_constraints.py
@@ -160,9 +160,12 @@ def generate_tile_and_fuse_constraints(
     subgroup_n_count: z3.ArithRef,
     mma_intrinsics: list[iree_gpu.MMAIntrinsic],
 ):
-    M, N, K = problem_size.MNK
+    M, N, K = map(list, problem_size.MNK)
     m_tiles, n_tiles, k_tiles, subgroup_m_tiles, subgroup_n_tiles = tile_sizes
     intrinsic_mn, intrinsic_k = intrinsic_size
+    M[-1] = ((M[-1] + intrinsic_mn - 1) / intrinsic_mn) * intrinsic_mn
+    N[-1] = ((N[-1] + intrinsic_mn - 1) / intrinsic_mn) * intrinsic_mn
+    K[-1] = ((K[-1] + intrinsic_k - 1) / intrinsic_k) * intrinsic_k
     wg_x, wg_y, wg_z = workgroup_size
     wg_threads = wg_x
     constraints = [wg_y == 1, wg_z == 1]
@@ -300,9 +303,11 @@ def generate_compilation_infos(
     subgroup_size: int,
     subgroup_m_count: int,
     subgroup_n_count: int,
+    promote_operands: list[int],
     codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline,
     pipeline_options_search_space: PipelineOptionsSearchSpace,
     allowed_waves_per_eu: list[int],
+    required_padding: bool,
 ) -> list[iree_codegen.CompilationInfoAttr]:
     # Create the LoweringConfigAttr.
     lowering_config_args = {
@@ -312,8 +317,19 @@ def generate_compilation_infos(
         "reduction": reduction_tile_sizes,
         "subgroup_m_count": subgroup_m_count,
         "subgroup_n_count": subgroup_n_count,
-        "promote_operands": [0, 1],
+        "promote_operands": promote_operands,
     }
+
+    if required_padding:
+        workgroup_tile_m, workgroup_tile_n, _ = workgroup_tile_sizes
+        _, _, reduction_tile_k = reduction_tile_sizes
+        _, _, intrinsic_k = mma_attr.mnk_shape
+        lowering_config_args["padding"] = (
+            workgroup_tile_m,
+            workgroup_tile_n,
+            reduction_tile_k * intrinsic_k,
+        )
+
     if codegen_pipeline == iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse:
         lowering_config_args["subgroup"] = subgroup_tile_sizes
 
@@ -382,7 +398,7 @@ def generate_solutions(
     k_vars = [z3.Int(f"k{i}") for i in range(len(K))]
     subgroup_m_vars = [z3.Int(f"subgroup_m{i}") for i in range(len(M))]
     subgroup_n_vars = [z3.Int(f"subgroup_n{i}") for i in range(len(N))]
-    # m, n, k = z3.Int("m"), z3.Int("n"), z3.Int("k")
+
     subgroup_size = z3.Int("subgroup_size")
     intrinsic_mn = z3.Int("intrinsic_mn")
     intrinsic_k = z3.Int("intrinsic_k")
@@ -439,11 +455,14 @@ def generate_solutions(
     while solver.check() == z3.sat:
         model = solver.model()
         lookup = lambda var: model[var].as_long()
-        mma_attr = getMMAAttr(
-            problem_size.res_type.element_type,
+        intrinsic_mnk_shape = (
             lookup(intrinsic_mn),
             lookup(intrinsic_mn),
             lookup(intrinsic_k),
+        )
+        mma_attr = getMMAAttr(
+            problem_size.res_type.element_type,
+            *intrinsic_mnk_shape,
             problem_size.lhs_type.element_type,
             problem_size.rhs_type.element_type,
         )
@@ -502,6 +521,14 @@ def generate_solutions(
             [lookup(v) for v in k_vars],
         )
 
+        required_padding = any(
+            p[-1] % i != 0
+            for p, i in zip(problem_size.MNK, intrinsic_mnk_shape, strict=True)
+        )
+        promote_operands = [0, 1]
+        if required_padding:
+            promote_operands = [0, 1, 2]
+
         compilation_infos = generate_compilation_infos(
             tuner_ctx,
             mma_attr,
@@ -512,9 +539,11 @@ def generate_solutions(
             lookup(subgroup_size),
             lookup(sg_m_cnt),
             lookup(sg_n_cnt),
+            promote_operands,
             codegen_pipeline,
             pipeline_options_search_space,
             allowed_waves_per_eu,
+            required_padding=required_padding,
         )
 
         solver.add(z3.simplify(z3.Not(z3.And(list(x == model[x] for x in all_vars)))))

--- a/sharktuner/sharktuner/dispatch_constraints.py
+++ b/sharktuner/sharktuner/dispatch_constraints.py
@@ -519,6 +519,7 @@ def generate_solutions(
             for p, i in zip(problem_size.MNK, intrinsic_mnk_shape, strict=True)
         )
         promote_operands = [0, 1]
+        padding = None
         if required_padding:
             # TODO: Remove promotion of operand 2 once codegen supports handling padded outputs without promotion.
             promote_operands = [0, 1, 2]
@@ -530,8 +531,6 @@ def generate_solutions(
                 workgroup_tile_n,
                 reduction_tile_k * mma_intrinsic_k,
             ]
-        else:
-            padding = None
 
         compilation_infos = generate_compilation_infos(
             tuner_ctx,

--- a/sharktuner/sharktuner/dispatch_constraints_test.py
+++ b/sharktuner/sharktuner/dispatch_constraints_test.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 """
-Usage: python -m pytest candidate_gen_test.py
+Usage: python -m pytest dispatch_constraints_test.py
 """
 
 import pytest
@@ -49,6 +49,44 @@ def test_generate_solutions(tuner_ctx: common.TunerContext) -> None:
     )
 
     assert configs is not None
+
+
+def test_generate_solutions_tile_and_fuse(tuner_ctx: common.TunerContext) -> None:
+    matmul_size = common.ContractionSizes([5369], [112], [112])
+    contraction_dims = common.ContractionDimensions([0], [1], [2])
+    lhs_type = common.ShapedType([5369, 112], tuner_ctx.type.f16)
+    rhs_type = common.ShapedType([112, 112], tuner_ctx.type.f16)
+    res_type = common.ShapedType([5369, 112], tuner_ctx.type.f32)
+    problem_size = common.ProblemSize(
+        matmul_size,
+        lhs_type,
+        rhs_type,
+        res_type,
+        common.DispatchKind.contraction,
+        contraction_dims,
+    )
+
+    mma_intrinsics = [
+        iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
+    ]
+
+    solutions = list(
+        dispatch_constraints.generate_solutions(
+            tuner_ctx=tuner_ctx,
+            problem_size=problem_size,
+            num_subgrups=4,
+            mma_intrinsics=mma_intrinsics,
+            allowed_waves_per_eu=[2],
+            pipeline_options_search_space=dispatch_constraints.PipelineOptionsSearchSpace(),
+            codegen_pipeline=iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse,
+        )
+    )
+
+    assert len(solutions) > 0, "No solutions generated with TileAndFuse pipeline."
+    assert all(isinstance(sol, iree_codegen.CompilationInfoAttr) for sol in solutions)
+    assert all(
+        "padding =" in str(sol.lowering_config) for sol in solutions
+    ), "Not all lowering configs have padding option"
 
 
 def test_calculate_shared_memory_usage_in_bytes(tuner_ctx: common.TunerContext) -> None:

--- a/sharktuner/sharktuner/dispatch_constraints_test.py
+++ b/sharktuner/sharktuner/dispatch_constraints_test.py
@@ -87,6 +87,11 @@ def test_generate_solutions_tile_and_fuse(tuner_ctx: common.TunerContext) -> Non
     assert all(
         "padding =" in str(sol.lowering_config) for sol in solutions
     ), "Not all lowering configs have padding option"
+    assert all(
+        [int(x) for x in sol.lowering_config.attributes["promote_operands"]]
+        == [0, 1, 2]
+        for sol in solutions
+    ), "Not all lowering configs have promote_operands = [0, 1, 2]"
 
 
 def test_calculate_shared_memory_usage_in_bytes(tuner_ctx: common.TunerContext) -> None:


### PR DESCRIPTION
Motivated by bug reported from this [input](https://gist.github.com/rkayaith/0c537b5b917488a890273f7d886791c7) 

**Problem:**
In the current tuner, tile sizes are required to both evenly divide the problem size and be multiples of the intrinsic size. When the problem size is not a multiple of the intrinsic size, the solver fails to find any valid solutions.

**Solution:**
The simplest fix is to round the problem size up to the nearest multiple of the intrinsic size when generating constraints, and then account for the necessary padding in the lowering configuration.

This PR introduces two main changes from Max's local experimental tuning branch into the main tuner branch:

- Change 1: modify the constraint generation to support unaligned problem shapes.
- Change 2: add padding information to the lowering configuration.
- Include corresponding tests for the above changes.



