### PR TITLE
Fix for elementwise binary with broadcasting

### DIFF
--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -420,7 +420,7 @@ def split_elementwise_binary(
         operator(pt_x, pt_y, *args, **kwargs) for pt_x, pt_y in zip(pt_xs, pt_ys)
     ]
     return SplitPrimitiveTensor(
-        shard_dim=x.shard_dim,
+        shard_dim=x_shard_dim,
         shape=torch.broadcast_shapes(x.shape, y.shape),
         ts=partials,
     )
@@ -1313,7 +1313,8 @@ def reshard_like_replicated_to_replicated(
 def reshard_like_replicated_to_split(
     tensor: ReplicatedTensor, like: SplitPrimitiveTensor
 ) -> SplitPrimitiveTensor:
-    return reshard_split(tensor, dim=like.shard_dim, count=like.shard_count)
+    dim = like.shard_dim - max(0, len(like.shape) - len(tensor.shape))
+    return reshard_split(tensor, dim=dim, count=like.shard_count)
 
 
 @reshard_like.override(SplitPrimitiveTensor, SplitPrimitiveTensor)

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -250,49 +250,34 @@ class ElementwiseTest(unittest.TestCase):
 
         torch.testing.assert_close(actual_result, expected_result)
 
-    def testRhsAndLhsShardedAddWithBroadcasting(self):
-        a = torch.rand(1, 4, 5, 6, dtype=torch.float32)
-        b = torch.rand(3, 4, 1, 6, dtype=torch.float32)
+    @parameterized.expand(tuple(itertools.product([0, 1, 2, 3], repeat=2)))
+    def testRhsAndLhsShardedAddWithBroadcasting(self, i: int, j: int):
+        a = torch.rand((1, 4, 5, 6)[i:], dtype=torch.float32)
+        b = torch.rand((3, 4, 1, 6)[j:], dtype=torch.float32)
 
         expected_result = a + b
 
-        shard_dim = 3
         shard_count = 3
-        sharded_a = ops.reshard_split(a, dim=shard_dim, count=shard_count)
-        sharded_b = ops.reshard_split(b, dim=shard_dim, count=shard_count)
+        sharded_a = ops.reshard_split(a, dim=a.dim() - 1, count=shard_count)
+        sharded_b = ops.reshard_split(b, dim=b.dim() - 1, count=shard_count)
         sharded_result = sharded_a + sharded_b
         actual_result = ops.reshard_like(sharded_result, expected_result)
 
         torch.testing.assert_close(actual_result, expected_result)
 
-    @parameterized.expand(
-        [
-            (0,),
-            (1,),
-            (2,),
-        ]
-    )
-    def testMe2(self, i: int):
-        a = torch.rand((1, 1, 6)[i:], dtype=torch.float32)
-        b = torch.rand(4, 5, 6, dtype=torch.float32)
+    @parameterized.expand(tuple(itertools.product([0, 1, 2], repeat=2)))
+    def testShardedReplicatedAddWithBroadcasting(self, i: int, j: int):
+        a = torch.rand((4, 1, 6)[i:], dtype=torch.float32)
+        b = torch.rand((4, 5, 6)[j:], dtype=torch.float32)
 
         expected_result = a + b
 
         a_s = ops.replicate(a, count=3)
-        b_s = ops.reshard_split(b, dim=2, count=3)
+        b_s = ops.reshard_split(b, dim=b.dim() - 1, count=3)
         actual_result = a_s + b_s
-
+        actual_result2 = b_s + a_s
         torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
-
-    def testMe(self):
-        a = torch.rand(6, dtype=torch.float32)
-        b = torch.rand(4, 5, 6, dtype=torch.float32)
-
-        expected_result = a + b
-        a_s = ops.replicate(a, count=3)
-        b_s = ops.reshard_split(b, dim=2, count=3)
-        sharded_result = a_s + b_s
-        pass
+        torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result2))
 
     @parameterized.expand(
         [
@@ -300,8 +285,8 @@ class ElementwiseTest(unittest.TestCase):
             (torch.div,),
             (torch.fmin,),
             (torch.fmax,),
-            (torch.sub),
-            (torch.mul),
+            (torch.sub,),
+            (torch.mul,),
         ]
     )
     def testBinaryOperators(self, operator):

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -267,11 +267,41 @@ class ElementwiseTest(unittest.TestCase):
 
     @parameterized.expand(
         [
+            (0,),
+            (1,),
+            (2,),
+        ]
+    )
+    def testMe2(self, i: int):
+        a = torch.rand((1, 1, 6)[i:], dtype=torch.float32)
+        b = torch.rand(4, 5, 6, dtype=torch.float32)
+
+        expected_result = a + b
+
+        a_s = ops.replicate(a, count=3)
+        b_s = ops.reshard_split(b, dim=2, count=3)
+        actual_result = a_s + b_s
+
+        torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
+
+    def testMe(self):
+        a = torch.rand(6, dtype=torch.float32)
+        b = torch.rand(4, 5, 6, dtype=torch.float32)
+
+        expected_result = a + b
+        a_s = ops.replicate(a, count=3)
+        b_s = ops.reshard_split(b, dim=2, count=3)
+        sharded_result = a_s + b_s
+        pass
+
+    @parameterized.expand(
+        [
             (torch.add,),
             (torch.div,),
             (torch.fmin,),
             (torch.fmax,),
             (torch.sub),
+            (torch.mul),
         ]
     )
     def testBinaryOperators(self, operator):


### PR DESCRIPTION
**Changes/Fixes**
- `split_elementwise_binary` was using incorrect shard_dim because of a typo.
- `reshard_like_replicated_to_split` did not correctly work for broadcastable tensors of different dimensions.
- Test coverage