### PR TITLE
make function lazy_PyWorkerEventLoop thread safe

### DIFF
--- a/shortfin/python/lib_ext.cc
+++ b/shortfin/python/lib_ext.cc
@@ -127,6 +127,7 @@ class Refs {
       py::module_::import_("threading").attr("main_thread");
 
   py::handle lazy_PyWorkerEventLoop() {
+    iree::slim_mutex_lock_guard g(mutex_event_loop_);
     if (!lazy_PyWorkerEventLoop_.is_valid()) {
       lazy_PyWorkerEventLoop_ = py::module_::import_("_shortfin.asyncio_bridge")
                                     .attr("PyWorkerEventLoop");
@@ -144,8 +145,9 @@ class Refs {
   }
 
  private:
-  iree::slim_mutex mu_;
+  iree::slim_mutex mutex_event_loop_; // thread safe for accessing lazy_PyWorkerEventLoop_
   py::object lazy_PyWorkerEventLoop_;
+  iree::slim_mutex mu_; // thread safe for accessing default_system_type_
   std::optional<std::string> default_system_type_;
 };
 


### PR DESCRIPTION
- Why
While working towards GIL_free, realize this function lazy_PyWorkerEventLoop could be accessed from different threads, therefore it is necessary to make it thread-safe

- How
Instead of using std::mutex, follow the existed function default_system_type using iree::slim_mutex