### PR TITLE
Change ops.view to support multiple dim expansions and collapses

### DIFF
--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -1484,6 +1484,110 @@ def unshard_unsharded(input: Tensor) -> Tensor:
     return input
 
 
+def _calculate_view_dimension_mapping(
+    from_shape: Sequence[int], to_shape: Sequence[int]
+) -> List[List[int]]:
+    """
+    Calculate a mapping from the dimensions in `from_shape` to those in `to_shape`.
+    """
+    from_shape, to_shape = list(from_shape), list(to_shape)
+    assert len(from_shape) > 0 and len(to_shape) > 0, "Scalars not supported"
+    assert all(d != 0 for d in from_shape + to_shape), "Zero dimensions not supported"
+    from_shape, to_shape = _reshape_infer_dynamic_dim(list(from_shape), list(to_shape))
+
+    # Trivial cases
+    if len(from_shape) == 1:
+        return [[i for i in range(len(to_shape))]]
+    if len(to_shape) == 1:
+        return [[0] for _ in range(len(from_shape))]
+
+    def _get_cumulative_boundaries(shape: Sequence[int]) -> List[int]:
+        """
+        Get the cumulitive number of elements at the start of each dimension.
+        Add an extra 1 at the start to represent the start of the first dimension.
+        For example, for shape (2, 3, 4) it returns [1, 2, 6, 24].
+        """
+        return [1] + list(itertools.accumulate(shape, lambda x, y: x * y))
+
+    bounds_to = _get_cumulative_boundaries(to_shape)
+    bounds_from = _get_cumulative_boundaries(from_shape)
+
+    mapping = [[] for _ in range(len(from_shape))]
+    to_dim_idx_start = 0
+    for from_dim in range(len(from_shape)):
+        from_bound_start = bounds_from[from_dim]
+        from_bound_end = bounds_from[from_dim + 1]
+
+        to_dim = to_dim_idx_start
+        while to_dim < len(to_shape):
+            to_bound_start = bounds_to[to_dim]
+            to_bound_end = bounds_to[to_dim + 1]
+
+            # Check if the two ranges overlap
+            overlap_start = max(to_bound_start, from_bound_start)
+            overlap_end = min(to_bound_end, from_bound_end)
+            range_overlaps = overlap_start < overlap_end
+
+            # Special case for dim of size 1
+            size_one_dim_overlap = False
+            if from_bound_start == from_bound_end:  # `from_dim` is 1
+                if (
+                    from_bound_start >= to_bound_start
+                    and from_bound_start < to_bound_end
+                ):
+                    # `from_dim` is within the range of `to_dim`.
+                    # E.g. [5, 1, 6] to [5, 6]
+                    size_one_dim_overlap = True
+                elif (
+                    from_bound_start == to_bound_start
+                    and from_bound_end == to_bound_start
+                ):
+                    size_one_dim_overlap = True
+
+            if range_overlaps or size_one_dim_overlap:
+                # Overlap exists
+                assert to_dim not in mapping[from_dim]
+                mapping[from_dim].append(to_dim)
+
+                if to_bound_end >= from_bound_end:
+                    # We have exhausted the current `from_dim`
+                    if to_bound_end == from_bound_end:
+                        # This `to_dim` ends *exactly* at the end of the current `from_dim`.
+                        # This `to_dim` is exhausted, start next search with next `to_dim`.
+                        to_dim_idx_start = to_dim + 1
+                    else:  # to_bound_end > from_bound_end
+                        # This `to_dim` ends *after* the current `from_dim` ends.
+                        # We need to check the next `from_dim` for the current `to_dim`;
+                        # This `to_dim` is split across multiple `from_dim`s.
+                        to_dim_idx_start = to_dim
+                    # Found all contributions of this `from_dim`, more to the next.
+                    break
+                else:  # to_bounds_end < from_bounds_end
+                    # This to_dim ends *before* the current `from_dim` ends.
+                    # We need to check the next to_dim for the current `from_dim`.
+                    to_dim += 1
+            elif to_bound_start > from_bound_end:
+                # This `to_dim` starts *after* the current `from_dim` ends.
+                # No further `to_dim`s will overlap this `from_dim`.
+                # The next search should start from this `to_dim`.
+                to_dim_idx_start = to_dim
+                break
+            else:  # to_bounds_end <= from_bounds_start
+                # This `to_dim` ends *before* or *at* the start of the current `from_dim`.
+                # Move to check the next `to_dim` for the current `from_dim`.
+                to_dim += 1
+        # Update search start if inner loop finishes by exhaustion
+        if to_dim == len(to_shape):
+            to_dim_idx_start = to_dim
+
+        # Handle empty mapping for size 1 dimensions that didn't get mapped (happens if this is trailing 1)
+        if from_shape[from_dim] == 1 and not mapping[from_dim]:
+            last_valid_idx = len(to_shape) - 1
+            mapping[from_dim].append(last_valid_idx)
+
+    return mapping
+
+
 def _reshape_get_flatten_dim_range(
     from_shape: List[int], to_shape: List[int]
 ) -> Optional[Tuple[int, int]]:
@@ -1509,7 +1613,11 @@ def _reshape_infer_dynamic_dim(
 
     shape2_dynamic_dims = [i for i, d in enumerate(shape2) if d <= 0]
     if len(shape2_dynamic_dims) == 0:
+        assert math.prod(shape1) == math.prod(
+            shape2
+        ), f"Size mismatch: {shape1} vs {shape2}"
         return shape1, shape2
+
     shape2_dynamic_dim = shape2_dynamic_dims[0]
     shape1_size = math.prod(shape1)
     shape2_size_without_dynamic_dim = math.prod(d for d in shape2 if d > 0)
@@ -1575,11 +1683,6 @@ def unsqueeze_replicated(tensor: ReplicatedTensor, dim: int) -> SplitPrimitiveTe
 
 @view.override(ReplicatedTensor)
 def view_replicated(tensor: ReplicatedTensor, shape: List[int]) -> ReplicatedTensor:
-    view_split_range = _reshape_get_single_split_dim(tensor.shape, shape)
-    if view_split_range is None:
-        raise ValueError(
-            "Only taking a tensor view where splitting a single dimension is supported"
-        )
     shards = [view(shard, shape) for shard in tensor.shards]
     res = ReplicatedTensor(ts=shards)
     assert math.prod(res.shape) == math.prod(tensor.shape)
@@ -1588,28 +1691,45 @@ def view_replicated(tensor: ReplicatedTensor, shape: List[int]) -> ReplicatedTen
 
 @view.override(SplitPrimitiveTensor)
 def view_split(tensor: SplitPrimitiveTensor, shape: List[int]) -> SplitPrimitiveTensor:
-    view_split_range = _reshape_get_single_split_dim(tensor.shape, shape)
-    if view_split_range is None:
-        raise ValueError(
-            "Only taking a tensor view where splitting a single dimension is supported"
-        )
-    view_split_dim = view_split_range[0]
-
-    if view_split_dim == tensor.shard_dim:
-        if tensor.shape[view_split_dim] % tensor.shard_count != 0:
+    shard_dim = tensor.shard_dim
+    mapping = _calculate_view_dimension_mapping(from_shape=tensor.shape, to_shape=shape)
+    if len(mapping[shard_dim]) != 1:
+        if tensor.shape[tensor.shard_dim] % tensor.shard_count != 0:
             raise ValueError(
                 "Only splitting a dimension that is multiple of the shard count is supported"
             )
-        if shape[view_split_dim] % tensor.shard_count != 0:
+        if shape[tensor.shard_dim] % tensor.shard_count != 0:
             raise ValueError(
                 "The resulting leading splitting dimension must be multiple of the shard count"
             )
 
-    shard_dim = tensor.shard_dim
-    if shard_dim > view_split_dim:
-        new_dims_count = len(shape) - len(tensor.shape)
-        shard_dim += new_dims_count
+    # Account for collapsed or expanded dims
+    collapsed_dims = []
+    delta = 0
+    for from_dim, to_dims in enumerate(mapping[: shard_dim + 1]):
+        if len(to_dims) > 1:
+            # Expanded dims move shard_dim to the right by 1 for each new dim.
+            if from_dim == shard_dim:
+                pass  # Do nothing since we want to shard based on the leading dim if the shard_dim is expanded.
+            else:
+                delta += len(to_dims) - 1
+        # A to_dim can be split to be both expand itself and be collapsed with others, must check.
+        for to_dim in to_dims:
+            # Collapsed dims move shard_dim to the left by 1 for each dim after the first.
+            if to_dim in collapsed_dims:
+                delta -= 1
+            collapsed_dims.append(to_dim)
+    # Account for extra dims of size 1
+    dims_not_seen = [i for i in range(min(mapping[shard_dim]))]
+    for to_dims in mapping[:shard_dim]:
+        for to_dim in to_dims:
+            if to_dim in dims_not_seen:
+                dims_not_seen.remove(to_dim)
+
+    shard_dim += delta + len(dims_not_seen)
+
     new_shard_shape = list(shape)
+    # NOTE: dynamic shard_dim is handled implicitly because of int division.
     new_shard_shape[shard_dim] //= tensor.shard_count
     shards = [view(shard, new_shard_shape) for shard in tensor.shards]
     res = SplitPrimitiveTensor(shard_dim=shard_dim, ts=shards)

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -6,6 +6,7 @@
 
 import unittest
 import itertools
+import math
 from parameterized import parameterized, parameterized_class
 
 import torch
@@ -48,6 +49,159 @@ class AllReduceTest(unittest.TestCase):
 
         for shard in actual_result.shards:
             torch.testing.assert_close(shard.as_torch(), expected_result)
+
+
+class CalculateViewDimensionMappingTest(unittest.TestCase):
+    # NOTE: Don't have to test dynamic dim versions since `_calculate_view_dimension_mapping`
+    #       Immediately calls `_reshape_infer_dynamic_dim` which collapses the result back to
+    #       a non-dynamic test version.
+    #       `_reshape_infer_dynamic_dim` is already being tested above.
+    def setUp(self):
+        from sharktank.ops.sharded_impls import _calculate_view_dimension_mapping
+
+        self.calc_map = _calculate_view_dimension_mapping
+
+    def _test_mapping(
+        self,
+        from_shape: list[int],
+        to_shape: list[int],
+        expected_mapping: list[int],
+    ):
+        actual_mapping = self.calc_map(from_shape=from_shape, to_shape=to_shape)
+        assert len(actual_mapping) == len(expected_mapping)
+        assert all(
+            sorted(i_to_lst_actual) == sorted(i_to_lst_expected)
+            for i_to_lst_actual, i_to_lst_expected in zip(
+                actual_mapping, expected_mapping
+            )
+        )
+
+    @parameterized.expand(
+        (
+            ([5],),
+            ([1],),
+            ([3, 4],),
+            ([3, 1],),
+            ([1, 4],),
+            ([3, 4, 5],),
+            ([1, 4, 5],),
+            ([3, 4, 1],),
+            ([1, 1, 3, 4, 5],),
+            ([1, 1, 3, 4, 5, 1],),
+            ([1, 1, 3, 4, 5, 1, 1],),
+        )
+    )
+    def testMappingToSelf(self, shape: tuple[int, ...]):
+        self._test_mapping(
+            from_shape=shape,
+            to_shape=shape,
+            expected_mapping=[[i] for i in range(len(shape))],
+        )
+
+    @parameterized.expand(
+        (
+            ([3, 4, 5, 1], [[0], [1], [2]]),
+            ([3, 4, 5, 1, 1], [[0], [1], [2]]),
+            ([1, 3, 4, 5], [[1], [2], [3]]),
+            ([1, 1, 3, 4, 5], [[2], [3], [4]]),
+            ([1, 1, 3, 4, 5, 1], [[2], [3], [4]]),
+            ([1, 1, 3, 4, 5, 1, 1], [[2], [3], [4]]),
+        )
+    )
+    def testMappingAdding1s(
+        self, to_shape: tuple[int, ...], expected_mapping: list[int]
+    ):
+        self._test_mapping(
+            from_shape=[3, 4, 5], to_shape=to_shape, expected_mapping=expected_mapping
+        )
+
+    @parameterized.expand(
+        (
+            (
+                [1, 5, 1, 6, 1, 1, 3, 1, 1],
+                [[0], [1], [1], [2], [3], [4], [5], [6], [7], [8]],
+            ),
+            (
+                [5, 1, 6, 1, 1, 3, 1, 1],
+                [[0], [0], [0], [1], [2], [3], [4], [5], [6], [7]],
+            ),
+            (
+                [1, 1, 5, 6, 1, 1, 3, 1, 1],
+                [[0], [1], [2], [3], [3], [4], [5], [6], [7], [8]],
+            ),
+            (
+                [1, 1, 5, 1, 6, 1, 3, 1, 1],
+                [[0], [1], [2], [3], [4], [5], [6], [6], [7], [8]],
+            ),
+            (
+                [1, 1, 5, 1, 6, 3, 1, 1],
+                [[0], [1], [2], [3], [4], [5], [5], [5], [6], [7]],
+            ),
+            (
+                [1, 1, 5, 1, 6, 1, 1, 3, 1],
+                [[0], [1], [2], [3], [4], [5], [6], [7], [8], [8]],
+            ),
+            (
+                [1, 1, 5, 1, 6, 1, 1, 3],
+                [[0], [1], [2], [3], [4], [5], [6], [7], [7], [7]],
+            ),
+            ([5, 6, 3], [[0], [0], [0], [1], [1], [2], [2], [2], [2], [2]]),
+        )
+    )
+    def testMappingRemoving1s(self, to_shape: list[int], expected_mapping: list[int]):
+        self._test_mapping(
+            from_shape=[1, 1, 5, 1, 6, 1, 1, 3, 1, 1],
+            to_shape=to_shape,
+            expected_mapping=expected_mapping,
+        )
+
+    @parameterized.expand(
+        (
+            ([8], [4, 2], [[0, 1]]),
+            ([5, 4], [5, 2, 2], [[0], [1, 2]]),
+            ([5, 4, 3], [5, 2, 2, 3], [[0], [1, 2], [3]]),
+        )
+    )
+    def testMappingExpand(
+        self,
+        from_shape: list[int],
+        to_shape: list[int],
+        expected_mapping: list[int],
+    ):
+        self._test_mapping(
+            from_shape=from_shape, to_shape=to_shape, expected_mapping=expected_mapping
+        )
+
+    @parameterized.expand(
+        (
+            ([4, 2], [8], [[0], [0]]),
+            ([5, 2, 2], [5, 4], [[0], [1], [1]]),
+            ([5, 2, 2, 3], [5, 4, 3], [[0], [1], [1], [2]]),
+        )
+    )
+    def testMappingCollapse(
+        self, from_shape: list[int], to_shape: list[int], expected_mapping: list[int]
+    ):
+        self._test_mapping(
+            from_shape=from_shape, to_shape=to_shape, expected_mapping=expected_mapping
+        )
+
+    @parameterized.expand(
+        (
+            ([5, 4, 9], [20, 3, 3], [[0], [0], [1, 2]]),
+            ([5, 4, 9], [1, 1, 20, 3, 3, 1, 1], [[2], [2], [3, 4]]),
+            ([7, 5, 4, 9], [7, 20, 3, 3], [[0], [1], [1], [2, 3]]),
+            ([7, 5, 4, 9], [7, 1, 20, 3, 3], [[0], [2], [2], [3, 4]]),
+            ([9, 5, 4, 9], [3, 3, 20, 3, 3], [[0, 1], [2], [2], [3, 4]]),
+            ([9, 5, 4, 9], [3, 3, 1, 20, 3, 1, 3], [[0, 1], [3], [3], [4, 6]]),
+        )
+    )
+    def testMappingExpandCollapse(
+        self, from_shape: list[int], to_shape: list[int], expected_mapping: list[int]
+    ):
+        self._test_mapping(
+            from_shape=from_shape, to_shape=to_shape, expected_mapping=expected_mapping
+        )
 
 
 class CatTest(unittest.TestCase):
@@ -1076,6 +1230,41 @@ class ReshapeTest(unittest.TestCase):
         assert expected_result.is_deep_equal(actual_result)
 
 
+class ReshapeInferDynamicDimTest(unittest.TestCase):
+    def setUp(self):
+        import sharktank.ops.sharded_impls as sharded_impls
+
+        self.infer_dim = sharded_impls._reshape_infer_dynamic_dim
+
+    @parameterized.expand(
+        (
+            ([2, 4, 5], [-1, 10]),
+            ([2, 4, 5], [-1, 5]),
+            (
+                [2, 4, 5],
+                [2, -1],
+            ),
+        )
+    )
+    def testOnlyDynamicDim(self, shape1: list[int], shape2: list[int]):
+        expected_result = list(torch.rand(shape1).view(shape2).shape)
+        _, actual_result = self.infer_dim(shape1, shape2)
+        assert actual_result == expected_result
+
+        actual_result, _ = self.infer_dim(shape2, shape1)
+        assert actual_result == expected_result
+
+    def testExpandCollapseAndDynamicDim(self):
+        shape1 = (4, 5, 7, 4, 2)
+        shape2 = (2, 2, -1, 8)
+        expected_result = list(torch.rand(shape1).view(shape2).shape)
+        _, actual_result = self.infer_dim(shape1, shape2)
+        assert actual_result == expected_result
+
+        actual_result, _ = self.infer_dim(shape2, shape1)
+        assert actual_result == expected_result
+
+
 class ReshardSplitTest(unittest.TestCase):
     def testReshardReplicated(self):
         tensor = torch.rand(4, 5, 6, dtype=torch.float32)
@@ -1238,6 +1427,72 @@ class UnshardTest(unittest.TestCase):
         actual_result = ops.unshard(sharded)
         expected_result = tensor
         assert ops.equal(expected_result, actual_result)
+
+
+class ViewTest(unittest.TestCase):
+    def setUp(self):
+        torch.random.manual_seed(12345)
+
+    @parameterized.expand((([4, 30],), ([-1, 30],), ([20, 6],), ([20, -1],)))
+    def testViewReplicatedCollapse(self, new_shape: list[int]):
+        tensor = torch.rand(4, 5, 6, dtype=torch.float32)
+        tensor_rep = ops.replicate(tensor, count=3)
+
+        expected_result = ops.view(tensor, new_shape)
+        actual_result = tensor_rep.view(new_shape)
+        ops.equal(expected_result, actual_result)
+
+    @parameterized.expand((([8, 5, 3, 2],), ([4, 2, 5, 3, 2],)))
+    def testViewReplicatedExpand(self, new_shape: list[int]):
+        tensor = torch.rand(8, 5, 6, dtype=torch.float32)
+        tensor_rep = ops.replicate(tensor, count=3)
+
+        expected_result = ops.view(tensor, new_shape)
+        actual_result = tensor_rep.view(new_shape)
+        ops.equal(expected_result, actual_result)
+
+    @parameterized.expand(
+        (
+            ([4, 8, 5, 2],),
+            ([-1, 8, 5, 2],),
+            ([4, 8, 10],),
+            ([-1, 8, 10],),
+            ([4, -1, 5, 2],),
+        )
+    )
+    def testViewSplitCollapse(self, new_shape: list[int]):
+        tensor = torch.rand(2, 2, 8, 5, 2, dtype=torch.float32)
+        tensor_split = ops.reshard_split(tensor, dim=2, count=2)
+
+        expected_result = ops.view(tensor, new_shape)
+        actual_result = tensor_split.view(new_shape)
+        ops.equal(expected_result, actual_result)
+
+    @parameterized.expand((([8, 5, 3, 2],), ([4, 2, 5, 3, 2],)))
+    def testViewSplitExpand(self, new_shape: list[int]):
+        tensor = torch.rand(8, 5, 6, dtype=torch.float32)
+        tensor_split = ops.reshard_split(tensor, dim=0, count=2)
+        expected_result = ops.view(tensor, new_shape)
+        actual_result = tensor_split.view(new_shape)
+        ops.equal(expected_result, actual_result)
+
+    @parameterized.expand(
+        (
+            ([16, 8, 40],),
+            ([2, 8, 8, 5, 8],),
+            ([8, 2, 8, 5, 8],),
+            ([-1, 8, 40],),
+            ([2, -1, 8, 5, 8],),
+            ([8, -1, 8, 5, 8],),
+        )
+    )
+    def testViewSplitCollapseExpand(self, new_shape: list[int]):
+        tensor = torch.rand(4, 4, 8, 5, 8, dtype=torch.float32)
+        tensor_split = ops.reshard_split(tensor, dim=2, count=2)
+
+        expected_result = ops.view(tensor, new_shape)
+        actual_result = tensor_split.view(new_shape)
+        ops.equal(expected_result, actual_result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implement a more general version of ops.view for SplitPrimitiveTensor that supports more than one dim being expanded or collapsed, along with a lot of test of the functionality.

Needed for deepseek.