### PR TITLE
ops.topk enhancements

### DIFF
--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -516,9 +516,14 @@ def squeeze_default(tensor, dim: Optional[int] = None) -> AnyTensor:
         return torch.squeeze(unbox_tensor(tensor), dim)
 
 
-@topk.override(AllOfType(AnyTensor, PrimitiveTensor))
-def topk_default(tensor, k: int, dim: int) -> AnyTensor:
-    return torch.topk(tensor, k=k, dim=dim)
+@topk.override(AllOfType(Tensor, PrimitiveTensor))
+def topk_default(
+    tensor, k: int, dim: int, largest: bool, sorted: bool
+) -> tuple[Tensor | PrimitiveTensor, Tensor | PrimitiveTensor]:
+    result = torch.topk(
+        unbox_tensor(tensor), k=k, dim=dim, largest=largest, sorted=sorted
+    )
+    return result.values, result.indices
 
 
 @view.override(Tensor)

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -519,7 +519,7 @@ def squeeze_default(tensor, dim: Optional[int] = None) -> AnyTensor:
 @topk.override(AllOfType(Tensor, PrimitiveTensor))
 def topk_default(
     tensor, k: int, dim: int, largest: bool, sorted: bool
-) -> tuple[Tensor | PrimitiveTensor, Tensor | PrimitiveTensor]:
+) -> tuple[Tensor, Tensor]:
     result = torch.topk(
         unbox_tensor(tensor), k=k, dim=dim, largest=largest, sorted=sorted
     )

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -1258,16 +1258,23 @@ def _squeeze_trampoline(
 
 
 @overridable
-def topk(tensor, k: int, dim: int) -> AnyTensor:
+def topk(tensor, k: int, dim: int, largest: bool, sorted: bool) -> AnyTensor:
     """See torch.topk"""
     ...
 
 
 @topk.trampoline
-def _topk_trampoline(d: SignatureDispatcher, tensor, k: int, dim: int) -> AnyTensor:
+def _topk_trampoline(
+    d: SignatureDispatcher,
+    tensor,
+    k: int,
+    dim: int,
+    largest: bool = True,
+    sorted: bool = True,
+) -> AnyTensor:
     tensors = (tensor,)
-    for override in d.find_overrides(tensor):
-        result = override(tensor, k=k, dim=dim)
+    for override in d.find_overrides(tensors):
+        result = override(tensor, k=k, dim=dim, largest=largest, sorted=sorted)
         if result is not NotImplemented:
             return override, result
     else:

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -406,6 +406,13 @@ class InferenceTensor(ABC):
 
         return squeeze(self, dim)
 
+    def topk(
+        self, k: int, dim: int, largest: bool = True, sorted: bool = True
+    ) -> Tuple["AnyTensor"]:
+        from sharktank.ops import topk
+
+        return topk(self, k, dim, largest, sorted)
+
     def transpose(self, dim0: int, dim1: int) -> "AnyTensor":
         from sharktank.ops import transpose
 


### PR DESCRIPTION
- Extend to ShardedTensors
- Fix bug in trampoline (wrong variable used for `find_overrides`)
- Updated pipeline parallelism `func_wrapper` to support multiple returns