### PR TITLE
[model_tuner] Add output of best spec file.

### DIFF
--- a/sharktuner/model_tuner/model_tuner.py
+++ b/sharktuner/model_tuner/model_tuner.py
@@ -70,6 +70,12 @@ def arg_parse() -> argparse.Namespace:
         default="",
         help="Path to the flags file for iree-benchmark-module for model benchmarking.",
     )
+    client_args.add_argument(
+        "--spec-output-path",
+        type=Path,
+        help="Path to write the best tuned spec after",
+        default="tuning-spec.mlir",
+    )
     # Remaining arguments come from libtuner
     args = libtuner.parse_arguments(parser)
     return args
@@ -138,6 +144,9 @@ def main() -> None:
         for id in top_candidates:
             logging.info(f"{candidate_trackers[id].spec_path.resolve()}")
         if stop_after_phase == libtuner.ExecutionPhases.benchmark_dispatches:
+            top_spec_path = path_config.specs_dir / path_config.get_candidate_spec_filename(top_candidates[0])
+            shutil.copy(top_spec_path, args.simple_best_spec_output_path)
+            print(f"Saved top spec ({top_spec_path}) to {args.simple_best_spec_output_path}")
             return
 
         print("Compiling models with top candidates...")
@@ -170,6 +179,10 @@ def main() -> None:
         for id in top_model_candidates:
             logging.info(f"{candidate_trackers[id].spec_path.resolve()}")
         print(f"Top model candidates: {top_model_candidates}")
+
+        top_spec_path = path_config.specs_dir / path_config.get_candidate_spec_filename(top_model_candidates[0])
+        shutil.copy(top_spec_path, args.simple_best_spec_output_path)
+        print(f"Saved top spec ({top_spec_path}) to {args.simple_best_spec_output_path}")
 
         print("Check the detailed execution logs in:")
         print(path_config.run_log.resolve())

--- a/sharktuner/model_tuner/model_tuner.py
+++ b/sharktuner/model_tuner/model_tuner.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import argparse
+import shutil
 from pathlib import Path
 from sharktuner import libtuner
 from sharktuner.common import *
@@ -71,9 +72,9 @@ def arg_parse() -> argparse.Namespace:
         help="Path to the flags file for iree-benchmark-module for model benchmarking.",
     )
     client_args.add_argument(
-        "--spec-output-path",
+        "--output-td-spec",
         type=Path,
-        help="Path to write the best tuned spec after",
+        help="Path to write the best tuned spec. Dumps the best tuned model spec by default, and the best tuned dispatch spec when --stop-after is set to 'benchmark-dispatches'.",
         default="tuning-spec.mlir",
     )
     # Remaining arguments come from libtuner
@@ -148,10 +149,8 @@ def main() -> None:
                 path_config.specs_dir
                 / path_config.get_candidate_spec_filename(top_candidates[0])
             )
-            shutil.copy(top_spec_path, args.simple_best_spec_output_path)
-            print(
-                f"Saved top spec ({top_spec_path}) to {args.simple_best_spec_output_path}"
-            )
+            shutil.copy(top_spec_path, args.output_td_spec)
+            print(f"Saved top spec ({top_spec_path}) to {args.output_td_spec}")
             return
 
         print("Compiling models with top candidates...")
@@ -188,10 +187,8 @@ def main() -> None:
         top_spec_path = path_config.specs_dir / path_config.get_candidate_spec_filename(
             top_model_candidates[0]
         )
-        shutil.copy(top_spec_path, args.simple_best_spec_output_path)
-        print(
-            f"Saved top spec ({top_spec_path}) to {args.simple_best_spec_output_path}"
-        )
+        shutil.copy(top_spec_path, args.output_td_spec)
+        print(f"Saved top spec ({top_spec_path}) to {args.output_td_spec}")
 
         print("Check the detailed execution logs in:")
         print(path_config.run_log.resolve())

--- a/sharktuner/model_tuner/model_tuner.py
+++ b/sharktuner/model_tuner/model_tuner.py
@@ -144,9 +144,14 @@ def main() -> None:
         for id in top_candidates:
             logging.info(f"{candidate_trackers[id].spec_path.resolve()}")
         if stop_after_phase == libtuner.ExecutionPhases.benchmark_dispatches:
-            top_spec_path = path_config.specs_dir / path_config.get_candidate_spec_filename(top_candidates[0])
+            top_spec_path = (
+                path_config.specs_dir
+                / path_config.get_candidate_spec_filename(top_candidates[0])
+            )
             shutil.copy(top_spec_path, args.simple_best_spec_output_path)
-            print(f"Saved top spec ({top_spec_path}) to {args.simple_best_spec_output_path}")
+            print(
+                f"Saved top spec ({top_spec_path}) to {args.simple_best_spec_output_path}"
+            )
             return
 
         print("Compiling models with top candidates...")
@@ -180,9 +185,13 @@ def main() -> None:
             logging.info(f"{candidate_trackers[id].spec_path.resolve()}")
         print(f"Top model candidates: {top_model_candidates}")
 
-        top_spec_path = path_config.specs_dir / path_config.get_candidate_spec_filename(top_model_candidates[0])
+        top_spec_path = path_config.specs_dir / path_config.get_candidate_spec_filename(
+            top_model_candidates[0]
+        )
         shutil.copy(top_spec_path, args.simple_best_spec_output_path)
-        print(f"Saved top spec ({top_spec_path}) to {args.simple_best_spec_output_path}")
+        print(
+            f"Saved top spec ({top_spec_path}) to {args.simple_best_spec_output_path}"
+        )
 
         print("Check the detailed execution logs in:")
         print(path_config.run_log.resolve())


### PR DESCRIPTION
`model_tuner` now outputs the spec file for the best configuration, with the path configurable using `--output-td-spec`.

This is adapted from changes in https://github.com/Max191/shark-ai/commit/6de0af4971ed1daa016dcbe047a9f4069ef52a73