### PR TITLE
Implement ops.sum

### DIFF
--- a/sharktank/sharktank/ops/_registry.py
+++ b/sharktank/sharktank/ops/_registry.py
@@ -20,6 +20,7 @@ __all__ = [
     "AllOfType",
     "AnyOfType",
     "IsOfType",
+    "NotOfType",
     "overridable",
     "SignatureDispatcher",
     "BoolTypeExpr",
@@ -160,6 +161,29 @@ class AnyOfType(BoolTypeExpr):
 
         def expr(*types: type):
             return any(
+                [issubclass(t, required) for t in types for required in self._types]
+            )
+
+        super().__init__(expr)
+
+
+class NotOfType(BoolTypeExpr):
+    """Returns True if none of the types are from a set of types.
+
+    ```python
+    # False. int is in (int, float).
+    NotOfType(int, float)(int, str)
+
+     # True. str is not in (int, float).
+    NotOfType(int, float)(str, str)
+    ```
+    """
+
+    def __init__(self, *types: type):
+        self._types = types
+
+        def expr(*types: type):
+            return not any(
                 [issubclass(t, required) for t in types for required in self._types]
             )
 

--- a/sharktank/sharktank/ops/custom_impls.py
+++ b/sharktank/sharktank/ops/custom_impls.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 
+from collections.abc import Iterable
 from typing import Union
 from torch import Tensor
 
@@ -26,8 +27,9 @@ from sharktank.types import (
     SuperBlockOffsetScaled_4_6_Layout,
 )
 
-from sharktank.types.tensors import unbox_tensor
+from sharktank.types.tensors import AnyTensor, unbox_tensor
 from .signatures import *
+from ._registry import NotOfType
 
 
 # Fused FP matmul.
@@ -124,6 +126,25 @@ def matmul_generic_tensor_super_block_offset_scaled_4_6_i4(
         sb_mins_low,
         rhs_unpacked.qs_bit_packed,
     )
+
+
+@sum.override(NotOfType(AnyTensor))
+def sum_iterable(
+    input: Iterable,
+    dim: int | list[int] | None = None,
+    keepdim: bool = False,
+    *,
+    dtype,
+):
+    """Sum over an iterable of tensors."""
+    assert isinstance(input, Iterable), "argument must be an iterable"
+    if dim is not None:
+        raise NotImplementedError("dim is not supported for iterable sum")
+    if keepdim:
+        raise NotImplementedError("keepdim is not supported for iterable sum")
+    if dtype is not None:
+        raise NotImplementedError("dtype is not supported for iterable sum")
+    return __builtins__["sum"](input)
 
 
 @view_as_complex.override(Union[Tensor, PrimitiveTensor])

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -496,6 +496,17 @@ def sharded_sum_unsharded(maybe_sharded):
     return unbox_tensor(maybe_sharded)
 
 
+@sum.override(AllOfType(Tensor, PrimitiveTensor))
+def sum_default(
+    tensor: Tensor | PrimitiveTensor,
+    dim: Union[int, List[int]] | None = None,
+    keepdim: bool = False,
+    *,
+    dtype: torch.dtype,
+) -> Tensor:
+    return torch.sum(unbox_tensor(tensor), dim=dim, keepdim=keepdim, dtype=dtype)
+
+
 @unflatten.override(Tensor)
 def unflatten_default(
     input: Union[Tensor, PrimitiveTensor], dim: int, sizes: Tuple[int]

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -498,13 +498,13 @@ def sharded_sum_unsharded(maybe_sharded):
 
 @sum.override(AllOfType(Tensor, PrimitiveTensor))
 def sum_default(
-    tensor: Tensor | PrimitiveTensor,
+    input: Tensor | PrimitiveTensor,
     dim: Union[int, List[int]] | None = None,
     keepdim: bool = False,
     *,
     dtype: torch.dtype,
 ) -> Tensor:
-    return torch.sum(unbox_tensor(tensor), dim=dim, keepdim=keepdim, dtype=dtype)
+    return torch.sum(unbox_tensor(input), dim=dim, keepdim=keepdim, dtype=dtype)
 
 
 @unflatten.override(Tensor)

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -67,6 +67,7 @@ __all__ = [
     "sigmoid",
     "softmax",
     "squeeze",
+    "sum",
     "to",
     "topk",
     "trace_tensor",
@@ -1251,6 +1252,36 @@ def _squeeze_trampoline(
     tensors = (tensor,)
     for override in d.find_overrides(tensor):
         result = override(tensor, dim)
+        if result is not NotImplemented:
+            return override, result
+    else:
+        d.fail(tensors)
+
+
+@overridable
+def sum(
+    input,
+    dim: Union[int, List[int]],
+    keepdim: bool = False,
+    *,
+    dtype: torch.dtype = None,
+) -> AnyTensor:
+    """See torch.sum"""
+    ...
+
+
+@sum.trampoline
+def _sum_trampoline(
+    d: SignatureDispatcher,
+    input,
+    dim: Union[int, List[int]],
+    keepdim: bool = False,
+    *,
+    dtype: torch.dtype = None,
+) -> AnyTensor:
+    tensors = (input,)
+    for override in d.find_overrides(tensors):
+        result = override(input, dim=dim, keepdim=keepdim, dtype=dtype)
         if result is not NotImplemented:
             return override, result
     else:

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -1274,7 +1274,7 @@ def sum(
 def _sum_trampoline(
     d: SignatureDispatcher,
     input,
-    dim: Union[int, List[int]],
+    dim: int | List[int] | None = None,
     keepdim: bool = False,
     *,
     dtype: torch.dtype = None,

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -406,6 +406,17 @@ class InferenceTensor(ABC):
 
         return squeeze(self, dim)
 
+    def sum(
+        self,
+        dim: Union[int, List[int]],
+        keepdim: bool = False,
+        *,
+        dtype: torch.dtype = None,
+    ) -> "AnyTensor":
+        from sharktank.ops import sum
+
+        return sum(self, dim=dim, keepdim=keepdim, dtype=dtype)
+
     def topk(
         self, k: int, dim: int, largest: bool = True, sorted: bool = True
     ) -> Tuple["AnyTensor"]:

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -1460,6 +1460,27 @@ class SoftmaxTest(unittest.TestCase):
         ops.equal(expected_result, ops.softmax(sharded_tensor, dim=dim + 1))
 
 
+class SumTest(unittest.TestCase):
+    def setUp(self):
+        torch.random.manual_seed(12345)
+
+    @parameterized.expand(((0,), ([0, 1],), ([2, 0],)))
+    def testSumReplicated(self, sum_dim: int | list[int]):
+        tensor = torch.rand(4, 6, 5, dtype=torch.float32)
+        expected_result = ops.sum(tensor, dim=sum_dim)
+        actual_result = ops.sum(ops.replicate(tensor, count=3), dim=sum_dim)
+        torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
+
+    @parameterized.expand(((0,), ([0, 1],), ([2, 0],)))
+    def testSumSplit(self, sum_dim: int | list[int]):
+        tensor = torch.rand(4, 6, 5, dtype=torch.float32)
+        dim = 1
+        expected_result = ops.sum(tensor, dim=sum_dim)
+        sharded_tensor = ops.reshard_split(tensor, dim=dim, count=2)
+        actual_result = ops.sum(sharded_tensor, dim=sum_dim)
+        torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
+
+
 class TopKTest(unittest.TestCase):
     def setUp(self):
         torch.random.manual_seed(12345)

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -4,6 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from collections.abc import Iterable
+from typing import Callable
 import unittest
 import itertools
 import math
@@ -1479,6 +1481,15 @@ class SumTest(unittest.TestCase):
         sharded_tensor = ops.reshard_split(tensor, dim=dim, count=2)
         actual_result = ops.sum(sharded_tensor, dim=sum_dim)
         torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
+
+    @parameterized.expand(((list,), (tuple,), (reversed,)))
+    def testSumBuiltinFunction(
+        self, iterable_transform: Callable[[Iterable], Iterable]
+    ):
+        values = list(range(1, 10))
+        expected_result = __builtins__["sum"](values)
+        actual_result = ops.sum(iterable_transform(values))
+        assert expected_result == actual_result
 
 
 class TopKTest(unittest.TestCase):

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -1466,20 +1466,22 @@ class SumTest(unittest.TestCase):
     def setUp(self):
         torch.random.manual_seed(12345)
 
-    @parameterized.expand(((0,), ([0, 1],), ([2, 0],)))
-    def testSumReplicated(self, sum_dim: int | list[int]):
+    @parameterized.expand(list(itertools.product((0, [0, 1], [2, 0]), [True, False])))
+    def testSumReplicated(self, sum_dim: int | list[int], keepdim: bool):
         tensor = torch.rand(4, 6, 5, dtype=torch.float32)
-        expected_result = ops.sum(tensor, dim=sum_dim)
-        actual_result = ops.sum(ops.replicate(tensor, count=3), dim=sum_dim)
+        expected_result = ops.sum(tensor, dim=sum_dim, keepdim=keepdim)
+        actual_result = ops.sum(
+            ops.replicate(tensor, count=3), dim=sum_dim, keepdim=keepdim
+        )
         torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
 
-    @parameterized.expand(((0,), ([0, 1],), ([2, 0],)))
-    def testSumSplit(self, sum_dim: int | list[int]):
+    @parameterized.expand(list(itertools.product((0, [0, 1], [2, 0]), [True, False])))
+    def testSumSplit(self, sum_dim: int | list[int], keepdim: bool):
         tensor = torch.rand(4, 6, 5, dtype=torch.float32)
         dim = 1
-        expected_result = ops.sum(tensor, dim=sum_dim)
+        expected_result = ops.sum(tensor, dim=sum_dim, keepdim=keepdim)
         sharded_tensor = ops.reshard_split(tensor, dim=dim, count=2)
-        actual_result = ops.sum(sharded_tensor, dim=sum_dim)
+        actual_result = ops.sum(sharded_tensor, dim=sum_dim, keepdim=keepdim)
         torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
 
     @parameterized.expand(((list,), (tuple,), (reversed,)))


### PR DESCRIPTION
Implementing this will clobber the builtin ops function within the ops namespace and anywhere we do `from sharktank.ops import *`. 