### PR TITLE
[model_tuner] Fix double-registration of option

### DIFF
--- a/sharktuner/model_tuner/README.md
+++ b/sharktuner/model_tuner/README.md
@@ -28,7 +28,7 @@ cp tmp/dump/module_main_dispatch_0_rocm_hsaco_fb_benchmark.mlir tmp/mmt_benchmar
 For an initial trial to test the tuning loop, use following command:
 
 ```shell
-cd ../../
+cd ..
 python -m model_tuner model_tuner/double_mmt.mlir \
     model_tuner/tmp/mmt_benchmark.mlir \
     --compile-flags-file=model_tuner/compile_flags.txt \
@@ -37,7 +37,7 @@ python -m model_tuner model_tuner/double_mmt.mlir \
     --num-dispatch-candidates=5 --num-model-candidates=3 \
 ```
 
-[!TIP]
+> [!TIP]
 Use the `--starter-td-spec` option to pass an existing td spec for the run.
 You can use following default td spec: [Default Spec](https://github.com/iree-org/iree/blob/main/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_gfx942.mlir).
 

--- a/sharktuner/sharktuner/libtuner.py
+++ b/sharktuner/sharktuner/libtuner.py
@@ -279,12 +279,6 @@ def parse_arguments(
         help="Stop execution after specified phase",
     )
     general_args.add_argument(
-        "--num-model-candidates",
-        help="Maximum number of stage 2 candidates",
-        type=int,
-        default=50,
-    )
-    general_args.add_argument(
         "--dry-run",
         action="store_true",
         help="Do not attempt to run any modules or initialize the IREE runtime",


### PR DESCRIPTION
Since the option renaming in b19f0f8759a376706935f94d9dd1f7b21cda2ee5, the model tuner fails during argument parsing due to multiple options having the same name. The option is only used in `model_tuner.py`, so I've kept the one registered there.