### PR TITLE
Ops.zero_like and ops.scatter_

### DIFF
--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -445,6 +445,7 @@ def scatter__default(
     *,
     reduce: str | None = None,
 ) -> Tensor:
+    assert isinstance(value, Number), "Tensor version of this op not implemented"
     inout = unbox_tensor(inout)
     index = unbox_tensor(index)
     if reduce is not None:

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -436,6 +436,24 @@ def permute(tensor: Tensor, dims: List[int]):
     return torch.permute(torch_tensor, dims)
 
 
+@scatter_.override(AllOfType(Tensor, PrimitiveTensor))
+def scatter__default(
+    inout: Tensor | PrimitiveTensor,
+    dim: int,
+    index: Tensor | PrimitiveTensor,
+    value,
+    *,
+    reduce: str | None = None,
+) -> Tensor:
+    inout = unbox_tensor(inout)
+    index = unbox_tensor(index)
+    if reduce is not None:
+        inout.scatter_(dim, index, value, reduce=reduce)
+    else:
+        inout.scatter_(dim, index, value)
+    return inout
+
+
 @sigmoid.override(Tensor)
 def sigmoid_default(tensor: Tensor) -> Tensor:
     return tensor.sigmoid()

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -566,3 +566,23 @@ def view_as_complex_default(tensor: Union[Tensor, PrimitiveTensor]) -> Tensor:
 @view_as_real.override(Tensor)
 def view_as_real_default(tensor: Union[Tensor, PrimitiveTensor]) -> Tensor:
     return torch.view_as_real(unbox_tensor(tensor))
+
+
+@zeros_like.override(AllOfType(Tensor, PrimitiveTensor))
+def zeros_like_default(
+    tensor: Union[Tensor, PrimitiveTensor],
+    *,
+    dtype: torch.dtype | None,
+    layout: torch.layout | None,
+    device: torch.device | None,
+    requires_grad: bool,
+    memory_format: torch.memory_format,
+) -> Tensor:
+    return torch.zeros_like(
+        unbox_tensor(tensor),
+        dtype=dtype,
+        layout=layout,
+        device=device,
+        requires_grad=requires_grad,
+        memory_format=memory_format,
+    )

--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -1940,5 +1940,29 @@ def view_as_real_rep(tensor: ReplicatedTensor) -> ReplicatedTensor:
     return ReplicatedTensor(ts=shards)
 
 
+@zeros_like.override(AllOfType(ReplicatedTensor, SplitPrimitiveTensor))
+def zeros_like_replicated(
+    tensor: ReplicatedTensor | SplitPrimitiveTensor,
+    *,
+    dtype: torch.dtype | None,
+    layout: torch.layout | None,
+    device: torch.device | None,
+    requires_grad: bool,
+    memory_format: torch.memory_format,
+) -> ReplicatedTensor | SplitPrimitiveTensor:
+    shards = [
+        zeros_like(
+            unbox_tensor(shard),
+            dtype=dtype,
+            layout=layout,
+            device=device,
+            requires_grad=requires_grad,
+            memory_format=memory_format,
+        )
+        for shard in tensor.shards
+    ]
+    return tensor.clone(ts=shards)
+
+
 # Note: Must be last thing in file
 sharded_unwrap_override()

--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -2031,7 +2031,7 @@ def zeros_like_replicated(
 ) -> ReplicatedTensor | SplitPrimitiveTensor:
     shards = [
         zeros_like(
-            unbox_tensor(shard),
+            shard,
             dtype=dtype,
             layout=layout,
             device=device,

--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -1412,10 +1412,11 @@ def scatter_replicated_replicated(
     inout: ReplicatedTensor,
     dim: int,
     index: ReplicatedTensor,
-    value,
+    value: Number,
     *,
     reduce: str = None,
 ) -> ReplicatedTensor:
+    assert isinstance(value, Number), "Tensor version of this op not implemented"
     assert inout.shard_count == index.shard_count
     for shard, index_shard in zip(inout.shards, index.shards):
         scatter_(shard, dim, index_shard, value, reduce=reduce)
@@ -1427,10 +1428,11 @@ def scatter_split_split(
     inout: SplitPrimitiveTensor,
     dim: int,
     index: SplitPrimitiveTensor,
-    value,
+    value: Number,
     *,
     reduce: str = None,
 ) -> SplitPrimitiveTensor:
+    assert isinstance(value, Number), "Tensor version of this op not implemented"
     if dim == inout.shard_dim:
         # `index` can contain indices into any of `inout`s shards in any of its entries.
         # Can't know ahead of time how to seperate out its values based on sliices.

--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -1417,11 +1417,9 @@ def scatter_replicated_replicated(
     reduce: str = None,
 ) -> ReplicatedTensor:
     assert inout.shard_count == index.shard_count
-    shards = [
+    for shard, index_shard in zip(inout.shards, index.shards):
         scatter_(shard, dim, index_shard, value, reduce=reduce)
-        for shard, index_shard in zip(inout.shards, index.shards)
-    ]
-    return inout.clone(ts=shards)
+    return inout
 
 
 @scatter_.override(SplitPrimitiveTensor, SplitPrimitiveTensor)

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -79,6 +79,7 @@ __all__ = [
     "view",
     "view_as_complex",
     "view_as_real",
+    "zeros_like",
 ]
 
 IntOrSequenceInt = Union[int, Sequence[int]]
@@ -1359,6 +1360,47 @@ def _view_as_real_trampoline(d: SignatureDispatcher, tensor: AnyTensor) -> AnyTe
     tensors = (tensor,)
     for override in d.find_overrides(tensors):
         result = override(tensor)
+        if result is not NotImplemented:
+            return override, result
+    else:
+        d.fail(tensors)
+
+
+@overridable
+def zeros_like(
+    tensor: AnyTensor,
+    *,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    requires_grad: bool = False,
+    memory_format: torch.memory_format = torch.preserve_format,
+) -> AnyTensor:
+    """See torch.zeros_like"""
+    ...
+
+
+@zeros_like.trampoline
+def _zeros_like_trampoline(
+    d: SignatureDispatcher,
+    tensor: AnyTensor,
+    *,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    requires_grad: bool = False,
+    memory_format: torch.memory_format = torch.preserve_format,
+) -> AnyTensor:
+    tensors = (tensor,)
+    for override in d.find_overrides(tensors):
+        result = override(
+            tensor,
+            dtype=dtype,
+            layout=layout,
+            device=device,
+            requires_grad=requires_grad,
+            memory_format=memory_format,
+        )
         if result is not NotImplemented:
             return override, result
     else:

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -379,6 +379,13 @@ class InferenceTensor(ABC):
             shape = args[0]
         return reshape(self, shape)
 
+    def scatter_(
+        self, dim: int, index: "AnyTensor", value, *, reduce=None
+    ) -> "AnyTensor":
+        from sharktank.ops import scatter_
+
+        return scatter_(self, dim, index, value, reduce=reduce)
+
     def sigmoid(self) -> "AnyTensor":
         from sharktank.ops import sigmoid
 

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -1390,14 +1390,17 @@ class Scatter_Test(unittest.TestCase):
         ops.scatter_(tensor, 0, index, value)
         assert ops.equal(tensor, sharded_tensor)
 
-    def testScatterSplitSplitNonShardDim(self):
-        tensor = torch.zeros(4, 6, dtype=torch.float32)
-        index = torch.randint(0, 4, (2, 1))
+    @parameterized.expand((([3, 1],), ([3, 2],), ([9, 1],), ([9, 6],)))
+    def testScatterSplitSplitNonShardDim(self, index_shape: list[int]):
+        scatter_dim = 1
         value = 1
-        sharded_tensor = ops.reshard_split(tensor, dim=0, count=2)
-        index_sharded = ops.reshard_split(index, dim=0, count=2)
-        ops.scatter_(sharded_tensor, 1, index_sharded, value)
-        ops.scatter_(tensor, 1, index, value)
+        tensor = torch.zeros(9, 6, dtype=torch.float32)
+        index = torch.randint(0, tensor.shape[scatter_dim], index_shape)
+
+        sharded_tensor = ops.reshard_split(tensor, dim=0, count=3)
+        index_sharded = ops.reshard_split(index, dim=0, count=3)
+        ops.scatter_(tensor, scatter_dim, index, value)
+        ops.scatter_(sharded_tensor, scatter_dim, index_sharded, value)
         assert ops.equal(tensor, sharded_tensor)
 
 

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -1084,7 +1084,7 @@ class MatmulTest(unittest.TestCase):
         b_sharded = ops.replicate(b, count=shard_count)
         actual_result = ops.matmul(a_sharded, b_sharded)
         for shard in actual_result.shards:
-            assert ops.equal(shard, unsharded_result)
+            torch.testing.assert_close(unsharded_result, unbox_tensor(shard))
 
 
 @parameterized_class(
@@ -1487,7 +1487,7 @@ class SoftmaxTest(unittest.TestCase):
         dim = 1
         expected_result = ops.softmax(tensor, dim=dim)
         actual_result = ops.softmax(ops.replicate(tensor, count=3), dim=dim)
-        assert ops.equal(expected_result, actual_result)
+        torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
 
     def testSoftmaxSplit(self):
         tensor = torch.rand(2, 2, 2, dtype=torch.float32)
@@ -1496,11 +1496,11 @@ class SoftmaxTest(unittest.TestCase):
 
         expected_result = ops.softmax(tensor, dim=dim - 1)
         actual_result = ops.softmax(sharded_tensor, dim=dim - 1)
-        assert ops.equal(expected_result, actual_result)
+        torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
 
         expected_result = ops.softmax(tensor, dim=dim + 1)
         actual_result = ops.softmax(sharded_tensor, dim=dim + 1)
-        assert ops.equal(expected_result, actual_result)
+        torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
 
 
 class SumTest(unittest.TestCase):

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -1372,14 +1372,13 @@ class Scatter_Test(unittest.TestCase):
 
     def testScatterReplicatedReplicated(self):
         tensor = torch.zeros(4, 6, dtype=torch.float32)
+        sharded_tensor = ops.replicate(tensor, count=3)
         index = torch.randint(0, 4, (2, 1))
         value = 1
         index_sharded = ops.replicate(index, count=3)
-        actual_result = ops.scatter_(
-            ops.replicate(tensor, count=3), 1, index_sharded, value
-        )
-        expected_result = ops.scatter_(tensor, 1, index, value)
-        assert ops.equal(expected_result, actual_result)
+        ops.scatter_(sharded_tensor, 1, index_sharded, value)
+        ops.scatter_(tensor, 1, index, value)
+        assert ops.equal(tensor, sharded_tensor)
 
     def testScatterSplitSplitShardDim(self):
         tensor = torch.zeros(4, 6, dtype=torch.float32)
@@ -1387,9 +1386,9 @@ class Scatter_Test(unittest.TestCase):
         value = 1
         sharded_tensor = ops.reshard_split(tensor, dim=0, count=2)
         index_sharded = ops.reshard_split(index, dim=0, count=2)
-        actual_result = ops.scatter_(sharded_tensor, 0, index_sharded, value)
-        expected_result = ops.scatter_(tensor, 0, index, value)
-        assert ops.equal(expected_result, actual_result)
+        ops.scatter_(sharded_tensor, 0, index_sharded, value)
+        ops.scatter_(tensor, 0, index, value)
+        assert ops.equal(tensor, sharded_tensor)
 
     def testScatterSplitSplitNonShardDim(self):
         tensor = torch.zeros(4, 6, dtype=torch.float32)
@@ -1397,9 +1396,9 @@ class Scatter_Test(unittest.TestCase):
         value = 1
         sharded_tensor = ops.reshard_split(tensor, dim=0, count=2)
         index_sharded = ops.reshard_split(index, dim=0, count=2)
-        actual_result = ops.scatter_(sharded_tensor, 1, index_sharded, value)
-        expected_result = ops.scatter_(tensor, 1, index, value)
-        assert ops.equal(expected_result, actual_result)
+        ops.scatter_(sharded_tensor, 1, index_sharded, value)
+        ops.scatter_(tensor, 1, index, value)
+        assert ops.equal(tensor, sharded_tensor)
 
 
 class ShardLikeTest(unittest.TestCase):

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -1635,5 +1635,26 @@ class ViewTest(unittest.TestCase):
         assert ops.equal(expected_result, actual_result)
 
 
+class ZerosLikeTest(unittest.TestCase):
+    def setUp(self):
+        torch.random.manual_seed(12345)
+
+    def testZerosLikeReplicated(self):
+        tensor = torch.rand(9, 5, 6, dtype=torch.float32)
+        shard_count = 3
+        expected_result = ops.zeros_like(tensor)
+        actual_result = ops.zeros_like(ops.replicate(tensor, count=shard_count))
+        assert ops.equal(expected_result, actual_result)
+
+    def testZerosLikeSplit(self):
+        tensor = torch.rand(9, 5, 6, dtype=torch.float32)
+        shard_count = 3
+        expected_result = ops.zeros_like(tensor)
+        actual_result = ops.zeros_like(
+            ops.reshard_split(tensor, dim=0, count=shard_count)
+        )
+        assert ops.equal(expected_result, actual_result)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`scatter_split_split` has a naive implementation and a more efficient version may be possible.