### PR TITLE
Use correct tensor_parallelism_size

### DIFF
--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -71,7 +71,7 @@ def main():
         )
     else:
         block_to_device_lookup = tuple(
-            tuple(range(args.tensor_parallelism_size)) for _ in range(hp.block_count)
+            tuple(range(tensor_parallelism_size)) for _ in range(hp.block_count)
         )
 
     llama_config = LlamaModelConfig(


### PR DESCRIPTION
Current code uses the value inside args, but that value is optional and the value inside the dataset is preferentially used elsewhere in the code.