### PR TITLE
Add mlir_kernel for inline mlir kernels

### DIFF
--- a/sharktank/sharktank/kernels/mlir_kernel.py
+++ b/sharktank/sharktank/kernels/mlir_kernel.py
@@ -1,0 +1,285 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import ClassVar, Type, cast, Optional, Callable, Dict
+import inspect
+import textwrap
+import logging
+from dataclasses import dataclass
+
+import torch
+import sympy
+from jinja2 import Environment, BaseLoader
+
+from sharktank.kernels.base import *
+from sharktank.types.tensors import dtype_to_serialized_short_name
+from sharktank.utils.logging import get_logger
+from iree.turbine.transforms.merger import Merger
+from iree.turbine.support.ir_imports import (
+    Operation,
+    MLIRError,
+)
+
+DataType = torch.dtype
+
+logger = get_logger("sharktank.ops")
+_JINJA2_ENVIRONMENT: Optional[Environment] = None
+
+
+def _get_jinja2_env() -> Environment:
+    global _JINJA2_ENVIRONMENT
+    if _JINJA2_ENVIRONMENT is None:
+        _JINJA2_ENVIRONMENT = Environment(loader=BaseLoader())
+    return _JINJA2_ENVIRONMENT
+
+
+@dataclass
+class _Dim:
+    dynamic: bool
+    dim: sympy.Symbol
+
+
+class _StaticDim:
+    def __getattr__(self, n: str) -> "_Dim":
+        return _Dim(False, sympy.Symbol(n, integer=True, nonnegative=True))
+
+
+class _DynDim:
+    def __getattr__(self, n) -> "_Dim":
+        return _Dim(True, sympy.Symbol(n, integer=True, nonnegative=True))
+
+
+class MLIRTensor:
+    shapes: ClassVar[tuple[_Dim, ...]]
+    dtype: ClassVar[torch.dtype]
+    tensor: Optional[torch.Tensor]
+
+    def __init__(self, t: Optional[torch.Tensor] = None):
+        self.tensor = t
+
+    def __class_getitem__(
+        cls, shape_and_dtype: tuple[_Dim | DataType, ...]
+    ) -> Type["MLIRTensor"]:
+        """Syntax: `KernelBuffer[shape1, shape2, ..., shapeN, dtype]`"""
+
+        if not isinstance(shape_and_dtype, tuple) or len(shape_and_dtype) < 2:
+            raise TypeError(f"Expected at least 2 arguments, got: {shape_and_dtype}")
+
+        shape = shape_and_dtype[:-1]
+        ty = shape_and_dtype[-1]
+
+        if not all(isinstance(s, _Dim) for s in shape):
+            raise TypeError(f"Expected shape to be a tuple of _Dim, got {shape}")
+        if not isinstance(ty, DataType):
+            raise TypeError(f"Expected dtype to be a DataType, got {ty}")
+
+        shape = cast(tuple[_Dim, ...], shape)
+        ty = cast(DataType, ty)
+
+        class SubType(cls):
+            shapes = shape
+            dtype = ty
+
+        return cast(Type["MLIRTensor"], SubType)
+
+
+class MLIRSpec:
+    mlir: str
+    subs: dict
+
+    def __init__(self, mlir: str, subs: dict = {}):
+        self.mlir = mlir
+        self.subs = subs
+
+
+def mlir_kernel(
+    *, inputs: tuple[type[MLIRTensor], ...], results: tuple[type[MLIRTensor], ...]
+):
+    def fun(func: Callable[..., MLIRSpec]):
+        sig = inspect.signature(func)
+        params = sig.parameters
+        args = list(params.keys())
+
+        if len(args) != len(inputs) + len(results):
+            raise TypeError(
+                "Number of arguments to kernel should be same as the mlir_kernel spec"
+            )
+
+        input_args = args[: len(inputs)]
+        result_args = args[len(inputs) :]
+
+        # Create a sympy dimension mapping to input dimensions
+
+        @CustomOp.register(library=LIBRARY)
+        class kernel(CustomOp):
+            @property
+            def signature(self) -> str:
+                input_tensors = [f"Tensor {arg}" for arg in input_args]
+                result_tensors = ["Tensor" for _ in result_args]
+                return f'{func.__name__}({", ".join(input_tensors)}) -> ({", ".join(result_tensors)})'
+
+            def select(self, sel: KernelSelection):
+                # Create input descriptions.
+                input_descs = [sel.arg_tensor(i) for i in range(len(input_args))]
+
+                # Specialize static dimensions.
+                for sym_ty, desc in zip(inputs, input_descs):
+                    static_dims = [
+                        i for i, dim in enumerate(sym_ty.shapes) if not dim.dynamic
+                    ]
+                    desc.specialize_dims(*static_dims)
+
+                # Create a verifier for static dimensions.
+                dims = {}
+                for sym_ty, ty in zip(inputs, input_descs):
+                    for sym_dim, dim in zip(sym_ty.shapes, ty.t.shape):
+                        if sym_dim.dim in dims:
+                            if not sym_dim.dynamic and dims[sym_dim.dim] != dim:
+                                raise ValueError("Mismatched dim error")
+                        else:
+                            dims[sym_dim.dim] = dim
+
+                # Specialize static dimensions on return type.
+                for sym_ty in results:
+                    resolved_shape = [dims[dim.dim] for dim in sym_ty.shapes]
+                    desc = sel.return_new_tensor(
+                        size=resolved_shape, dtype=sym_ty.dtype
+                    )
+                    static_dims = [
+                        i for i, dim in enumerate(sym_ty.shapes) if not dim.dynamic
+                    ]
+                    desc.specialize_dims(*static_dims)
+
+            def generate(self, ksel: KernelSelection, kb: KernelBuilder):
+                # Create input descriptions and types.
+                input_values = [kb.arg_value(i) for i in range(len(input_args))]
+                input_types = [RankedTensorType(val.type) for val in input_values]
+
+                # Resolve dimensions for type aliasing.
+                dims = {}
+                for sym_ty, ty in zip(inputs, input_types):
+                    for sym_dim, dim in zip(sym_ty.shapes, ty.shape):
+                        if sym_dim.dynamic:
+                            # For dynamic dimensions, map the dim to None.
+                            dim = None
+
+                        if sym_dim.dim in dims:
+                            if dims[sym_dim.dim] != dim:
+                                raise ValueError("Mismatched dim error")
+                        else:
+                            dims[sym_dim.dim] = dim
+
+                # Get the MLIR spec.
+                mlir_spec = func(*input_values, *([None] * len(result_args)))
+
+                # Insert type aliases to the mlir_spec.
+                mlir = self._get_type_aliases(dims) + mlir_spec.mlir
+
+                # Generate kernel name
+                kernel_name = self._get_kernel_name(func.__name__, dims)
+
+                # Generate the MLIR spec using jinja.
+                asm = (
+                    _get_jinja2_env()
+                    .from_string(mlir)
+                    .render({"kernel_name": kernel_name, **mlir_spec.subs})
+                )
+                try:
+                    module_op = Operation.parse(asm, context=kb.context)
+                except MLIRError as e:
+                    lines = asm.splitlines()
+                    lines_numbered = "\n".join(
+                        [f"      {str(i+1):>5}: {l}" for i, l in enumerate(lines)]
+                    )
+                    raise RuntimeError(
+                        f"Error parsing generated op template:"
+                        f"\n{textwrap.indent(str(e), '  ')}"
+                        f"\n{lines_numbered}"
+                    )
+                op = module_op.operation
+
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug("Generated kernel IR %s:\n%s", kernel_name, str(op))
+                merger = Merger(
+                    op, kb.module_body.owner, target_symbol_table=kb.symbol_table
+                )
+                merger.merge()
+
+                symbol_name = kb.symbol_table[kernel_name]
+                kb.yield_results(*call_function(symbol_name, *kb.arg_bindings))
+
+            def _get_type_aliases(self, dims: Dict[sympy.Symbol, Optional[int]]) -> str:
+                aliases = ""
+                for arg, sym_ty in zip(input_args, inputs):
+                    mlir_shapes = [
+                        "?" if dims[dim.dim] == None else str(dims[dim.dim])
+                        for dim in sym_ty.shapes
+                    ]
+                    dtype = dtype_to_serialized_short_name(sym_ty.dtype)
+                    aliases += f'!{arg} = tensor<{"x".join(mlir_shapes)}x{dtype}>\n'
+                    aliases += f"!{arg}_dtype = {dtype}\n"
+                for arg, sym_ty in zip(result_args, results):
+                    mlir_shapes = [
+                        "?" if dims[dim.dim] == None else str(dims[dim.dim])
+                        for dim in sym_ty.shapes
+                    ]
+                    dtype = dtype_to_serialized_short_name(sym_ty.dtype)
+                    aliases += f'!{arg} = tensor<{"x".join(mlir_shapes)}x{dtype}>\n'
+                    aliases += f"!{arg}_dtype = {dtype}\n"
+                return aliases
+
+            def _get_kernel_name(
+                self, prefix: str, dims: Dict[sympy.Symbol, Optional[int]]
+            ) -> str:
+                kernel_name = prefix
+
+                # Add input args as suffix.
+                kernel_name += "_"
+                input_names = []
+                for sym_ty in inputs:
+                    input_dims = []
+                    for sym_dim in sym_ty.shapes:
+                        input_dim = sym_dim.dim.name
+                        if not sym_dim.dynamic:
+                            input_dim += f"_{dims[sym_dim.dim]}"
+                        input_dims.append(input_dim)
+                    input_name = (
+                        "_".join(input_dims)
+                        + "_"
+                        + dtype_to_serialized_short_name(sym_ty.dtype)
+                    )
+                    input_names.append(input_name)
+                kernel_name += "_".join(input_names)
+
+                # Add result args as suffix.
+                result_names = []
+                kernel_name += "_"
+                for sym_ty in results:
+                    result_dims = []
+                    for sym_dim in sym_ty.shapes:
+                        result_dim = sym_dim.dim.name
+                        if not sym_dim.dynamic:
+                            result_dim += f"_{dims[sym_dim.dim]}"
+                        result_dims.append(result_dim)
+                    result_name = (
+                        "_".join(result_dims)
+                        + "_"
+                        + dtype_to_serialized_short_name(sym_ty.dtype)
+                    )
+                    result_names.append(result_name)
+                kernel_name += "_".join(result_names)
+
+                return kernel_name
+
+        return kernel
+
+    return fun
+
+
+StaticDim = _StaticDim()
+DynDim = _DynDim()
+
+__all__ = ["StaticDim", "DynDim", "MLIRTensor", "mlir_kernel", "MLIRSpec"]

--- a/sharktank/sharktank/kernels/mlir_kernel.py
+++ b/sharktank/sharktank/kernels/mlir_kernel.py
@@ -102,6 +102,20 @@ class MLIRSpec:
 def mlir_kernel(
     *, inputs: tuple[type[MLIRTensor], ...], results: tuple[type[MLIRTensor], ...]
 ):
+    """
+    A decorator that allows a user to inject inline mlir kernels directly into
+    the model.
+
+    TODO:
+        - Add user guide with examples.
+        - Allow constant dimensions and dtypes for results, currently we only
+          support result dimensions to be derived symbolically from inputs.
+        - Add more input signature types (other than MLIRTensor) like MLIRInt,
+          MLIRFloat, MLIRListOfTensor.
+        - Add more default substitutions like passing the value of a resolved
+          symbol as a substitution to jinja generator.
+    """
+
     def fun(func: Callable[..., MLIRSpec]) -> Callable:
         sig = inspect.signature(func)
         params = sig.parameters

--- a/sharktank/tests/kernels/mlir_kernel_test.py
+++ b/sharktank/tests/kernels/mlir_kernel_test.py
@@ -12,10 +12,13 @@ from sharktank.kernels.mlir_kernel import *
 N = DynDim.N
 M = StaticDim.M
 
+S = Dtype.S
+I64 = Dtype.I64
+
 
 @mlir_kernel(
-    inputs=(MLIRTensor[N, M, torch.float16], MLIRTensor[N, torch.int64]),
-    results=(MLIRTensor[N, M, torch.float16],),
+    inputs=(MLIRTensor[N, M, S], MLIRTensor[N, I64]),
+    results=(MLIRTensor[N, M, S],),
 )
 def sharktank_gather(source, indices, result=None):
     mlir = """
@@ -50,6 +53,8 @@ class mlir_kernel_test(unittest.TestCase):
 
     def test_mlir_kernel(self):
         source = torch.randn([64, 32]).to(torch.float16)
-        indices = torch.arange(64)
+        indices = torch.tensor([3, 7, 54])
         out = sharktank_gather(source, indices)
-        torch.testing.assert_close(source, out)
+        torch.testing.assert_close(source[3], out[0])
+        torch.testing.assert_close(source[7], out[1])
+        torch.testing.assert_close(source[54], out[2])

--- a/sharktank/tests/kernels/mlir_kernel_test.py
+++ b/sharktank/tests/kernels/mlir_kernel_test.py
@@ -1,0 +1,55 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import torch
+import unittest
+
+from sharktank.kernels.mlir_kernel import *
+
+N = DynDim.N
+M = StaticDim.M
+
+
+@mlir_kernel(
+    inputs=(MLIRTensor[N, M, torch.float16], MLIRTensor[N, torch.int64]),
+    results=(MLIRTensor[N, M, torch.float16],),
+)
+def sharktank_gather(source, indices, result=None):
+    mlir = """
+    module {
+    util.func @{{kernel_name}}(%source: !source, %indices: !indices) -> !result {
+      %c0 = arith.constant 0 : index
+      %n_dim = tensor.dim %source, %c0 : !source
+      %empty = tensor.empty(%n_dim) : !result
+      %result = linalg.generic {
+        indexing_maps = [
+        affine_map<(d0, d1) -> (d0)>,
+        affine_map<(d0, d1) -> (d0, d1)>],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%indices : !indices)
+        outs(%empty : !result) {
+        ^bb0(%in: !indices_dtype, %o: !source_dtype):
+          %n = arith.index_cast %in : !indices_dtype to index
+          %m = linalg.index 1 : index
+          %extracted = tensor.extract %source[%n, %m] : !source
+          linalg.yield %extracted : !source_dtype
+        } -> !result
+        util.return %result : !result
+    }
+    }
+    """
+    return MLIRSpec(mlir)
+
+
+class mlir_kernel_test(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(42)
+
+    def test_mlir_kernel(self):
+        source = torch.randn([64, 32]).to(torch.float16)
+        indices = torch.arange(64)
+        out = sharktank_gather(source, indices)
+        torch.testing.assert_close(source, out)


### PR DESCRIPTION
This patch adds the @mlir_kernel decorator and surrounding infrastructure, the idea of this decorator is to automatically generate custom ops for a simplified input spec, allowing developers to write inline mlir in sharktank models.