### PR TITLE
[docs] Update documentation after adding sharktuner nightly releases

### DIFF
--- a/docs/nightly_releases.md
+++ b/docs/nightly_releases.md
@@ -67,6 +67,23 @@ python -c "from sharktank import ops; print('Sanity check passed')"
 deactivate
 ```
 
+## Quickstart - sharktuner
+
+```bash
+# Set up a virtual environment to isolate packages from other envs.
+python3.11 -m venv 3.11.venv
+source 3.11.venv/bin/activate
+
+# Install 'sharktuner' package from nightly releases.
+pip install sharktuner -f https://github.com/nod-ai/shark-ai/releases/expanded_assets/dev-wheels --pre
+
+# Test the installation.
+python -c "import sharktuner; print('Sanity check passed')"
+
+# Deactivate the virtual environment when done.
+deactivate
+```
+
 ## Quickstart - shortfin
 
 ```bash

--- a/sharktuner/README.md
+++ b/sharktuner/README.md
@@ -60,7 +60,7 @@ pip install -r requirements-dev.txt
 #### Using nightly IREE's Python bindings:
 
 ```shell
-pip install -r ../requirements-iree-unpinned.txt
+pip install --upgrade -r ../requirements-iree-unpinned.txt
 ```
 
 ## Examples

--- a/sharktuner/model_tuner/README.md
+++ b/sharktuner/model_tuner/README.md
@@ -1,9 +1,9 @@
-# Simple Example Tuner
+# Getting Started with Model Tuner
 
-Example of tuning a dispatch and a full model.
+Example of tuning a dispatch and a full model using `model_tuner`
 
 ## Environments
-Follow instructions in [`/sharktuner/README.md`](../../README.md)
+Follow instructions in [`/sharktuner/README.md`](../README.md)
 
 ## Running the Tuner
 
@@ -28,7 +28,7 @@ cp tmp/dump/module_main_dispatch_0_rocm_hsaco_fb_benchmark.mlir tmp/mmt_benchmar
 For an initial trial to test the tuning loop, use following command:
 
 ```shell
-cd ../../
+cd ../
 python -m model_tuner model_tuner/double_mmt.mlir \
     model_tuner/tmp/mmt_benchmark.mlir \
     --compile-flags-file=model_tuner/compile_flags.txt \


### PR DESCRIPTION
Update `shark-ai/docs/nightly_releases.md` doc after adding sharktuner to nightly releases and various other nits.