### PR TITLE
Delete llama 70b iree compile xfail

### DIFF
--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -668,9 +668,7 @@ class BenchmarkLlama3_1_70B(BaseBenchmarkTest):
         )
 
     @pytest.mark.xfail(
-        run=False,
-        reason="https://github.com/iree-org/iree/issues/20581",
-        raises=IreeCompileException,
+        reason="Benchmarking Error", strict=True, raises=IreeBenchmarkException
     )
     def testBenchmark70B_f16_TP8_Non_Decomposed_Input_Len_128(self):
         output_file_name = self.dir_path_70b / "f16_torch_128_tp8"
@@ -720,9 +718,7 @@ class BenchmarkLlama3_1_70B(BaseBenchmarkTest):
         )
 
     @pytest.mark.xfail(
-        run=False,
-        reason="https://github.com/iree-org/iree/issues/20581",
-        raises=IreeCompileException,
+        reason="Benchmarking Error", strict=True, raises=IreeBenchmarkException
     )
     def testBenchmark70B_f16_TP8_Non_Decomposed_Input_Len_2048(self):
         output_file_name = self.dir_path_70b / "f16_torch_2048_tp8"


### PR DESCRIPTION
Delete the iree compile xfail bring in https://github.com/nod-ai/shark-ai/pull/1285/files
The iree benchmark xfail will stay with error code 5 typically indicates an "Access Denied" issue.