### PR TITLE
Update flux_flags_gfx942.txt

### DIFF
--- a/shortfin/python/shortfin_apps/flux/examples/flux_flags_gfx942.txt
+++ b/shortfin/python/shortfin_apps/flux/examples/flux_flags_gfx942.txt
@@ -22,4 +22,4 @@ sampler
 --iree-preprocessing-pass-pipeline='builtin.module(util.func(iree-global-opt-raise-special-ops, iree-flow-canonicalize),iree-preprocessing-transpose-convolution-pipeline, iree-preprocessing-pad-to-intrinsics, util.func(iree-dispatch-creation-bubble-up-expand-shapes, canonicalize, cse, canonicalize), util.func(iree-preprocessing-generalize-linalg-matmul-experimental))'
 vae
 --iree-dispatch-creation-enable-aggressive-fusion
---iree-preprocessing-pass-pipeline='builtin.module(util.func(iree-global-opt-raise-special-ops, iree-flow-canonicalize), iree-preprocessing-transpose-convolution-pipeline, iree-preprocessing-pad-to-intrinsics, util.func(iree-preprocessing-generalize-linalg-matmul-experimental))'
+--iree-preprocessing-pass-pipeline='builtin.module(util.func(iree-global-opt-raise-special-ops, iree-flow-canonicalize), iree-preprocessing-pad-to-intrinsics, util.func(iree-preprocessing-generalize-linalg-matmul-experimental))'


### PR DESCRIPTION
- after this iree commit https://github.com/iree-org/iree/commit/8dcd3709765bfbd6889f2e6e93aef694835945a6, vae compilation doesn't need  `iree-preprocessing-transpose-convolution-pipeline` pipeline.
- tested without the pipeline, no regression. 
- compilation segfaults with pipeline
