### PR TITLE
Refactor pipeline parallelism work and fix block offset

### DIFF
--- a/sharktank/sharktank/evaluate/perplexity_iree.py
+++ b/sharktank/sharktank/evaluate/perplexity_iree.py
@@ -135,7 +135,7 @@ class PerplexityIree:
     def load_model(self, dataset: Dataset, tokenizer: InferenceTokenizer):
         hp = configs.LlamaHParams.from_gguf_props(dataset.properties)
 
-        pp = self.pipeline_parallelims_size
+        pp = self.pipeline_parallelism_size
         tp = self.tensor_parallelism_size
         block_count = hp.block_count
         block_to_pipeline = [i * pp // block_count for i in range(block_count)]

--- a/sharktank/sharktank/evaluate/perplexity_iree.py
+++ b/sharktank/sharktank/evaluate/perplexity_iree.py
@@ -139,7 +139,7 @@ class PerplexityIree:
         tp = self.tensor_parallelism_size
         block_count = hp.block_count
         block_to_pipeline = [i * pp // block_count for i in range(block_count)]
-        pipeline_to_devices = [(p + d for d in range(tp)) for p in range(pp)]
+        pipeline_to_devices = [[d + p * tp for d in range(tp)] for p in range(pp)]
 
         config = LlamaModelConfig(
             hp=hp,

--- a/sharktank/sharktank/evaluate/perplexity_iree.py
+++ b/sharktank/sharktank/evaluate/perplexity_iree.py
@@ -134,14 +134,12 @@ class PerplexityIree:
 
     def load_model(self, dataset: Dataset, tokenizer: InferenceTokenizer):
         hp = configs.LlamaHParams.from_gguf_props(dataset.properties)
-        block_to_device_lookup = []
-        for i in range(hp.block_count):
-            pp_group = int(i * self.pipeline_parallelism_size / hp.block_count)
-            zero_4_group = self.tensor_parallelism_size * pp_group
-            devices = tuple(
-                i + zero_4_group for i in range(self.tensor_parallelism_size)
-            )
-            block_to_device_lookup.append(devices)
+
+        pp = self.pipeline_parallelims_size
+        tp = self.tensor_parallelism_size
+        block_count = hp.block_count
+        block_to_pipeline = [i * pp // block_count for i in range(block_count)]
+        pipeline_to_devices = [(p + d for d in range(tp)) for p in range(pp)]
 
         config = LlamaModelConfig(
             hp=hp,
@@ -154,7 +152,8 @@ class PerplexityIree:
             block_seq_stride=self.block_seq_stride,
             attention_kernel=self.attention_kernel,
             use_hf=self.use_hf,
-            block_to_device_lookup=block_to_device_lookup,
+            block_to_pipeline_map=block_to_pipeline,
+            pipeline_to_device_map=pipeline_to_devices,
         )
 
         theta = dataset.root_theta

--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -77,7 +77,7 @@ def main():
         )
     else:
         block_to_pipeline = tuple([0] * hp.block_count)
-        pipeline_to_devices = tuple([tuple([0])])
+        pipeline_to_devices = tuple([tuple(range(args.tensor_parallelism_size))])
 
     llama_config = LlamaModelConfig(
         hp,

--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -85,7 +85,6 @@ def main():
         pipeline_parallelism_size=args.pipeline_parallelism_size,
         block_to_pipeline_map=block_to_pipeline,
         pipeline_to_device_map=pipeline_to_devices,
-        block_to_device_lookup=block_to_device_lookup,
         use_hf=args.use_hf,
         static_tables=False,  # Rely on the compiler for hoisting tables.
         attention_kernel=args.attention_kernel,

--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -72,18 +72,19 @@ def main():
             )
 
     if args.pipeline_parallelism_size > 1:
-        block_to_device_lookup = pipeline_parallelize_theta(
+        block_to_pipeline, pipeline_to_devices = pipeline_parallelize_theta(
             dataset.root_theta, args.pipeline_parallelism_size
         )
     else:
-        block_to_device_lookup = tuple(
-            tuple(range(args.tensor_parallelism_size)) for _ in range(hp.block_count)
-        )
+        block_to_pipeline = tuple([0] * hp.block_count)
+        pipeline_to_devices = tuple([tuple([0])])
 
     llama_config = LlamaModelConfig(
         hp,
         tensor_parallelism_size=args.tensor_parallelism_size,
         pipeline_parallelism_size=args.pipeline_parallelism_size,
+        block_to_pipeline_map=block_to_pipeline,
+        pipeline_to_device_map=pipeline_to_devices,
         block_to_device_lookup=block_to_device_lookup,
         use_hf=args.use_hf,
         static_tables=False,  # Rely on the compiler for hoisting tables.

--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -175,7 +175,7 @@ def main():
                     for tp in range(llama_config.tensor_parallelism_size):
                         i = pipeline * llama_config.tensor_parallelism_size + tp
                         arg_affinities[i] = DeviceAffinity(
-                            str(model.cache.pipeline_to_device_lookup[pipeline][tp])
+                            str(model.cache.pipeline_to_devices[pipeline][tp])
                         )
 
             return unpacked, shard_dim, dynamic_shapes, arg_affinities
@@ -224,7 +224,8 @@ def main():
             arg_affinities = {key + 3: arg_affinities[key] for key in arg_affinities}
 
             for i in range(3):
-                arg_affinities[i] = DeviceAffinity(str(block_to_device_lookup[0][0]))
+                device = str(pipeline_to_devices[0])
+                arg_affinities[i] = DeviceAffinity(device)
 
         dynamic_shapes = {
             "tokens": {1: sl_dim},
@@ -263,7 +264,7 @@ def main():
                 tokens = ops.replicate(
                     tokens,
                     count=shard_count,
-                    devices=llama_config.block_to_device_lookup[0],
+                    devices=llama_config.pipeline_to_devices[0],
                 )
                 if attention_mask is None:
                     attention_mask = [None] * model.cache.pipeline_count
@@ -336,7 +337,7 @@ def main():
 
             # Inputs have default affinity 0
             for i in range(4):
-                arg_affinities[i] = DeviceAffinity(str(block_to_device_lookup[0][0]))
+                arg_affinities[i] = DeviceAffinity(str(pipeline_to_devices[0][0]))
 
         dynamic_shapes = {
             "tokens": {},
@@ -387,7 +388,7 @@ def main():
                 tokens = ops.replicate(
                     tokens,
                     count=shard_count,
-                    devices=llama_config.block_to_device_lookup[0],
+                    devices=llama_config.pipeline_to_devices[0],
                 )
                 _attention_mask, _start_positions, _seq_block_ids = [], [], []
                 for pipeline in range(model.cache.pipeline_count):

--- a/sharktank/sharktank/layers/configs/llm_configs.py
+++ b/sharktank/sharktank/layers/configs/llm_configs.py
@@ -190,9 +190,11 @@ class LlamaModelConfig:
     # If greater than 1, the model will re-wrap all non-sharded tensors as sharded over 1 device.
     pipeline_parallelism_size: int = 1
 
-    # Mapping between a transformer block and the device(s) it is on.
-    # None for no pipeline parallelism. If not none, must also account for sharding.
-    block_to_device_lookup: tuple[tuple[int, ...], ...] = None
+    # Mapping between a transformer block and the corresponding pipeline
+    block_to_pipeline_map: tuple[int, ...] = None
+
+    # Mapping between a pipeline and the corresponding devices
+    pipeline_to_device_map: tuple[tuple[int, ...], ...] = None
 
     # Which attention kernel to use.
     attention_kernel: str = "torch"
@@ -209,16 +211,6 @@ class LlamaModelConfig:
     # be the difference of many gigabytes of static data being embedded in
     # the program and not.
     static_tables: bool = True
-
-    def __post_init__(self):
-        if not self.block_to_device_lookup:
-            assert (
-                self.pipeline_parallelism_size == 1
-            ), "Must specify block_to_device_lookup if pipeline parallelism is used"
-            self.block_to_device_lookup = tuple(
-                tuple(range(self.tensor_parallelism_size))
-                for _ in range(self.hp.block_count)
-            )
 
 
 @dataclass

--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -68,7 +68,7 @@ class PagedAttention:
         device: Optional[torch.device] = None,
         shard_count: int = 1,
         block_to_pipeline_map: list[int] | None = None,
-        pipeline_to_device_map: list[int] | None = None,
+        pipeline_to_device_map: list[list[int]] | None = None,
     ):
         self.transformer_block_count = transformer_block_count
         self.head_count_kv = attn_head_count

--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -178,7 +178,6 @@ class PagedAttention:
         flat_sharded_page_tables = []
         for pipeline in range(self.pipeline_count):
             devices = self.pipeline_to_device_map[pipeline]
-            devices = self.pipeline_to_device_map[pipeline]
 
             block_min = self.pipeline_to_block_offset[pipeline]
             block_sz = self.pipeline_to_block_count[pipeline]

--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -88,7 +88,7 @@ class PagedAttention:
         )
 
         self.pipeline_to_device_map = (
-            [range(self.shard_count)]
+            [list(range(self.shard_count))]
             if pipeline_to_device_map is None
             else pipeline_to_device_map
         )

--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -11,6 +11,7 @@ tightly coupled transformer blocks a bit less "stringy" with loose tensors
 and dims floating around everywhere.
 """
 
+from itertools import accumulate
 from typing import Optional, Tuple, Union, List
 
 import abc
@@ -66,7 +67,8 @@ class PagedAttention:
         attn_dtype: torch.dtype = torch.float32,
         device: Optional[torch.device] = None,
         shard_count: int = 1,
-        block_to_device_lookup: tuple[tuple[int, ...], ...] | None = None,
+        block_to_pipeline_map: list[int] | None = None,
+        pipeline_to_device_map: list[int] | None = None,
     ):
         self.transformer_block_count = transformer_block_count
         self.head_count_kv = attn_head_count
@@ -75,40 +77,36 @@ class PagedAttention:
         self.block_seq_stride = block_seq_stride
         self.shard_count = shard_count
 
-        if block_to_device_lookup is None:
-            block_to_device_lookup = tuple(
-                tuple(range(self.shard_count))
-                for _ in range(self.transformer_block_count)
-            )
-        assert len(block_to_device_lookup) == transformer_block_count
-        block_to_pipeline_lookup = [0]
-        pipeline_to_device_lookup = [block_to_device_lookup[0]]
-        pipeline = 0
-        for block in range(1, transformer_block_count):
-            ds_prev, ds_curr = (
-                block_to_device_lookup[block - 1],
-                block_to_device_lookup[block],
-            )
-            assert all(d for d in ds_prev) >= 0
-            assert all(d for d in ds_curr) >= 0
-            if not all(d_prev == d_curr for d_prev, d_curr in zip(ds_prev, ds_curr)):
-                pipeline += 1
-                pipeline_to_device_lookup.append(ds_curr)
-            block_to_pipeline_lookup.append(pipeline)
+        self.block_to_pipeline_map = (
+            [0] * transformer_block_count
+            if block_to_pipeline_map is None
+            else block_to_pipeline_map
+        )
+        assert all(
+            a <= b
+            for a, b in zip(self.block_to_pipeline_map, self.block_to_pipeline_map[1:])
+        )
 
-        self.pipeline_to_device_lookup = tuple(pipeline_to_device_lookup)
-        self.block_to_pipeline_lookup = tuple(block_to_pipeline_lookup)
-        self.pipeline_count = len(pipeline_to_device_lookup)
+        self.pipeline_to_device_map = (
+            [range(self.shard_count)]
+            if pipeline_to_device_map is None
+            else pipeline_to_device_map
+        )
+        self.pipeline_count = len(self.pipeline_to_device_map)
 
         if attn_head_count % shard_count != 0:
             raise ValueError(
                 f"The attention head count {attn_head_count} must be a multiple of the tensor parallelism size {shard_count}."
             )
 
-        self.pipeline_to_block_count = tuple(
-            sum(1 for block in block_to_pipeline_lookup if block == i)
+        self.pipeline_to_block_count = list(
+            sum(1 for block in self.block_to_pipeline_map if block == i)
             for i in range(self.pipeline_count)
         )
+        self.pipeline_to_block_offset = [0] + list(
+            accumulate(self.pipeline_to_block_count)
+        )[:-1]
+
         # Some derived values based on attributes.
         self.sub_page_dims = [
             [
@@ -123,6 +121,7 @@ class PagedAttention:
         self.page_slab_flat_dims = [
             math.prod(sub_page_dim) for sub_page_dim in self.sub_page_dims
         ]
+
         self.device = device
         self.cache_dtype = cache_dtype
         self.attn_dtype = attn_dtype
@@ -135,31 +134,23 @@ class PagedAttention:
             len(state) == self.pipeline_count
         ), f"Expected {self.pipeline_count}-element state. Got: {len(state)}"
 
-        if self.shard_count == 1 and self.pipeline_count == 1:
-            assert all(
-                not isinstance(page_slab, SplitPrimitiveTensor) for page_slab in state
-            )
-            return [
-                page_slab.unflatten(1, self.sub_page_dims[pipeline])
-                for pipeline, page_slab in enumerate(state)
-            ]
-
-        assert all(page_slab.shard_count == self.shard_count for page_slab in state)
         unflattened = []
         for pipeline, page_slab in enumerate(state):
+            shards = [page_slab] if self.shard_count == 1 else page_slab.shards
             shards = [
-                shard.unflatten(1, self.sub_page_dims[pipeline])
-                for shard in page_slab.shards
+                shard.unflatten(1, self.sub_page_dims[pipeline]) for shard in shards
             ]
-            unflattened.append(
-                (
-                    SplitPrimitiveTensor(
-                        ts=shards, shard_dim=4, devices=page_slab.devices
-                    )
-                    if len(shards) > 1
-                    else ReplicatedTensor(ts=shards, devices=page_slab.devices)
+
+            result = shards[0]
+            if self.shard_count > 1:
+                result = SplitPrimitiveTensor(
+                    ts=shards, shard_dim=4, devices=page_slab.devices
                 )
-            )
+            elif pipeline > 1:
+                result = ReplicatedTensor(ts=shards, devices=page_slab.devices)
+
+            unflattened.append(result)
+
         return unflattened
 
     def shard_state(
@@ -186,41 +177,39 @@ class PagedAttention:
 
         flat_sharded_page_tables = []
         for pipeline in range(self.pipeline_count):
-            # TODO: Do I need to make copies here, or are views enough?
-            assert (
-                self.pipeline_to_block_count[pipeline] != 1
-            ), "1 tensor per pipeline not supported. dim gets collapsed"
-            i_min = sum(self.pipeline_to_block_count[:pipeline])
-            i_max = i_min + self.pipeline_to_block_count[pipeline]
+            devices = self.pipeline_to_device_map[pipeline]
+            devices = self.pipeline_to_device_map[pipeline]
+
+            block_min = self.pipeline_to_block_offset[pipeline]
+            block_sz = self.pipeline_to_block_count[pipeline]
+            block_max = block_min + block_sz
+            selected = page_table[:, block_min:block_max, ...]
+
             if self.shard_count == 1:
-                sharded_page_table = ops.replicate(
-                    page_table[:, i_min:i_max, ...],
-                    count=1,
-                    devices=self.pipeline_to_device_lookup[pipeline],
-                )
+                sharded_page_table = ops.replicate(selected, count=1, devices=devices)
             else:
                 sharded_page_table = ops.reshard_split(
-                    page_table[:, i_min:i_max, ...],
-                    dim=4,
-                    count=self.shard_count,
-                    devices=self.pipeline_to_device_lookup[pipeline],
+                    selected, dim=4, count=self.shard_count, devices=devices
                 )
+
             shards_flattened = [
                 ops.flatten(shard, start_dim=1) for shard in sharded_page_table.shards
             ]
             flat_sharded_page_tables.append(
-                SplitPrimitiveTensor(
-                    ts=shards_flattened,
-                    shard_dim=1,
-                    devices=self.pipeline_to_device_lookup[pipeline],
-                )
+                SplitPrimitiveTensor(ts=shards_flattened, shard_dim=1, devices=devices)
                 if self.shard_count > 1
-                else ReplicatedTensor(
-                    ts=shards_flattened,
-                    devices=self.pipeline_to_device_lookup[pipeline],
-                )
+                else ReplicatedTensor(ts=shards_flattened, devices=devices)
             )
         return flat_sharded_page_tables
+
+    def unshard_state(
+        self, state: List[torch.Tensor | SplitPrimitiveTensor]
+    ) -> List[torch.Tensor]:
+        state = self.unflatten_page_tables(state)
+        state = [ops.unshard(s) for s in state]
+        catted = ops.cat(state, dim=1)
+        catted = ops.flatten(catted, 1)
+        return catted
 
     @property
     def pad_sequence_stride(self) -> int:
@@ -235,13 +224,13 @@ class PagedAttention:
         shards = [
             [
                 torch.empty(
-                    [page_count, self.page_slab_flat_dims[pipeline]],
+                    [page_count, shard_dims],
                     dtype=self.cache_dtype,
                     device=self.device,
                 )
                 for _ in range(self.shard_count)
             ]
-            for pipeline in range(self.pipeline_count)
+            for shard_dims in self.page_slab_flat_dims
         ]
 
         if self.shard_count == 1 and self.pipeline_count == 1:
@@ -253,7 +242,7 @@ class PagedAttention:
                 if len(shards[i]) > 1
                 else ReplicatedTensor(ts=shards[i], devices=devices)
             )
-            for i, devices in enumerate(self.pipeline_to_device_lookup)
+            for i, devices in enumerate(self.pipeline_to_device_map)
         ]
 
     def read(
@@ -278,7 +267,10 @@ class PagedAttention:
         efficient unless if the compiler can fuse the gather.
         """
         page_tables = self.unflatten_page_tables(state)  # 6D
-        page_table = page_tables[self.block_to_pipeline_lookup[transformer_block_index]]
+        pipeline = self.block_to_pipeline_map[transformer_block_index]
+        page_table = page_tables[pipeline]
+        block_offset = self.pipeline_to_block_offset[pipeline]
+        transformer_block_index = transformer_block_index - block_offset
 
         bs, block_seq_len, *_ = page_ids.shape
         # Blocks dim 1,2 according to the configured block stride.
@@ -294,9 +286,7 @@ class PagedAttention:
         # Gather both partitions and split post gather. This is more
         # computationally efficient without gather fusion:
         subblock_table = page_table.flatten(start_dim=0, end_dim=1)
-        page_stride = self.pipeline_to_block_count[
-            self.block_to_pipeline_lookup[transformer_block_index]
-        ]
+        page_stride = self.pipeline_to_block_count[pipeline]
 
         transformer_block_index = torch.full(
             (bs, block_seq_len), transformer_block_index, device=self.device
@@ -329,10 +319,17 @@ class PagedAttention:
         """
         device = self.device
         page_tables = self.unflatten_page_tables(state)  # 6D
-        page_table = page_tables[self.block_to_pipeline_lookup[transformer_block_index]]
+        pipeline = self.block_to_pipeline_map[transformer_block_index]
+        devices = self.pipeline_to_device_map[pipeline]
+        transformer_block_count = self.pipeline_to_block_count[pipeline]
+        block_offset = self.pipeline_to_block_offset[pipeline]
+
+        page_table = page_tables[pipeline]
         page_table = page_table.flatten(0, 3)
         bs, *_ = seq_positions.shape
         assert len(cache_partitions) == self.cache_partition_count
+
+        transformer_block_index = transformer_block_index - block_offset
 
         # [bs, 1, atten_head_count, attn_head_dim]
         for idx, cache_partition in enumerate(cache_partitions):
@@ -343,40 +340,26 @@ class PagedAttention:
             page_offset = (seq_positions % self.block_seq_stride).unsqueeze(1)
 
             # [1, 1]
+            partitions = torch.tensor(idx, device=device).unsqueeze(0)
+            transformer_block = torch.full(
+                (bs, 1), transformer_block_index, device=device
+            )
             if isinstance(seq_positions, ReplicatedTensor):
-                partitions = [
-                    torch.tensor(idx, device=device).unsqueeze(0)
-                    for _ in range(seq_positions.shard_count)
-                ]
+                partitions = [partitions] * seq_positions.shard_count
+                transformer_block = [transformer_block] * seq_positions.shard_count
 
-                transformer_block = [
-                    torch.full((bs, 1), transformer_block_index, device=device)
-                    for _ in range(seq_positions.shard_count)
-                ]
-
-                devices = self.pipeline_to_device_lookup[
-                    self.block_to_pipeline_lookup[transformer_block_index]
-                ]
                 partitions = ReplicatedTensor(ts=partitions, devices=devices)
                 transformer_block = ReplicatedTensor(
                     ts=transformer_block, devices=devices
                 )
-            else:
-                partitions = torch.tensor(idx, device=device).unsqueeze(0)
-                transformer_block = torch.full(
-                    (bs, 1), transformer_block_index, device=device
-                )
 
             partitions = partitions.repeat(bs, 1)
 
-            transformer_block_count_in_pipeline = self.pipeline_to_block_count[
-                self.block_to_pipeline_lookup[transformer_block_index]
-            ]
-
             index = page_id
-            index = index * transformer_block_count_in_pipeline + transformer_block
+            index = index * transformer_block_count + transformer_block
             index = index * self.cache_partition_count + partitions
             index = index * self.block_seq_stride + page_offset
+
             values = ops.to(cache_partition, dtype=page_table.dtype)
             if page_table.dtype == torch.float8_e4m3fnuz:
                 # Workaround for Torch not supporting torch.Tensor.index_copy_ for f8.
@@ -402,7 +385,7 @@ class PagedAttention:
         in-place scatter cannot be fused.
         """
         page_tables = self.unflatten_page_tables(state)  # 6D
-        page_table = page_tables[self.block_to_pipeline_lookup[transformer_block_index]]
+        page_table = page_tables[self.block_to_pipeline_map[transformer_block_index]]
         bs, block_seq_len, *_ = page_ids.shape
 
         # Reshape the page cache into sub-blocks so that we can index at the
@@ -413,10 +396,14 @@ class PagedAttention:
         #   [page, attn_layer, cache_partition]
         # Where the cache line can be 0 (k) or 1 (v).
         subblock_table = page_table.flatten(start_dim=0, end_dim=2)
-        transformer_block_count_in_pipeline = self.pipeline_to_block_count[
-            self.block_to_pipeline_lookup[transformer_block_index]
-        ]
-        page_stride = transformer_block_count_in_pipeline * self.cache_partition_count
+        pipeline = self.block_to_pipeline_map[transformer_block_index]
+
+        # We have to offset according to the pipeline sharding:
+        block_offset = self.pipeline_to_block_offset[pipeline]
+        transformer_block_index = transformer_block_index - block_offset
+
+        transformer_block_count = self.pipeline_to_block_count[pipeline]
+        page_stride = transformer_block_count * self.cache_partition_count
         transformer_block_stride = self.cache_partition_count
         base_subblock_ids = page_ids * page_stride + (
             transformer_block_index * transformer_block_stride

--- a/sharktank/sharktank/layers/paged_llama_attention_block.py
+++ b/sharktank/sharktank/layers/paged_llama_attention_block.py
@@ -41,13 +41,15 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         attention_scale: Optional[float] = None,
         softcap: Optional[float] = None,
         fake_quant: Optional[bool] = True,
-        block_to_device_lookup: tuple[tuple[int, ...], ...] | None = None,
+        block_to_pipeline_map: tuple[tuple[int, ...], ...] | None = None,
+        pipeline_to_device_map: tuple[tuple[int, ...], ...] | None = None,
     ):
         super().__init__(theta)
 
         self.paged_attention = PagedAttention(
             transformer_block_count=cache.transformer_block_count,
-            block_to_device_lookup=block_to_device_lookup,
+            block_to_pipeline_map=block_to_pipeline_map,
+            pipeline_to_device_map=pipeline_to_device_map,
             attn_head_count=head_count_kv,
             attn_head_dim=head_dim,
             block_seq_stride=cache.block_seq_stride,

--- a/sharktank/sharktank/models/llm/llm.py
+++ b/sharktank/sharktank/models/llm/llm.py
@@ -90,7 +90,7 @@ class PagedLlmModelV1(BaseCausalLMModel):
                     use_hf=self.config.use_hf,
                     tensor_parallelism_size=self.config.tensor_parallelism_size,
                     pipeline_parallelism=config.pipeline_parallelism_size > 1,
-                    devices=self.cache.pipeline_to_device_lookup[pipeline],
+                    devices=self.cache.pipeline_to_device_map[pipeline],
                     dtype=self.config.activation_dtype,
                 )
                 for pipeline in range(self.config.pipeline_parallelism_size)
@@ -112,7 +112,6 @@ class PagedLlmModelV1(BaseCausalLMModel):
                     cache=self.cache,
                     config=self.config,
                     fake_quant=self.fake_quant,
-                    block_to_device_lookup=self.config.block_to_device_lookup,
                 )
                 for n in range(self.hp.block_count)
             ]
@@ -121,11 +120,17 @@ class PagedLlmModelV1(BaseCausalLMModel):
     def _inter_layer_callback(self, x: ShardedTensor, curr_block: int) -> ShardedTensor:
         from ... import ops
 
-        if curr_block == len(self.config.block_to_device_lookup) - 1:
+        if self.config.block_to_pipeline_map is None:
             return x
 
-        curr_devices = self.config.block_to_device_lookup[curr_block]
-        next_devices = self.config.block_to_device_lookup[curr_block + 1]
+        if curr_block >= len(self.config.block_to_pipeline_map) - 1:
+            return x
+
+        pipeline_0 = self.config.block_to_pipeline_map[curr_block]
+        pipeline_1 = self.config.block_to_pipeline_map[curr_block + 1]
+
+        curr_devices = self.config.pipeline_to_device_map[pipeline_0]
+        next_devices = self.config.pipeline_to_device_map[pipeline_1]
         if all(d_curr == d_next for d_curr, d_next in zip(curr_devices, next_devices)):
             return x
 
@@ -161,19 +166,14 @@ class PagedLlmModelV1(BaseCausalLMModel):
         for block_idx, block in enumerate(self.attn_blocks):
             if block_idx == 0:
                 self.trace_tensor(f"llama.attn_block.{block_idx}.input", h)
+            pipeline = self.cache.block_to_pipeline_map[block_idx]
             h = block(
                 h,
-                embedding=self.attention_embedding[
-                    self.cache.block_to_pipeline_lookup[block_idx]
-                ],
+                embedding=self.attention_embedding[pipeline],
                 start_index=0,
-                attention_mask=attention_mask[
-                    self.cache.block_to_pipeline_lookup[block_idx]
-                ],
+                attention_mask=attention_mask[pipeline],
                 cache_state=cache_state,
-                seq_block_ids=seq_block_ids[
-                    self.cache.block_to_pipeline_lookup[block_idx]
-                ],
+                seq_block_ids=seq_block_ids[pipeline],
             )
             h = self._inter_layer_callback(h, block_idx)
             self.trace_tensor(f"llama.attn_block.{block_idx}.output", h)
@@ -302,7 +302,6 @@ class AttentionFFNBlock(ThetaLayer):
         cache: PagedAttention,  # TODO: Add deepseek PagedLatentAttention
         config: LlamaModelConfig,
         fake_quant: bool = True,
-        block_to_device_lookup: tuple[tuple[int, ...], ...] | None = None,
     ):
         super().__init__(theta)
 
@@ -322,8 +321,9 @@ class AttentionFFNBlock(ThetaLayer):
                 rms_epsilon=config.hp.attention_layer_norm_rms_epsilon,
                 attention_kernel=attention_kernel,
                 fake_quant=fake_quant,
-                block_to_device_lookup=block_to_device_lookup,
                 softcap=config.hp.attention_softcap,
+                block_to_pipeline_map=config.block_to_pipeline_map,
+                pipeline_to_device_map=config.pipeline_to_device_map,
             ),
         )
 

--- a/sharktank/sharktank/models/llm/llm.py
+++ b/sharktank/sharktank/models/llm/llm.py
@@ -251,6 +251,7 @@ class PagedLlmModelV1(BaseCausalLMModel):
         for block_idx, block in enumerate(self.attn_blocks):
             if block_idx == 0:
                 self.trace_tensor(f"llama.attn_block.{block_idx}.input", h)
+            # TODO: Hacky, shouldn't need to read info out of self.cache
             pipeline = self.cache.block_to_pipeline_map[block_idx]
             h = block(  # TODO: Should we index into attention_mask and cache here?
                 h,

--- a/sharktank/sharktank/models/llm/llm.py
+++ b/sharktank/sharktank/models/llm/llm.py
@@ -253,7 +253,7 @@ class PagedLlmModelV1(BaseCausalLMModel):
                 self.trace_tensor(f"llama.attn_block.{block_idx}.input", h)
             pipeline = self.cache.block_to_pipeline_map[block_idx]
             h = block(  # TODO: Should we index into attention_mask and cache here?
-                h,  # TODO: Hacky, shouldn't need to read info out of self.cache
+                h,
                 start_positions=start_positions[pipeline],
                 embedding=self.attention_embedding[pipeline],
                 embedding_batch_mask=embedding_batch_masks[pipeline],

--- a/sharktank/sharktank/types/pipelining.py
+++ b/sharktank/sharktank/types/pipelining.py
@@ -74,7 +74,8 @@ def pipeline_parallelize_theta(
         i * pipeline_parallelism_size // block_count for i in range(block_count)
     ]
     pipeline_to_devices = [
-        (p + d for d in range(shard_count)) for p in range(pipeline_parallelism_size)
+        [p * shard_count + d for d in range(shard_count)]
+        for p in range(pipeline_parallelism_size)
     ]
 
     assert (

--- a/sharktank/sharktank/types/pipelining.py
+++ b/sharktank/sharktank/types/pipelining.py
@@ -67,16 +67,23 @@ def pipeline_parallelize_theta(
     shard_count = 1 if isinstance(_t, DefaultPrimitiveTensor) else _t.shard_count
     num_blocks = len(theta.tensor("blk"))
 
-    block_to_device_lookup = []
-    block_indices = sorted(theta.tensor("blk").keys(), key=lambda item: int(item))
+    block_indices = theta.tensor("blk").keys()
+    block_count = len(block_indices)
+
+    block_to_pipeline = [
+        i * pipeline_parallelism_size // block_count for i in range(block_count)
+    ]
+    pipeline_to_devices = [
+        (p + d for d in range(shard_count)) for p in range(pipeline_parallelism_size)
+    ]
+
     assert (
         bi == i for i, bi in enumerate(block_indices)
     ), "Blocks assumed to be numbered contiguously from [0, N-1]"
     for blk_idx in block_indices:
-        pp_group = int(int(blk_idx) * pipeline_parallelism_size / num_blocks)
-        zero_4_group = shard_count * pp_group
-        devices = tuple(i + zero_4_group for i in range(shard_count))
-        block_to_device_lookup.append(devices)
+        blk_idx = int(blk_idx)
+        pipeline = block_to_pipeline[blk_idx]
+        devices = pipeline_to_devices[pipeline]
 
         block_data = theta.tensor("blk", blk_idx)
         for t_name in block_data.keys():
@@ -86,4 +93,4 @@ def pipeline_parallelize_theta(
     parallelize_in_place(theta.tensor("output_norm"), block_to_device_lookup[-1])
     parallelize_in_place(theta.tensor("output"), block_to_device_lookup[-1])
 
-    return tuple(block_to_device_lookup)
+    return tuple(block_to_pipeline), tuple(pipeline_to_devices)

--- a/sharktank/sharktank/utils/create_cache.py
+++ b/sharktank/sharktank/utils/create_cache.py
@@ -15,7 +15,8 @@ def create_paged_kv_cache(config: LlamaModelConfig) -> PagedAttention:
     dtype = config.kv_cache_dtype or config.attention_dtype
     return PagedAttention(
         transformer_block_count=hp.block_count,
-        block_to_device_lookup=config.block_to_device_lookup,
+        block_to_pipeline_map=config.block_to_pipeline_map,
+        pipeline_to_device_map=config.pipeline_to_device_map,
         attn_head_count=hp.attention_head_count_kv,
         attn_head_dim=hp.attn_head_dim,
         cache_partition_count=2,  # One for each of K/V.

--- a/sharktank/tests/layers/pipelined_paged_attention_test.py
+++ b/sharktank/tests/layers/pipelined_paged_attention_test.py
@@ -33,14 +33,14 @@ class PipelinedPagedAttentionTest(unittest.TestCase):
         self.block_seq_len = 2
         self.max_seq_len = self.block_seq_len * self.block_seq_stride
 
-        block_to_device_lookup = []
-        for block in range(self.transformer_block_count):
-            pp_group = int(block * self.pipeline_count / self.transformer_block_count)
-            zero_4_group = self.shard_count * pp_group
-            block_to_device_lookup.append(
-                tuple(i + zero_4_group for i in range(self.shard_count))
-            )
-        self.block_to_device_lookup = tuple(block_to_device_lookup)
+        self.block_to_pipeline_map = [
+            block * self.pipeline_count // self.transformer_block_count
+            for block in range(self.transformer_block_count)
+        ]
+        self.pipeline_to_device_map = [
+            tuple(i + pipeline * self.shard_count for i in range(self.shard_count))
+            for pipeline in range(self.pipeline_count)
+        ]
 
         self.cache = PagedAttention(
             transformer_block_count=self.transformer_block_count,
@@ -53,7 +53,8 @@ class PipelinedPagedAttentionTest(unittest.TestCase):
         )
         self.pipelined_cache = PagedAttention(
             shard_count=self.shard_count,
-            block_to_device_lookup=self.block_to_device_lookup,
+            block_to_pipeline_map=self.block_to_pipeline_map,
+            pipeline_to_device_map=self.pipeline_to_device_map,
             transformer_block_count=self.transformer_block_count,
             attn_head_count=self.attn_head_count,
             block_seq_stride=self.block_seq_stride,
@@ -79,13 +80,9 @@ class PipelinedPagedAttentionTest(unittest.TestCase):
         cache_state: List[torch.Tensor],
         pipelined_cache_state: List[SplitPrimitiveTensor],
     ):
-        pipelined_states_unreplicated = [
-            ops.unshard(unflatted_page).flatten(start_dim=1)
-            for unflatted_page in self.pipelined_cache.unflatten_page_tables(
-                pipelined_cache_state
-            )
-        ]
-        pipelined_states_as_single = ops.cat(pipelined_states_unreplicated, dim=1)
+        pipelined_states_as_single = self.pipelined_cache.unshard_state(
+            pipelined_cache_state
+        )
         assert iterables_equal(cache_state[0].shape, pipelined_states_as_single.shape)
         assert ops.equal(
             cache_state[0],
@@ -134,7 +131,7 @@ class PipelinedPagedAttentionTest(unittest.TestCase):
             pipelined_cache_state,
         ) = self.make_unpipelined_and_pipelined_equal_cache_states()
 
-        transformer_block_index = 1
+        transformer_block_index = 3
         page_ids = torch.randint(
             low=0, high=self.page_count, size=[self.batch_size, self.block_seq_len]
         ).reshape([self.batch_size, self.block_seq_len])
@@ -144,7 +141,11 @@ class PipelinedPagedAttentionTest(unittest.TestCase):
             page_ids=page_ids,
             seq_len=self.block_seq_len * self.block_seq_stride,
         )
-        pipelined_page_ids = ops.replicate(page_ids, count=self.shard_count)
+        pipeline = self.block_to_pipeline_map[transformer_block_index]
+        devices = self.pipeline_to_device_map[pipeline]
+        pipelined_page_ids = ops.replicate(
+            page_ids, count=self.shard_count, devices=devices
+        )
         pipelined_read = self.pipelined_cache.read(
             state=pipelined_cache_state,
             transformer_block_index=transformer_block_index,
@@ -169,7 +170,7 @@ class PipelinedPagedAttentionTest(unittest.TestCase):
             )
             for _ in range(self.cache_partition_count)
         ]
-        transformer_block_index = 1
+        transformer_block_index = 3
         seq_positions = torch.randint(
             low=0, high=self.max_seq_len, size=[self.batch_size]
         )
@@ -186,8 +187,14 @@ class PipelinedPagedAttentionTest(unittest.TestCase):
         pipelined_cache_partitions = deepcopy(
             [ops.replicate(t, count=self.shard_count) for t in cache_partitions]
         )
-        pipelined_seq_positions = ops.replicate(seq_positions, count=self.shard_count)
-        pipelined_page_ids = ops.replicate(page_ids, count=self.shard_count)
+        pipeline = self.block_to_pipeline_map[transformer_block_index]
+        devices = self.pipeline_to_device_map[pipeline]
+        pipelined_seq_positions = ops.replicate(
+            seq_positions, count=self.shard_count, devices=devices
+        )
+        pipelined_page_ids = ops.replicate(
+            page_ids, count=self.shard_count, devices=devices
+        )
         self.pipelined_cache.write_timestep(
             state=pipelined_cache_state,
             cache_partitions=pipelined_cache_partitions,
@@ -214,7 +221,7 @@ class PipelinedPagedAttentionTest(unittest.TestCase):
             )
             for _ in range(self.cache_partition_count)
         ]
-        transformer_block_index = 1
+        transformer_block_index = 3
         assert self.batch_size * self.block_seq_len <= self.page_count
         page_ids = torch.randperm(self.batch_size * self.block_seq_len).reshape(
             [self.batch_size, self.block_seq_len]
@@ -228,7 +235,11 @@ class PipelinedPagedAttentionTest(unittest.TestCase):
         pipelined_cache_partitions = deepcopy(
             [ops.replicate(t, count=self.shard_count) for t in cache_partitions]
         )
-        pipelined_page_ids = ops.replicate(page_ids, count=self.shard_count)
+        pipeline = self.block_to_pipeline_map[transformer_block_index]
+        devices = self.pipeline_to_device_map[pipeline]
+        pipelined_page_ids = ops.replicate(
+            page_ids, count=self.shard_count, devices=devices
+        )
         self.pipelined_cache.write(
             state=pipelined_cache_state,
             cache_partitions=pipelined_cache_partitions,

--- a/sharktank/tests/layers/pipelined_sharded_paged_attention_test.py
+++ b/sharktank/tests/layers/pipelined_sharded_paged_attention_test.py
@@ -33,14 +33,14 @@ class PipelinedShardedPagedAttentionTest(unittest.TestCase):
         self.block_seq_len = 2
         self.max_seq_len = self.block_seq_len * self.block_seq_stride
 
-        block_to_device_lookup = []
-        for block in range(self.transformer_block_count):
-            pp_group = int(block * self.pipeline_count / self.transformer_block_count)
-            zero_4_group = self.shard_count * pp_group
-            block_to_device_lookup.append(
-                tuple(i + zero_4_group for i in range(self.shard_count))
-            )
-        self.block_to_device_lookup = tuple(block_to_device_lookup)
+        self.block_to_pipeline_map = [
+            block * self.pipeline_count // self.transformer_block_count
+            for block in range(self.transformer_block_count)
+        ]
+        self.pipeline_to_device_map = [
+            tuple(i + pipeline * self.shard_count for i in range(self.shard_count))
+            for pipeline in range(self.pipeline_count)
+        ]
 
         self.cache = PagedAttention(
             transformer_block_count=self.transformer_block_count,
@@ -53,7 +53,8 @@ class PipelinedShardedPagedAttentionTest(unittest.TestCase):
         )
         self.pipelined_sharded_cache = PagedAttention(
             shard_count=self.shard_count,
-            block_to_device_lookup=self.block_to_device_lookup,
+            block_to_pipeline_map=self.block_to_pipeline_map,
+            pipeline_to_device_map=self.pipeline_to_device_map,
             transformer_block_count=self.transformer_block_count,
             attn_head_count=self.attn_head_count,
             block_seq_stride=self.block_seq_stride,
@@ -81,21 +82,13 @@ class PipelinedShardedPagedAttentionTest(unittest.TestCase):
         cache_state: List[torch.Tensor],
         pipelined_sharded_cache_state: List[SplitPrimitiveTensor],
     ):
-        pipelined_sharded_states_as_unsharded = [
-            ops.unshard(unflatted_page).flatten(start_dim=1)
-            for unflatted_page in self.pipelined_sharded_cache.unflatten_page_tables(
-                pipelined_sharded_cache_state
-            )
-        ]
-        pipelined_sharded_states_as_single = ops.cat(
-            pipelined_sharded_states_as_unsharded, dim=1
+        pipelined_states_as_single = self.pipelined_sharded_cache.unshard_state(
+            pipelined_sharded_cache_state
         )
-        assert iterables_equal(
-            cache_state[0].shape, pipelined_sharded_states_as_single.shape
-        )
+        assert iterables_equal(cache_state[0].shape, pipelined_states_as_single.shape)
         assert ops.equal(
             cache_state[0],
-            pipelined_sharded_states_as_single,
+            pipelined_states_as_single,
         )
 
     def testAllocate(self):
@@ -159,7 +152,7 @@ class PipelinedShardedPagedAttentionTest(unittest.TestCase):
             sharded_cache_state,
         ) = self.make_unsharded_and_sharded_equal_cache_states()
 
-        transformer_block_index = 1
+        transformer_block_index = 3
         page_ids = torch.randint(
             low=0, high=self.page_count, size=[self.batch_size, self.block_seq_len]
         ).reshape([self.batch_size, self.block_seq_len])
@@ -169,7 +162,11 @@ class PipelinedShardedPagedAttentionTest(unittest.TestCase):
             page_ids=page_ids,
             seq_len=self.block_seq_len * self.block_seq_stride,
         )
-        sharded_page_ids = ops.replicate(page_ids, count=self.shard_count)
+        pipeline = self.block_to_pipeline_map[transformer_block_index]
+        devices = self.pipeline_to_device_map[pipeline]
+        sharded_page_ids = ops.replicate(
+            page_ids, count=self.shard_count, devices=devices
+        )
         sharded_read = self.pipelined_sharded_cache.read(
             state=sharded_cache_state,
             transformer_block_index=transformer_block_index,
@@ -194,7 +191,7 @@ class PipelinedShardedPagedAttentionTest(unittest.TestCase):
             )
             for _ in range(self.cache_partition_count)
         ]
-        transformer_block_index = 1
+        transformer_block_index = 3
         seq_positions = torch.randint(
             low=0, high=self.max_seq_len, size=[self.batch_size]
         )
@@ -214,8 +211,14 @@ class PipelinedShardedPagedAttentionTest(unittest.TestCase):
                 for t in cache_partitions
             ]
         )
-        sharded_seq_positions = ops.replicate(seq_positions, count=self.shard_count)
-        sharded_page_ids = ops.replicate(page_ids, count=self.shard_count)
+        pipeline = self.block_to_pipeline_map[transformer_block_index]
+        devices = self.pipeline_to_device_map[pipeline]
+        sharded_seq_positions = ops.replicate(
+            seq_positions, count=self.shard_count, devices=devices
+        )
+        sharded_page_ids = ops.replicate(
+            page_ids, count=self.shard_count, devices=devices
+        )
         self.pipelined_sharded_cache.write_timestep(
             state=sharded_cache_state,
             cache_partitions=sharded_cache_partitions,
@@ -259,7 +262,11 @@ class PipelinedShardedPagedAttentionTest(unittest.TestCase):
                 for t in cache_partitions
             ]
         )
-        sharded_page_ids = ops.replicate(page_ids, count=self.shard_count)
+        pipeline = self.block_to_pipeline_map[transformer_block_index]
+        devices = self.pipeline_to_device_map[pipeline]
+        sharded_page_ids = ops.replicate(
+            page_ids, count=self.shard_count, devices=devices
+        )
         self.pipelined_sharded_cache.write(
             state=sharded_cache_state,
             cache_partitions=sharded_cache_partitions,


### PR DESCRIPTION
Pipeline parallelism had issues with transformer block offset. Updated and cleaned up the block / device mappings to instead use two separate mappings. This allows a cleaner implementation that relies less on replicated behavior.

Included an `unshard` operation for the KV cache as the existing tests replicated the reconstruction which should be part of PagedAttention.