### PR TITLE
Remove seq_len parameter from kv cache

### DIFF
--- a/sharktank/sharktank/export_layer/export_paged_attention.py
+++ b/sharktank/sharktank/export_layer/export_paged_attention.py
@@ -41,7 +41,6 @@ def paged_attention(
     bs, batch_seq_len, _, _ = xq.shape
 
     # Full sequence length.
-    kv_seq_len = seq_block_ids.shape[1] * attention_block.cache.block_seq_stride
 
     if start_positions is None:
         attn_output = paged_attention.forward_prefill(
@@ -62,7 +61,6 @@ def paged_attention(
             cache_state=cache_state,
             seq_block_ids=seq_block_ids,
             block_index=block_index,
-            kv_seq_len=kv_seq_len,
             start_positions=start_positions,
             head_count_attn=head_count,
             mask=attention_mask,

--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -261,7 +261,6 @@ class PagedAttention:
         state: list[Union[torch.Tensor, SplitPrimitiveTensor]],
         *,
         transformer_block_index: int,
-        seq_len: int,
         page_ids: Optional[Union[torch.Tensor, ReplicatedTensor]] = None,
     ):
         """Reads K/V caches the page table for the given page_ids.
@@ -305,8 +304,8 @@ class PagedAttention:
         selected = ops.index_select(subblock_table, 0, subblock_ids.flatten(0, 1))
 
         selected = selected.unflatten(0, blocked_shape[:2])
-        key = selected[:, :, 0, :seq_len].flatten(1, 2)[:, :seq_len]
-        value = selected[:, :, 1, :seq_len].flatten(1, 2)[:, :seq_len]
+        key = selected[:, :, 0, :].flatten(1, 2)
+        value = selected[:, :, 1, :].flatten(1, 2)
 
         return key, value
 
@@ -558,7 +557,6 @@ class PagedAttention:
         v: torch.Tensor,
         cache_state: list[torch.Tensor],
         seq_block_ids: torch.Tensor,
-        kv_seq_len: int,
         block_index: int,
         start_positions: torch.Tensor,
         attention_kernel: str,
@@ -586,7 +584,6 @@ class PagedAttention:
             cache_state,
             transformer_block_index=block_index,
             page_ids=seq_block_ids,
-            seq_len=kv_seq_len,
         )
 
         return self.attention(

--- a/sharktank/sharktank/layers/paged_llama_attention_block.py
+++ b/sharktank/sharktank/layers/paged_llama_attention_block.py
@@ -144,9 +144,6 @@ class PagedLlamaAttentionBlock(ThetaLayer):
             xq = embedding.apply_batched_mask(xt=xq, mask=embedding_batch_mask)
             xk = embedding.apply_batched_mask(xt=xk, mask=embedding_batch_mask)
 
-        # Full sequence length.
-        kv_seq_len = seq_block_ids.shape[1] * self.paged_attention.block_seq_stride
-
         # Used by fp8_e4m3fnuz model
         if self.cache_quantizer is not None:
             if not self.fake_quant:
@@ -180,7 +177,6 @@ class PagedLlamaAttentionBlock(ThetaLayer):
                 cache_state=cache_state,
                 seq_block_ids=seq_block_ids,
                 block_index=self.block_index,
-                kv_seq_len=kv_seq_len,
                 start_positions=start_positions,
                 head_count_attn=self.head_count,
                 cache_quantizer=self.cache_quantizer,

--- a/sharktank/tests/layers/pipelined_paged_attention_test.py
+++ b/sharktank/tests/layers/pipelined_paged_attention_test.py
@@ -142,14 +142,12 @@ class PipelinedPagedAttentionTest(unittest.TestCase):
             state=cache_state,
             transformer_block_index=transformer_block_index,
             page_ids=page_ids,
-            seq_len=self.block_seq_len * self.block_seq_stride,
         )
         pipelined_page_ids = ops.replicate(page_ids, count=self.shard_count)
         pipelined_read = self.pipelined_cache.read(
             state=pipelined_cache_state,
             transformer_block_index=transformer_block_index,
             page_ids=pipelined_page_ids,
-            seq_len=self.block_seq_len * self.block_seq_stride,
         )
         for unpipelined, pipelined in zip(unpipelined_read, pipelined_read):
             assert ops.equal(unpipelined, ops.unshard(pipelined))

--- a/sharktank/tests/layers/pipelined_sharded_paged_attention_test.py
+++ b/sharktank/tests/layers/pipelined_sharded_paged_attention_test.py
@@ -167,14 +167,12 @@ class PipelinedShardedPagedAttentionTest(unittest.TestCase):
             state=cache_state,
             transformer_block_index=transformer_block_index,
             page_ids=page_ids,
-            seq_len=self.block_seq_len * self.block_seq_stride,
         )
         sharded_page_ids = ops.replicate(page_ids, count=self.shard_count)
         sharded_read = self.pipelined_sharded_cache.read(
             state=sharded_cache_state,
             transformer_block_index=transformer_block_index,
             page_ids=sharded_page_ids,
-            seq_len=self.block_seq_len * self.block_seq_stride,
         )
         for unsharded, sharded in zip(unsharded_read, sharded_read):
             assert ops.equal(unsharded, ops.unshard(sharded))

--- a/sharktank/tests/layers/sharded_paged_kv_cache_test.py
+++ b/sharktank/tests/layers/sharded_paged_kv_cache_test.py
@@ -114,14 +114,12 @@ class ShardedPagedKVCacheTest(unittest.TestCase):
             state=cache_state,
             transformer_block_index=transformer_block_index,
             page_ids=page_ids,
-            seq_len=self.block_seq_len * self.block_seq_stride,
         )
         sharded_page_ids = ops.replicate(page_ids, count=self.shard_count)
         sharded_read = self.sharded_cache.read(
             state=sharded_cache_state,
             transformer_block_index=transformer_block_index,
             page_ids=sharded_page_ids,
-            seq_len=self.block_seq_len * self.block_seq_stride,
         )
         for unsharded, sharded in zip(unsharded_read, sharded_read):
             assert ops.equal(unsharded, ops.unshard(sharded))


### PR DESCRIPTION
There is no good benefit to use `seq_len` to select a subset from the KV cache reading function. If the user wants a subset it is better to post slice (as thats effectively teh result otherwise).