### PR TITLE
Update project license and drop classifer

### DIFF
--- a/shark-ai/pyproject.toml
+++ b/shark-ai/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "SHARK AI meta package"
 readme = "README.md"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "License :: OSI Approved :: Apache Software License",

--- a/shark-ai/pyproject.toml
+++ b/shark-ai/pyproject.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 license = "Apache-2.0"
 classifiers = [
   "Development Status :: 3 - Alpha",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
 ]
 # Version is set via the `setup.py` and requirements are set via files below.

--- a/sharktank/pyproject.toml
+++ b/sharktank/pyproject.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 license = "Apache-2.0"
 classifiers = [
   "Development Status :: 3 - Alpha",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
 ]
 

--- a/sharktank/pyproject.toml
+++ b/sharktank/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "SHARK layers and inference models for genai"
 readme = "README.md"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "License :: OSI Approved :: Apache Software License",

--- a/sharktuner/pyproject.toml
+++ b/sharktuner/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "IREE Dispatch Tuner"
 readme = "README.md"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "License :: OSI Approved :: Apache Software License",

--- a/sharktuner/pyproject.toml
+++ b/sharktuner/pyproject.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 license = "Apache-2.0"
 classifiers = [
   "Development Status :: 3 - Alpha",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/shortfin/pyproject.toml
+++ b/shortfin/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 description = "SHARK inference library and serving engine"
 readme = "README.md"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "License :: OSI Approved :: Apache Software License",

--- a/shortfin/pyproject.toml
+++ b/shortfin/pyproject.toml
@@ -18,7 +18,6 @@ readme = "README.md"
 license = "Apache-2.0"
 classifiers = [
   "Development Status :: 3 - Alpha",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
This addresses the following warning:

* `project.license`:
  ```
  Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

  By 2026-Feb-18, you need to update your project and remove deprecated calls or your builds will no longer be supported.

  See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
  ```
* `classifiers`
  ```
  Please consider removing the following classifiers in favor of a SPDX license expression:

  License :: OSI Approved :: Apache Software License

  See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
  ```