### PR TITLE
[sharktank] General implementation for trivially replicable ops

### DIFF
--- a/sharktank/sharktank/ops/__init__.py
+++ b/sharktank/sharktank/ops/__init__.py
@@ -20,6 +20,7 @@ from . import _registry
 from sharktank.types.tensors import unbox_tensor
 from .signatures import *
 from .shape import *
+from .utils import trivially_replicable
 
 # Ensure that implementations are registered.
 # Note that delegation prefers matching ops defined later, so order here

--- a/sharktank/sharktank/ops/_registry.py
+++ b/sharktank/sharktank/ops/_registry.py
@@ -20,7 +20,7 @@ __all__ = [
     "AllOfType",
     "AnyOfType",
     "IsOfType",
-    "NotOfType",
+    "AllNotOfType",
     "overridable",
     "SignatureDispatcher",
     "BoolTypeExpr",
@@ -167,15 +167,15 @@ class AnyOfType(BoolTypeExpr):
         super().__init__(expr)
 
 
-class NotOfType(BoolTypeExpr):
+class AllNotOfType(BoolTypeExpr):
     """Returns True if none of the types are from a set of types.
 
     ```python
     # False. int is in (int, float).
-    NotOfType(int, float)(int, str)
+    AllNotOfType(int, float)(int, str)
 
      # True. str is not in (int, float).
-    NotOfType(int, float)(str, str)
+    AllNotOfType(int, float)(str, str)
     ```
     """
 
@@ -338,12 +338,34 @@ class SignatureDispatcher:
         return targets
 
 
-def overridable(f):
+def overridable(
+    f: Callable[..., Any] | None = None, is_trivially_replicable: bool = True
+):
     """Decorator to apply to overridable ops.
 
     Such ops can then have specializations stacked against them with the
     @override decorator.
+
+    is_trivially_replicable:
+        If True will automatically register a wrapper variant with all tensor
+        arguments and results as replicated. This replicated op variant will call the
+        underlying unreplicated variant with for all shards correspondingly. Then
+        construct replicated results from all corresponding shards.
     """
+    if f is None:
+        return functools.partial(
+            overridable, is_trivially_replicable=is_trivially_replicable
+        )
+
     dispatcher = SignatureDispatcher(f)
     functools.update_wrapper(dispatcher, f)
+
+    if is_trivially_replicable:
+        from sharktank.ops.utils import trivially_replicable
+        from sharktank.types import ReplicatedTensor
+
+        dispatcher.override(AllOfType(ReplicatedTensor))(
+            trivially_replicable(dispatcher)
+        )
+
     return dispatcher

--- a/sharktank/sharktank/ops/_registry.py
+++ b/sharktank/sharktank/ops/_registry.py
@@ -210,10 +210,11 @@ class SignatureDispatcher:
         "_trampoline",
     ]
 
-    def __init__(self, sigf: Callable):
+    def __init__(self, sigf: Callable, is_trivially_replicable: bool = True):
         self._target_cache = dict()
         self._trampoline: Optional[Callable] = None
         self._overrides: list[_TargetOverride] = []
+        self.is_trivially_replicable = is_trivially_replicable
 
     def __call__(self, *args, **kwargs):
         trampoline = self._trampoline
@@ -357,15 +358,7 @@ def overridable(
             overridable, is_trivially_replicable=is_trivially_replicable
         )
 
-    dispatcher = SignatureDispatcher(f)
+    dispatcher = SignatureDispatcher(f, is_trivially_replicable=is_trivially_replicable)
     functools.update_wrapper(dispatcher, f)
-
-    if is_trivially_replicable:
-        from sharktank.ops.utils import trivially_replicable
-        from sharktank.types import ReplicatedTensor
-
-        dispatcher.override(AllOfType(ReplicatedTensor))(
-            trivially_replicable(dispatcher)
-        )
 
     return dispatcher

--- a/sharktank/sharktank/ops/custom_impls.py
+++ b/sharktank/sharktank/ops/custom_impls.py
@@ -29,7 +29,7 @@ from sharktank.types import (
 
 from sharktank.types.tensors import AnyTensor, unbox_tensor
 from .signatures import *
-from ._registry import NotOfType
+from ._registry import AllNotOfType
 
 
 # Fused FP matmul.
@@ -128,7 +128,7 @@ def matmul_generic_tensor_super_block_offset_scaled_4_6_i4(
     )
 
 
-@sum.override(NotOfType(AnyTensor))
+@sum.override(AllNotOfType(AnyTensor))
 def sum_iterable(
     input: Iterable,
     dim: int | list[int] | None = None,

--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -213,16 +213,6 @@ def argmax_split(
     return SplitPrimitiveTensor(ts=shards, shard_dim=tensor.shard_dim)
 
 
-@cat.override(AllOfType(ReplicatedTensor))
-def cat_replicated(tensors: Sequence[ReplicatedTensor], dim: int) -> ReplicatedTensor:
-    assert len(tensors) > 0
-    shard_count = tensors[0].shard_count
-    assert all([t.shard_count == shard_count for t in tensors])
-
-    shards = [cat(shards, dim) for shards in zip(*[t.shards for t in tensors])]
-    return ReplicatedTensor(ts=shards)
-
-
 @cat.override(AllOfType(SplitPrimitiveTensor))
 def cat_split(
     tensors: Sequence[SplitPrimitiveTensor], dim: int
@@ -412,28 +402,10 @@ conv2d.override(Tensor, SplitPrimitiveTensor, auto_dequant=True)(
 # Sharded elementwise.
 
 
-@elementwise.override(ReplicatedTensor)
-def replicated_elementwise_unary(operator, x: ReplicatedTensor, *args, **kwargs):
-    partials = [operator(unbox_tensor(pt), *args, **kwargs) for pt in x.shards]
-    return ReplicatedTensor(ts=partials)
-
-
 @elementwise.override(SplitPrimitiveTensor)
 def split_elementwise_unary(operator, x: SplitPrimitiveTensor, *args, **kwargs):
     partials = [operator(unbox_tensor(pt), *args, **kwargs) for pt in x.shards]
     return SplitPrimitiveTensor(shard_dim=x.shard_dim, shape=x.shape, ts=partials)
-
-
-@elementwise.override(ReplicatedTensor, ReplicatedTensor)
-def replicated_elementwise_binary(
-    operator, x: ReplicatedTensor, y: ReplicatedTensor, *args, **kwargs
-):
-    assert x.shard_count == y.shard_count
-    shards = [
-        operator(unbox_tensor(shard_x), unbox_tensor(shard_y), *args, **kwargs)
-        for shard_x, shard_y in zip(x.shards, y.shards)
-    ]
-    return ReplicatedTensor(ts=shards)
 
 
 @elementwise.override(SplitPrimitiveTensor, SplitPrimitiveTensor)
@@ -453,18 +425,6 @@ def split_elementwise_binary(
         shape=torch.broadcast_shapes(x.shape, y.shape),
         ts=partials,
     )
-
-
-@einsum_2args.override(AllOfType(ReplicatedTensor))
-def einsum_2args_replicated(
-    input0: ReplicatedTensor, input1: ReplicatedTensor, einsum_str: str
-) -> ReplicatedTensor:
-    assert input0.shard_count == input1.shard_count
-    shards = [
-        einsum_2args(input0_shard, input1_shard, einsum_str)
-        for input0_shard, input1_shard in zip(input0.shards, input1.shards)
-    ]
-    return ReplicatedTensor(ts=shards)
 
 
 @elementwise.override(SplitPrimitiveTensor, Number)
@@ -551,29 +511,6 @@ def elementwise_binary_replicated_lhs_unsharded_rhs(
     return elementwise(operator, x_replicated, y, *args, **kwargs)
 
 
-# Embedding Lookup
-@embedding_lookup.override(ReplicatedTensor, ReplicatedTensor)
-def embedding_lookup_default(
-    input: ReplicatedTensor,
-    embedding_matrix: ReplicatedTensor,
-    dtype: Optional[torch.dtype],
-):
-    assert input.shard_count == embedding_matrix.shard_count
-    shards = [
-        embedding_lookup(input_shard, embedding_matrix_shard, dtype)
-        for input_shard, embedding_matrix_shard in zip(
-            input.shards, embedding_matrix.shards
-        )
-    ]
-    return ReplicatedTensor(ts=shards)
-
-
-@expand.override(ReplicatedTensor)
-def expand_replicated(tensor: ReplicatedTensor, shape: List[int]) -> ReplicatedTensor:
-    shards = [expand(shard, shape) for shard in tensor.shards]
-    return tensor.clone(ts=shards)
-
-
 @expand.override(SplitPrimitiveTensor)
 def expand_split(
     tensor: SplitPrimitiveTensor, shape: List[int]
@@ -589,14 +526,6 @@ def expand_split(
     shape[shard_dim] = -1
     shards = [expand(shard, shape) for shard in tensor.shards]
     return SplitPrimitiveTensor(ts=shards, shard_dim=tensor.shard_dim)
-
-
-@flatten.override(ReplicatedTensor)
-def flatten_replicated(
-    input: ReplicatedTensor, start_dim: int, end_dim: int
-) -> ReplicatedTensor:
-    shards = [shard.flatten(start_dim, end_dim) for shard in input.shards]
-    return ReplicatedTensor(ts=shards)
 
 
 @flatten.override(SplitPrimitiveTensor)
@@ -622,18 +551,6 @@ def flatten_split(
     return SplitPrimitiveTensor(ts=shards, shard_dim=shard_dim)
 
 
-@gather.override(ReplicatedTensor, ReplicatedTensor)
-def gather_replicated(
-    input: ReplicatedTensor, dim: int, index: ReplicatedTensor
-) -> Tensor:
-    assert input.shard_count == index.shard_count
-    shards = [
-        gather(input_shard, dim, index_shard)
-        for input_shard, index_shard in zip(input.shards, index.shards)
-    ]
-    return ReplicatedTensor(ts=shards)
-
-
 @group_norm_affine.override(
     SplitPrimitiveTensor, SplitPrimitiveTensor, SplitPrimitiveTensor
 )
@@ -652,24 +569,6 @@ def shareded_group_norm_affine(input, weight, bias, *, num_groups, eps):
     ]
 
     return SplitPrimitiveTensor(shard_dim=1, ts=result_shards)
-
-
-@index_copy_.override(ReplicatedTensor, ReplicatedTensor, ReplicatedTensor)
-def index_copy__replicated_replicated_replicated(
-    inout: ReplicatedTensor,
-    dim: int,
-    index: ReplicatedTensor,
-    tensor: ReplicatedTensor,
-) -> ReplicatedTensor:
-    assert (
-        inout.shard_count == index.shard_count
-        and inout.shard_count == tensor.shard_count
-    )
-    for inout_shard, index_shard, tensor_shard in zip(
-        inout.shards, index.shards, tensor.shards
-    ):
-        index_copy_(inout_shard, dim, index_shard, tensor_shard)
-    return inout
 
 
 @index_copy_.override(SplitPrimitiveTensor, ReplicatedTensor, ReplicatedTensor)
@@ -711,19 +610,6 @@ def index_copy__split_replicated_split(
     return inout
 
 
-@index_put_.override(AllOfType(ReplicatedTensor))
-def index_put__replicated(
-    inout: ReplicatedTensor,
-    indices: Tuple[ReplicatedTensor],
-    values: ReplicatedTensor,
-) -> ReplicatedTensor:
-    assert inout.shard_count == values.shard_count
-    for i, shard in enumerate(inout.shards):
-        shard_indices = [idx.shards[i] for idx in indices]
-        shard.index_put_(shard_indices, values.shards[i])
-    return inout
-
-
 @index_put_.override(
     AllOfExprsVariadic(
         IsOfType(SplitPrimitiveTensor),
@@ -745,20 +631,6 @@ def index_put__split(
     return inout
 
 
-@index_select.override(ReplicatedTensor, ReplicatedTensor)
-def index_select_replicated(
-    tensor: ReplicatedTensor,
-    dim: int,
-    index: ReplicatedTensor,
-) -> ReplicatedTensor:
-    assert tensor.shard_count == index.shard_count
-    shards = [
-        index_select(tensor_shard, dim, index_shard)
-        for tensor_shard, index_shard in zip(tensor.shards, index.shards)
-    ]
-    return ReplicatedTensor(ts=shards)
-
-
 @index_select.override(SplitPrimitiveTensor, ReplicatedTensor)
 def index_select_split_replicated(
     tensor: SplitPrimitiveTensor,
@@ -774,31 +646,6 @@ def index_select_split_replicated(
         for tensor_shard, index_shard in zip(tensor.shards, index.shards)
     ]
     return SplitPrimitiveTensor(ts=shards, shard_dim=tensor.shard_dim)
-
-
-@interpolate.override(ReplicatedTensor)
-def interpolate_replicated(
-    input: ReplicatedTensor,
-    size: Optional[int | List[int]],
-    scale_factor: Optional[float | List[float]],
-    mode: str,
-    align_corners: Optional[bool],
-    recompute_scale_factor: Optional[bool],
-    antialias: bool,
-) -> ReplicatedTensor:
-    shards = [
-        torch.nn.functional.interpolate(
-            input=unbox_tensor(shard),
-            size=size,
-            scale_factor=scale_factor,
-            mode=mode,
-            align_corners=align_corners,
-            recompute_scale_factor=recompute_scale_factor,
-            antialias=antialias,
-        )
-        for shard in input.shards
-    ]
-    return ReplicatedTensor(ts=shards)
 
 
 @interpolate.override(SplitPrimitiveTensor)
@@ -867,20 +714,6 @@ for types in itertools.product([Tensor, ShardedTensor], repeat=2):
         linear.override(*types, auto_dequant=True)(linear_sharded)
 
 
-@masked_fill.override(AllOfType(ReplicatedTensor))
-def masked_fill_replicated(
-    tensor: ReplicatedTensor,
-    mask: ReplicatedTensor,
-    value: Number,
-) -> ReplicatedTensor:
-    assert tensor.shard_count == mask.shard_count
-    shards = [
-        shard.masked_fill(mask_shard, value)
-        for shard, mask_shard in zip(tensor.shards, mask.shards)
-    ]
-    return ReplicatedTensor(ts=shards)
-
-
 @masked_fill.override(AllOfType(SplitPrimitiveTensor))
 def masked_fill_split(
     tensor: SplitPrimitiveTensor,
@@ -896,22 +729,6 @@ def masked_fill_split(
 
 
 # Sharded matmuls.
-
-
-@matmul.override(ReplicatedTensor, ReplicatedTensor)
-def matmul_replicated(
-    lhs: ReplicatedTensor, rhs: ReplicatedTensor, *, transpose_rhs: bool
-) -> ReplicatedTensor:
-    assert lhs.shard_count == rhs.shard_count
-
-    if transpose_rhs:
-        return matmul(lhs, rhs.T)
-
-    shards = [
-        matmul(lhs_shard, rhs_shard)
-        for (lhs_shard, rhs_shard) in zip(lhs.shards, rhs.shards)
-    ]
-    return ReplicatedTensor(ts=shards)
 
 
 @matmul.override(ReplicatedTensor, SplitPrimitiveTensor)
@@ -1045,37 +862,6 @@ def matmul_split(
     assert False, "Sharding configuration not supported"
 
 
-# Scaled dot product attention
-@scaled_dot_product_attention.override(
-    ReplicatedTensor, ReplicatedTensor, ReplicatedTensor, Optional[ReplicatedTensor]
-)
-def scaled_dot_product_attention_replicated(
-    q: ReplicatedTensor,
-    k: ReplicatedTensor,
-    v: ReplicatedTensor,
-    a: Optional[ReplicatedTensor],
-    is_causal: bool,
-    scale: float,
-) -> ReplicatedTensor:
-    if q.shard_count != k.shard_count or q.shard_count != v.shard_count:
-        raise ValueError("Incompatible number of shards for qkv")
-
-    if a and q.shard_count != a.shard_count:
-        raise ValueError(
-            f"Incompatible number of shards for a ({a.shard_count}) should be ({q.shard_count})"
-        )
-    a_shards = [None] * q.shard_count if a is None else a.shards
-
-    output_shards = []
-    for q_s, k_s, v_s, a_s in zip(q.shards, k.shards, v.shards, a_shards):
-        o_s = scaled_dot_product_attention(
-            q_s, k_s, v_s, a_s, is_causal=is_causal, scale=scale
-        )
-        output_shards.append(o_s)
-
-    return ReplicatedTensor(ts=output_shards)
-
-
 @scaled_dot_product_attention.override(
     SplitPrimitiveTensor,
     SplitPrimitiveTensor,
@@ -1111,18 +897,6 @@ def scaled_dot_product_attention_sharded(
         output_shards.append(o_s)
 
     return SplitPrimitiveTensor(ts=output_shards, shard_dim=q.shard_dim)
-
-
-@mean.override(ReplicatedTensor)
-def mean_replicated(
-    x: ReplicatedTensor,
-    dim: Union[int, List[int]],
-    keepdim: bool,
-    *,
-    dtype: torch.dtype,
-) -> ReplicatedTensor:
-    shards = [mean(shard, dim=dim, keepdim=keepdim, dtype=dtype) for shard in x.shards]
-    return ReplicatedTensor(ts=shards)
 
 
 @mean.override(SplitPrimitiveTensor)
@@ -1172,19 +946,8 @@ def module_register_buffer_sharded(
     setattr(module, name, tensor)
 
 
-@pad.override(ReplicatedTensor)
-def pad_replicated(
-    input: ReplicatedTensor,
-    _pad: List[int],
-    mode: str = None,
-    value: Optional[float] = None,
-) -> ReplicatedTensor:
-    shards = [pad(shard, _pad=_pad, mode=mode, value=value) for shard in input.shards]
-    return ReplicatedTensor(ts=shards)
-
-
 @pad.override(SplitPrimitiveTensor)
-def pad_replicated(
+def pad_split(
     input: SplitPrimitiveTensor,
     _pad: List[int],
     mode: str = None,
@@ -1228,18 +991,6 @@ def permute_split(tensor: SplitPrimitiveTensor, dims: List[int]):
     permuted_shards = [permute(shard, dims) for shard in tensor.shards]
     permuted_shard_dim = dims[tensor.shard_dim]
     return SplitPrimitiveTensor(ts=permuted_shards, shard_dim=permuted_shard_dim)
-
-
-@permute.override(ReplicatedTensor)
-def permute_replicated(tensor: ReplicatedTensor, dims: List[int]):
-    permuted_shards = [permute(shard, dims) for shard in tensor.shards]
-    return ReplicatedTensor(ts=permuted_shards)
-
-
-@repeat.override(ReplicatedTensor)
-def repeat_replicated(input: ReplicatedTensor, *sizes: List[int]) -> ReplicatedTensor:
-    shards = [repeat(shard, *sizes) for shard in input.shards]
-    return ReplicatedTensor(ts=shards)
 
 
 @replicate.override(ReplicatedTensor)
@@ -1474,22 +1225,6 @@ def reshard_like_unreduced_to_replicated(
     return replicate(tensor, count=like.shard_count)
 
 
-@scatter_.override(ReplicatedTensor, ReplicatedTensor)
-def scatter_replicated_replicated(
-    inout: ReplicatedTensor,
-    dim: int,
-    index: ReplicatedTensor,
-    value: Number,
-    *,
-    reduce: str = None,
-) -> ReplicatedTensor:
-    assert isinstance(value, Number), "Tensor version of this op not implemented"
-    assert inout.shard_count == index.shard_count
-    for shard, index_shard in zip(inout.shards, index.shards):
-        scatter_(shard, dim, index_shard, value, reduce=reduce)
-    return inout
-
-
 @scatter_.override(SplitPrimitiveTensor, SplitPrimitiveTensor)
 def scatter_split_split(
     inout: SplitPrimitiveTensor,
@@ -1597,14 +1332,6 @@ def sigmoid_sharded(tensor: ShardedTensor) -> ShardedTensor:
     return elementwise(torch.sigmoid, tensor)
 
 
-@softmax.override(ReplicatedTensor)
-def softmax_replicated(
-    tensor: ReplicatedTensor, dim: Optional[int], dtype: Optional[torch.dtype]
-) -> ReplicatedTensor:
-    shards = [softmax(shard, dim=dim, dtype=dtype) for shard in tensor.shards]
-    return tensor.clone(ts=shards)
-
-
 @softmax.override(SplitPrimitiveTensor)
 def softmax_split(
     tensor: SplitPrimitiveTensor, dim: Optional[int], dtype: Optional[torch.dtype]
@@ -1617,21 +1344,6 @@ def softmax_split(
     return SplitPrimitiveTensor(
         ts=shards, shard_dim=tensor.shard_dim, shape=tensor.shape
     )
-
-
-@sum.override(ReplicatedTensor)
-def sum_replicated(
-    input: ReplicatedTensor,
-    dim: int | List[int] | None,
-    keepdim: bool,
-    *,
-    dtype: torch.dtype,
-) -> ReplicatedTensor:
-    assert dim is not None, "sum dim must be specified"
-    shards = [
-        sum(shard, dim=dim, keepdim=keepdim, dtype=dtype) for shard in input.shards
-    ]
-    return ReplicatedTensor(ts=shards)
 
 
 @sum.override(SplitPrimitiveTensor)
@@ -1681,19 +1393,6 @@ def to_sharded(tensor: ShardedTensor, *args, **kwargs):
     return tensor.clone(ts=shards)
 
 
-@topk.override(ReplicatedTensor)
-def topk_replicated(
-    input: ReplicatedTensor, k: int, dim: int, largest: bool, sorted: bool
-) -> tuple[ReplicatedTensor, ReplicatedTensor]:
-    values, indices = zip(
-        *(
-            topk(shard, k=k, dim=dim, largest=largest, sorted=sorted)
-            for shard in input.shards
-        )
-    )
-    return ReplicatedTensor(ts=values), ReplicatedTensor(ts=indices)
-
-
 @topk.override(SplitPrimitiveTensor)
 def topk_split(
     input: SplitPrimitiveTensor, k: int, dim: int, largest: bool, sorted: bool
@@ -1721,14 +1420,6 @@ def topk_split(
         return values, indices
 
 
-@transpose.override(ReplicatedTensor)
-def transpose_replicated(
-    tensor: ReplicatedTensor, dim0: int, dim1: int
-) -> ReplicatedTensor:
-    shards = [transpose(shard, dim0, dim1) for shard in tensor.shards]
-    return ReplicatedTensor(ts=shards)
-
-
 @transpose.override(SplitPrimitiveTensor)
 def transpose_split(
     tensor: SplitPrimitiveTensor, dim0: int, dim1: int
@@ -1740,14 +1431,6 @@ def transpose_split(
     elif shard_dim == dim1:
         shard_dim = dim0
     return SplitPrimitiveTensor(ts=shards, shard_dim=shard_dim)
-
-
-@unflatten.override(ReplicatedTensor)
-def unflatten_replicated(
-    input: ReplicatedTensor, dim: int, sizes: Tuple[int]
-) -> ReplicatedTensor:
-    shards = [unflatten(shard, dim, sizes) for shard in input.shards]
-    return input.clone(ts=shards)
 
 
 @unflatten.override(SplitPrimitiveTensor)
@@ -1987,20 +1670,6 @@ def unsqueeze_split(tensor: SplitPrimitiveTensor, dim: int) -> SplitPrimitiveTen
     return SplitPrimitiveTensor(ts=shards, shard_dim=shard_dim)
 
 
-@unsqueeze.override(ReplicatedTensor)
-def unsqueeze_replicated(tensor: ReplicatedTensor, dim: int) -> SplitPrimitiveTensor:
-    shards = [torch.unsqueeze(unbox_tensor(shard), dim) for shard in tensor.shards]
-    return ReplicatedTensor(ts=shards)
-
-
-@view.override(ReplicatedTensor)
-def view_replicated(tensor: ReplicatedTensor, shape: List[int]) -> ReplicatedTensor:
-    shards = [view(shard, shape) for shard in tensor.shards]
-    res = ReplicatedTensor(ts=shards)
-    assert math.prod(res.shape) == math.prod(tensor.shape)
-    return res
-
-
 @view.override(SplitPrimitiveTensor)
 def view_split(tensor: SplitPrimitiveTensor, shape: List[int]) -> SplitPrimitiveTensor:
     shard_dim = tensor.shard_dim
@@ -2055,22 +1724,10 @@ def view_as_complex_split(tensor: SplitPrimitiveTensor) -> SplitPrimitiveTensor:
     return SplitPrimitiveTensor(ts=shards, shard_dim=tensor.shard_dim)
 
 
-@view_as_complex.override(ReplicatedTensor)
-def view_as_complex_rep(tensor: ReplicatedTensor) -> ReplicatedTensor:
-    shards = [view_as_complex(shard) for shard in tensor.shards]
-    return ReplicatedTensor(ts=shards)
-
-
 @view_as_real.override(SplitPrimitiveTensor)
 def view_as_real_split(tensor: SplitPrimitiveTensor) -> SplitPrimitiveTensor:
     shards = [view_as_real(shard) for shard in tensor.shards]
     return SplitPrimitiveTensor(ts=shards, shard_dim=tensor.shard_dim)
-
-
-@view_as_real.override(ReplicatedTensor)
-def view_as_real_rep(tensor: ReplicatedTensor) -> ReplicatedTensor:
-    shards = [view_as_real(shard) for shard in tensor.shards]
-    return ReplicatedTensor(ts=shards)
 
 
 @zeros_like.override(AllOfType(ReplicatedTensor, SplitPrimitiveTensor))

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -88,7 +88,7 @@ __all__ = [
 IntOrSequenceInt = Union[int, Sequence[int]]
 
 
-@overridable
+@overridable(is_trivially_replicable=False)
 def all_gather(maybe_sharded: AnyTensor, *, dim: int | None = None) -> AnyTensor:
     "Gather/concatenate on all devices along dimension `dim`."
     ...
@@ -107,7 +107,7 @@ def _all_gather_trampoline(
         d.fail(tensors)
 
 
-@overridable
+@overridable(is_trivially_replicable=False)
 def all_reduce(tensor: AnyTensor) -> AnyTensor:
     "Reduce on all devices."
     ...
@@ -303,7 +303,7 @@ def _embedding_lookup_trampoline(
         d.fail(tensors)
 
 
-@overridable
+@overridable(is_trivially_replicable=False)
 def equal(a: AnyTensor, b: AnyTensor) -> bool:
     """Compares 2 tensors for equality, such that they elements and dtype are equal.
 
@@ -836,7 +836,7 @@ def _mean_trampoline(
         d.fail(tensors)
 
 
-@overridable
+@overridable(is_trivially_replicable=False)
 def module_register_buffer(
     module: torch.nn.Module, name: str, tensor: AnyTensor
 ) -> None:
@@ -988,7 +988,7 @@ def _reshape_trampoline(d: SignatureDispatcher, input, shape) -> AnyTensor:
         d.fail(dispatch_args)
 
 
-@overridable
+@overridable(is_trivially_replicable=False)
 def reshard(
     input: AnyTensor | Theta,
     spec: (
@@ -1013,7 +1013,7 @@ def _reshard_trampoline(d: SignatureDispatcher, input, spec) -> ShardedTensor:
         d.fail(dispatch_args)
 
 
-@overridable
+@overridable(is_trivially_replicable=False)
 def reshard_split(
     input: AnyTensor, *, dim: int, count: int, devices: tuple[int, ...] | None
 ) -> ShardedTensor:
@@ -1046,7 +1046,7 @@ def _reshard_split_trampoline(
         d.fail(tensors)
 
 
-@overridable
+@overridable(is_trivially_replicable=False)
 def reshard_like(input: AnyTensor, like: AnyTensor) -> AnyTensor:
     """Shard `input` the same way as `like`.
 
@@ -1098,7 +1098,7 @@ def _scatter__trampoline(
         d.fail(tensors)
 
 
-@overridable
+@overridable(is_trivially_replicable=False)
 def sharded_cat(maybe_sharded: AnyTensor):
     """Concats all shards along the sharding dimension.
 
@@ -1118,7 +1118,7 @@ def _sharded_cat_trampoline(d: SignatureDispatcher, maybe_sharded: AnyTensor):
         d.fail(tensors)
 
 
-@overridable
+@overridable(is_trivially_replicable=False)
 def sharded_sum(maybe_sharded: AnyTensor):
     ...
 
@@ -1209,7 +1209,7 @@ def _transfer_to_logical_device_trampoline(
         d.fail(tensors)
 
 
-@overridable
+@overridable(is_trivially_replicable=False)
 def barrier_on_logical_device(tensor: AnyTensor, ordinal: int) -> AnyTensor:
     """Transfer the tensor to a device with ordinal `ordinal`."""
     ...
@@ -1228,7 +1228,7 @@ def _barrier_on_logical_device_trampoline(
         d.fail(tensors)
 
 
-@overridable
+@overridable(is_trivially_replicable=False)
 def transfer_to_logical_device(tensor: AnyTensor, ordinal: int) -> AnyTensor:
     """Transfer the tensor to a device with ordinal `ordinal`."""
     ...
@@ -1285,7 +1285,7 @@ def _unflatten_trampoline(
         d.fail(dispatch_args)
 
 
-@overridable
+@overridable(is_trivially_replicable=False)
 def unshard(tensor: AnyTensor) -> AnyTensor:
     """Return the tensor that has the same elements and shape, but is not sharded."""
     ...

--- a/sharktank/sharktank/ops/utils.py
+++ b/sharktank/sharktank/ops/utils.py
@@ -1,0 +1,175 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import functools
+
+from typing import Callable, Sequence, Any
+from sharktank.utils import tree
+
+
+def call_trivially_replicable(
+    fn: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> Any:
+    """Call an function with replicated tensor arguments that can be called with
+    unsharded tensors.
+
+    It is expected that all replicated tensors have the same number of shards.
+    The function will be called with each set of matching shard indices and
+    replicated tensor(s) will be constructed from the resulting shards.
+
+    This wrapper handles tee-like structures in the arguments and results. It will
+    traverse them and handle nested tensors. Note that sequence and dictionary types
+    will be reconstructed with dict and tuple types, so the underlying function fn
+    must be polymorphic in this regard and not expect concrete types.
+
+    When collecting the results all non-tensor results are taken from the first device.
+    """
+
+    from sharktank.types import (
+        ReplicatedTensor,
+        is_any_tensor,
+    )
+
+    def is_leaf(v: Any) -> bool:
+        return is_any_tensor(v) or tree.is_leaf_default(v)
+
+    flat_args = tree.flatten(
+        (
+            args,
+            kwargs,
+        ),
+        is_leaf=is_leaf,
+    )
+    first_replicated_tensor_arg = [
+        arg for arg in flat_args if isinstance(arg, ReplicatedTensor)
+    ]
+    first_replicated_tensor_arg = (
+        None
+        if len(first_replicated_tensor_arg) == 0
+        else first_replicated_tensor_arg[0]
+    )
+    if first_replicated_tensor_arg is None:
+        # No replicated tensor arguments, just call the function.
+        return fn(*args, **kwargs)
+
+    shard_count = first_replicated_tensor_arg.shard_count
+
+    per_shard_args_and_kwargs = [
+        _extract_per_shard_args_and_kwargs(i, args, kwargs) for i in range(shard_count)
+    ]
+    per_shard_results = [
+        fn(*per_shard_args, **per_shard_kwargs)
+        for per_shard_args, per_shard_kwargs in per_shard_args_and_kwargs
+    ]
+
+    def reduce_to_list_of_tensors_fn(a: Any, b: Any) -> Any:
+        if not is_any_tensor(b):
+            return a
+        a.append(b)
+        return a
+
+    def tensor_to_empty_list(x: Any) -> list:
+        if is_any_tensor(x):
+            return []
+        return x
+
+    reduce_initial = tree.map_leaves(
+        per_shard_results[0], f=tensor_to_empty_list, is_leaf=is_leaf
+    )
+
+    # Make a lists of tensor shards that correspond to the same replicated tensor.
+    reduced_results = tree.reduce_horizontal(
+        fn=reduce_to_list_of_tensors_fn,
+        trees=per_shard_results,
+        is_leaf=is_leaf,
+        initial=reduce_initial,
+    )
+
+    def make_replicated_tensor_if_tensor_collection(x: Any) -> Any:
+        if _is_tensor_collection(x):
+            return ReplicatedTensor(ts=x, devices=first_replicated_tensor_arg.devices)
+        return x
+
+    result_with_replicated_tensor = tree.map_leaves(
+        reduced_results,
+        f=make_replicated_tensor_if_tensor_collection,
+        is_leaf=_is_leaf_or_tensor_collection,
+    )
+    return result_with_replicated_tensor
+
+
+def trivially_replicable(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """A decorator to turn an trivially replicable operation into a replicated
+    operation.
+
+    An operation is trivially replicable if the replicated variant just executes the
+    operation on all devices with the respective shards.
+
+    E.g.
+    ```
+    @trivially_replicable
+    def fn(a: torch.Tensor) -> torch.Tensor:
+        return a
+
+    arg = torch.Tensor([1, 2, 3])
+    shard_count = 2
+    replicated_arg = ReplicatedTensor(
+        ts=arg, shard_count=shard_count
+    )
+    fn(replicated_arg)
+    ```
+
+    ```
+    ReplicatedTensor(<unnamed>, [3], shard_count=2 of [3])
+    ```
+    """
+
+    def wrapper(*args, **kwargs):
+        return call_trivially_replicable(fn, args, kwargs)
+
+    return wrapper
+
+
+def _extract_per_shard_args_and_kwargs(
+    shard_index: int, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    return tree.map_leaves(
+        (args, kwargs),
+        f=functools.partial(
+            _extract_tensor_shard_if_replicate, shard_index=shard_index
+        ),
+        is_leaf=_is_leaf,
+    )
+
+
+def _extract_tensor_shard_if_replicate(v: Any, shard_index: int) -> Any:
+    from sharktank.types import (
+        ReplicatedTensor,
+    )
+
+    if isinstance(v, ReplicatedTensor):
+        return v.shards[shard_index]
+    return v
+
+
+def _is_leaf(v: Any) -> bool:
+    from sharktank.types import (
+        is_any_tensor,
+    )
+
+    return is_any_tensor(v) or tree.is_leaf_default(v)
+
+
+def _is_leaf_or_tensor_collection(x: Any) -> bool:
+    return _is_leaf(x) or _is_tensor_collection(x)
+
+
+def _is_tensor_collection(x: Any) -> bool:
+    from sharktank.types import (
+        is_any_tensor,
+    )
+
+    return isinstance(x, Sequence) and all(is_any_tensor(v) for v in x)

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -46,6 +46,7 @@ __all__ = [
     "dtype_to_serialized_short_name",
     "flatten_tensor_tree",
     "InferenceTensor",
+    "is_any_tensor",
     "MetaDataValueType",
     "PlanarQuantizedTensor",
     "PrimitiveTensor",
@@ -1457,6 +1458,10 @@ class UnreducedTensor(ShardedTensorBase):
         kwargs["shape"] = kwargs.get("shape", self.shape)
         kwargs["devices"] = kwargs.get("devices", self.devices)
         return UnreducedTensor(**kwargs)
+
+
+def is_any_tensor(x: Any) -> bool:
+    return isinstance(x, InferenceTensor) or isinstance(x, torch.Tensor)
 
 
 def flatten_tensor_tree(

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -1461,7 +1461,7 @@ class UnreducedTensor(ShardedTensorBase):
 
 
 def is_any_tensor(x: Any) -> bool:
-    return isinstance(x, InferenceTensor) or isinstance(x, torch.Tensor)
+    return isinstance(x, (InferenceTensor, torch.Tensor))
 
 
 def flatten_tensor_tree(

--- a/sharktank/sharktank/utils/tree.py
+++ b/sharktank/sharktank/utils/tree.py
@@ -6,6 +6,7 @@
 
 from typing import Dict, Any, Callable, Mapping, Iterable, Sequence, Union
 from collections.abc import Mapping as MappingABC, Iterable as IterableABC
+import functools
 
 Key = Any
 Leaf = Any
@@ -14,7 +15,7 @@ IsLeaf = Callable[[Tree], bool]
 
 
 def is_leaf_default(tree: Tree) -> bool:
-    return not isinstance(tree, IterableABC)
+    return not isinstance(tree, IterableABC) or isinstance(tree, str)
 
 
 def is_not_tuple_list_or_dict(tree: Tree) -> bool:
@@ -22,51 +23,149 @@ def is_not_tuple_list_or_dict(tree: Tree) -> bool:
 
 
 def map_nodes(
-    tree: Tree, f: Callable[[Tree], Tree], is_leaf: IsLeaf | None = None
+    tree: Tree,
+    f: Callable[[Tree], Tree],
+    is_leaf: IsLeaf = is_leaf_default,
+    *,
+    dict_type: type = dict,
+    sequence_type: type = tuple
 ) -> Tree:
     """Apply `f` for each node in the tree. Leaves and branches.
 
     This includes the root `tree` as well."""
-    if is_leaf is None:
-        is_leaf = is_leaf_default
-
     if is_leaf(tree):
         return f(tree)
     elif isinstance(tree, MappingABC):
-        return f({k: map_nodes(v, f, is_leaf) for k, v in tree.items()})
+        return f(
+            dict_type(
+                (
+                    k,
+                    map_nodes(
+                        v, f, is_leaf, dict_type=dict_type, sequence_type=sequence_type
+                    ),
+                )
+                for k, v in tree.items()
+            )
+        )
     else:
-        return f([map_nodes(v, f, is_leaf) for v in tree])
+        return f(
+            sequence_type(
+                map_nodes(
+                    v, f, is_leaf, dict_type=dict_type, sequence_type=sequence_type
+                )
+                for v in tree
+            )
+        )
 
 
 def map_leaves(
-    tree: Tree, f: Callable[[Tree], Tree], is_leaf: IsLeaf | None = None
+    tree: Tree,
+    f: Callable[[Tree], Tree],
+    is_leaf: IsLeaf = is_leaf_default,
+    *,
+    dict_type: type = dict,
+    sequence_type: type = tuple
 ) -> Tree:
     """Apply `f` for each leaf in the tree."""
-    if is_leaf is None:
-        is_leaf = is_leaf_default
+    if is_leaf(tree):
+        return f(tree)
+    elif isinstance(tree, MappingABC):
+        return dict_type(
+            (
+                k,
+                map_leaves(
+                    v, f, is_leaf, dict_type=dict_type, sequence_type=sequence_type
+                ),
+            )
+            for k, v in tree.items()
+        )
+    else:
+        return sequence_type(
+            map_leaves(v, f, is_leaf, dict_type=dict_type, sequence_type=sequence_type)
+            for v in tree
+        )
 
-    def f_leaves_and_nodes(t: Tree) -> Tree:
-        if is_leaf(t):
-            return f(t)
-        else:
-            return t
 
-    return map_nodes(tree, f_leaves_and_nodes, is_leaf)
-
-
-def flatten(tree: Tree, is_leaf: IsLeaf | None = None) -> Sequence[Leaf]:
+def flatten(tree: Tree, is_leaf: IsLeaf = is_leaf_default) -> Sequence[Leaf]:
     """Get the leaves of the tree."""
-    return [x for x in _flatten(tree, is_leaf)]
+    return [x for x in iterate_leaves(tree, is_leaf)]
 
 
-def _flatten(tree: Tree, is_leaf: IsLeaf | None = None) -> Iterable[Leaf]:
-    if is_leaf is None:
-        is_leaf = is_leaf_default
+def iterate_leaves(tree: Tree, is_leaf: IsLeaf = is_leaf_default) -> Iterable[Leaf]:
     if is_leaf(tree):
         yield tree
     elif isinstance(tree, MappingABC):
         for v in tree.values():
-            yield from flatten(v, is_leaf)
+            yield from iterate_leaves(v, is_leaf)
     else:
         for v in tree:
-            yield from flatten(v, is_leaf)
+            yield from iterate_leaves(v, is_leaf)
+
+
+_initial_missing = object()
+
+
+def reduce_horizontal(
+    fn: Callable[[Any, Leaf], Any],
+    trees: Sequence[Tree],
+    initial: Tree = _initial_missing,
+    is_leaf: IsLeaf = is_leaf_default,
+    dict_type: type = dict,
+    sequence_type: type = tuple,
+) -> Tree:
+    """Reduce a list of trees such that elements with the same path in the tree are
+    aligned.
+
+    E.g.
+    ```
+    {"a": a1, {"b": b1}}
+    {"a": a2, {"b": b2}}
+    ```
+    """
+    if initial is _initial_missing:
+        initial = trees[0]
+        trees = trees[1:]
+
+    return _reduce_horizontal(fn, trees, initial, is_leaf, dict_type, sequence_type)
+
+
+def _reduce_horizontal(
+    fn: Callable[[Any, Leaf], Any],
+    trees: Sequence[Tree],
+    initial: Tree,
+    is_leaf: IsLeaf,
+    dict_type: type,
+    sequence_type: type,
+) -> Tree:
+    if len(trees) == 0:
+        return initial
+
+    if is_leaf(trees[0]):
+        return functools.reduce(fn, trees, initial)
+
+    if isinstance(trees[0], MappingABC):
+        return dict_type(
+            (
+                k,
+                _reduce_horizontal(
+                    fn,
+                    trees=[tree[k] for tree in trees],
+                    initial=initial_v,
+                    is_leaf=is_leaf,
+                    dict_type=dict_type,
+                    sequence_type=sequence_type,
+                ),
+            )
+            for k, initial_v in initial.items()
+        )
+    return sequence_type(
+        _reduce_horizontal(
+            fn,
+            trees=[tree[i] for tree in trees],
+            initial=initial_v,
+            is_leaf=is_leaf,
+            dict_type=dict_type,
+            sequence_type=sequence_type,
+        )
+        for i, initial_v in enumerate(initial)
+    )

--- a/sharktank/sharktank/utils/tree.py
+++ b/sharktank/sharktank/utils/tree.py
@@ -118,8 +118,17 @@ def reduce_horizontal(
 
     E.g.
     ```
-    {"a": a1, {"b": b1}}
-    {"a": a2, {"b": b2}}
+    trees = [
+        {"a": "a1", "b": ["b1"]},
+        {"a": "a2", "b": ["b2"]}
+    ]
+    reduce_horizontal(str.__add__, trees)
+    ```
+
+    results in
+
+    ```
+    {"a": "a1a2", "b": ["b1b2"]}
     ```
     """
     if initial is _initial_missing:

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -299,26 +299,6 @@ class CatTest(unittest.TestCase):
         actual_result = ops.cat([sharded_a, sharded_b], dim=cat_dim)
         assert expected_result.is_deep_equal(actual_result, compare_name=False)
 
-    def testCatReplicatedShouldFail(self):
-        """Concatenation of replicated tensors."""
-        shard_count = 2
-        cat_dim = 0
-        # Done to ensure no overlap with default devices so incorrect placement is caught
-        devices = tuple(range(shard_count, 2 * shard_count))
-
-        a = torch.rand(5, 4, dtype=torch.float32)
-        b = torch.rand(3, 4, dtype=torch.float32)
-
-        sharded_a = ReplicatedTensor(ts=a, shard_count=shard_count, devices=devices)
-        sharded_b = ReplicatedTensor(
-            ts=b, shard_count=shard_count, devices=tuple(range(shard_count))
-        )
-
-        with pytest.raises(
-            ValueError, match="All tensors must be placed on the same devices"
-        ):
-            ops.cat([sharded_a, sharded_b], dim=cat_dim)
-
 
 class ConvTest(unittest.TestCase):
     def testConv2dShardedInputAndOutputChannelsOneGroup(self):

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -1747,6 +1747,114 @@ class TransposeTest(unittest.TestCase):
             assert ops.equal(shard, expected)
 
 
+class TriviallyReplicableTest(unittest.TestCase):
+    def testOneArgOneResult(self):
+        @ops.trivially_replicable
+        def fn(a: torch.Tensor) -> torch.Tensor:
+            return a
+
+        arg = torch.Tensor([1, 2, 3])
+        shard_count = 2
+        replicated_arg = ReplicatedTensor(
+            ts=arg, shard_count=shard_count, devices=(1, 2)
+        )
+        replicated_result = fn(replicated_arg)
+        replicated_arg.is_deep_equal(replicated_result)
+
+    @parameterized.expand(
+        (
+            [1],
+            [2],
+        )
+    )
+    def testMultipleArgumentsAndResults(self, shard_count: int):
+        @ops.trivially_replicable
+        def fn(a: torch.Tensor, b: torch.Tensor) -> tuple[torch.Tensor, ...]:
+            # Swap order
+            return b, a
+
+        args = [torch.Tensor([1, 2, 3]), torch.Tensor([4, 5])]
+        replicated_args = [
+            ReplicatedTensor(ts=arg, shard_count=shard_count) for arg in args
+        ]
+        replicated_result = fn(*replicated_args)
+        replicated_args[0].is_deep_equal(replicated_result[1])
+        replicated_args[1].is_deep_equal(replicated_result[0])
+
+    def testListOfTensorsAsArgumentsAndResults(self):
+        @ops.trivially_replicable
+        def fn(a: list[torch.Tensor]) -> list[torch.Tensor]:
+            return a
+
+        arg = torch.Tensor([1, 2, 3])
+        shard_count = 2
+        replicated_arg = ReplicatedTensor(
+            ts=arg, shard_count=shard_count, devices=(1, 2)
+        )
+        replicated_result = fn(replicated_arg)
+        replicated_arg.is_deep_equal(replicated_result)
+
+    def testNestedTreeOfTensorsAsArgumentsAndResults(self):
+        @ops.trivially_replicable
+        def fn(a: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+            return a
+
+        arg = torch.Tensor([1, 2, 3])
+        shard_count = 2
+        replicated_arg = {
+            "a": [ReplicatedTensor(ts=arg, shard_count=shard_count, devices=(1, 2))]
+        }
+        replicated_result = fn(replicated_arg)
+        replicated_arg["a"][0].is_deep_equal(replicated_result["a"][0])
+
+    def testNonTensorArgumentsAndResults(self):
+        @ops.trivially_replicable
+        def fn(a: str, b: torch.Tensor, c: int) -> tuple[str, torch.Tensor, int]:
+            return a, b, c
+
+        args = ("a", torch.Tensor([1, 2, 3]), 1)
+        shard_count = 2
+        replicated_args = (
+            args[0],
+            ReplicatedTensor(ts=args[1], shard_count=shard_count),
+            args[2],
+        )
+        replicated_result = fn(*replicated_args)
+        replicated_args[0] == replicated_result[0]
+        replicated_args[1].is_deep_equal(replicated_result[1])
+        replicated_args[2] == replicated_result[2]
+
+    def testSignatureRegistration(self):
+        from sharktank.ops._registry import overridable, SignatureDispatcher
+
+        @overridable(is_trivially_replicable=True)
+        def f(a: torch.Tensor) -> torch.Tensor:
+            ...
+
+        @f.override(torch.Tensor)
+        def f_unsharded(a: torch.Tensor) -> torch.Tensor:
+            return a
+
+        @f.trampoline
+        def trampoline(
+            d: SignatureDispatcher,
+            a: AnyTensor,
+        ) -> AnyTensor:
+            tensors = (a,)
+            for override in d.find_overrides(tensors):
+                result = override(a)
+                if result is not NotImplemented:
+                    return override, result
+            else:
+                d.fail(tensors)
+
+        arg = torch.Tensor([1, 2, 3])
+        shard_count = 2
+        replicated_arg = ReplicatedTensor(ts=arg, shard_count=shard_count)
+        replicated_result = f(replicated_arg)
+        replicated_arg.is_deep_equal(replicated_result)
+
+
 class UnflattenTest(unittest.TestCase):
     def testUnflattenReplicated(self):
         a = torch.randn(3, 4, 1)

--- a/sharktank/tests/utils/tree_test.py
+++ b/sharktank/tests/utils/tree_test.py
@@ -1,0 +1,30 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Any
+from unittest import TestCase
+from sharktank.utils.tree import flatten, map_leaves, reduce_horizontal
+from sharktank.utils import iterables_equal
+
+
+class TreeTest(TestCase):
+    def testReduceHorizontal(self):
+        trees = [{"a": "a1", "b": ["b1"]}, {"a": "a2", "b": ["b2"]}]
+        result = reduce_horizontal(str.__add__, trees)
+        expected = {"a": "a1a2", "b": ["b1b2"]}
+        assert result["a"] == expected["a"]
+        assert result["b"][0] == expected["b"][0]
+
+    def testMapLeaves(self):
+        tree = {"a": "a", "b": ["b"]}
+        result = map_leaves(tree, str.upper)
+        expected = {"a": "A", "b": ["B"]}
+        assert result["a"] == expected["a"]
+        assert result["b"][0] == expected["b"][0]
+
+    def testFlatten(self):
+        tree = [1, {"a": 2, "b": 3}, [4]]
+        assert iterables_equal(flatten(tree), [1, 2, 3, 4])


### PR DESCRIPTION
The majority of operations have essentially the same replication mechanism across device. We call the underlying unsharded op with the corresponding shards and then construct a replicated tensor form the resulting shards.

This change solves this in general way to not have to write the same replication pattern for all ops.