### PR TITLE
Drop support for torch 2.3

### DIFF
--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -27,19 +27,12 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
-        torch-version: ["2.3.0", "2.4.1", "2.5.1"]
+        torch-version: ["2.4.1", "2.5.1"]
         runs-on: [ubuntu-24.04]
         include:
           - runs-on: windows-2022
-            python-version: "3.11"
-            torch-version: "2.3.0"
-          - runs-on: windows-2022
             python-version: "3.12"
             torch-version: "2.4.1"
-        exclude:
-          - python-version: "3.12"
-             # `torch.compile` requires torch>=2.4.0 for Python 3.12+
-            torch-version: "2.3.0"
       fail-fast: false
     runs-on: ${{matrix.runs-on}}
     defaults:
@@ -62,10 +55,6 @@ jobs:
         with:
           path: ${{ env.PIP_CACHE_DIR }}
           key: pip-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('*requirements*.txt','sharktank/requirements*.txt') }}
-
-      - name: Install numpy
-        if: ${{ matrix.runs-on == 'windows-2022' && matrix.torch-version == '2.3.0' }}
-        run: pip install "numpy<2.0"
 
       - name: Install pip deps
         run: |
@@ -120,10 +109,6 @@ jobs:
         with:
           path: ${{ env.PIP_CACHE_DIR }}
           key: pip-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('*requirements*.txt','sharktank/requirements*.txt') }}
-
-      - name: Install numpy
-        if: ${{ matrix.runs-on == 'windows-2022' && matrix.torch-version == '2.3.0' }}
-        run: pip install "numpy<2.0"
 
       - name: Install pip deps
         run: |

--- a/docs/shortfin/llm/user/llama_serving.md
+++ b/docs/shortfin/llm/user/llama_serving.md
@@ -85,7 +85,7 @@ following either https://pytorch.org/get-started/locally/ or our recommendation:
 
 ```bash
 # Fast installation of torch with just CPU support.
-pip install torch --index-url https://download.pytorch.org/whl/cpu "torch>=2.3.0,<2.6.0"
+pip install torch --index-url https://download.pytorch.org/whl/cpu "torch>=2.4.0,<2.6.0"
 ```
 
 ### Prepare a working directory

--- a/pytorch-cpu-requirements.txt
+++ b/pytorch-cpu-requirements.txt
@@ -1,2 +1,2 @@
 --index-url https://download.pytorch.org/whl/cpu/
-torch==2.3.0
+torch==2.5.1

--- a/pytorch-rocm-requirements.txt
+++ b/pytorch-rocm-requirements.txt
@@ -1,2 +1,2 @@
 --index-url https://download.pytorch.org/whl/rocm6.2
-torch>=2.3.0
+torch>=2.5.1


### PR DESCRIPTION
Torch 2.3 is more than an year old and we don't want to support it. On several occasions it caused problems during model tracing.

Next steps are to support Torch 2.6 and 2.7.
Then we can drop support for 2.4.