### PR TITLE
[sharktank] Tensor-parallel MoE block

### DIFF
--- a/sharktank/sharktank/layers/ffn_moe_block.py
+++ b/sharktank/sharktank/layers/ffn_moe_block.py
@@ -138,16 +138,19 @@ class DenseFFNMOE(ThetaLayer):
         """
         num_tokens, input_feature_dim = h.shape
 
+        router_scores = ops.reshard_like(
+            torch.empty([num_tokens, self.num_experts]), like=h
+        )
         # (self.num_experts, num_tokens)
         router_scores = (
-            torch.full([num_tokens, self.num_experts], 0, dtype=h.dtype)
+            ops.zeros_like(router_scores, dtype=h.dtype)
             .scatter_(1, top_experts_index, expert_gate)
             .transpose(0, 1)
         )
 
         # (self.num_experts, num_tokens)
         router_indices = (
-            torch.arange(num_tokens, device=h.device)
+            ops.reshard_like(torch.arange(num_tokens), router_scores)
             .view(1, -1)
             .expand(self.num_experts, -1)
         )
@@ -168,6 +171,7 @@ class DenseFFNMOE(ThetaLayer):
             self.num_experts * num_tokens, input_feature_dim
         )
         routed_out = routed_out * router_scores.reshape(-1, 1)
+        routed_out = ops.reshard_like(routed_out, like=h)
 
         # (num_tokens, input_feature_dim)
         return ops.zeros_like(h).scatter_add(

--- a/sharktank/sharktank/layers/ffn_moe_block.py
+++ b/sharktank/sharktank/layers/ffn_moe_block.py
@@ -122,19 +122,19 @@ class DenseFFNMOE(ThetaLayer):
         expert_gate: torch.Tensor,
     ) -> torch.Tensor:
         """
-        h:
-            Input tokens.
-            Shape of (batch_size * sequence_length, input_feature_dim).
-        top_experts_index:
-            indexes of selected top experts for each token.
-            Shape of (batch_size * sequence_length, num_top_experts).
-            Value range is [0, num_of_experts)
-        expert_gate:
-            router weights of selected top experts for each token.
-            Shape of (batch_size * sequence_length, num_top_experts).
+            h:
+                Input tokens.
+                Shape of (batch_size * sequence_length, input_feature_dim).
+            top_experts_index:
+                indexes of selected top experts for each token.
+                Shape of (batch_size * sequence_length, num_top_experts).
+                Value range is [0, num_of_experts)
+            expert_gate:
+                router weights of selected top experts for each token.
+                Shape of (batch_size * sequence_length, num_top_experts).
 
         Returns:
-            Tensor of shape (batch_size * sequence_length, expert_feature_dim)
+                Tensor of shape (batch_size * sequence_length, expert_feature_dim)
         """
         num_tokens, input_feature_dim = h.shape
 

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -491,24 +491,29 @@ def permute(tensor: Tensor, dims: List[int]):
     return torch.permute(torch_tensor, dims)
 
 
-@scatter_.override(AllOfType(Tensor, PrimitiveTensor))
+@scatter_.override(
+    AllOfExprs(
+        IsOfType(Tensor, PrimitiveTensor),
+        IsOfType(Tensor, PrimitiveTensor),
+        IsOfType(Tensor, PrimitiveTensor, Number),
+    )
+)
 def scatter__default(
     inout: Tensor | PrimitiveTensor,
     dim: int,
     index: Tensor | PrimitiveTensor,
-    value,
+    src: Tensor | PrimitiveTensor | Number,
     *,
     reduce: str | None = None,
 ) -> Tensor:
     inout = unbox_tensor(inout)
     index = unbox_tensor(index)
-    if isinstance(value, (torch.Tensor, InferenceTensor)):
-        assert isinstance(value, (torch.Tensor, PrimitiveTensor))
-        value = unbox_tensor(value)
+    if isinstance(src, (torch.Tensor, PrimitiveTensor)):
+        src = unbox_tensor(src)
     if reduce is not None:
-        inout.scatter_(dim, index, value, reduce=reduce)
+        inout.scatter_(dim, index, src, reduce=reduce)
     else:
-        inout.scatter_(dim, index, value)
+        inout.scatter_(dim, index, src)
     return inout
 
 
@@ -517,13 +522,11 @@ def scatter_add_default(
     input: Tensor | PrimitiveTensor,
     dim: int,
     index: Tensor | PrimitiveTensor,
-    src: Tensor | PrimitiveTensor | Number,
+    src: Tensor | PrimitiveTensor,
 ) -> Tensor:
     input = unbox_tensor(input)
     index = unbox_tensor(index)
-    if isinstance(src, (torch.Tensor, InferenceTensor)):
-        assert isinstance(src, (torch.Tensor, PrimitiveTensor))
-        src = unbox_tensor(src)
+    src = unbox_tensor(src)
     return torch.scatter_add(input, dim, index, src)
 
 

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -500,14 +500,31 @@ def scatter__default(
     *,
     reduce: str | None = None,
 ) -> Tensor:
-    assert isinstance(value, Number), "Tensor version of this op not implemented"
     inout = unbox_tensor(inout)
     index = unbox_tensor(index)
+    if isinstance(value, (torch.Tensor, InferenceTensor)):
+        assert isinstance(value, (torch.Tensor, PrimitiveTensor))
+        value = unbox_tensor(value)
     if reduce is not None:
         inout.scatter_(dim, index, value, reduce=reduce)
     else:
         inout.scatter_(dim, index, value)
     return inout
+
+
+@scatter_add.override(AllOfType(Tensor, PrimitiveTensor))
+def scatter_add_default(
+    input: Tensor | PrimitiveTensor,
+    dim: int,
+    index: Tensor | PrimitiveTensor,
+    src: Tensor | PrimitiveTensor | Number,
+) -> Tensor:
+    input = unbox_tensor(input)
+    index = unbox_tensor(index)
+    if isinstance(src, (torch.Tensor, InferenceTensor)):
+        assert isinstance(src, (torch.Tensor, PrimitiveTensor))
+        src = unbox_tensor(src)
+    return torch.scatter_add(input, dim, index, src)
 
 
 @sigmoid.override(Tensor)

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -65,6 +65,7 @@ __all__ = [
     "reshard_like",
     "scaled_dot_product_attention",
     "scatter_",
+    "scatter_add",
     "sharded_cat",
     "sharded_sum",
     "sigmoid",
@@ -297,6 +298,47 @@ def _embedding_lookup_trampoline(
     tensors = (input, embedding_matrix)
     for override in d.find_overrides(tensors):
         result = override(input, embedding_matrix, dtype)
+        if result is not NotImplemented:
+            return override, result
+    else:
+        d.fail(tensors)
+
+
+@overridable
+def empty_like(
+    tensor: AnyTensor,
+    *,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    requires_grad: bool = False,
+    memory_format: torch.memory_format = torch.preserve_format,
+) -> AnyTensor:
+    """See torch.zeros_like"""
+    ...
+
+
+@empty_like.trampoline
+def _zeros_like_trampoline(
+    d: SignatureDispatcher,
+    tensor: AnyTensor,
+    *,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    requires_grad: bool = False,
+    memory_format: torch.memory_format = torch.preserve_format,
+) -> AnyTensor:
+    tensors = (tensor,)
+    for override in d.find_overrides(tensors):
+        result = override(
+            tensor,
+            dtype=dtype,
+            layout=layout,
+            device=device,
+            requires_grad=requires_grad,
+            memory_format=memory_format,
+        )
         if result is not NotImplemented:
             return override, result
     else:
@@ -674,7 +716,7 @@ def linear(
 
     Equivalent to:
     ```
-    y = torch.matmul(input, weight.T) + bias
+    y = torch.matmul(input, weight.mT) + bias
     ```
 
     This operator is defined to operate on a limited number of quantized types.
@@ -733,10 +775,8 @@ def matmul(lhs: AnyTensor, rhs: AnyTensor, *, transpose_rhs: bool = False):
     """Performs a matmul where the RHS may be an InferenceTensor.
 
     Unlike torch.matmul, this variant is optimized for emission of a fused
-    `matmul(lhs, rhs.T)` and the `transpose_rhs=` defaults to True, indicating
-    the the RHS is expected to have been transposed already (by some outside
-    force). Most inference optimizers will store their weights in this way
-    and assume fusions that operate on them, so we just make it the default.
+    `matmul(lhs, rhs.mT)` when `transpose_rhs=True`. Most inference optimizers
+    will store their weights in this way and assume fusions that operate on them.
 
     Args:
     lhs: Left hand side tensor. Can have dimensionality > 2 for batch.
@@ -1092,6 +1132,34 @@ def _scatter__trampoline(
     tensors = (inout, index)
     for override in d.find_overrides(tensors):
         result = override(inout, dim, index, value, reduce=reduce)
+        if result is not NotImplemented:
+            return override, result
+    else:
+        d.fail(tensors)
+
+
+@overridable
+def scatter_add(
+    input: AnyTensor, dim: int, index: AnyTensor, src: AnyTensor | Number
+) -> AnyTensor:
+    """
+    See torch.scatter_add
+    NOTE: Does not modify the inout tensor in place for ShardedTensors, will return copy.
+    """
+    ...
+
+
+@scatter_add.trampoline
+def _scatter_add_trampoline(
+    d: SignatureDispatcher,
+    input: AnyTensor,
+    dim: int,
+    index: AnyTensor,
+    src: AnyTensor | Number,
+) -> AnyTensor:
+    tensors = (input, index, src)
+    for override in d.find_overrides(tensors):
+        result = override(input, dim, index, src)
         if result is not NotImplemented:
             return override, result
     else:

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -444,14 +444,19 @@ class InferenceTensor(ABC):
         return reshape(self, shape)
 
     def scatter_(
-        self, dim: int, index: "AnyTensor", value, *, reduce=None
+        self,
+        dim: int,
+        index: "AnyTensor",
+        src: Union["AnyTensor", Number],
+        *,
+        reduce=None,
     ) -> "AnyTensor":
         from sharktank.ops import scatter_
 
-        return scatter_(self, dim, index, value, reduce=reduce)
+        return scatter_(self, dim, index, src, reduce=reduce)
 
     def scatter_add(
-        self, dim: int, index: "AnyTensor", src: Union["AnyTensor", Number]
+        self, dim: int, index: "AnyTensor", src: "AnyTensor"
     ) -> "AnyTensor":
         from sharktank.ops import scatter_add
 

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -354,6 +354,12 @@ class InferenceTensor(ABC):
 
         return permute(self, dims=dims)
 
+    @property
+    def mT(self) -> "AnyTensor":
+        from sharktank.ops import transpose
+
+        return transpose(self, -2, -1)
+
     def bool(self) -> "InferenceTensor":
         from sharktank.ops import to
 
@@ -444,6 +450,13 @@ class InferenceTensor(ABC):
 
         return scatter_(self, dim, index, value, reduce=reduce)
 
+    def scatter_add(
+        self, dim: int, index: "AnyTensor", src: Union["AnyTensor", Number]
+    ) -> "AnyTensor":
+        from sharktank.ops import scatter_add
+
+        return scatter_add(self, dim, index, src)
+
     def sigmoid(self) -> "AnyTensor":
         from sharktank.ops import sigmoid
 
@@ -513,6 +526,12 @@ class InferenceTensor(ABC):
             assert len(args) == 1
             shape = args[0]
         return view(self, shape)
+
+    def __gt__(self, lhs: Union["AnyTensor", Number]) -> "AnyTensor":
+        from sharktank.ops import elementwise
+        from operator import gt
+
+        return elementwise(gt, self, lhs)
 
     def __add__(self, rhs):
         from sharktank.ops import elementwise

--- a/sharktank/tests/layers/mixture_of_experts_block_test.py
+++ b/sharktank/tests/layers/mixture_of_experts_block_test.py
@@ -12,6 +12,9 @@ import torch
 from iree.turbine.aot import *
 from sharktank.models.llama.testing import make_moe_block_theta, make_rand_torch
 from sharktank.layers.mixture_of_experts_block import MoeBlock
+from sharktank.types.sharding import MoeBlockSharding
+from sharktank.ops import reshard, reshard_like, replicate
+from sharktank.types import unbox_tensor
 
 
 class MoeBlockTest(unittest.TestCase):
@@ -199,6 +202,106 @@ class MoeBlockTest(unittest.TestCase):
         res_pre_gather = moe_with_pre_gather_ffn(input)
         res_dense = moe_with_dense_ffn(input)
         torch.testing.assert_close(res_pre_gather, res_dense)
+
+    @parameterized.expand(
+        [
+            param(
+                dtype=torch.float32,
+                feature_dim=7,
+                expert_hidden_dim=3,
+                num_experts=12,
+                n_expert_groups=4,
+                n_limited_groups=2,
+                expert_used_count=2,
+                num_shared_experts=5,
+                shared_expert_hidden_dim=6,
+                batch_size=8,
+                sequence_length=9,
+                rms_epsilon=0.01,
+                moe_activation_fn=torch.nn.functional.silu,
+                score_experts_fn=torch.nn.functional.sigmoid,
+                normalize_experts=True,
+                add_residual=False,
+                route_scale=None,
+                tensor_parallelism_size=2,
+            ),
+        ]
+    )
+    def testTensorParallel(
+        self,
+        dtype: torch.dtype,
+        feature_dim: int,
+        expert_hidden_dim: int,
+        num_experts: int,
+        n_expert_groups: int | None,
+        n_limited_groups: int | None,
+        expert_used_count: int,
+        num_shared_experts: int,
+        shared_expert_hidden_dim: int,
+        batch_size: int,
+        sequence_length: int,
+        rms_epsilon: float,
+        moe_activation_fn: Callable[[torch.Tensor], torch.Tensor],
+        score_experts_fn: Callable[[torch.Tensor], torch.Tensor],
+        normalize_experts: bool,
+        add_residual: bool,
+        route_scale: float,
+        tensor_parallelism_size: int,
+    ):
+        from sharktank.layers.testing import make_random_moe_block_theta
+        from sharktank.layers import MoeBlock
+
+        devices = [i for i in range(tensor_parallelism_size)]
+
+        theta = make_random_moe_block_theta(
+            in_dim=feature_dim,
+            expert_hidden_dim=expert_hidden_dim,
+            num_experts=num_experts,
+            with_ffn_norm=False,
+            num_shared_experts=num_shared_experts,
+            shared_expert_hidden_dim=shared_expert_hidden_dim,
+            with_layer_output_norm=True,
+            dtype=dtype,
+        )
+        theta_sharding_spec = MoeBlockSharding(shard_count=tensor_parallelism_size)
+        sharded_theta = reshard(theta, spec=theta_sharding_spec)
+
+        block = MoeBlock(
+            theta=theta,
+            expert_count=num_experts,
+            n_expert_groups=n_expert_groups,
+            n_limited_groups=n_limited_groups,
+            expert_used_count=expert_used_count,
+            rms_epsilon=rms_epsilon,
+            moe_activation=moe_activation_fn,
+            score_experts=score_experts_fn,
+            normalize_experts=normalize_experts,
+            add_residual=add_residual,
+            route_scale=route_scale,
+        )
+        sharded_block = MoeBlock(
+            theta=sharded_theta,
+            expert_count=num_experts,
+            n_expert_groups=n_expert_groups,
+            n_limited_groups=n_limited_groups,
+            expert_used_count=expert_used_count,
+            rms_epsilon=rms_epsilon,
+            moe_activation=moe_activation_fn,
+            score_experts=score_experts_fn,
+            normalize_experts=normalize_experts,
+            add_residual=add_residual,
+            route_scale=route_scale,
+            tensor_parallel_devices=devices,
+        )
+
+        input = (
+            torch.rand([batch_size, sequence_length, feature_dim], dtype=dtype) - 0.5
+        )
+        sharded_input = replicate(input, count=tensor_parallelism_size)
+        expected = block(input)
+        actual = sharded_block(sharded_input)
+        actual = unbox_tensor(reshard_like(actual, like=expected))
+        torch.testing.assert_close(actual, expected)
 
 
 if __name__ == "__main__":

--- a/sharktank/tests/layers/mixture_of_experts_block_test.py
+++ b/sharktank/tests/layers/mixture_of_experts_block_test.py
@@ -225,6 +225,26 @@ class MoeBlockTest(unittest.TestCase):
                 route_scale=None,
                 tensor_parallelism_size=2,
             ),
+            param(
+                dtype=torch.bfloat16,
+                feature_dim=2,
+                expert_hidden_dim=6,
+                num_experts=9,
+                n_expert_groups=3,
+                n_limited_groups=3,
+                expert_used_count=7,
+                num_shared_experts=8,
+                shared_expert_hidden_dim=10,
+                batch_size=2,
+                sequence_length=3,
+                rms_epsilon=0.02,
+                moe_activation_fn=torch.nn.functional.gelu,
+                score_experts_fn=torch.nn.functional.sigmoid,
+                normalize_experts=True,
+                add_residual=False,
+                route_scale=1.1,
+                tensor_parallelism_size=3,
+            ),
         ]
     )
     def testTensorParallel(
@@ -250,8 +270,6 @@ class MoeBlockTest(unittest.TestCase):
     ):
         from sharktank.layers.testing import make_random_moe_block_theta
         from sharktank.layers import MoeBlock
-
-        devices = [i for i in range(tensor_parallelism_size)]
 
         theta = make_random_moe_block_theta(
             in_dim=feature_dim,
@@ -291,7 +309,6 @@ class MoeBlockTest(unittest.TestCase):
             normalize_experts=normalize_experts,
             add_residual=add_residual,
             route_scale=route_scale,
-            tensor_parallel_devices=devices,
         )
 
         input = (

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -6,6 +6,7 @@
 
 import unittest
 
+import numpy as np
 import torch
 import torch.nn.functional as F
 import iree.turbine.aot as aot
@@ -350,6 +351,34 @@ class TestOpExport(unittest.TestCase):
         ep = torch.export.export(my_module, (a, d, qs, m))
         s = str(ep)
         self.assertIn("mmt_block_scaled_offset_q4_unsigned.default", s)
+
+
+class TestScatter(unittest.TestCase):
+    def setUp(self):
+        torch.random.manual_seed(0)
+        self.rng = np.random.default_rng(0)
+
+    def testInplaceSourceAsNumber(self):
+        dim = 1
+        input = torch.randint(low=0, high=10, size=[3, 8, 5], dtype=torch.int32)
+        index = torch.tensor(
+            self.rng.choice(input.shape[dim], size=[2, 2, 2], replace=False)
+        )
+        src = 2
+        expected = input.scatter_(dim, index, src)
+        actual = DefaultPrimitiveTensor(data=input).scatter_(dim, index, src)
+        assert ops.equal(actual, expected)
+
+    def testInplaceSourceAsTensor(self):
+        dim = 1
+        input = torch.randint(low=0, high=10, size=[3, 8, 5], dtype=torch.int32)
+        index = torch.tensor(
+            self.rng.choice(input.shape[dim], size=[2, 2, 2], replace=False)
+        )
+        src = torch.randint_like(index, low=0, high=10, dtype=torch.int32)
+        expected = input.scatter_(dim, index, src)
+        actual = DefaultPrimitiveTensor(data=input).scatter_(dim, index, src)
+        assert ops.equal(actual, expected)
 
 
 class TestScatterAdd(unittest.TestCase):

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -352,6 +352,22 @@ class TestOpExport(unittest.TestCase):
         self.assertIn("mmt_block_scaled_offset_q4_unsigned.default", s)
 
 
+class TestScatterAdd(unittest.TestCase):
+    def setUp(self):
+        torch.random.manual_seed(0)
+
+    def test(self):
+        dim = 1
+        input = torch.randint(low=0, high=10, size=[3, 4, 5], dtype=torch.int32)
+        index = torch.randint(
+            low=0, high=input.shape[dim], size=[3, 10, 5], dtype=torch.int64
+        )
+        src = torch.randint_like(index, low=0, high=10, dtype=torch.int32)
+        expected = input.scatter_add(dim, index, src)
+        actual = DefaultPrimitiveTensor(data=input).scatter_add(dim, index, src)
+        assert ops.equal(actual, expected)
+
+
 class TestTraceTensors(TempDirTestBase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Add support for expert-prallel dense mixture of experts block.

This change includes adding support for matmul where the RHS is a 3D tensor split on the batch dimension. This drives some changes like using `.mT` instead of `.T` when `transpose_b=True`.

Made `scatter_` work with non-number source arguments.

Fixed dispatching to trivially replicable to handle if some dispatch args are not tensors, but all tensor args are replicated.