### PR TITLE
Add multiprocess support

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/generate.py
+++ b/shortfin/python/shortfin_apps/llm/components/generate.py
@@ -135,7 +135,8 @@ class ClientGenerateBatchProcess(sf.Process):
         "decode_batcher",
         "gen_req",
         "prefill_batcher",
-        "responder",
+        # "responder",
+        "response_handler",
         "tokenizer",
         "decode_config",
         "service",
@@ -145,14 +146,20 @@ class ClientGenerateBatchProcess(sf.Process):
         self,
         service: LlmGenerateService,
         gen_req: GenerateReqInput,
-        responder: FastAPIResponder,
+        # responder: FastAPIResponder,
+
+        response_handler: callable,
+        # takes a single arg which is bytes/None, or a list of bytes/None
+        # for streaming
+
         fiber: sf.Fiber | None = None,
     ):
         super().__init__(
             fiber=service.fiber_pool.fibers[0].fiber if fiber is None else fiber
         )
         self.gen_req = gen_req
-        self.responder = responder
+        # self.responder = responder
+        self.response_handler = response_handler
         self.tokenizer = service.tokenizer
         self.prefill_batcher = service.prefill_batcher
         self.decode_batcher = service.decode_batcher
@@ -167,55 +174,71 @@ class ClientGenerateBatchProcess(sf.Process):
 
     async def run(self):
         logger.debug("Started ClientBatchGenerateProcess: %r", self)
-
-        try:
-            streaming = self.gen_req.stream
-            self.responder.start_response()
-            if streaming:
-                self.responder.stream_start()
-
-            # Launch all individual generate processes and wait for them to finish.
-            gen_processes = []
-            input_ids = self.gen_req.input_ids
-            is_pretokenized = input_ids is not None
-
-            if is_pretokenized:
-                input_batch = [input_ids] if self.gen_req.is_single else input_ids
-            else:
-                input_batch = self.tokenize()
-            for index, input_tokens in enumerate(input_batch):
-                decode_config = copy(self.decode_config)
-                decode_config.update_from_sampling_params(
-                    self.gen_req.sampling_params
-                    if self.gen_req.is_single
-                    else self.gen_req.sampling_params[index]
-                )
-                gen_process = GenerateItemProcess(
-                    self,
-                    self.gen_req,
-                    index,
-                    self.gen_req.text
-                    if self.gen_req.is_single
-                    else self.gen_req.text[index],
-                    input_tokens if is_pretokenized else input_tokens.ids,
-                    eos_token_id=self.tokenizer.eos_token_id,
-                    decode_config=decode_config,
-                )
-                gen_processes.append(gen_process)
-                gen_process.launch()
-
-            await asyncio.gather(*gen_processes)
-            self.generate_response(gen_processes, streaming)
-        finally:
+        
+        # Try to add request to queue
+        if not self.service.add_to_queue():
+            error_response = JSONResponse(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                content={
+                    "error": "Server queue is full. Please try again later.",
+                    "code": "QUEUE_FULL",
+                    "current_size": self.service.current_queue_size,
+                    "max_size": self.service.max_queue_size
+                }
+            )
+            self.responder.send_response(error_response)
             self.responder.ensure_response()
+            return
+
+        # try:
+        streaming = self.gen_req.stream
+        # self.responder.start_response()
+        # if streaming:
+        #     self.responder.stream_start()
+
+        # Launch all individual generate processes and wait for them to finish.
+        gen_processes = []
+        input_ids = self.gen_req.input_ids
+        is_pretokenized = input_ids is not None
+
+        if is_pretokenized:
+            input_batch = [input_ids] if self.gen_req.is_single else input_ids
+        else:
+            input_batch = self.tokenize()
+        for index, input_tokens in enumerate(input_batch):
+            decode_config = copy(self.decode_config)
+            decode_config.update_from_sampling_params(
+                self.gen_req.sampling_params
+                if self.gen_req.is_single
+                else self.gen_req.sampling_params[index]
+            )
+            gen_process = GenerateItemProcess(
+                self,
+                self.gen_req,
+                index,
+                self.gen_req.text
+                if self.gen_req.is_single
+                else self.gen_req.text[index],
+                input_tokens if is_pretokenized else input_tokens.ids,
+                eos_token_id=self.tokenizer.eos_token_id,
+                decode_config=decode_config,
+            )
+            gen_processes.append(gen_process)
+            gen_process.launch()
+
+        await asyncio.gather(*gen_processes)
+        self.generate_response(gen_processes, streaming)
+        # finally:
+        #     self.responder.ensure_response()
 
     def generate_response(
         self, gen_processes: List[GenerateItemProcess], streaming: bool
     ):
         if streaming:
             logger.info("Responding to streaming batch")
-            self.responder.stream_part(b"data: [DONE]\n\n")
-            self.responder.stream_part(None)
+            # self.responder.stream_part(b"data: [DONE]\n\n")
+            # self.responder.stream_part(None)
+            self.response_handler([b"data: [DONE]\n\n", None])
             return
 
         logging.debug("Responding to one shot batch")
@@ -225,7 +248,8 @@ class ClientGenerateBatchProcess(sf.Process):
                 result_tokens = result_tokens[0]
             out = io.BytesIO()
             out.write(bytes(json.dumps(result_tokens), "utf-8"))
-            self.responder.send_response(out.getvalue())
+            # self.responder.send_response(out.getvalue())
+            self.response_handler(out.getvalue())
             return
 
         response_map = {}
@@ -254,7 +278,8 @@ class ClientGenerateBatchProcess(sf.Process):
         response = json.dumps(response)
         out = io.BytesIO()
         out.write(response.encode())
-        self.responder.send_response(out.getvalue())
+        # self.responder.send_response(out.getvalue())
+        self.response_handler(out.getvalue())
 
     def _respond_multi_responses(
         self, result_token_ids: List[List[int]], out: io.BytesIO
@@ -292,7 +317,8 @@ class ClientGenerateBatchProcess(sf.Process):
             out.write(f"data({rid}): ".encode())
             out.write(str(result_tokens[0]).encode())
             out.write(b"\n\n")
-        self.responder.stream_part(out.getvalue())
+        # self.responder.stream_part(out.getvalue())
+        self.response_handler(out.getvalue())
         gen_process.streamed_tokens_index += len(result_tokens)
 
     def tokenize(self) -> list[Encoding]:

--- a/shortfin/python/shortfin_apps/llm/components/service.py
+++ b/shortfin/python/shortfin_apps/llm/components/service.py
@@ -7,7 +7,6 @@
 import logging
 
 from dataclasses import dataclass
-from typing import List
 
 import shortfin as sf
 import shortfin.array as sfnp
@@ -28,7 +27,6 @@ from .kvcache.base_attention_cache import (
 from .kvcache.trie_attention_cache import TriePagedAttentionCache
 from .kvcache.page_pool import PagePoolConfig, PagePool
 from .manager import LlmSystemManager
-from .service_debug_dumper import SERVICE_DEBUG_DUMPER
 from .tokenizer import Tokenizer
 from .token_selection_strategy import get_strategy_from_str, is_ref_counted
 
@@ -48,6 +46,7 @@ class LlmGenerateService(GenerateService):
         self,
         *,
         name: str,
+        instance_num: int,  # Instance number within the service manager
         sysman: LlmSystemManager,
         tokenizer: Tokenizer,
         model_params: ModelParams,
@@ -57,6 +56,7 @@ class LlmGenerateService(GenerateService):
     ):
         super().__init__(sysman)
         self.name = name
+        self.instance_num = instance_num
         self.tokenizer = tokenizer
         self.model_params = model_params
         self.server_params = server_params
@@ -76,7 +76,7 @@ class LlmGenerateService(GenerateService):
 
     def add_to_queue(self) -> bool:
         """Try to add a request to the queue. Returns True if successful, False if queue is full."""
-        print(f"Adding to queue: {self.current_queue_size} >= {self.max_queue_size}")
+        # print(f"Instance {self.instance_num} adding to queue: {self.current_queue_size} of {self.max_queue_size}")
         if self.current_queue_size >= self.max_queue_size:
             return False
         self.current_queue_size += 1

--- a/shortfin/python/shortfin_apps/llm/components/service_manager.py
+++ b/shortfin/python/shortfin_apps/llm/components/service_manager.py
@@ -1,0 +1,380 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import asyncio
+import logging
+import multiprocessing
+
+from concurrent.futures import ThreadPoolExecutor
+from multiprocessing import JoinableQueue
+import os
+from pathlib import Path
+from typing import List, Tuple
+
+from .config_struct import ModelParams, ServerParams
+from .token_selection_strategy import DecodeConfig
+from .generate import ClientGenerateBatchProcess
+from .io_struct import GenerateReqInput
+from .manager import LlmSystemManager
+from .service import LlmGenerateService
+from .service_debug_dumper import SERVICE_DEBUG_DUMPER
+from .tokenizer import Tokenizer
+
+logger = logging.getLogger(__name__)
+
+
+class LlmServiceEnvironment:
+    """
+    Environment  for LLM services, responsible for creating and managing
+    instances of LlmGenerateService.
+
+    This class, which also holds the shortfin system, is a singleton per
+    process. For single-process usage, create one of these at the server
+    (lifecycle) level. For multi-process usage, create one of these in each
+    subprocess.
+    """
+
+    @staticmethod
+    def get_server_params(args) -> ServerParams:
+        server_params = ServerParams.load(
+            args.server_config if hasattr(args, "server_config") else None
+        )
+        server_params.update_from_args(args)
+        return server_params
+
+    @staticmethod
+    def get_model_params(model_config: Path) -> ModelParams:
+        model_params = ModelParams.load_json(model_config)
+        return model_params
+    
+    def __init__(self, args, create_multiple_services: bool):
+        # Load server configuration with priority:
+        # command line > config file > defaults
+        model_params = LlmServiceEnvironment.get_model_params(args.model_config)
+        server_params = LlmServiceEnvironment.get_server_params(args)
+        self.num_instances = server_params.instances if create_multiple_services else 1
+        decode_bs = model_params.decode_batch_sizes[-1]
+        if server_params.decode_config is None:
+            decode_config = DecodeConfig(
+                args.num_beams,
+                args.token_selection_strategy,
+                logits_normalization=model_params.logits_normalization,
+                max_decode_batch_size=decode_bs,
+            )
+            server_params.decode_config = decode_config
+
+        # Setup system (configure devices, etc).
+        sysman = LlmSystemManager(
+            device=args.device,
+            device_ids=server_params.device_ids,
+            async_allocs=server_params.amdgpu_async_allocations,
+            amdgpu_allocators=server_params.amdgpu_allocators,
+            amdgpu_allow_device_reuse=server_params.amdgpu_allow_device_reuse,
+        )
+
+        # Setup each service we are hosting.
+        eos_token = LlmServiceProcess.get_eos_from_tokenizer_config(
+            args.tokenizer_config_json
+        )
+        tokenizer = Tokenizer.from_tokenizer_json_file(
+            args.tokenizer_json, eos_token=eos_token
+        )
+        print(f"Creating {self.num_instances} instances")
+        # Create a list of LLM instances
+        services: List[LlmGenerateService] = {}
+        for i in range(self.num_instances):
+            service = LlmGenerateService(
+                name=f"instance{i}",
+                instance_num=i,
+                sysman=sysman,
+                tokenizer=tokenizer,
+                model_params=model_params,
+                server_params=server_params,
+                program_isolation=server_params.program_isolation,
+            )
+            service.load_inference_module(args.vmfb)
+            service.load_inference_parameters(*args.parameters, parameter_scope="model")
+            services[i] = service
+
+        self.sysman = sysman
+        self.services = services
+
+    def start(self):
+        self.sysman.start()
+        for service_name, service in self.services.items():
+            print(f"Initializing service '{service_name}'")
+            service.start()
+
+    def shutdown(self):
+        for service_name, service in self.services.items():
+            print(f"Shutting down service '{service_name}'")
+            service.shutdown()
+        self.sysman.shutdown()
+
+
+class LlmServiceProcess(multiprocessing.Process):
+    @staticmethod
+    def get_eos_from_tokenizer_config(json_path):
+        import json
+
+        with open(json_path, "rt") as f:
+            json_text = f.read()
+        config = json.loads(json_text)
+        return config["eos_token"]
+
+    def __init__(
+        self, args, request_queue: JoinableQueue, response_queue: JoinableQueue
+    ):
+        super().__init__()
+        self.args = args
+        self.request_queue: JoinableQueue = request_queue
+        self.response_queue: JoinableQueue = response_queue
+        self.service_environment = None
+        self.service = None  # Single instance in this process
+
+    def run(self):
+        print(f"Starting LLM service process {self.name}")
+        self.service_environment = LlmServiceEnvironment(
+            self.args, create_multiple_services=False)
+        self.service = self.service_environment.services[0]  # Single instance in this process
+        self.service_environment.start()
+        print(f"LlmServiceProcess {self.name} ready")
+
+        while True:
+            request_packet: Tuple[int, GenerateReqInput] = self.request_queue.get()
+            self.request_queue.task_done()
+            request_counter = request_packet[0]
+            request = request_packet[1]
+            # print(f"LlmServiceProcess {self.name} received request packet: {request_counter}")
+
+            if request is None:
+                # Shutdown signal
+                self.response_queue.put((0, None))
+                break
+
+            if not self.service.add_to_queue():
+                logger.warning(f"Queue full, dropping request {request_counter}: {request}")
+                continue
+
+            def response_handler(response, response_counter=request_counter):
+                # print(f"LlmServiceProcess {self.name} sending response packet {response_counter}")
+                self.response_queue.put((response_counter, response))
+                self.service.remove_from_queue()
+
+            ClientGenerateBatchProcess(
+                self.service, request, response_handler).launch()
+            # Don't wait for it to finish! response_handler should take care of
+            # notifying when the response is ready. Waiting here increases
+            # latency
+
+        print(f"Shutting down LLM service process {self.name}")
+        self.service_environment.shutdown()
+
+
+class LlmServiceManager:
+    """
+    Base class for managing LLM service instances.
+    """
+
+    def __init__(self, args):
+        self.args = args
+        self.cur_instance_num = 0
+        self.request_counter = 0
+        self.num_instances = 0
+
+    def start(self):
+        """
+        Start all resources contained in this service manager.
+        """
+        pass
+
+    async def send_request(self, gen_req: GenerateReqInput, response_handler: callable):
+        """
+        Send a request to an LLM service instance. The response is sent
+        to the given callable and takes the form of a single byte array or a
+        list of byte arrays.
+        """
+        pass
+
+    def shutdown(self):
+        """
+        Shutdown all resources contained in this service manager.
+        """
+        pass
+
+    def get_next_instance_num(self) -> int:
+        """
+        Get the next service instance number in a round-robin fashion.
+        """
+        self.cur_instance_num += 1
+        if self.cur_instance_num >= self.num_instances:
+            self.cur_instance_num = 0
+        return self.cur_instance_num
+
+
+class LlmSingleProcessServiceManager(LlmServiceManager):
+    """
+    Manages all service instances in a single process.
+    """
+
+    def __init__(self, args):
+        super().__init__(args)
+        self.service_environment = LlmServiceEnvironment(args, create_multiple_services=True)
+        self.num_instances = self.service_environment.num_instances
+
+    def start(self):
+        self.service_environment.start()
+
+    async def send_request(self, gen_req: GenerateReqInput, response_handler: callable):
+        self.request_counter += 1
+        # instance_num = self.get_next_instance_num()
+        # Fill up the queue of the current instance first, so that the batcher
+        # can dispatch a batch ASAP
+        instance_num = self.cur_instance_num
+        while not self.service_environment.services[instance_num].add_to_queue():
+            instance_num = self.get_next_instance_num()
+            await asyncio.sleep(0.001)
+
+        service = self.service_environment.services[instance_num]
+
+        def response_handler_wrapper(response, service=service):
+            response_handler(response)
+            service.remove_from_queue()
+
+        ClientGenerateBatchProcess(
+                service, gen_req, response_handler_wrapper).launch()
+        # Don't wait for it to finish! response_handler should take care of
+        # notifying when the response is ready. Waiting here increases latency
+
+    def shutdown(self):
+        self.service_environment.shutdown()
+
+
+class LlmMultiProcessServiceManager(LlmServiceManager):
+    """
+    Manages each service instance in its own process.
+    """
+    class Instance:
+        def __init__(self, instance_num: int, args, max_queue_size: int):
+            self.instance_num = instance_num
+            self.max_queue_size = max_queue_size
+            self.num_outstanding_requests = 0
+            self.is_ready_to_board = True
+            self.request_queue = JoinableQueue()
+            self.response_queue = JoinableQueue()
+            self.executor = ThreadPoolExecutor(max_workers=1)
+            self.response_map: dict[int, callable] = {}
+            self.service_process = LlmServiceProcess(
+                args,
+                request_queue=self.request_queue,
+                response_queue=self.response_queue,
+            )
+
+        def start(self):
+            self.service_process.start()
+
+            def receive_responses():
+                while True:
+                    response_packet: Tuple[int, bytes] = self.response_queue.get()
+                    self.response_queue.task_done()
+                    if response_packet[1] is None:
+                        break
+                    response_counter = response_packet[0]
+                    if response_counter in self.response_map:
+                        # print(f"Instance: Received response for request counter: {response_counter}")
+                        response_handler = self.response_map.pop(response_counter)
+                        response_handler(response_packet[1])
+                        self.remove_from_queue()
+                    else:
+                        logger.warning(
+                            f"Instance: Received response for unknown request counter: {response_counter}"
+                        )
+
+            self.executor.submit(receive_responses)
+
+        def add_to_queue(self) -> bool:
+            if not self.is_ready_to_board:
+                return False
+            self.num_outstanding_requests += 1
+            if self.num_outstanding_requests >= self.max_queue_size:
+              print(f"Instance {self.instance_num}: Flight is full")
+              self.is_ready_to_board = False
+            return True
+
+        def remove_from_queue(self):
+            print(f"Instance {self.instance_num}: Removing request {self.num_outstanding_requests} of {self.max_queue_size}" )
+            self.num_outstanding_requests -= 1
+            if (self.num_outstanding_requests < 0):
+                logger.warning(
+                    f"Instance {self.instance_num}: Outstanding requests count is negative: {self.num_outstanding_requests}"
+                )
+            if (self.num_outstanding_requests == 0):
+                self.is_ready_to_board = True
+                print(f"Instance {self.instance_num}: Flight is ready to board again")
+
+        async def send_request(self, request_counter: int,
+                               gen_req: GenerateReqInput,
+                               response_handler: callable):
+            # print(f"Generating multi-process with service: {self.instance_num}")
+            # print(f"Enqueuing request {request_counter}"
+            #       f" to instance {self.instance_num}")
+            print(f"Instance {self.instance_num}: Adding request ID {request_counter}, {self.num_outstanding_requests} of {self.max_queue_size}")
+            self.request_queue.put((request_counter, gen_req))
+            # put shouldn't block, as the caller checked that the queue wasn't full before calling this method
+            self.response_map[request_counter] = response_handler
+
+        def shutdown(self):
+            print(f"Shutting down LlmMultiProcessServiceManager instance {self.instance_num}")
+            # Signal the service process to shut down
+            self.request_queue.put((0, None))
+            # Wait for the service process to finish
+            self.service_process.join()
+            self.response_queue.join()
+            self.executor.shutdown(wait=True)
+            print(f"LlmMultiProcessServiceManager instance {self.instance_num} shutdown complete")
+    
+    def __init__(self, args):
+        super().__init__(args)
+        self.server_params = LlmServiceEnvironment.get_server_params(args)
+        self.model_params = LlmServiceEnvironment.get_model_params(
+            args.model_config)
+        self.num_instances = self.server_params.instances
+        max_queue_size = max(self.model_params.decode_batch_sizes)
+
+        self.instances: List[LlmMultiProcessServiceManager.Instance] = [
+            LlmMultiProcessServiceManager.Instance(i, args, max_queue_size)
+            for i in range(self.num_instances)
+        ]
+
+    def start(self):
+        for instance in self.instances:
+            instance.start()
+
+    async def send_request(self, gen_req: GenerateReqInput, response_handler: callable):
+        self.request_counter += 1
+
+        # Save global request counter before the await, or else it may change
+        # if another request is sent
+        request_counter = self.request_counter
+
+        # instance_num = self.get_next_instance_num()
+        # Fill up the queue of the current instance first, so that the batcher
+        # can dispatch a batch ASAP
+        instance_num = self.cur_instance_num
+        first_tried_instance_num = instance_num
+        while not self.instances[instance_num].add_to_queue():
+            instance_num = self.get_next_instance_num()
+            if instance_num == first_tried_instance_num:
+                await asyncio.sleep(0.001)
+        self.cur_instance_num = instance_num
+
+        await self.instances[instance_num].send_request(
+            request_counter, gen_req, response_handler
+        )
+
+    def shutdown(self):
+        for instance in self.instances:
+            instance.shutdown()

--- a/shortfin/python/shortfin_apps/llm/server.py
+++ b/shortfin/python/shortfin_apps/llm/server.py
@@ -68,6 +68,11 @@ def parse_args(argv):
     parser.add_argument(
         "--instances", type=int, default=1, help="Number of shortfin instances to run"
     )
+    parser.add_argument(
+        "--in-process",
+        action="store_true",
+        help="Run services in a single process instead of using multiple processes."
+    )
     return parser.parse_args(argv)
 
 


### PR DESCRIPTION
Service is refactored to allow for either single process (as it is already), with multiple services in that process, or one process per service.

**Default is multi-process!** Please provide feedback if you would rather see single process as the default.

- Factored HTTP out of `ClientGenerateBatchProcess`, replacing it with a generic `response_handler` callback
- Factored Service creation out of lifecycle, replacing it with a service manager class. There are two service managers: one for single process and one for multi-process
- Added `instance_num` to service, so that the service can self-identify which instance it is (for diagnostic messages etc.)
- Shortfin and service setup moved to a new `LlmServiceEnvironment` class, used by both service managers
- Multi-process service manager uses a request and response queue to send request objects to a subprocess, managed by `LlmServiceProcess`, which returns the raw bytes of the response to the main process
- Multi-process service manager has some refinements to service selection to try to keep batches of 16 together: new requests don't go into a queue until the previous flight has disembarked. Gains ~0.5-0.7 RPS. More work to be done after the merge
- Single process service selection has some minor tweaks, but the multi-process algorithm isn't there yet because it's more invasive to the service class. Will revisit after merge
- `generate_request` HTTP handler refactored to delegate service selection to service manager. Provides the HTTP-aware response handler to `ClientGenerateBatchProcess`
- New command line switch to choose single process over multi-process