### PR TITLE
Fixed missing index

### DIFF
--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -224,7 +224,7 @@ def main():
             arg_affinities = {key + 3: arg_affinities[key] for key in arg_affinities}
 
             for i in range(3):
-                device = str(pipeline_to_devices[0])
+                device = str(pipeline_to_devices[0][0])
                 arg_affinities[i] = DeviceAffinity(device)
 
         dynamic_shapes = {


### PR DESCRIPTION
Without this PR, TP models cannot be compiled because argument affinity is wrong. E.g.

**Expected**
`func.func @prefill_bs1(%arg0: !torch.vtensor<[1,?],si64> {iree.abi.affinity = #hal.device.promise<@__device_0>}`
**Actual**
`func.func @prefill_bs1(%arg0: !torch.vtensor<[1,?],si64> {iree.abi.affinity = #hal.device.promise<@__device_(0, 1)>}`

I think we need some sort of CI test that runs of PRs to export and compile a tiny model with TP and PP in order to catch these kinds of issues.