### PR TITLE
Perplexity test for pipeline parallelized Llama 8B

### DIFF
--- a/sharktank/tests/evaluate/perplexity_iree_test.py
+++ b/sharktank/tests/evaluate/perplexity_iree_test.py
@@ -110,9 +110,7 @@ class PerplexityTest(unittest.TestCase):
             msg=f"Current perplexity deviates baseline by {perplexity_difference}",
         )
 
-    @pytest.mark.skip(
-        reason="Not fully implemented yet: https://github.com/nod-ai/shark-ai/issues/1306."
-    )
+    @is_nightly
     def test_llama3_8B_f16_pp2(self):
 
         # Llama 3.1 8B pipepiline parallelism


### PR DESCRIPTION
- Fixed check on `--tensor-parallelism-size` to ensure that dataset and cli flag agree to avoid hard to debug error messages.
- Re-enable xfailed PPL test

Closes #1306.