### PR TITLE
[tuner] Improve support for convolutions

### DIFF
--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -81,9 +81,6 @@ class ConvolutionOpInterfaceTuner(DispatchTuner, ConvolutionOpInterfaceParser):
         compilation_info: iree_codegen.CompilationInfoAttr,
     ) -> ir.Module:
         conv_op = self.get_root_op()
-        assert (
-            conv_op.name == "linalg.conv_2d_nhwc_hwcf"
-        ), "expected linalg.conv_2d_nhwc_hwcf"
         func_name = self.get_root_op_func_name()
         return build_td_spec(conv_op.context, conv_op, compilation_info, func_name)
 

--- a/sharktuner/sharktuner/common.py
+++ b/sharktuner/sharktuner/common.py
@@ -253,27 +253,6 @@ def read_input_mlir(filename: str) -> list[str]:
 
 
 @dataclass
-class ConvDimInfo:
-    n: int
-    oh: int
-    ow: int
-    oc: int
-    fh: int
-    fw: int
-    ic: int
-
-    @staticmethod
-    def from_rhs_res(rhs_shaped_type: ShapedType, res_shaped_type: ShapedType):
-        n, oh, ow, oc = res_shaped_type.shape
-        fh, fw, ic, _ = rhs_shaped_type.shape
-        return ConvDimInfo(n, oh, ow, oc, fh, fw, ic)
-
-    @staticmethod
-    def from_problem_size(problem_size: ProblemSize):
-        return ConvDimInfo.from_rhs_res(problem_size.rhs_type, problem_size.res_type)
-
-
-@dataclass
 class MLIRTransformation:
     """Transformation of MLIR context"""
 

--- a/sharktuner/sharktuner/dispatch_constraints.py
+++ b/sharktuner/sharktuner/dispatch_constraints.py
@@ -53,12 +53,15 @@ def get_dispatch_constraints(
     if problem_size.dispatch_kind != DispatchKind.conv:
         return []
 
-    dim_info = ConvDimInfo.from_problem_size(problem_size)
-    conv_constraints = []
-    # WARNING: This sometimes makes the constraints UNSAT for some reason.
-    conv_constraints += [tile_m <= dim_info.ow]
-    conv_constraints += [tile_n <= dim_info.oc]
-    conv_constraints += [tile_k <= dim_info.ic]
+    max_tile_m = problem_size.matmul_size.M[-1]
+    [max_tile_n] = problem_size.matmul_size.N
+    max_tile_k = problem_size.matmul_size.K[-1]
+    conv_constraints = [
+        # WARNING: This sometimes makes the constraints UNSAT for some reason.
+        tile_m <= max_tile_m,
+        tile_n <= max_tile_n,
+        tile_k <= max_tile_k,
+    ]
     return conv_constraints
 
 

--- a/sharktuner/sharktuner/dispatch_constraints.py
+++ b/sharktuner/sharktuner/dispatch_constraints.py
@@ -526,13 +526,14 @@ def generate_solutions(
         if required_padding:
             # TODO: Remove promotion of operand 2 once codegen supports handling padded outputs without promotion.
             promote_operands = [0, 1, 2]
-            workgroup_tile_m, workgroup_tile_n, _ = workgroup_tile_sizes
-            _, _, reduction_tile_k = reduction_tile_sizes
             _, _, mma_intrinsic_k = mma_attr.mnk_shape
             padding = [
-                workgroup_tile_m,
-                workgroup_tile_n,
-                reduction_tile_k * mma_intrinsic_k,
+                *(workgroup_tile_sizes[d] for d in problem_size.contraction_dims.m),
+                *(workgroup_tile_sizes[d] for d in problem_size.contraction_dims.n),
+                *(
+                    reduction_tile_sizes[d] * mma_intrinsic_k
+                    for d in problem_size.contraction_dims.k
+                ),
             ]
 
         compilation_infos = generate_compilation_infos(

--- a/sharktuner/sharktuner/dispatch_parser.py
+++ b/sharktuner/sharktuner/dispatch_parser.py
@@ -96,41 +96,50 @@ class ContractionOpInterfaceParser(DispatchParser):
         )
 
 
-# TODO(Max191): Support more convolution types. Only NHWC convs are supported.
 class ConvolutionOpInterfaceParser(DispatchParser):
     def __init__(self, root_op: ir.Operation):
         super().__init__(root_op)
-        self.supported_ops = ["linalg.conv_2d_nhwc_hwcf"]
 
     def has_valid_root_op(self) -> bool:
         root_op = self.get_root_op()
-        if not linalg.isa_convolution_op(root_op):
-            return False
-
-        return root_op.name in self.supported_ops
+        return linalg.isa_convolution_op(root_op)
 
     def get_problem_size(self) -> ProblemSize:
         root_op = self.get_root_op()
-        lhs_type = ir.RankedTensorType(root_op.operands[0].type)
-        rhs_type = ir.RankedTensorType(root_op.operands[1].type)
-        res_type = ir.RankedTensorType(root_op.operands[2].type)
-        dim_info = ConvDimInfo.from_rhs_res(rhs_type, res_type)
+
+        def find_iter_dim_size(iter_dim: int, operand: int):
+            operand_type = root_op.operands[operand].type
+            indexing_map = linalg.get_indexing_maps(root_op)[operand]
+            tensor_dim = list(indexing_map.value.results).index(
+                ir.AffineExpr.get_dim(iter_dim)
+            )
+            return operand_type.shape[tensor_dim]
+
         convolution_dims = linalg.infer_convolution_dimensions(root_op)
         assert convolution_dims, "no convolution dimensions"
+        contraction_dims = ContractionDimensions(
+            batch=list(convolution_dims.depth),
+            m=list(convolution_dims.batch) + list(convolution_dims.output_image),
+            n=list(convolution_dims.output_channel),
+            k=list(convolution_dims.filter_loop) + list(convolution_dims.input_channel),
+        )
+        # Parallel dimension sizes come from the output operand, and reduction
+        # dimension sizes come from filter.
+        matmul_size = ContractionSizes(
+            B=[find_iter_dim_size(d, operand=2) for d in contraction_dims.batch],
+            M=[find_iter_dim_size(d, operand=2) for d in contraction_dims.m],
+            N=[find_iter_dim_size(d, operand=2) for d in contraction_dims.n],
+            K=[find_iter_dim_size(d, operand=1) for d in contraction_dims.k],
+        )
+
+        lhs_type = root_op.operands[0].type
+        rhs_type = root_op.operands[1].type
+        res_type = root_op.operands[2].type
         return ProblemSize(
-            matmul_size=ContractionSizes(
-                M=[dim_info.n, dim_info.oh, dim_info.ow],
-                N=[dim_info.oc],
-                K=[dim_info.fh, dim_info.fw, dim_info.ic],
-            ),
+            matmul_size=matmul_size,
             lhs_type=ShapedType(lhs_type.shape, lhs_type.element_type),
             rhs_type=ShapedType(rhs_type.shape, rhs_type.element_type),
             res_type=ShapedType(res_type.shape, res_type.element_type),
             dispatch_kind=DispatchKind.conv,
-            contraction_dims=ContractionDimensions(
-                m=list(convolution_dims.batch) + list(convolution_dims.output_image),
-                n=list(convolution_dims.output_channel),
-                k=list(convolution_dims.filter_loop)
-                + list(convolution_dims.input_channel),
-            ),
+            contraction_dims=contraction_dims,
         )

--- a/sharktuner/sharktuner/dispatch_parser.py
+++ b/sharktuner/sharktuner/dispatch_parser.py
@@ -107,6 +107,8 @@ class ConvolutionOpInterfaceParser(DispatchParser):
         convolution_dims = linalg.infer_convolution_dimensions(root_op)
         assert convolution_dims, "no convolution dimensions"
         # Only allow 'nhwc_hwcf' convs.
+        # TODO: This dispatch parser class supports more layouts, but constraint
+        #       generation is not tested. Relax this check as support is verified.
         if (
             list(convolution_dims.batch) != [0]
             or list(convolution_dims.output_image) != [1, 2]

--- a/sharktuner/tests/dispatch_parser_test.py
+++ b/sharktuner/tests/dispatch_parser_test.py
@@ -12,6 +12,9 @@ import pytest
 
 from typing import Generator
 
+# TODO: remove after https://github.com/llvm/llvm-project/pull/117918 is resolved.
+import sharktuner
+
 from iree.compiler import ir  # type: ignore
 from iree.compiler.dialects import func  # type: ignore
 from iree.compiler.dialects import iree_gpu  # type: ignore
@@ -24,7 +27,7 @@ from sharktuner import dispatch_parser
 from sharktuner.test_utils import tuner_ctx
 
 
-CONTRACTION_TEMPLATE = r"""
+GENERIC_TEMPLATE = r"""
 builtin.module{{
     func.func @test(%arg0: {lhs_type}, %arg1: {rhs_type}) -> {res_type} {{
         %cst = arith.constant 0.000000e+00 : f32
@@ -55,7 +58,7 @@ def test_get_contraction_operation(tuner_ctx: common.TunerContext) -> None:
     context = tuner_ctx.mlir_ctx
 
     with ir.Location.unknown():
-        transpose_b_str = CONTRACTION_TEMPLATE.format(
+        transpose_b_str = GENERIC_TEMPLATE.format(
             lhs_type=ir.RankedTensorType.get([16, 64], ir.F16Type.get()),
             rhs_type=ir.RankedTensorType.get([32, 64], ir.F16Type.get()),
             res_type=ir.RankedTensorType.get([16, 32], ir.F32Type.get()),
@@ -82,7 +85,7 @@ def test_get_contraction_operation(tuner_ctx: common.TunerContext) -> None:
     assert isinstance(shapes.res_type.element_type, ir.F32Type)
 
     with ir.Location.unknown():
-        bmm_transposed_inputs_str = CONTRACTION_TEMPLATE.format(
+        bmm_transposed_inputs_str = GENERIC_TEMPLATE.format(
             lhs_type=ir.RankedTensorType.get([5, 8, 128], ir.F16Type.get()),
             rhs_type=ir.RankedTensorType.get([128, 40, 5], ir.F16Type.get()),
             res_type=ir.RankedTensorType.get([5, 40, 8], ir.F32Type.get()),
@@ -103,7 +106,7 @@ def test_get_contraction_operation(tuner_ctx: common.TunerContext) -> None:
     assert shapes.matmul_size.K == [128]
 
     with ir.Location.unknown():
-        bmm_transposed_inputs_str = CONTRACTION_TEMPLATE.format(
+        bmm_transposed_inputs_str = GENERIC_TEMPLATE.format(
             lhs_type=ir.RankedTensorType.get(
                 [16, 8, 15, 16, 64, 256], ir.F16Type.get()
             ),
@@ -223,7 +226,7 @@ def test_get_named_contraction_op():
         assert shape.res_type.shape == [5, 7]
 
 
-def test_get_conv_operation(tuner_ctx: common.TunerContext) -> None:
+def test_get_conv_nhwc_hwcf_operation(tuner_ctx: common.TunerContext) -> None:
     context = tuner_ctx.mlir_ctx
     module_str = """
         builtin.module{
@@ -246,6 +249,82 @@ def test_get_conv_operation(tuner_ctx: common.TunerContext) -> None:
     assert (
         parser.has_valid_root_op()
     ), f"ConvolutionOpInterfaceParser does not support the op: {root_op.name}"
+
+    problem_size = parser.get_problem_size()
+    assert problem_size.contraction_dims.batch == []
+    assert problem_size.contraction_dims.m == [0, 1, 2]
+    assert problem_size.contraction_dims.n == [3]
+    assert problem_size.contraction_dims.k == [4, 5, 6]
+    assert problem_size.matmul_size.B == []
+    assert problem_size.matmul_size.M == [2, 32, 32]
+    assert problem_size.matmul_size.N == [16]
+    assert problem_size.matmul_size.K == [3, 3, 16]
+
+
+def test_get_group_conv_operation(tuner_ctx: common.TunerContext) -> None:
+    context = tuner_ctx.mlir_ctx
+    module_str = """
+    module {
+      func.func @test(%arg0: tensor<2x10x10x7x4xf32>, %arg1: tensor<7x16x3x3x4xf32>, %arg2: tensor<2x8x8x7x16xf32>) -> tensor<2x8x8x7x16xf32> {
+        %0 = linalg.conv_2d_nhwgc_gfhwc {
+           root_op,
+           dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>
+        } ins(%arg0, %arg1: tensor<2x10x10x7x4xf32>, tensor<7x16x3x3x4xf32>)
+          outs(%arg2: tensor<2x8x8x7x16xf32>) -> tensor<2x8x8x7x16xf32>
+        return %0 : tensor<2x8x8x7x16xf32>
+      }
+    }
+    """
+    module = ir.Module.parse(module_str, context)
+    module = ir.Module.parse(module_str, context)
+    root_op_list = iree_codegen.get_tuner_root_ops(module)
+    assert len(root_op_list) == 1
+    root_op = root_op_list[0]
+    parser = dispatch_parser.ConvolutionOpInterfaceParser(root_op)
+    assert parser.get_root_op_func_name() == "match_test"
+    assert parser.has_valid_root_op()
+
+    problem_size = parser.get_problem_size()
+    assert problem_size.contraction_dims.batch == [3]
+    assert problem_size.contraction_dims.m == [0, 1, 2]
+    assert problem_size.contraction_dims.n == [4]
+    assert problem_size.contraction_dims.k == [5, 6, 7]
+    assert problem_size.matmul_size.B == [7]
+    assert problem_size.matmul_size.M == [2, 8, 8]
+    assert problem_size.matmul_size.N == [16]
+    assert problem_size.matmul_size.K == [3, 3, 4]
+
+
+def test_get_generic_conv_operation(tuner_ctx: common.TunerContext) -> None:
+    context = tuner_ctx.mlir_ctx
+    with ir.Location.name("generic_conv"):
+        # nhwc_fhwc
+        module_str = GENERIC_TEMPLATE.format(
+            lhs_type=ir.RankedTensorType.get([2, 7, 7, 32], ir.F16Type.get()),
+            rhs_type=ir.RankedTensorType.get([64, 3, 3, 32], ir.F16Type.get()),
+            res_type=ir.RankedTensorType.get([2, 5, 5, 64], ir.F32Type.get()),
+            lhs_map="affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1 + d4, d2 + d5, d6)>",
+            rhs_map="affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>",
+            res_map="affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>",
+            iterator_types='["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]',
+        )
+    module = ir.Module.parse(module_str, context)
+    root_op_list = iree_codegen.get_tuner_root_ops(module)
+    assert len(root_op_list) == 1
+    root_op = root_op_list[0]
+    parser = dispatch_parser.ConvolutionOpInterfaceParser(root_op)
+    assert parser.get_root_op_func_name() == "match_test"
+    assert parser.has_valid_root_op()
+
+    problem_size = parser.get_problem_size()
+    assert problem_size.contraction_dims.batch == []
+    assert problem_size.contraction_dims.m == [0, 1, 2]
+    assert problem_size.contraction_dims.n == [3]
+    assert problem_size.contraction_dims.k == [4, 5, 6]
+    assert problem_size.matmul_size.B == []
+    assert problem_size.matmul_size.M == [2, 5, 5]
+    assert problem_size.matmul_size.N == [64]
+    assert problem_size.matmul_size.K == [3, 3, 32]
 
 
 def test_get_mmt_tile_sizes(tuner_ctx: common.TunerContext) -> None:


### PR DESCRIPTION
This improves support for convolutions in the tuner by:
- generalizing `ConvolutionOpInterfaceParser` to support parsing `linalg.generic` ops, as well as additional layouts. However since constraint generation for more layouts is untested, only `nhwc_hwcf` and the generic equivalent are considered valid.
- supporting generating the padding lowering attribute for convolutions