### PR TITLE
IREE Bump to `3.5.0rc20250509` + Disable/Enable async_caching in Shortfin

### DIFF
--- a/requirements-iree-pinned.txt
+++ b/requirements-iree-pinned.txt
@@ -2,6 +2,6 @@
 
 # Keep these versions synced with SHORTFIN_IREE_GIT_TAG in shortfin/CMakeLists.txt
 --find-links https://iree.dev/pip-release-links.html
-iree-base-compiler==3.5.0rc20250507
-iree-base-runtime==3.5.0rc20250507
-iree-turbine==3.5.0rc20250507
+iree-base-compiler==3.5.0rc20250509
+iree-base-runtime==3.5.0rc20250509
+iree-turbine==3.5.0rc20250509

--- a/shortfin/CMakeLists.txt
+++ b/shortfin/CMakeLists.txt
@@ -47,7 +47,7 @@ add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 # Prefer to keep the IREE git tag synced with the Python package version in the
 # requirements-iree-pinned.txt file. At a minimum, the compiler from those
 # packages must be compatible with the runtime at this source ref.
-set(SHORTFIN_IREE_GIT_TAG "iree-3.5.0rc20250507")
+set(SHORTFIN_IREE_GIT_TAG "iree-3.5.0rc20250509")
 
 
 # build options

--- a/shortfin/python/shortfin_apps/llm/components/config_struct.py
+++ b/shortfin/python/shortfin_apps/llm/components/config_struct.py
@@ -235,6 +235,7 @@ class ServerParams:
     # Device configuration
     device_ids: list[str] = field(default_factory=list)
     amdgpu_async_allocations: bool = False
+    amdgpu_async_caching: bool = False
     amdgpu_allocators: Optional[str] = None
     amdgpu_allow_device_reuse: bool = False
 

--- a/shortfin/python/shortfin_apps/llm/components/lifecycle.py
+++ b/shortfin/python/shortfin_apps/llm/components/lifecycle.py
@@ -68,6 +68,7 @@ class ShortfinLlmLifecycleManager:
             device=args.device,
             device_ids=server_params.device_ids,
             async_allocs=server_params.amdgpu_async_allocations,
+            async_caching=server_params.amdgpu_async_caching,
             amdgpu_allocators=server_params.amdgpu_allocators,
             amdgpu_allow_device_reuse=server_params.amdgpu_allow_device_reuse,
         )

--- a/shortfin/python/shortfin_apps/llm/components/manager.py
+++ b/shortfin/python/shortfin_apps/llm/components/manager.py
@@ -13,6 +13,7 @@ class LlmSystemManager(SystemManager):
         device="local-task",
         device_ids=None,
         async_allocs=True,
+        async_caching=True,
         amdgpu_allocators=None,
         amdgpu_allow_device_reuse=False,
     ):
@@ -20,6 +21,7 @@ class LlmSystemManager(SystemManager):
             device=device,
             device_ids=device_ids,
             async_allocs=async_allocs,
+            async_caching=async_caching,
             amdgpu_allocators=amdgpu_allocators,
             amdgpu_allow_device_reuse=amdgpu_allow_device_reuse,
             logger_name=__name__,

--- a/shortfin/python/shortfin_apps/utils.py
+++ b/shortfin/python/shortfin_apps/utils.py
@@ -40,7 +40,7 @@ def get_system_args(parser):
     parser.add_argument(
         "--amdgpu_async_caching",
         action="store_true",
-        help="Enable asynchronous caching for amdgpu device contexts."
+        help="Enable asynchronous caching for amdgpu device contexts.",
     )
     parser.add_argument(
         "--amdgpu_allow_device_reuse",

--- a/shortfin/python/shortfin_apps/utils.py
+++ b/shortfin/python/shortfin_apps/utils.py
@@ -38,6 +38,11 @@ def get_system_args(parser):
         help="Enable asynchronous allocations for amdgpu device contexts.",
     )
     parser.add_argument(
+        "--amdgpu_async_caching",
+        action="store_true",
+        help="Enable asynchronous caching for amdgpu device contexts."
+    )
+    parser.add_argument(
         "--amdgpu_allow_device_reuse",
         action="store_true",
         help="Allows the same device to be used for each instance",
@@ -55,6 +60,7 @@ class SystemManager:
         device: str = "local-task",
         device_ids: list[Union[str, int]] = None,
         async_allocs: bool = True,
+        async_caching: bool = True,
         amdgpu_allow_device_reuse: bool = False,
         amdgpu_allocators: Optional[bool] = None,
         logger_name: str = __name__,
@@ -71,12 +77,14 @@ class SystemManager:
                 sb = sf.SystemBuilder(
                     system_type="amdgpu",
                     amdgpu_async_allocations=async_allocs,
+                    amdgpu_async_caching=async_caching,
                     amdgpu_allow_device_reuse=amdgpu_allow_device_reuse,
                 )
             else:
                 sb = sf.SystemBuilder(
                     system_type="amdgpu",
                     amdgpu_async_allocations=async_allocs,
+                    amdgpu_async_caching=async_caching,
                     amdgpu_allocators=amdgpu_allocators,
                     amdgpu_allow_device_reuse=amdgpu_allow_device_reuse,
                 )

--- a/shortfin/src/shortfin/local/systems/amdgpu.cc
+++ b/shortfin/src/shortfin/local/systems/amdgpu.cc
@@ -55,6 +55,9 @@ void AMDGPUSystemBuilder::InitializeDefaultSettings() {
   default_device_params_.async_allocations =
       config_options().GetBool("amdgpu_async_allocations", true);
 
+  default_device_params_.async_caching =
+      config_options().GetBool("amdgpu_async_caching", true);
+
   amdgpu_allow_device_reuse_ =
       config_options().GetBool("amdgpu_allow_device_reuse", false);
 


### PR DESCRIPTION
This allows us to enable or disable the [async_caching flag](https://github.com/iree-org/iree/commit/03f2a52413d482ccb8598bc0c90e8f79e7adceb0) in Shortfin, that was recently added @AWoloszyn.

This fixes the issue or of allocating and not releasing progressively higher values of RAM, as observed in some long running benchmark tests.

Our CLI defaults this value to `false`. It can enabled by passing in `--amdgpu_async_caching` when starting the server