### PR TITLE
[shark Tank] Implementation of sharded_gather

### DIFF
--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -603,7 +603,7 @@ def sharded_cat_unsharded(maybe_sharded):
 
 @sharded_gather.override(Tensor)
 def sharded_gather_unsharded(input):
-    return unbox_tensor(input)
+    return input
 
 
 @sharded_sum.override(Tensor)

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -585,6 +585,11 @@ def sharded_cat_unsharded(maybe_sharded):
     return unbox_tensor(maybe_sharded)
 
 
+@sharded_gather.override(Tensor)
+def sharded_gather_unsharded(input):
+    return unbox_tensor(input)
+
+
 @sharded_sum.override(Tensor)
 def sharded_sum_unsharded(maybe_sharded):
     return unbox_tensor(maybe_sharded)

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -603,7 +603,7 @@ def sharded_cat_unsharded(maybe_sharded):
 
 @sharded_gather.override(Tensor)
 def sharded_gather_unsharded(input):
-    return input
+    return [input]
 
 
 @sharded_sum.override(Tensor)

--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -1384,9 +1384,7 @@ def sharded_cat_unsharded(tensor: SplitPrimitiveTensor):
 
 
 @sharded_gather.override(SplitPrimitiveTensor)
-def sharded_gather_split(
-    input: SplitPrimitiveTensor, root_rank: int, dim: int | None
-) -> List[Tensor]:
+def sharded_gather_split(input: SplitPrimitiveTensor, root_rank: int) -> List[Tensor]:
 
     shard_ts = [
         (
@@ -1400,9 +1398,7 @@ def sharded_gather_split(
 
 
 @sharded_gather.override(ReplicatedTensor)
-def sharded_gather_replicated(
-    input: ReplicatedTensor, root_rank: int, dim: int | None
-) -> List[Tensor]:
+def sharded_gather_replicated(input: ReplicatedTensor, root_rank: int) -> List[Tensor]:
     shard = input.shards[root_rank]
     return [shard.as_torch().clone() for _ in range(input.shard_count)]
 

--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -1360,9 +1360,35 @@ def sharded_cat_unsharded(tensor: SplitPrimitiveTensor):
     return torch.cat(shard_ts, dim=tensor.shard_dim)
 
 
+@sharded_gather.override(SplitPrimitiveTensor)
+def sharded_gather_split(
+    input: SplitPrimitiveTensor, device_ordinal: int, concat: bool = False
+) -> Union[List[Tensor], Tensor]:
+    shard_ts = [
+        (
+            transfer_to_logical_device(shard, device_ordinal)
+            if i != 0
+            else barrier_on_logical_device(shard, device_ordinal)
+        )
+        for i, shard in enumerate(input.shards)
+    ]
+    if concat:
+        return torch.cat(shard_ts, dim=input.shard_dim)
+    return shard_ts
+
+
+@sharded_gather.override(ReplicatedTensor)
+def sharded_gather_replicated(
+    input: ReplicatedTensor, device_ordinal: int, concat: bool = False
+) -> Union[List[Tensor], Tensor]:
+    shard = input.shards[device_ordinal]
+    if concat:
+        return shard.as_torch()
+
+    return [shard.as_torch().clone() for _ in range(input.shard_count)]
+
+
 # Sharded sum.
-
-
 def _sharded_sum_sharded(tensor: ShardedTensor) -> Tensor:
     reduced = functools.reduce(
         lambda x, y: elementwise(torch.add, x, y),

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -1216,20 +1216,18 @@ def _sharded_cat_trampoline(d: SignatureDispatcher, maybe_sharded: AnyTensor):
 
 
 @overridable(is_trivially_replicable=False)
-def sharded_gather(
-    input: AnyTensor, root_rank: int, dim: int | None = None
-) -> AnyTensor:
+def sharded_gather(input: AnyTensor, root_rank: int) -> AnyTensor:
     """Gather the input tensor from all devices to the given device ordinal."""
     ...
 
 
 @sharded_gather.trampoline
 def _sharded_gather_trampoline(
-    d: SignatureDispatcher, input: AnyTensor, root_rank: int, dim: int | None = None
+    d: SignatureDispatcher, input: AnyTensor, root_rank: int
 ) -> AnyTensor:
     dispatch_args = (input,)
     for override in d.find_overrides(dispatch_args):
-        result = override(input, root_rank, dim)
+        result = override(input, root_rank)
         if result is not NotImplemented:
             return override, result
     else:

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -1216,7 +1216,7 @@ def _sharded_cat_trampoline(d: SignatureDispatcher, maybe_sharded: AnyTensor):
 
 
 @overridable(is_trivially_replicable=False)
-def sharded_gather(input: AnyTensor, root_rank: int) -> AnyTensor:
+def sharded_gather(input: AnyTensor, root_rank: int) -> list[AnyTensor]:
     """Gather the input tensor from all devices to the given device ordinal."""
     ...
 

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -1216,18 +1216,20 @@ def _sharded_cat_trampoline(d: SignatureDispatcher, maybe_sharded: AnyTensor):
 
 
 @overridable(is_trivially_replicable=False)
-def sharded_gather(input: AnyTensor, device_ordinal: int, concat: bool) -> AnyTensor:
+def sharded_gather(
+    input: AnyTensor, root_rank: int, dim: int | None = None
+) -> AnyTensor:
     """Gather the input tensor from all devices to the given device ordinal."""
     ...
 
 
 @sharded_gather.trampoline
 def _sharded_gather_trampoline(
-    d: SignatureDispatcher, input: AnyTensor, device_ordinal: int, concat: bool
+    d: SignatureDispatcher, input: AnyTensor, root_rank: int, dim: int | None = None
 ) -> AnyTensor:
     dispatch_args = (input,)
     for override in d.find_overrides(dispatch_args):
-        result = override(input, device_ordinal, concat)
+        result = override(input, root_rank, dim)
         if result is not NotImplemented:
             return override, result
     else:

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -1203,10 +1203,7 @@ def sharded_gather(input: AnyTensor, device_ordinal: int, concat: bool) -> AnyTe
 def _sharded_gather_trampoline(
     d: SignatureDispatcher, input: AnyTensor, device_ordinal: int, concat: bool
 ) -> AnyTensor:
-    dispatch_args = (
-        input,
-        device_ordinal,
-    )
+    dispatch_args = (input,)
     for override in d.find_overrides(dispatch_args):
         result = override(input, device_ordinal, concat)
         if result is not NotImplemented:

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -1635,6 +1635,12 @@ class SoftmaxTest(unittest.TestCase):
         torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
 
 
+class ShardedGatherTest(unittest.TestCase):
+    """TODO:placeholder for Test gather on sharded tensors."""
+
+    pass
+
+
 class SumTest(unittest.TestCase):
     def setUp(self):
         torch.random.manual_seed(12345)

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -1632,31 +1632,6 @@ class SigmoidTest(unittest.TestCase):
         torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
 
 
-class SoftmaxTest(unittest.TestCase):
-    def setUp(self):
-        torch.random.manual_seed(12345)
-
-    def testSoftmaxReplicated(self):
-        tensor = torch.rand(2, 4, 3, dtype=torch.float32)
-        dim = 1
-        expected_result = ops.softmax(tensor, dim=dim)
-        actual_result = ops.softmax(ops.replicate(tensor, count=3), dim=dim)
-        torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
-
-    def testSoftmaxSplit(self):
-        tensor = torch.rand(2, 2, 2, dtype=torch.float32)
-        dim = 1
-        sharded_tensor = ops.reshard_split(tensor, dim=dim, count=2)
-
-        expected_result = ops.softmax(tensor, dim=dim - 1)
-        actual_result = ops.softmax(sharded_tensor, dim=dim - 1)
-        torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
-
-        expected_result = ops.softmax(tensor, dim=dim + 1)
-        actual_result = ops.softmax(sharded_tensor, dim=dim + 1)
-        torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
-
-
 class ShardedGatherTest(unittest.TestCase):
     def setUp(self):
         torch.random.manual_seed(12345)
@@ -1690,6 +1665,31 @@ class ShardedGatherTest(unittest.TestCase):
         self.assertEqual(actual[0].shape, (2, 5, 4))
         for i, shard in enumerate(actual):
             assert ops.equal(shard, base_tensor)
+
+
+class SoftmaxTest(unittest.TestCase):
+    def setUp(self):
+        torch.random.manual_seed(12345)
+
+    def testSoftmaxReplicated(self):
+        tensor = torch.rand(2, 4, 3, dtype=torch.float32)
+        dim = 1
+        expected_result = ops.softmax(tensor, dim=dim)
+        actual_result = ops.softmax(ops.replicate(tensor, count=3), dim=dim)
+        torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
+
+    def testSoftmaxSplit(self):
+        tensor = torch.rand(2, 2, 2, dtype=torch.float32)
+        dim = 1
+        sharded_tensor = ops.reshard_split(tensor, dim=dim, count=2)
+
+        expected_result = ops.softmax(tensor, dim=dim - 1)
+        actual_result = ops.softmax(sharded_tensor, dim=dim - 1)
+        torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
+
+        expected_result = ops.softmax(tensor, dim=dim + 1)
+        actual_result = ops.softmax(sharded_tensor, dim=dim + 1)
+        torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
 
 
 class SplitTest(unittest.TestCase):

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -1673,7 +1673,7 @@ class ShardedGatherTest(unittest.TestCase):
         self.assertEqual(actual[0].shape, (2, 5, 4))
 
         for i, shard in enumerate(actual):
-            ops.equal(shard, shards[i])
+            assert ops.equal(shard, shards[i])
 
     def testGatherReplicated(self):
         shard_count = 3
@@ -1689,7 +1689,7 @@ class ShardedGatherTest(unittest.TestCase):
         self.assertEqual(len(actual), shard_count)
         self.assertEqual(actual[0].shape, (2, 5, 4))
         for i, shard in enumerate(actual):
-            ops.equal(shard, base_tensor)
+            assert ops.equal(shard, base_tensor)
 
 
 class SplitTest(unittest.TestCase):


### PR DESCRIPTION
Fixes #1396
Implementation of sharded_gather ops
this op is not an override for torch.gather which works based on indexing. It focuses on gathering SplitPrimitiveTensor and ReplicatedTensor shards across devices into a single device.