### PR TITLE
Use numpy.argpartition instead of sfnp for select_top_k

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/sampler.py
+++ b/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/sampler.py
@@ -45,10 +45,10 @@ class Sampler:
         """
         partitioned_tokens = np.argpartition(logits, k)
         # Slice off all axes except the last one
-        zero_indices = [0] * (len(partitioned_tokens.shape) - 1)
+        zero_indices = (0,) * (partitioned_tokens.ndim - 1)
 
         # Obtain tokens & values from partition
-        top_tokens = partitioned_tokens[*zero_indices, k:].tolist()
+        top_tokens = partitioned_tokens[zero_indices + (slice(k, None),)].tolist()
         values_view = logits.view(*zero_indices).items
 
         top_values = []

--- a/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/sampler.py
+++ b/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/sampler.py
@@ -48,7 +48,7 @@ class Sampler:
         zero_indices = [0] * (len(partitioned_tokens.shape) - 1)
 
         # Obtain tokens & values from partition
-        top_tokens = partitioned_tokens[*zero_indices, k:]
+        top_tokens = partitioned_tokens[*zero_indices, k:].tolist()
         values_view = logits.view(*zero_indices).items
 
         top_values = []

--- a/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/sampler.py
+++ b/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/sampler.py
@@ -6,6 +6,7 @@
 
 from dataclasses import dataclass
 
+import numpy as np
 import random
 from typing import List
 
@@ -42,14 +43,12 @@ class Sampler:
         """
         This function is used to get the top k tokens and their cumulative probabilities.
         """
-        partitioned_tokens = sfnp.argpartition(logits, k)
+        partitioned_tokens = np.argpartition(logits, k)
         # Slice off all axes except the last one
         zero_indices = [0] * (len(partitioned_tokens.shape) - 1)
 
         # Obtain tokens & values from partition
-        top_tokens: List[int] = partitioned_tokens.view(
-            *zero_indices, slice(k, None)
-        ).items.tolist()
+        top_tokens = partitioned_tokens[*zero_indices, k:]
         values_view = logits.view(*zero_indices).items
 
         top_values = []


### PR DESCRIPTION
Using numpy.argpartition results in speedup of select_top_k when compared to sfnp. 