### PR TITLE
[sharktank] Add reduce_scatter and split ops

### DIFF
--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -1215,9 +1215,7 @@ def _sharded_cat_trampoline(d: SignatureDispatcher, maybe_sharded: AnyTensor):
 
 
 @overridable(is_trivially_replicable=False)
-def sharded_sum(
-    maybe_sharded: AnyTensor, root_rank: int = 0
-) -> InferenceTensor | Tensor:
+def sharded_sum(maybe_sharded: AnyTensor, root_rank: int = 0) -> AnyTensor:
     """Reduce across the shards into a single device.
 
     root_rank:

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -16,6 +16,7 @@ from torch import Tensor, dtype
 from sharktank.types import (
     AnyTensor,
     ShardedTensor,
+    SplitPrimitiveTensor,
     Theta,
     sharding,
     InferenceTensor,
@@ -57,6 +58,7 @@ __all__ = [
     "pad",
     "permute",
     "rms_norm",
+    "reduce_scatter",
     "repeat",
     "replicate",
     "reshape",
@@ -70,6 +72,7 @@ __all__ = [
     "sharded_sum",
     "sigmoid",
     "softmax",
+    "split",
     "squeeze",
     "sum",
     "to",
@@ -897,6 +900,25 @@ def _module_register_buffer_trampoline(
         d.fail(args)
 
 
+@overridable(is_trivially_replicable=False)
+def reduce_scatter(tensor: AnyTensor, scatter_dim: int) -> AnyTensor:
+    """Reduces then splits/scatters across the devices."""
+    ...
+
+
+@reduce_scatter.trampoline
+def _reduce_scatter_trampoline(
+    d: SignatureDispatcher, tensor: AnyTensor, scatter_dim: int
+):
+    tensors = (tensor,)
+    for override in d.find_overrides(tensors):
+        result = override(tensor, scatter_dim)
+        if result is not NotImplemented:
+            return override, result
+    else:
+        d.fail(tensors)
+
+
 @overridable
 def rms_norm(
     x: AnyTensor, weight: AnyTensor, *, epsilon: float, orig_dtype: torch.dtype
@@ -1193,15 +1215,25 @@ def _sharded_cat_trampoline(d: SignatureDispatcher, maybe_sharded: AnyTensor):
 
 
 @overridable(is_trivially_replicable=False)
-def sharded_sum(maybe_sharded: AnyTensor):
+def sharded_sum(
+    maybe_sharded: AnyTensor, root_rank: int = 0
+) -> InferenceTensor | Tensor:
+    """Reduce across the shards into a single device.
+
+    root_rank:
+        Rank of receiving device within the tensor devices.
+        If sharded, `maybe_sharded.devices[root_rank]` is the destination.
+    """
     ...
 
 
 @sharded_sum.trampoline
-def _sharded_sum_trampoline(d: SignatureDispatcher, maybe_sharded: AnyTensor):
+def _sharded_sum_trampoline(
+    d: SignatureDispatcher, maybe_sharded: AnyTensor, root_rank: int = 0
+):
     tensors = (maybe_sharded,)
     for override in d.find_overrides(tensors):
-        result = override(maybe_sharded)
+        result = override(maybe_sharded, root_rank)
         if result is not NotImplemented:
             return override, result
     else:
@@ -1209,7 +1241,7 @@ def _sharded_sum_trampoline(d: SignatureDispatcher, maybe_sharded: AnyTensor):
 
 
 @overridable
-def sigmoid(tensoir: AnyTensor) -> AnyTensor:
+def sigmoid(tensor: AnyTensor) -> AnyTensor:
     """See torch.sigmoid"""
     ...
 
@@ -1243,6 +1275,30 @@ def _softmax_trampoline(
     dispatch_args = [tensor]
     for override in d.find_overrides(dispatch_args):
         result = override(tensor, dim=dim, dtype=dtype)
+        if result is not NotImplemented:
+            return override, result
+    else:
+        d.fail(dispatch_args)
+
+
+@overridable
+def split(
+    tensor: AnyTensor, split_size_or_sections: int | list[int], dim: int = 0
+) -> tuple[AnyTensor, ...]:
+    """See torch.split"""
+    ...
+
+
+@split.trampoline
+def _split_trampoline(
+    d: SignatureDispatcher,
+    tensor: AnyTensor,
+    split_size_or_sections: int | list[int],
+    dim: int,
+) -> tuple[AnyTensor, ...]:
+    dispatch_args = [tensor]
+    for override in d.find_overrides(dispatch_args):
+        result = override(tensor, split_size_or_sections, dim)
         if result is not NotImplemented:
             return override, result
     else:

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -479,6 +479,13 @@ class InferenceTensor(ABC):
 
         return softmax(self, dim, dtype=dtype)
 
+    def split(
+        self, split_size_or_sections: int | list[int], dim: int = 0
+    ) -> tuple["AnyTensor", ...]:
+        from sharktank.ops import split
+
+        return split(self, split_size_or_sections, dim)
+
     def squeeze(self, dim: Optional[int] = None) -> "AnyTensor":
         from sharktank.ops import squeeze
 

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -11,6 +11,7 @@ import itertools
 import pytest
 from parameterized import parameterized, parameterized_class
 
+import functools
 import torch
 import torch.nn.functional as F
 
@@ -1267,6 +1268,27 @@ class MeanTest(unittest.TestCase):
         torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
 
 
+class ReduceScatter(unittest.TestCase):
+    def setUp(self):
+        torch.random.manual_seed(0)
+
+    def testUnreduced(self):
+        dtype = torch.float32
+        shard_count = 3
+        shape = [2, shard_count * 5, 7]
+        scatter_dim = 1
+        input_shards = [torch.rand(shape, dtype=dtype) for _ in range(shard_count)]
+
+        expected = functools.reduce(torch.add, input_shards)
+
+        unreduced_input = UnreducedTensor(ts=input_shards)
+        actual = ops.reduce_scatter(unreduced_input, scatter_dim)
+        assert isinstance(actual, SplitPrimitiveTensor)
+        assert actual.shard_dim == scatter_dim
+        assert actual.shard_count == shard_count
+        assert ops.equal(expected, actual)
+
+
 class ReplicateTest(unittest.TestCase):
     def testReplicateReplicated(self):
         tensor = torch.rand(4, 5, dtype=torch.float32)
@@ -1633,6 +1655,32 @@ class SoftmaxTest(unittest.TestCase):
         expected_result = ops.softmax(tensor, dim=dim + 1)
         actual_result = ops.softmax(sharded_tensor, dim=dim + 1)
         torch.testing.assert_close(expected_result, ops.unbox_tensor(actual_result))
+
+
+class SplitTest(unittest.TestCase):
+    def setUp(self):
+        torch.random.manual_seed(0)
+
+    def testUnreduced(self):
+        split_dim = 2
+        shard_count = 3
+        input_shards = [
+            torch.rand(2, 5, 3, dtype=torch.float32) for _ in range(shard_count)
+        ]
+        split_size = 2
+        expected_shards = [
+            torch.split(shard, split_size, dim=split_dim) for shard in input_shards
+        ]
+
+        unreduced_input = UnreducedTensor(ts=input_shards)
+        actual_result = ops.split(unreduced_input, split_size, dim=split_dim)
+        assert len(actual_result) == len(expected_shards[0])
+        for t in actual_result:
+            assert isinstance(t, UnreducedTensor)
+
+        for i in range(len(expected_shards)):
+            for j in range(len(expected_shards[i])):
+                ops.equal(actual_result[j].shards[i], expected_shards[i][j])
 
 
 class SumTest(unittest.TestCase):


### PR DESCRIPTION
Adds reduce_scatter for an UnreducedTensor, which would be required for tensor-sharding the latent attention preprocessing.

A Split op is also added as it is used in the implementation of reduce_scatter.

The sharded_sum op is augmented with a new root_rank argument. It specifies the rank of the destination device within the sharded tensor. It has the same meaning as in MPI.