### PR TITLE
Restore separate threads for prefill and decode

### DIFF
--- a/app_tests/integration_tests/llm/shortfin/direct_to_batcher_test.py
+++ b/app_tests/integration_tests/llm/shortfin/direct_to_batcher_test.py
@@ -38,7 +38,7 @@ class BatchConsistencyTestProcess(sf.Process):
     """
 
     def __init__(self, service, input_tokens, batch_sizes, max_response_length):
-        super().__init__(fiber=service.fiber_pool.fibers[0])
+        super().__init__(fiber=service.main_fiber)
         self.service = service
         self.input_tokens = input_tokens
         self.batch_sizes = batch_sizes

--- a/shortfin/python/shortfin_apps/llm/cli.py
+++ b/shortfin/python/shortfin_apps/llm/cli.py
@@ -250,7 +250,9 @@ async def main(argv):
             gen_req = GenerateReqInput(
                 text=task.prompt, sampling_params=sampling_params
             )
-            ClientGenerateBatchProcess(service, gen_req, responder, fiber=fiber).launch()
+            ClientGenerateBatchProcess(
+                service, gen_req, responder, fiber=fiber
+            ).launch()
             await responder.response
             task.responder = responder
             task.result = responder.response.result()

--- a/shortfin/python/shortfin_apps/llm/cli.py
+++ b/shortfin/python/shortfin_apps/llm/cli.py
@@ -250,7 +250,7 @@ async def main(argv):
             gen_req = GenerateReqInput(
                 text=task.prompt, sampling_params=sampling_params
             )
-            ClientGenerateBatchProcess(service, gen_req, responder).launch()
+            ClientGenerateBatchProcess(service, gen_req, responder, fiber=fiber).launch()
             await responder.response
             task.responder = responder
             task.result = responder.response.result()

--- a/shortfin/python/shortfin_apps/llm/components/batcher.py
+++ b/shortfin/python/shortfin_apps/llm/components/batcher.py
@@ -49,22 +49,6 @@ class DoneWorkItem(sf.Message):
         self.count = count
 
 
-@dataclass
-class FiberPool:
-
-    fibers: List[sf.Fiber]
-    idle_fibers: List[sf.Fiber]
-
-    def get_fiber(self):
-        if len(self.idle_fibers) == 0:
-            return None
-
-        return self.idle_fibers.pop(0)
-
-    def return_fiber(self, fiber: sf.Fiber):
-        self.idle_fibers.append(fiber)
-
-
 class LlmBatcherProcess(BatcherProcess):
     """This batcher provides a high-level mechanism for dispatching LLM tasks."""
 
@@ -74,14 +58,14 @@ class LlmBatcherProcess(BatcherProcess):
     def __init__(
         self,
         name: str,
-        fiber_pool: FiberPool,
+        fiber: Fiber,
         page_cache: BasePagedAttentionCache,
         model_params: ModelParams,
         functions: dict[int, sf.ProgramFunction],
         ideal_batch_size: int,
         program_isolation: str,
     ):
-        super().__init__(fiber=fiber_pool.fibers[0])
+        super().__init__(fiber=fiber)
         self.name = name
         self.page_cache = page_cache
         self.model_params = model_params
@@ -93,7 +77,6 @@ class LlmBatcherProcess(BatcherProcess):
         self.page_seq_stride = self.model_params.paged_kv_cache.block_seq_stride
         self._current_workitems = 0
 
-        self.fiber_pool = fiber_pool
         self.program_isolation = program_isolation
 
     def handle_inference_request(self, request):
@@ -137,18 +120,11 @@ class LlmBatcherProcess(BatcherProcess):
             logger.info("Waiting a bit longer to fill flight")
             return
 
-        fiber = self.fiber_pool.get_fiber()
-        if fiber is None:
-            logger.info("Waiting for an idle fiber...")
-            return
-
         self.strobes = 0
         cache = self.page_cache
 
-        self.board(cache, fiber)
+        self.board(cache, self.fiber)
         logger.debug("Post boarding cache state: %r", cache)
-        if self.program_isolation != sf.ProgramIsolation.PER_FIBER:
-            self.fiber_pool.return_fiber(fiber)
 
     def make_process(self, cache: BasePagedAttentionCache, fiber: Fiber):
         ...
@@ -193,7 +169,7 @@ class PrefillBatcherProcess(LlmBatcherProcess):
 
     def __init__(
         self,
-        fiber_pool: FiberPool,
+        fiber: Fiber,
         page_cache: BasePagedAttentionCache,
         model_params: ModelParams,
         prefill_functions: dict[int, sf.ProgramFunction],
@@ -201,7 +177,7 @@ class PrefillBatcherProcess(LlmBatcherProcess):
     ):
         super().__init__(
             name="prefill",
-            fiber_pool=fiber_pool,
+            fiber=fiber,
             page_cache=page_cache,
             model_params=model_params,
             functions=prefill_functions,
@@ -215,7 +191,6 @@ class PrefillBatcherProcess(LlmBatcherProcess):
             self.functions,
             self.page_seq_stride,
             cache.page_pool.page_tables,
-            self.fiber_pool,
             self.program_isolation,
         )
 
@@ -249,7 +224,7 @@ class DecodeBatcherProcess(LlmBatcherProcess):
 
     def __init__(
         self,
-        fiber_pool: FiberPool,
+        fiber: Fiber,
         page_cache: BasePagedAttentionCache,
         model_params: ModelParams,
         decode_functions: dict[int, sf.ProgramFunction],
@@ -257,7 +232,7 @@ class DecodeBatcherProcess(LlmBatcherProcess):
     ):
         super().__init__(
             name="decode",
-            fiber_pool=fiber_pool,
+            fiber=fiber,
             page_cache=page_cache,
             model_params=model_params,
             functions=decode_functions,
@@ -271,7 +246,6 @@ class DecodeBatcherProcess(LlmBatcherProcess):
             self.functions,
             self.page_seq_stride,
             cache.page_pool.page_tables,
-            self.fiber_pool,
             self.program_isolation,
         )
 
@@ -297,7 +271,6 @@ class LlmExecutorProcess(sf.Process):
         functions: dict[int, sf.ProgramFunction],
         seq_stride: int,
         page_tables,
-        fiber_pool: FiberPool,
         program_isolation: sf.ProgramIsolation,
     ):
         super().__init__(fiber=fiber)
@@ -306,7 +279,6 @@ class LlmExecutorProcess(sf.Process):
         self.exec_requests: list[LlmInferenceExecRequest] = []
         self.page_tables = page_tables
         self.functions = functions
-        self.fiber_pool = fiber_pool
         self.program_isolation = program_isolation
 
     async def get_args(self, bs, device0):
@@ -386,7 +358,6 @@ class PrefillExecutorProcess(LlmExecutorProcess):
         functions: dict[int, sf.ProgramFunction],
         seq_stride: int,
         page_tables,
-        fiber_pool: FiberPool,
         program_isolation: sf.ProgramIsolation,
     ):
         super().__init__(
@@ -395,7 +366,6 @@ class PrefillExecutorProcess(LlmExecutorProcess):
             functions=functions,
             seq_stride=seq_stride,
             page_tables=page_tables,
-            fiber_pool=fiber_pool,
             program_isolation=program_isolation,
         )
 
@@ -477,9 +447,6 @@ class PrefillExecutorProcess(LlmExecutorProcess):
                 req.result_logits = logits_item
             req.done.set_success()
 
-        if self.program_isolation == sf.ProgramIsolation.PER_FIBER:
-            self.fiber_pool.return_fiber(self.fiber)
-
 
 class DecodeExecutorProcess(LlmExecutorProcess):
     """Executes a decode batch."""
@@ -490,7 +457,6 @@ class DecodeExecutorProcess(LlmExecutorProcess):
         functions: dict[int, sf.ProgramFunction],
         seq_stride: int,
         page_tables,
-        fiber_pool: FiberPool,
         isolation: sf.ProgramIsolation,
     ):
         super().__init__(
@@ -499,7 +465,6 @@ class DecodeExecutorProcess(LlmExecutorProcess):
             functions=functions,
             seq_stride=seq_stride,
             page_tables=page_tables,
-            fiber_pool=fiber_pool,
             program_isolation=isolation,
         )
 
@@ -597,6 +562,3 @@ class DecodeExecutorProcess(LlmExecutorProcess):
             else:
                 req.result_logits = logits_item
             req.done.set_success()
-
-        if self.program_isolation == sf.ProgramIsolation.PER_FIBER:
-            self.fiber_pool.return_fiber(self.fiber)

--- a/shortfin/python/shortfin_apps/llm/components/generate.py
+++ b/shortfin/python/shortfin_apps/llm/components/generate.py
@@ -140,9 +140,9 @@ class ClientGenerateBatchProcess(sf.Process):
         service: LlmGenerateService,
         gen_req: GenerateReqInput,
         responder: FastAPIResponder,
-        fiber: sf.Fiber | None = None,
+        fiber: sf.Fiber,
     ):
-        super().__init__(fiber=service.fiber_pool.fibers[0] if fiber is None else fiber)
+        super().__init__(fiber=fiber)
         self.service = service
         self.gen_req = gen_req
         self.responder = responder

--- a/shortfin/python/shortfin_apps/llm/components/service.py
+++ b/shortfin/python/shortfin_apps/llm/components/service.py
@@ -89,10 +89,14 @@ class LlmGenerateService(GenerateService):
         self.main_worker = self.sysman.ls.create_worker(f"{self.name}-inference-main-0")
         self.main_fiber = self.sysman.ls.create_fiber(self.main_worker)
 
-        self.prefill_worker = self.sysman.ls.create_worker(f"{self.name}-inference-prefill-0")
+        self.prefill_worker = self.sysman.ls.create_worker(
+            f"{self.name}-inference-prefill-0"
+        )
         self.prefill_fiber = self.sysman.ls.create_fiber(self.prefill_worker)
 
-        self.decode_worker = self.sysman.ls.create_worker(f"{self.name}-inference-decode-0")
+        self.decode_worker = self.sysman.ls.create_worker(
+            f"{self.name}-inference-decode-0"
+        )
         self.decode_fiber = self.sysman.ls.create_fiber(self.decode_worker)
 
         self.devices = self.prefill_fiber.devices_dict.values()

--- a/shortfin/python/shortfin_apps/llm/components/service.py
+++ b/shortfin/python/shortfin_apps/llm/components/service.py
@@ -12,7 +12,7 @@ from typing import List
 import shortfin as sf
 
 
-from .batcher import PrefillBatcherProcess, DecodeBatcherProcess, FiberPool
+from .batcher import PrefillBatcherProcess, DecodeBatcherProcess
 from .config_struct import ModelParams, ServerParams
 from .kvcache.base_attention_cache import (
     BasePagedAttentionCache,
@@ -85,18 +85,17 @@ class LlmGenerateService(GenerateService):
         logger.info(
             f"Creating {num_workers} workers, with {fibers_per_worker} fibers per worker..."
         )
-        fibers = []
-        for i in range(num_workers):
-            worker = self.sysman.ls.create_worker(f"{self.name}-inference-{i}")
-            for _ in range(fibers_per_worker):
-                fiber = self.sysman.ls.create_fiber(worker)
-                fibers.append(fiber)
 
-        self.fiber_pool = FiberPool(
-            fibers,
-            fibers,
-        )
-        self.devices = fibers[0].devices_dict.values()
+        self.main_worker = self.sysman.ls.create_worker(f"{self.name}-inference-main-0")
+        self.main_fiber = self.sysman.ls.create_fiber(self.main_worker)
+
+        self.prefill_worker = self.sysman.ls.create_worker(f"{self.name}-inference-prefill-0")
+        self.prefill_fiber = self.sysman.ls.create_fiber(self.prefill_worker)
+
+        self.decode_worker = self.sysman.ls.create_worker(f"{self.name}-inference-decode-0")
+        self.decode_fiber = self.sysman.ls.create_fiber(self.decode_worker)
+
+        self.devices = self.prefill_fiber.devices_dict.values()
 
     def initialize_page_cache(self):
         """Initialize page pool and attention cache."""
@@ -133,7 +132,7 @@ class LlmGenerateService(GenerateService):
         self.initialize_function_references()
 
         self.prefill_batcher = PrefillBatcherProcess(
-            self.fiber_pool,
+            self.prefill_fiber,
             self.page_cache,
             self.model_params,
             self.prefill_functions,
@@ -141,7 +140,7 @@ class LlmGenerateService(GenerateService):
         )
 
         self.decode_batcher = DecodeBatcherProcess(
-            self.fiber_pool,
+            self.decode_fiber,
             self.page_cache,
             self.model_params,
             self.decode_functions,

--- a/shortfin/python/shortfin_apps/llm/routes/generate.py
+++ b/shortfin/python/shortfin_apps/llm/routes/generate.py
@@ -23,5 +23,7 @@ async def generate_request(gen_req: GenerateReqInput, request: Request):
     service: GenerateService = request.app.state.services["default"]
     gen_req.post_init()
     responder = FastAPIResponder(request)
-    ClientGenerateBatchProcess(service, gen_req, responder, fiber=service.main_fiber).launch()
+    ClientGenerateBatchProcess(
+        service, gen_req, responder, fiber=service.main_fiber
+    ).launch()
     return await responder.response

--- a/shortfin/python/shortfin_apps/llm/routes/generate.py
+++ b/shortfin/python/shortfin_apps/llm/routes/generate.py
@@ -23,5 +23,5 @@ async def generate_request(gen_req: GenerateReqInput, request: Request):
     service: GenerateService = request.app.state.services["default"]
     gen_req.post_init()
     responder = FastAPIResponder(request)
-    ClientGenerateBatchProcess(service, gen_req, responder).launch()
+    ClientGenerateBatchProcess(service, gen_req, responder, fiber=service.main_fiber).launch()
     return await responder.response


### PR DESCRIPTION
Threading pool actually slowed existing throughput if enabling multiple threads on decode. Simplified to have separate threads between prefill and decode. This should allow pre-work to decouple streams between the two workloads.