### PR TITLE
Fix test_grok and remove xfail on it

### DIFF
--- a/sharktank/tests/models/grok/test_grok.py
+++ b/sharktank/tests/models/grok/test_grok.py
@@ -11,11 +11,6 @@ import torch
 import pytest
 
 
-@pytest.mark.xfail(
-    raises=AssertionError,
-    strict=False,
-    reason="https://github.com/nod-ai/shark-ai/issues/1270",
-)
 def test_grok():
     theta, config = generate(12345)
     model = PagedLlmModelV1(theta=theta, config=config)
@@ -50,4 +45,4 @@ def test_grok():
     ids = ids[0, 1:].cpu()
     logits = logits[0, :-1].to(torch.float32).cpu()
     cross_entropy = torch.nn.functional.cross_entropy(logits, ids)
-    assert pytest.approx(2.0267, 1e-2) == cross_entropy
+    assert pytest.approx(4.7464, 1e-2) == cross_entropy


### PR DESCRIPTION
The expected cross_entropy in the test does could not be replicated even with the commit that initially implemented it. The new value is the value optained by running the test on the original commit. Same result whether using cpu or rocm version of torch.

Closes #1270.