### PR TITLE
Fix relative import

### DIFF
--- a/sharktank/tests/tools/sharktank_test.py
+++ b/sharktank/tests/tools/sharktank_test.py
@@ -29,7 +29,6 @@ def test_export_compile(dummy_model_path: Path):
     with chdir(dummy_model_path):
         check_call(["shark", "model", "export", "dummy-model-local-llvm-cpu"])
         check_call(["shark", "model", "compile", "dummy-model-local-llvm-cpu"])
-        from .. import models
 
         register_all_models()
         config = ModelConfig.create(


### PR DESCRIPTION
Trying to run test locally raises an error:
```
    def test_export_compile(dummy_model_path: Path):
        with chdir(dummy_model_path):
            check_call(["shark", "model", "export", "dummy-model-local-llvm-cpu"])
            check_call(["shark", "model", "compile", "dummy-model-local-llvm-cpu"])
>           from .. import models
E           ImportError: attempted relative import with no known parent package

tests/tools/sharktank_test.py:32: ImportError
```

That line also does not appear to be needed as `register_all_models()` right below it does the same thing.