### PR TITLE
Provide useful error message for invalid sharding

### DIFF
--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -1194,6 +1194,10 @@ def reshard_split_replicated(
     if input.shard_count != count:
         raise ValueError(f"Number of shards not equal ({input.shard_count} != {count})")
 
+    assert (
+        input.shape[dim] > count
+    ), f"Cannot split dimension {dim} of size {input.shape[dim]} into {count} shards"
+
     def slice_range_along_dim(dim: int, start: int, end: int):
         res = [slice(None)] * len(input.shape)
         res[dim] = slice(start, end)

--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -1195,7 +1195,7 @@ def reshard_split_replicated(
         raise ValueError(f"Number of shards not equal ({input.shard_count} != {count})")
 
     assert (
-        input.shape[dim] > count
+        input.shape[dim] >= count
     ), f"Cannot split dimension {dim} of size {input.shape[dim]} into {count} shards"
 
     def slice_range_along_dim(dim: int, start: int, end: int):

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -1172,6 +1172,9 @@ class SplitPrimitiveTensor(ShardedTensorBase):
             assert (
                 shard_count > 1
             ), "SplitTensor must have at least 2 shards. Use ReplicatedTensor for 1 shard."
+            assert (
+                ts.shape[shard_dim] > shard_count
+            ), f"Cannot split dimension {shard_dim} of size {ts.shape[shard_dim]} into {shard_count} shards"
             ts = ts.split(ceildiv(ts.shape[shard_dim], shard_count), dim=shard_dim)
             ts = [transfer_to_logical_device(t, devices[i]) for i, t in enumerate(ts)]
             assert len(ts) == shard_count

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -1173,7 +1173,7 @@ class SplitPrimitiveTensor(ShardedTensorBase):
                 shard_count > 1
             ), "SplitTensor must have at least 2 shards. Use ReplicatedTensor for 1 shard."
             assert (
-                ts.shape[shard_dim] > shard_count
+                ts.shape[shard_dim] >= shard_count
             ), f"Cannot split dimension {shard_dim} of size {ts.shape[shard_dim]} into {shard_count} shards"
             ts = ts.split(ceildiv(ts.shape[shard_dim], shard_count), dim=shard_dim)
             ts = [transfer_to_logical_device(t, devices[i]) for i, t in enumerate(ts)]


### PR DESCRIPTION
Adds an assert and useful error message when trying to shard a tensor into more pieces than possible. E.g. tensor of shape [4, 32] into 8 pieces along dim 0 is impossible. Previously, this would return back 1 shard and then fail on a subsequent assert since `len(ts) != shard_count`, which is correct but harder to trace back to actual issue.