### PR TITLE
Reorder KV Cache contraction dimensions

### DIFF
--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -728,8 +728,8 @@ class PagedAttention:
 
     * transformer block
     * cache partition (K or V cache)
-    * block sequence stride (number of sequence positions per block)
     * attention heads
+    * block sequence stride (number of sequence positions per block)
     * attention dimensionality
 
     Note that the internal page structure matches the organization of the


### PR DESCRIPTION
The KV Cache should have contracting dimensions placed together. Specifically the block sequence stride should be after the KV heads but before the attn_dim.