### PR TITLE
[tuner]  create interface for constraint generation

### DIFF
--- a/sharktuner/model_tuner/model_tuner.py
+++ b/sharktuner/model_tuner/model_tuner.py
@@ -4,15 +4,16 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import logging
 import argparse
 import shutil
 from pathlib import Path
 from sharktuner import libtuner
-from sharktuner.common import *
+from sharktuner import common
 
 
 class ModelTuner(libtuner.TuningClient):
-    def __init__(self, tuner_context: libtuner.TunerContext):
+    def __init__(self, tuner_context: common.TunerContext):
         super().__init__(tuner_context)
         self.compile_flags: list[str] = []
         self.benchmark_flags: list[str] = []
@@ -110,7 +111,7 @@ def main() -> None:
         logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
     )
     print("Generating candidate tuning specs...")
-    with TunerContext(logger=root_logger) as tuner_context:
+    with common.TunerContext(logger=root_logger) as tuner_context:
         tuner_context.logger.addHandler(summary_handler)
         model_tuner = ModelTuner(tuner_context)
         candidates = libtuner.generate_candidate_specs(

--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -27,16 +27,18 @@ from abc import abstractmethod
 from iree.compiler import ir  # type: ignore
 from iree.compiler.dialects import iree_codegen  # type: ignore
 
-from .common import *
-from .dispatch_constraints import *
-from .dispatch_parser import *
-from .spec_builder import *
-from .constraint_generator import *
+from . import (
+    common,
+    dispatch_constraints,
+    dispatch_parser,
+    spec_builder,
+    constraint_generator,
+)
 
 tune_logger = logging.getLogger("tune")
 
 
-class DispatchTuner(DispatchParser):
+class DispatchTuner(dispatch_parser.DispatchParser):
     @abstractmethod
     def get_td_spec(
         self,
@@ -46,7 +48,7 @@ class DispatchTuner(DispatchParser):
         pass
 
     @abstractmethod
-    def get_constraint_generator(self) -> ConstraintGenerator:
+    def get_constraint_generator(self) -> constraint_generator.ConstraintGenerator:
         """Returns a ConstraintGenerator associated with this dispatch root op."""
         pass
 
@@ -66,12 +68,16 @@ class DispatchTunerRegistry:
         assert False, "Dispatch kind not supported"
 
 
-class ContractionOpInterfaceTuner(DispatchTuner, ContractionOpInterfaceParser):
+class ContractionOpInterfaceTuner(
+    DispatchTuner, dispatch_parser.ContractionOpInterfaceParser
+):
     def __init__(self, root_op: ir.Operation):
         super().__init__(root_op)
 
-    def get_constraint_generator(self) -> ConstraintGenerator:
-        return ContractionOpInterfaceConstraintGenerator(self.get_root_op())
+    def get_constraint_generator(self) -> constraint_generator.ConstraintGenerator:
+        return constraint_generator.ContractionOpInterfaceConstraintGenerator(
+            self.get_root_op()
+        )
 
     def get_td_spec(
         self,
@@ -79,17 +85,21 @@ class ContractionOpInterfaceTuner(DispatchTuner, ContractionOpInterfaceParser):
     ) -> ir.Module:
         contraction_op = self.get_root_op()
         func_name = self.get_root_op_func_name()
-        return build_td_spec(
+        return spec_builder.build_td_spec(
             contraction_op.context, contraction_op, compilation_info, func_name
         )
 
 
-class ConvolutionOpInterfaceTuner(DispatchTuner, ConvolutionOpInterfaceParser):
+class ConvolutionOpInterfaceTuner(
+    DispatchTuner, dispatch_parser.ConvolutionOpInterfaceParser
+):
     def __init__(self, root_op: ir.Operation):
         super().__init__(root_op)
 
-    def get_constraint_generator(self) -> ConstraintGenerator:
-        return ConvolutionOpInterfaceConstraintGenerator(self.get_root_op())
+    def get_constraint_generator(self) -> constraint_generator.ConstraintGenerator:
+        return constraint_generator.ConvolutionOpInterfaceConstraintGenerator(
+            self.get_root_op()
+        )
 
     def get_td_spec(
         self,
@@ -97,7 +107,9 @@ class ConvolutionOpInterfaceTuner(DispatchTuner, ConvolutionOpInterfaceParser):
     ) -> ir.Module:
         conv_op = self.get_root_op()
         func_name = self.get_root_op_func_name()
-        return build_td_spec(conv_op.context, conv_op, compilation_info, func_name)
+        return spec_builder.build_td_spec(
+            conv_op.context, conv_op, compilation_info, func_name
+        )
 
 
 def get_default_output_dir() -> str:
@@ -108,11 +120,11 @@ def get_default_output_dir() -> str:
 
 def generate_configs_and_td_specs(
     input_module: ir.Module,  # Path to the mlir file to be tuned
-    tuner_context: TunerContext,
+    tuner_context: common.TunerContext,
     limit: int = 4096,  # Max candidates to be generated
     num_subgroups: int = 4,  # GPU spec, used to determine candidate generation constraints
     allowed_waves_per_eu: list[int] = [2],
-    pipeline_options_search_space: PipelineOptionsSearchSpace = PipelineOptionsSearchSpace(),
+    pipeline_options_search_space: dispatch_constraints.PipelineOptionsSearchSpace = dispatch_constraints.PipelineOptionsSearchSpace(),
     codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline = iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute,
 ) -> list[ir.Module]:
     dispatch_tuners: list[type[DispatchTuner]] = [
@@ -143,7 +155,9 @@ def generate_configs_and_td_specs(
     assert dispatch_tuner, "No suitable dispatch tuner found"
 
     # Index 0 is reserved for default config, so it gets a placeholder spec.
-    config_specs: list[ir.Module] = [get_placeholder_spec(input_module.context)]
+    config_specs: list[ir.Module] = [
+        spec_builder.get_placeholder_spec(input_module.context)
+    ]
 
     # Get the MMA intrinisic intructions supported by the target.
     variant_op_list = iree_codegen.get_executable_variant_ops(input_module)
@@ -236,9 +250,9 @@ def strip_root_op_attr(module: ir.Module):
     root_ops: list[ir.Operation] = iree_codegen.get_tuner_root_ops(module)
     for root_op in root_ops:
         assert (
-            ROOT_OP_ATTR_NAME in root_op.opview.attributes
-        ), f"expected root op to have '{ROOT_OP_ATTR_NAME}' attr"
-        del root_op.opview.attributes[ROOT_OP_ATTR_NAME]
+            spec_builder.ROOT_OP_ATTR_NAME in root_op.opview.attributes
+        ), f"expected root op to have '{spec_builder.ROOT_OP_ATTR_NAME}' attr"
+        del root_op.opview.attributes[spec_builder.ROOT_OP_ATTR_NAME]
 
 
 # See the above comment for `strip_root_op_attr`.
@@ -313,10 +327,10 @@ def main() -> None:
     console_handler.setFormatter(formatter)
     tune_logger.addHandler(console_handler)
 
-    with TunerContext() as tuner_ctx:
+    with common.TunerContext() as tuner_ctx:
         mlir_text = strip_compilation_info(args.input)
-        mlir_module = parse_mlir(mlir_text, tuner_ctx)
-        pipeline_options_search_space = PipelineOptionsSearchSpace(
+        mlir_module = dispatch_parser.parse_mlir(mlir_text, tuner_ctx)
+        pipeline_options_search_space = dispatch_constraints.PipelineOptionsSearchSpace(
             prefetch_shared_memory=args.prefetch_shared_memory_options,
             no_reduce_shared_memory_bank_conflicts=args.no_reduce_shared_memory_bank_conflicts_options,
         )

--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -163,7 +163,7 @@ def generate_configs_and_td_specs(
     variant_op_list = iree_codegen.get_executable_variant_ops(input_module)
     assert len(variant_op_list) == 1, "Expect one executable variant op"
     variant_op = variant_op_list[0]
-    mma_list = iree_codegen.query_mma_intrinsics(variant_op)
+    mma_intrinsics = iree_codegen.query_mma_intrinsics(variant_op)
 
     constraint_generator = dispatch_tuner.get_constraint_generator()
 
@@ -172,7 +172,7 @@ def generate_configs_and_td_specs(
             tuner_context,
             codegen_pipeline,
             num_subgroups=num_subgroups,
-            mma_list=mma_list,
+            mma_intrinsics=mma_intrinsics,
             allowed_waves_per_eu=allowed_waves_per_eu,
             pipeline_options_search_space=pipeline_options_search_space,
         )

--- a/sharktuner/sharktuner/constraint_generator.py
+++ b/sharktuner/sharktuner/constraint_generator.py
@@ -315,15 +315,6 @@ class ContractionOpInterfaceConstraintGenerator(ConstraintGenerator):
         codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline,
         **pipeline_constraint_options,
     ) -> Iterator[iree_codegen.CompilationInfoAttr]:
-        num_subgroups = pipeline_constraint_options.get("num_subgroups", 4)
-        mma_intrinsics = pipeline_constraint_options["mma_list"]
-        allowed_waves_per_eu = pipeline_constraint_options.get(
-            "allowed_waves_per_eu", [2]
-        )
-        pipeline_options_search_space = pipeline_constraint_options.get(
-            "pipeline_options_search_space",
-            dispatch_constraints.PipelineOptionsSearchSpace(),
-        )
         return generate_generic_contraction_solutions(
             tuner_ctx=tuner_context,
             contraction_dims=self.dims,
@@ -333,10 +324,7 @@ class ContractionOpInterfaceConstraintGenerator(ConstraintGenerator):
             res_type=self.res_type,
             dispatch_kind=common.DispatchKind.contraction,
             codegen_pipeline=codegen_pipeline,
-            num_subgroups=num_subgroups,
-            mma_intrinsics=mma_intrinsics,
-            allowed_waves_per_eu=allowed_waves_per_eu,
-            pipeline_options_search_space=pipeline_options_search_space,
+            **pipeline_constraint_options,
         )
 
 
@@ -384,15 +372,6 @@ class ConvolutionOpInterfaceConstraintGenerator(ConstraintGenerator):
         codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline,
         **pipeline_constraint_options,
     ) -> Iterator[iree_codegen.CompilationInfoAttr]:
-        num_subgroups = pipeline_constraint_options.get("num_subgroups", 4)
-        mma_intrinsics = pipeline_constraint_options["mma_list"]
-        allowed_waves_per_eu = pipeline_constraint_options.get(
-            "allowed_waves_per_eu", [2]
-        )
-        pipeline_options_search_space = pipeline_constraint_options.get(
-            "pipeline_options_search_space",
-            dispatch_constraints.PipelineOptionsSearchSpace(),
-        )
         return generate_generic_contraction_solutions(
             tuner_ctx=tuner_context,
             contraction_dims=self.dims,
@@ -402,8 +381,5 @@ class ConvolutionOpInterfaceConstraintGenerator(ConstraintGenerator):
             res_type=self.res_type,
             dispatch_kind=common.DispatchKind.conv,
             codegen_pipeline=codegen_pipeline,
-            num_subgroups=num_subgroups,
-            mma_intrinsics=mma_intrinsics,
-            allowed_waves_per_eu=allowed_waves_per_eu,
-            pipeline_options_search_space=pipeline_options_search_space,
+            **pipeline_constraint_options,
         )

--- a/sharktuner/sharktuner/constraint_generator.py
+++ b/sharktuner/sharktuner/constraint_generator.py
@@ -1,0 +1,377 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+from abc import ABC, abstractmethod
+from typing import Iterator
+
+from iree.compiler import ir  # type: ignore
+from iree.compiler.dialects import iree_codegen  # type: ignore
+from iree.compiler.dialects import linalg, func  # type: ignore
+
+from .common import *
+from .dispatch_constraints import *
+
+
+def adjust_problem_size_for_pipeline(
+    contraction_dims: ContractionDimensions,
+    matmul_size: ContractionSizes,
+    dispatch_kind: DispatchKind,
+    pipeline_options_search_space: PipelineOptionsSearchSpace,
+    codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline,
+):
+    # Adjustment is only needed for IGEMM. Fail if the problem is not a conv
+    # going down the TileAndFuse pipeline.
+    if (
+        codegen_pipeline != iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse
+        or dispatch_kind != DispatchKind.conv
+    ):
+        return
+
+    pipeline_options_search_space.use_igemm_convolution = [True]
+
+    # Flatten the K dimensions into a single dimension for IGEMM lowering.
+    contraction_dims.k = [contraction_dims.k[0]]
+    matmul_size.K = [math.prod(matmul_size.K)]
+
+
+def generate_generic_contraction_solutions(
+    tuner_ctx: TunerContext,
+    contraction_dims: ContractionDimensions,
+    matmul_size: ContractionSizes,
+    lhs_type: ShapedType,
+    rhs_type: ShapedType,
+    res_type: ShapedType,
+    dispatch_kind: DispatchKind,
+    num_subgroups: int,
+    mma_intrinsics: list[iree_gpu.MMAIntrinsic],
+    allowed_waves_per_eu: list[int] = [2],
+    pipeline_options_search_space: PipelineOptionsSearchSpace = PipelineOptionsSearchSpace(),
+    codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline = iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute,
+) -> Iterator[iree_codegen.CompilationInfoAttr]:
+
+    adjust_problem_size_for_pipeline(
+        contraction_dims,
+        matmul_size,
+        dispatch_kind,
+        pipeline_options_search_space,
+        codegen_pipeline,
+    )
+
+    M, N, K = matmul_size.M, matmul_size.N, matmul_size.K
+    tuner_ctx.logger.debug(f"{M},{N},{K}")
+
+    m_vars = [z3.Int(f"m{i}") for i in range(len(M))]
+    n_vars = [z3.Int(f"n{i}") for i in range(len(N))]
+    k_vars = [z3.Int(f"k{i}") for i in range(len(K))]
+    subgroup_m_vars = [z3.Int(f"subgroup_m{i}") for i in range(len(M))]
+    subgroup_n_vars = [z3.Int(f"subgroup_n{i}") for i in range(len(N))]
+
+    subgroup_size = z3.Int("subgroup_size")
+    intrinsic_mn = z3.Int("intrinsic_mn")
+    intrinsic_k = z3.Int("intrinsic_k")
+    wg_x, wg_y, wg_z = z3.Int("wg_x"), z3.Int("wg_y"), z3.Int("wg_z")
+    sg_m_cnt = z3.Int("sg_m_cnt")
+    sg_n_cnt = z3.Int("sg_n_cnt")
+    all_vars = (
+        m_vars
+        + n_vars
+        + k_vars
+        + [
+            subgroup_size,
+            intrinsic_mn,
+            intrinsic_k,
+            wg_x,
+            wg_y,
+            wg_z,
+            sg_m_cnt,
+            sg_n_cnt,
+        ]
+    )
+
+    solver = z3.Solver()
+    match codegen_pipeline:
+        case iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute:
+            constraints = generate_vector_distribute_constraints(
+                matmul_size,
+                lhs_type,
+                rhs_type,
+                res_type,
+                [m_vars, n_vars, k_vars],
+                num_subgroups,
+                subgroup_size,
+                [intrinsic_mn, intrinsic_k],
+                [wg_x, wg_y, wg_z],
+                sg_m_cnt,
+                sg_n_cnt,
+                mma_intrinsics,
+                dispatch_kind,
+            )
+            constraints += [v == 0 for v in subgroup_m_vars + subgroup_n_vars]
+        case iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse:
+            constraints = generate_tile_and_fuse_constraints(
+                matmul_size,
+                lhs_type,
+                rhs_type,
+                res_type,
+                [m_vars, n_vars, k_vars, subgroup_m_vars, subgroup_n_vars],
+                num_subgroups,
+                subgroup_size,
+                [intrinsic_mn, intrinsic_k],
+                [wg_x, wg_y, wg_z],
+                sg_m_cnt,
+                sg_n_cnt,
+                mma_intrinsics,
+            )
+
+    solver.add(z3.simplify(z3.And(constraints)))
+    tuner_ctx.logger.debug(f"Initial constraints: {solver}")
+
+    i = 0
+    while solver.check() == z3.sat:
+        model = solver.model()
+        lookup = lambda var: model[var].as_long()
+        intrinsic_mnk_shape = (
+            lookup(intrinsic_mn),
+            lookup(intrinsic_mn),
+            lookup(intrinsic_k),
+        )
+        mma_attr = getMMAAttr(
+            res_type.element_type,
+            *intrinsic_mnk_shape,
+            lhs_type.element_type,
+            rhs_type.element_type,
+        )
+
+        def set_cdim_tile_sizes(tile_sizes, contraction_dims, csizes):
+            for dim, size in zip(contraction_dims, csizes):
+                tile_sizes[dim] = size
+
+        # Get workgroup tile sizes.
+        workgroup_tile_sizes = [0] * (
+            len(M) + len(N) + len(K) + len(contraction_dims.batch)
+        )
+        set_cdim_tile_sizes(
+            workgroup_tile_sizes,
+            contraction_dims.m,
+            [lookup(v) for v in m_vars],
+        )
+        set_cdim_tile_sizes(
+            workgroup_tile_sizes,
+            contraction_dims.n,
+            [lookup(v) for v in n_vars],
+        )
+        set_cdim_tile_sizes(
+            workgroup_tile_sizes,
+            contraction_dims.batch,
+            [1] * len(contraction_dims.batch),
+        )
+
+        # Get subgroup tile sizes.
+        subgroup_tile_sizes = [0] * (
+            len(M) + len(N) + len(K) + len(contraction_dims.batch)
+        )
+        set_cdim_tile_sizes(
+            subgroup_tile_sizes,
+            contraction_dims.m,
+            [lookup(v) for v in subgroup_m_vars],
+        )
+        set_cdim_tile_sizes(
+            subgroup_tile_sizes,
+            contraction_dims.n,
+            [lookup(v) for v in subgroup_n_vars],
+        )
+        set_cdim_tile_sizes(
+            subgroup_tile_sizes,
+            contraction_dims.batch,
+            [1] * len(contraction_dims.batch),
+        )
+
+        # Get reduction tile sizes.
+        reduction_tile_sizes = [0] * (
+            len(M) + len(N) + len(K) + len(contraction_dims.batch)
+        )
+        set_cdim_tile_sizes(
+            reduction_tile_sizes,
+            contraction_dims.k,
+            [lookup(v) for v in k_vars],
+        )
+
+        required_padding = any(
+            p[-1] % i != 0 for p, i in zip((M, N, K), intrinsic_mnk_shape, strict=True)
+        )
+        promote_operands = [0, 1]
+        padding = None
+        if required_padding:
+            # TODO: Remove promotion of operand 2 once codegen supports handling padded outputs without promotion.
+            promote_operands = [0, 1, 2]
+            _, _, mma_intrinsic_k = mma_attr.mnk_shape
+            padding = [
+                *(workgroup_tile_sizes[d] for d in contraction_dims.m),
+                *(workgroup_tile_sizes[d] for d in contraction_dims.n),
+                *(
+                    reduction_tile_sizes[d] * mma_intrinsic_k
+                    for d in contraction_dims.k
+                ),
+            ]
+
+        compilation_infos = generate_compilation_infos(
+            tuner_ctx,
+            mma_attr,
+            workgroup_tile_sizes,
+            reduction_tile_sizes,
+            subgroup_tile_sizes,
+            (lookup(wg_x), lookup(wg_y), lookup(wg_z)),
+            lookup(subgroup_size),
+            lookup(sg_m_cnt),
+            lookup(sg_n_cnt),
+            promote_operands,
+            codegen_pipeline,
+            pipeline_options_search_space,
+            allowed_waves_per_eu,
+            padding=padding,
+        )
+
+        solver.add(z3.simplify(z3.Not(z3.And(list(x == model[x] for x in all_vars)))))
+        i += 1
+
+        for compilation_info in compilation_infos:
+            yield compilation_info
+
+
+class ConstraintGenerator(ABC):
+    @abstractmethod
+    def generate_solutions(
+        self,
+        tuner_context: TunerContext,
+        codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline,
+        **kwargs,
+    ) -> Iterator[iree_codegen.CompilationInfoAttr]:
+        """
+        Generate a sequence of CompilationInfoAttr candidates based on the
+        tuning constraints for the given codegen pipeline.
+        """
+        pass
+
+
+class ContractionOpInterfaceConstraintGenerator(ConstraintGenerator):
+    def __init__(self, root_op: ir.Operation):
+        self.root_op = root_op
+        contraction_dims = linalg.infer_contraction_dimensions(root_op)
+        assert contraction_dims, "no contraction dimensions"
+
+        res_maps = linalg.get_indexing_maps(root_op)
+        maps = [map_attr.value for map_attr in res_maps]
+        lhs_dims = get_map_result_dim_positions(maps[0])
+        rhs_dims = get_map_result_dim_positions(maps[1])
+        res_dims = get_map_result_dim_positions(maps[2])
+
+        assert lhs_dims, "no lhs dimensions"
+        assert rhs_dims, "no rhs dimensions"
+        assert res_dims, "no result dimensions"
+
+        lhs_type = ir.RankedTensorType(root_op.operands[0].type)
+        rhs_type = ir.RankedTensorType(root_op.operands[1].type)
+        res_type = ir.RankedTensorType(root_op.operands[2].type)
+
+        matmul_size = ContractionSizes(
+            M=[lhs_type.shape[lhs_dims.index(dim)] for dim in contraction_dims.m],
+            N=[rhs_type.shape[rhs_dims.index(dim)] for dim in contraction_dims.n],
+            K=[lhs_type.shape[lhs_dims.index(dim)] for dim in contraction_dims.k],
+            B=[lhs_type.shape[lhs_dims.index(dim)] for dim in contraction_dims.batch],
+        )
+
+        self.dims = contraction_dims
+        self.matmul_size = matmul_size
+        self.lhs_type = ShapedType(lhs_type.shape, lhs_type.element_type)
+        self.rhs_type = ShapedType(rhs_type.shape, rhs_type.element_type)
+        self.res_type = ShapedType(res_type.shape, res_type.element_type)
+
+    def generate_solutions(
+        self,
+        tuner_context: TunerContext,
+        codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline,
+        **kwargs,
+    ) -> Iterator[iree_codegen.CompilationInfoAttr]:
+        return generate_generic_contraction_solutions(
+            tuner_ctx=tuner_context,
+            contraction_dims=self.dims,
+            matmul_size=self.matmul_size,
+            lhs_type=self.lhs_type,
+            rhs_type=self.rhs_type,
+            res_type=self.res_type,
+            dispatch_kind=DispatchKind.contraction,
+            num_subgroups=kwargs.get("num_subgroups", 4),
+            mma_intrinsics=kwargs["mma_list"],
+            allowed_waves_per_eu=kwargs.get("allowed_waves_per_eu", [2]),
+            pipeline_options_search_space=kwargs.get(
+                "pipeline_options_search_space", PipelineOptionsSearchSpace()
+            ),
+            codegen_pipeline=codegen_pipeline,
+        )
+
+
+class ConvolutionOpInterfaceConstraintGenerator(ConstraintGenerator):
+    def __init__(self, root_op: ir.Operation):
+        self.root_op = root_op
+
+        convolution_dims = linalg.infer_convolution_dimensions(root_op)
+        assert convolution_dims, "no convolution dimensions"
+
+        contraction_dims = ContractionDimensions(
+            batch=list(convolution_dims.depth),
+            m=list(convolution_dims.batch) + list(convolution_dims.output_image),
+            n=list(convolution_dims.output_channel),
+            k=list(convolution_dims.filter_loop) + list(convolution_dims.input_channel),
+        )
+
+        def find_iter_dim_size(iter_dim: int, operand: int):
+            operand_type = root_op.operands[operand].type
+            indexing_map = linalg.get_indexing_maps(root_op)[operand]
+            tensor_dim = list(indexing_map.value.results).index(
+                ir.AffineExpr.get_dim(iter_dim)
+            )
+            return operand_type.shape[tensor_dim]
+
+        matmul_size = ContractionSizes(
+            B=[find_iter_dim_size(d, operand=2) for d in contraction_dims.batch],
+            M=[find_iter_dim_size(d, operand=2) for d in contraction_dims.m],
+            N=[find_iter_dim_size(d, operand=2) for d in contraction_dims.n],
+            K=[find_iter_dim_size(d, operand=1) for d in contraction_dims.k],
+        )
+
+        lhs_type = root_op.operands[0].type
+        rhs_type = root_op.operands[1].type
+        res_type = root_op.operands[2].type
+
+        self.dims = contraction_dims
+        self.matmul_size = matmul_size
+        self.lhs_type = ShapedType(lhs_type.shape, lhs_type.element_type)
+        self.rhs_type = ShapedType(rhs_type.shape, rhs_type.element_type)
+        self.res_type = ShapedType(res_type.shape, res_type.element_type)
+
+    def generate_solutions(
+        self,
+        tuner_context: TunerContext,
+        codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline,
+        **kwargs,
+    ) -> Iterator[iree_codegen.CompilationInfoAttr]:
+        return generate_generic_contraction_solutions(
+            tuner_ctx=tuner_context,
+            contraction_dims=self.dims,
+            matmul_size=self.matmul_size,
+            lhs_type=self.lhs_type,
+            rhs_type=self.rhs_type,
+            res_type=self.res_type,
+            dispatch_kind=DispatchKind.conv,
+            num_subgroups=kwargs.get("num_subgroups", 4),
+            mma_intrinsics=kwargs["mma_list"],
+            allowed_waves_per_eu=kwargs.get("allowed_waves_per_eu", [2]),
+            pipeline_options_search_space=kwargs.get(
+                "pipeline_options_search_space", PipelineOptionsSearchSpace()
+            ),
+            codegen_pipeline=codegen_pipeline,
+        )

--- a/sharktuner/sharktuner/dispatch_parser.py
+++ b/sharktuner/sharktuner/dispatch_parser.py
@@ -47,11 +47,6 @@ class DispatchParser(metaclass=ABCMeta):
         """Check if the root_op is valid and supported by this tuner."""
         pass
 
-    @abstractmethod
-    def get_problem_size(self) -> ProblemSize:
-        """Extract problem size of the operation."""
-        pass
-
 
 class ContractionOpInterfaceParser(DispatchParser):
     def __init__(self, root_op: ir.Operation):
@@ -60,40 +55,6 @@ class ContractionOpInterfaceParser(DispatchParser):
     def has_valid_root_op(self) -> bool:
         root_op = self.get_root_op()
         return linalg.isa_contraction_op(root_op)
-
-    def get_problem_size(self) -> ProblemSize:
-        root_op = self.get_root_op()
-        contraction_dims = linalg.infer_contraction_dimensions(root_op)
-        assert contraction_dims, "no contraction dimensions"
-
-        res_maps = linalg.get_indexing_maps(root_op)
-        maps = [map_attr.value for map_attr in res_maps]
-        lhs_dims = get_map_result_dim_positions(maps[0])
-        rhs_dims = get_map_result_dim_positions(maps[1])
-        res_dims = get_map_result_dim_positions(maps[2])
-
-        lhs_type = ir.RankedTensorType(root_op.operands[0].type)
-        rhs_type = ir.RankedTensorType(root_op.operands[1].type)
-        res_type = ir.RankedTensorType(root_op.operands[2].type)
-
-        assert lhs_dims, "no lhs dimensions"
-        assert rhs_dims, "no rhs dimensions"
-        assert res_dims, "no result dimensions"
-
-        matmul_size = ContractionSizes(
-            M=[lhs_type.shape[lhs_dims.index(dim)] for dim in contraction_dims.m],
-            N=[rhs_type.shape[rhs_dims.index(dim)] for dim in contraction_dims.n],
-            K=[lhs_type.shape[lhs_dims.index(dim)] for dim in contraction_dims.k],
-            B=[lhs_type.shape[lhs_dims.index(dim)] for dim in contraction_dims.batch],
-        )
-        return ProblemSize(
-            matmul_size,
-            lhs_type=ShapedType(lhs_type.shape, lhs_type.element_type),
-            rhs_type=ShapedType(rhs_type.shape, rhs_type.element_type),
-            res_type=ShapedType(res_type.shape, res_type.element_type),
-            dispatch_kind=DispatchKind.contraction,
-            contraction_dims=contraction_dims,
-        )
 
 
 class ConvolutionOpInterfaceParser(DispatchParser):
@@ -119,43 +80,3 @@ class ConvolutionOpInterfaceParser(DispatchParser):
         ):
             return False
         return True
-
-    def get_problem_size(self) -> ProblemSize:
-        root_op = self.get_root_op()
-
-        def find_iter_dim_size(iter_dim: int, operand: int):
-            operand_type = root_op.operands[operand].type
-            indexing_map = linalg.get_indexing_maps(root_op)[operand]
-            tensor_dim = list(indexing_map.value.results).index(
-                ir.AffineExpr.get_dim(iter_dim)
-            )
-            return operand_type.shape[tensor_dim]
-
-        convolution_dims = linalg.infer_convolution_dimensions(root_op)
-        assert convolution_dims, "no convolution dimensions"
-        contraction_dims = ContractionDimensions(
-            batch=list(convolution_dims.depth),
-            m=list(convolution_dims.batch) + list(convolution_dims.output_image),
-            n=list(convolution_dims.output_channel),
-            k=list(convolution_dims.filter_loop) + list(convolution_dims.input_channel),
-        )
-        # Parallel dimension sizes come from the output operand, and reduction
-        # dimension sizes come from filter.
-        matmul_size = ContractionSizes(
-            B=[find_iter_dim_size(d, operand=2) for d in contraction_dims.batch],
-            M=[find_iter_dim_size(d, operand=2) for d in contraction_dims.m],
-            N=[find_iter_dim_size(d, operand=2) for d in contraction_dims.n],
-            K=[find_iter_dim_size(d, operand=1) for d in contraction_dims.k],
-        )
-
-        lhs_type = root_op.operands[0].type
-        rhs_type = root_op.operands[1].type
-        res_type = root_op.operands[2].type
-        return ProblemSize(
-            matmul_size=matmul_size,
-            lhs_type=ShapedType(lhs_type.shape, lhs_type.element_type),
-            rhs_type=ShapedType(rhs_type.shape, rhs_type.element_type),
-            res_type=ShapedType(res_type.shape, res_type.element_type),
-            dispatch_kind=DispatchKind.conv,
-            contraction_dims=contraction_dims,
-        )

--- a/sharktuner/sharktuner/dispatch_parser.py
+++ b/sharktuner/sharktuner/dispatch_parser.py
@@ -9,12 +9,13 @@
 
 from abc import ABCMeta, abstractmethod
 
+from iree.compiler import ir  # type: ignore
 from iree.compiler.dialects import linalg, func  # type: ignore
 
-from .common import *
+from . import common
 
 
-def parse_mlir(mlir_text: str, ctx: TunerContext) -> ir.Module:
+def parse_mlir(mlir_text: str, ctx: common.TunerContext) -> ir.Module:
     mlir_module = None
     try:
         mlir_module = ir.Module.parse(mlir_text, ctx.mlir_ctx)

--- a/sharktuner/sharktuner/merge_td_specs.py
+++ b/sharktuner/sharktuner/merge_td_specs.py
@@ -18,9 +18,6 @@ Usage:
 
 import argparse
 import logging
-import subprocess
-import tempfile
-import os
 
 from iree.compiler import ir  # type: ignore
 

--- a/sharktuner/tests/candidate_gen_test.py
+++ b/sharktuner/tests/candidate_gen_test.py
@@ -8,10 +8,7 @@
 Usage: python -m pytest candidate_gen_test.py
 """
 
-import pytest
-
-from typing import Generator
-
+from dataclasses import dataclass, field
 from iree.compiler import ir  # type: ignore
 from iree.compiler.dialects import iree_gpu  # type: ignore
 from iree.compiler.dialects import iree_codegen  # type: ignore

--- a/sharktuner/tests/common_test.py
+++ b/sharktuner/tests/common_test.py
@@ -11,8 +11,6 @@ Usage: python -m pytest common_test.py
 import pytest
 from sharktuner import common
 
-from typing import Generator
-
 from iree.compiler import ir  # type: ignore
 from iree.compiler.dialects import iree_gpu  # type: ignore
 from iree.compiler.dialects import iree_codegen  # type: ignore

--- a/sharktuner/tests/common_test.py
+++ b/sharktuner/tests/common_test.py
@@ -123,65 +123,33 @@ def test_get_pipeline_config(tuner_ctx: common.TunerContext) -> None:
 
 
 def test_get_compatible_mfma_intrinsics(tuner_ctx: common.TunerContext) -> None:
-    assert common.get_compatible_mfma_intrinsics(
-        common.ProblemSize(
-            common.ContractionSizes([2048], [1280], [1280]),
-            common.ShapedType([2048, 1280], tuner_ctx.type.f16),
-            common.ShapedType([1280, 1280], tuner_ctx.type.f16),
-            common.ShapedType([2048, 1280], tuner_ctx.type.f32),
-            common.DispatchKind.contraction,
-            common.ContractionDimensions([0], [1], [2]),
-        ),
-        [
-            iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
-            iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
-            iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
-            iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
-        ],
-    ) == [
+    all_intrinsics = [
         iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
         iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
-    ]
-
-    assert common.get_compatible_mfma_intrinsics(
-        common.ProblemSize(
-            common.ContractionSizes([2048], [1280], [1280]),
-            common.ShapedType([2048, 1280], tuner_ctx.type.i8),
-            common.ShapedType([1280, 1280], tuner_ctx.type.i8),
-            common.ShapedType([2048, 1280], tuner_ctx.type.i32),
-            common.DispatchKind.contraction,
-            common.ContractionDimensions([0], [1], [2]),
-        ),
-        [
-            iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
-            iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
-            iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
-            iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
-        ],
-    ) == [
         iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
         iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
     ]
 
-    assert (
-        common.get_compatible_mfma_intrinsics(
-            common.ProblemSize(
-                common.ContractionSizes([968], [320], [640], [64]),
-                common.ShapedType([64, 968, 640], tuner_ctx.type.f32),
-                common.ShapedType([64, 640, 320], tuner_ctx.type.f32),
-                common.ShapedType([64, 968, 320], tuner_ctx.type.f32),
-                common.DispatchKind.contraction,
-                common.ContractionDimensions([1], [2], [3], [0]),
-            ),
-            [
-                iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
-                iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
-                iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
-                iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
-            ],
-        )
-        == []
-    )
+    lhs = common.ShapedType([2048, 1280], tuner_ctx.type.f16)
+    rhs = common.ShapedType([1280, 1280], tuner_ctx.type.f16)
+    res = common.ShapedType([2048, 1280], tuner_ctx.type.f32)
+    assert common.get_compatible_mfma_intrinsics(lhs, rhs, res, all_intrinsics) == [
+        iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
+        iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
+    ]
+
+    lhs = common.ShapedType([2048, 1280], tuner_ctx.type.i8)
+    rhs = common.ShapedType([1280, 1280], tuner_ctx.type.i8)
+    res = common.ShapedType([2048, 1280], tuner_ctx.type.i32)
+    assert common.get_compatible_mfma_intrinsics(lhs, rhs, res, all_intrinsics) == [
+        iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
+        iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
+    ]
+
+    lhs = common.ShapedType([64, 968, 640], tuner_ctx.type.f32)
+    rhs = common.ShapedType([64, 640, 320], tuner_ctx.type.f32)
+    res = common.ShapedType([64, 968, 320], tuner_ctx.type.f32)
+    assert common.get_compatible_mfma_intrinsics(lhs, rhs, res, all_intrinsics) == []
 
 
 def test_get_lowering_config(tuner_ctx: common.TunerContext) -> None:

--- a/sharktuner/tests/constraint_generator_test.py
+++ b/sharktuner/tests/constraint_generator_test.py
@@ -1,0 +1,216 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+Usage: python -m pytest constraint_generator_test.py
+"""
+
+import pytest
+import z3  # type: ignore
+
+from typing import Generator
+
+from iree.compiler import ir  # type: ignore
+from iree.compiler.dialects import iree_gpu, iree_codegen  # type: ignore
+
+from sharktuner import common
+from sharktuner import constraint_generator
+from sharktuner import dispatch_constraints
+
+from sharktuner.test_utils import tuner_ctx
+
+
+def test_generate_solutions(tuner_ctx: common.TunerContext) -> None:
+    matmul_size = common.ContractionSizes([2048], [3840], [1280])
+    contraction_dims = common.ContractionDimensions([0], [1], [2])
+
+    lhs_type = common.ShapedType([2048, 1280], tuner_ctx.type.f16)
+    rhs_type = common.ShapedType([3840, 1280], tuner_ctx.type.f16)
+    res_type = common.ShapedType([2048, 3840], tuner_ctx.type.f32)
+
+    configs = constraint_generator.generate_generic_contraction_solutions(
+        tuner_ctx=tuner_ctx,
+        contraction_dims=contraction_dims,
+        matmul_size=matmul_size,
+        lhs_type=lhs_type,
+        rhs_type=rhs_type,
+        res_type=res_type,
+        dispatch_kind=common.DispatchKind.contraction,
+        num_subgroups=4,
+        mma_intrinsics=[
+            iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
+            iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
+            iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
+            iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
+        ],
+        pipeline_options_search_space=dispatch_constraints.PipelineOptionsSearchSpace(),
+        codegen_pipeline=iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute,
+    )
+    assert list(configs), "Expected at least one valid solution"
+
+
+def test_generate_solutions_tile_and_fuse_contraction_padding(
+    tuner_ctx: common.TunerContext,
+) -> None:
+    matmul_size = common.ContractionSizes([5369], [112], [112])
+    contraction_dims = common.ContractionDimensions([0], [1], [2])
+
+    lhs_type = common.ShapedType([5369, 112], tuner_ctx.type.f16)
+    rhs_type = common.ShapedType([112, 112], tuner_ctx.type.f16)
+    res_type = common.ShapedType([5369, 112], tuner_ctx.type.f32)
+
+    mma_intrinsics = [
+        iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
+    ]
+
+    solutions = list(
+        constraint_generator.generate_generic_contraction_solutions(
+            tuner_ctx=tuner_ctx,
+            contraction_dims=contraction_dims,
+            matmul_size=matmul_size,
+            lhs_type=lhs_type,
+            rhs_type=rhs_type,
+            res_type=res_type,
+            dispatch_kind=common.DispatchKind.contraction,
+            num_subgroups=4,
+            mma_intrinsics=mma_intrinsics,
+            allowed_waves_per_eu=[2],
+            pipeline_options_search_space=dispatch_constraints.PipelineOptionsSearchSpace(),
+            codegen_pipeline=iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse,
+        )
+    )
+
+    assert len(solutions) > 0, "No solutions generated with TileAndFuse pipeline."
+    assert all(isinstance(sol, iree_codegen.CompilationInfoAttr) for sol in solutions)
+
+    assert all(
+        "padding =" in str(sol.lowering_config) for sol in solutions
+    ), "Not all lowering configs have padding option."
+
+    assert all(
+        [int(x) for x in sol.lowering_config.attributes["promote_operands"]]
+        == [0, 1, 2]
+        for sol in solutions
+    ), "Not all lowering configs have promote_operands = [0, 1, 2]."
+
+
+def test_generate_solutions_tile_and_fuse_conv_padding(
+    tuner_ctx: common.TunerContext,
+) -> None:
+    contraction_dims = common.ContractionDimensions(
+        batch=[],
+        m=[0, 1, 2],
+        n=[3],
+        k=[4, 5, 6],
+    )
+    matmul_size = common.ContractionSizes(
+        B=[],
+        M=[2, 5, 5],
+        N=[64],
+        K=[3, 3, 32],
+    )
+    lhs_type = common.ShapedType([2, 7, 7, 32], tuner_ctx.type.f16)
+    rhs_type = common.ShapedType([64, 3, 3, 32], tuner_ctx.type.f16)
+    res_type = common.ShapedType([2, 5, 5, 64], tuner_ctx.type.f32)
+
+    solutions = list(
+        constraint_generator.generate_generic_contraction_solutions(
+            tuner_ctx=tuner_ctx,
+            contraction_dims=contraction_dims,
+            matmul_size=matmul_size,
+            lhs_type=lhs_type,
+            rhs_type=rhs_type,
+            res_type=res_type,
+            dispatch_kind=common.DispatchKind.conv,
+            num_subgroups=4,
+            mma_intrinsics=[iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16],
+            codegen_pipeline=iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse,
+        )
+    )
+
+    assert len(solutions) > 0, "No solutions generated with TileAndFuse pipeline."
+    assert all(isinstance(sol, iree_codegen.CompilationInfoAttr) for sol in solutions)
+    assert all(
+        "padding =" in str(sol.lowering_config) for sol in solutions
+    ), "Not all lowering configs have padding option"
+    assert all(
+        [int(x) for x in sol.lowering_config.attributes["promote_operands"]]
+        == [0, 1, 2]
+        for sol in solutions
+    ), "Not all lowering configs have promote_operands = [0, 1, 2]"
+
+
+def test_adjust_problem_size_for_pipeline(
+    tuner_ctx: common.TunerContext,
+) -> None:
+    # Matmul TileAndFuse: no change expected
+    matmul_size = common.ContractionSizes(
+        M=[32],
+        N=[64],
+        K=[128],
+        B=[2],
+    )
+    contraction_dims = common.ContractionDimensions(
+        m=[1],
+        n=[2],
+        k=[3],
+        batch=[0],
+    )
+    taf_pipeline = iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse
+    pipeline_options_space = dispatch_constraints.PipelineOptionsSearchSpace(
+        prefetch_shared_memory=[True],
+        no_reduce_shared_memory_bank_conflicts=[True, False],
+        use_igemm_convolution=[None],
+    )
+
+    constraint_generator.adjust_problem_size_for_pipeline(
+        contraction_dims=contraction_dims,
+        matmul_size=matmul_size,
+        dispatch_kind=common.DispatchKind.contraction,
+        pipeline_options_search_space=pipeline_options_space,
+        codegen_pipeline=taf_pipeline,
+    )
+    assert pipeline_options_space.use_igemm_convolution == [None]
+    assert matmul_size.K == [128]
+    assert contraction_dims.k == [3]
+
+    # Conv VectorDistribute: no change expected
+    conv_size = common.ContractionSizes(
+        M=[2, 32, 32],
+        N=[256],
+        K=[3, 3, 512],
+    )
+    conv_dims = common.ContractionDimensions(
+        m=[0, 1, 2],
+        n=[3],
+        k=[4, 5, 6],
+        batch=[],
+    )
+    vec_dist_pipeline = (
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
+    )
+    constraint_generator.adjust_problem_size_for_pipeline(
+        contraction_dims=conv_dims,
+        matmul_size=conv_size,
+        dispatch_kind=common.DispatchKind.conv,
+        pipeline_options_search_space=pipeline_options_space,
+        codegen_pipeline=vec_dist_pipeline,
+    )
+    assert pipeline_options_space.use_igemm_convolution == [None]
+    assert conv_size.K == [3, 3, 512]
+    assert conv_dims.k == [4, 5, 6]
+
+    # Conv TileAndFuse: expect flattened K dims and IGEMM enabled
+    constraint_generator.adjust_problem_size_for_pipeline(
+        contraction_dims=conv_dims,
+        matmul_size=conv_size,
+        dispatch_kind=common.DispatchKind.conv,
+        pipeline_options_search_space=pipeline_options_space,
+        codegen_pipeline=taf_pipeline,
+    )
+    assert pipeline_options_space.use_igemm_convolution == [True]
+    assert conv_size.K == [4608]
+    assert conv_dims.k == [4]

--- a/sharktuner/tests/constraint_generator_test.py
+++ b/sharktuner/tests/constraint_generator_test.py
@@ -122,7 +122,7 @@ def test_generate_solutions(tuner_ctx: common.TunerContext) -> None:
             tuner_context=tuner_ctx,
             codegen_pipeline=iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute,
             num_subgroups=4,
-            mma_list=[
+            mma_intrinsics=[
                 iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
                 iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
                 iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
@@ -171,7 +171,7 @@ def test_generate_solutions_tile_and_fuse_contraction_padding(
                 tuner_context=tuner_ctx,
                 codegen_pipeline=iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse,
                 num_subgroups=4,
-                mma_list=[
+                mma_intrinsics=[
                     iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
                 ],
                 allowed_waves_per_eu=[2],
@@ -243,7 +243,7 @@ def test_generate_solutions_tile_and_fuse_conv_padding(
                 tuner_context=tuner_ctx,
                 codegen_pipeline=iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse,
                 num_subgroups=4,
-                mma_list=[iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16],
+                mma_intrinsics=[iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16],
             )
         )
 

--- a/sharktuner/tests/dispatch_constraints_test.py
+++ b/sharktuner/tests/dispatch_constraints_test.py
@@ -13,8 +13,7 @@ import z3  # type: ignore
 
 from typing import Generator
 
-from iree.compiler import ir  # type: ignore
-from iree.compiler.dialects import iree_gpu, iree_codegen  # type: ignore
+from iree.compiler.dialects import iree_gpu  # type: ignore
 
 from sharktuner import common
 from sharktuner import dispatch_constraints
@@ -65,12 +64,6 @@ def test_generate_tile_and_fuse_constraints_valid_input(
         K=[128],
         B=[2],
     )
-    # contraction_dims = common.ContractionDimensions(
-    #     m=[1],
-    #     n=[2],
-    #     k=[3],
-    #     batch=[0],
-    # )
     lhs_type = common.ShapedType([2, 32, 128], tuner_ctx.type.f16)
     rhs_type = common.ShapedType([2, 64, 128], tuner_ctx.type.f16)
     res_type = common.ShapedType([2, 32, 64], tuner_ctx.type.f32)
@@ -146,14 +139,6 @@ def test_generate_tile_and_fuse_constraints_invalid_input(
     lhs_type = common.ShapedType([2, 32, 128], tuner_ctx.type.f16)
     rhs_type = common.ShapedType([2, 64, 128], tuner_ctx.type.f16)
     res_type = common.ShapedType([2, 32, 64], tuner_ctx.type.f32)
-    # problem_size = common.ProblemSize(
-    #     matmul_size,
-    #     lhs_type,
-    #     rhs_type,
-    #     res_type,
-    #     common.DispatchKind.contraction,
-    #     contraction_dims,
-    # )
     # Define input parameters as z3 Ints
     m, n, k = (
         [z3.Int("m0")],
@@ -213,14 +198,6 @@ def test_generate_vector_distribute_constraints_valid_input(
     res_type = common.ShapedType([1024, 1024], tuner_ctx.type.f32)
     dispatch_kind = common.DispatchKind.contraction
 
-    # problem_size = common.ProblemSize(
-    #     matmul_size,
-    #     lhs_type,
-    #     rhs_type,
-    #     res_type,
-    #     common.DispatchKind.contraction,
-    #     contraction_dims,
-    # )
     # Define input parameters as z3 Ints
     m, n, k = (
         [z3.Int("m")],
@@ -271,20 +248,11 @@ def test_generate_vector_distribute_constraints_invalid_input(
 ) -> None:
     # Define input parameters that should lead to unsatisfiable constraints
     matmul_size = common.ContractionSizes([1024], [1024], [1024])
-    # contraction_dims = common.ContractionDimensions([0], [1], [2])
     lhs_type = common.ShapedType([1024, 1024], tuner_ctx.type.f16)
     rhs_type = common.ShapedType([1024, 1024], tuner_ctx.type.f16)
     res_type = common.ShapedType([1024, 1024], tuner_ctx.type.f32)
     dispatch_kind = common.DispatchKind.contraction
 
-    # problem_size = common.ProblemSize(
-    #     matmul_size,
-    #     lhs_type,
-    #     rhs_type,
-    #     res_type,
-    #     common.DispatchKind.contraction,
-    #     contraction_dims,
-    # )
     m, n, k = (
         [z3.Int("m")],
         [z3.Int("n")],

--- a/sharktuner/tests/dispatch_constraints_test.py
+++ b/sharktuner/tests/dispatch_constraints_test.py
@@ -22,300 +22,38 @@ from sharktuner import dispatch_constraints
 from sharktuner.test_utils import tuner_ctx
 
 
-def test_generate_solutions(tuner_ctx: common.TunerContext) -> None:
-    matmul_size = common.ContractionSizes([2048], [3840], [1280])
-    contraction_dims = common.ContractionDimensions([0], [1], [2])
-    lhs_type = common.ShapedType([2048, 1280], tuner_ctx.type.f16)
-    rhs_type = common.ShapedType([3840, 1280], tuner_ctx.type.f16)
-    res_type = common.ShapedType([2048, 3840], tuner_ctx.type.f32)
-    problem_size = common.ProblemSize(
-        matmul_size,
-        lhs_type,
-        rhs_type,
-        res_type,
-        common.DispatchKind.contraction,
-        contraction_dims,
-    )
-    configs = dispatch_constraints.generate_solutions(
-        tuner_ctx,
-        problem_size,
-        4,
-        [
-            iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
-            iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
-            iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
-            iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
-        ],
-    )
-
-    assert configs is not None
-
-
-def test_generate_solutions_tile_and_fuse_contraction_padding(
-    tuner_ctx: common.TunerContext,
-) -> None:
-    matmul_size = common.ContractionSizes([5369], [112], [112])
-    contraction_dims = common.ContractionDimensions([0], [1], [2])
-    lhs_type = common.ShapedType([5369, 112], tuner_ctx.type.f16)
-    rhs_type = common.ShapedType([112, 112], tuner_ctx.type.f16)
-    res_type = common.ShapedType([5369, 112], tuner_ctx.type.f32)
-    problem_size = common.ProblemSize(
-        matmul_size,
-        lhs_type,
-        rhs_type,
-        res_type,
-        common.DispatchKind.contraction,
-        contraction_dims,
-    )
-
-    mma_intrinsics = [
-        iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
-    ]
-
-    solutions = list(
-        dispatch_constraints.generate_solutions(
-            tuner_ctx=tuner_ctx,
-            problem_size=problem_size,
-            num_subgrups=4,
-            mma_intrinsics=mma_intrinsics,
-            allowed_waves_per_eu=[2],
-            pipeline_options_search_space=dispatch_constraints.PipelineOptionsSearchSpace(),
-            codegen_pipeline=iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse,
-        )
-    )
-
-    assert len(solutions) > 0, "No solutions generated with TileAndFuse pipeline."
-    assert all(isinstance(sol, iree_codegen.CompilationInfoAttr) for sol in solutions)
-    assert all(
-        "padding =" in str(sol.lowering_config) for sol in solutions
-    ), "Not all lowering configs have padding option"
-    assert all(
-        [int(x) for x in sol.lowering_config.attributes["promote_operands"]]
-        == [0, 1, 2]
-        for sol in solutions
-    ), "Not all lowering configs have promote_operands = [0, 1, 2]"
-
-
-def test_generate_solutions_tile_and_fuse_conv_padding(
-    tuner_ctx: common.TunerContext,
-) -> None:
-    matmul_size = common.ContractionSizes(B=[], M=[2, 5, 5], N=[64], K=[3, 3, 32])
-    lhs_type = common.ShapedType([2, 7, 7, 32], tuner_ctx.type.f16)
-    rhs_type = common.ShapedType([64, 3, 3, 32], tuner_ctx.type.f16)
-    res_type = common.ShapedType([2, 5, 5, 64], tuner_ctx.type.f32)
-    contraction_dims = common.ContractionDimensions(
-        batch=[], m=[0, 1, 2], n=[3], k=[4, 5, 6]
-    )
-    problem_size = common.ProblemSize(
-        matmul_size,
-        lhs_type,
-        rhs_type,
-        res_type,
-        common.DispatchKind.conv,
-        contraction_dims,
-    )
-
-    solutions = list(
-        dispatch_constraints.generate_solutions(
-            tuner_ctx=tuner_ctx,
-            problem_size=problem_size,
-            num_subgrups=4,
-            mma_intrinsics=[iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16],
-            codegen_pipeline=iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse,
-        )
-    )
-
-    assert len(solutions) > 0, "No solutions generated with TileAndFuse pipeline."
-    assert all(isinstance(sol, iree_codegen.CompilationInfoAttr) for sol in solutions)
-    assert all(
-        "padding =" in str(sol.lowering_config) for sol in solutions
-    ), "Not all lowering configs have padding option"
-    assert all(
-        [int(x) for x in sol.lowering_config.attributes["promote_operands"]]
-        == [0, 1, 2]
-        for sol in solutions
-    ), "Not all lowering configs have promote_operands = [0, 1, 2]"
-
-
 def test_calculate_shared_memory_usage_in_bytes(tuner_ctx: common.TunerContext) -> None:
-    matmul_size = common.ContractionSizes([1024], [1024], [1024])
-    contraction_dims = common.ContractionDimensions([0], [1], [2])
     lhs_type = common.ShapedType([1024, 1024], tuner_ctx.type.f16)
     rhs_type = common.ShapedType([1024, 1024], tuner_ctx.type.f16)
-    res_type = common.ShapedType([1024, 1024], tuner_ctx.type.f32)
-    problem_size = common.ProblemSize(
-        matmul_size,
-        lhs_type,
-        rhs_type,
-        res_type,
-        common.DispatchKind.contraction,
-        contraction_dims,
-    )
     assert (
         dispatch_constraints.calculate_shared_memory_usage_in_bytes(
-            problem_size, [512], [64], [128]
+            rhs_type, rhs_type, [512], [64], [128]
         )
         == 147456
     )
 
     lhs_type = common.ShapedType([1024, 1024], tuner_ctx.type.i8)
-    problem_size = common.ProblemSize(
-        matmul_size,
-        lhs_type,
-        rhs_type,
-        res_type,
-        common.DispatchKind.contraction,
-        contraction_dims,
-    )
     assert (
         dispatch_constraints.calculate_shared_memory_usage_in_bytes(
-            problem_size, [512], [64], [128]
+            lhs_type, rhs_type, [512], [64], [128]
         )
         == 81920
     )
 
     rhs_type = common.ShapedType([1024, 1024], tuner_ctx.type.i32)
-    problem_size = common.ProblemSize(
-        matmul_size,
-        lhs_type,
-        rhs_type,
-        res_type,
-        common.DispatchKind.contraction,
-        contraction_dims,
-    )
     assert (
         dispatch_constraints.calculate_shared_memory_usage_in_bytes(
-            problem_size, [128], [64], [32]
+            lhs_type, rhs_type, [128], [64], [32]
         )
         == 12288
     )
 
     assert (
         dispatch_constraints.calculate_shared_memory_usage_in_bytes(
-            problem_size, [2, 64], [4, 16], [8, 4]
+            lhs_type, rhs_type, [2, 64], [4, 16], [8, 4]
         )
         == 12288
     )
-
-
-def test_adjust_problem_size_for_pipeline(
-    tuner_ctx: common.TunerContext,
-):
-    # Test Matmul TileAndFuse. Expect no change.
-    matmul_size = common.ContractionSizes(
-        M=[32],
-        N=[64],
-        K=[128],
-        B=[2],
-    )
-    contraction_dims = common.ContractionDimensions(
-        m=[1],
-        n=[2],
-        k=[3],
-        batch=[0],
-    )
-    lhs_type = common.ShapedType([2, 32, 128], tuner_ctx.type.f16)
-    rhs_type = common.ShapedType([2, 64, 128], tuner_ctx.type.f16)
-    res_type = common.ShapedType([2, 32, 64], tuner_ctx.type.f32)
-    matmul_problem_size = common.ProblemSize(
-        matmul_size,
-        lhs_type,
-        rhs_type,
-        res_type,
-        common.DispatchKind.contraction,
-        contraction_dims,
-    )
-    pipeline_options_space = dispatch_constraints.PipelineOptionsSearchSpace(
-        prefetch_shared_memory=[True],
-        no_reduce_shared_memory_bank_conflicts=[True, False],
-        use_igemm_convolution=[None],
-    )
-    taf_pipeline = iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse
-    dispatch_constraints.adjust_problem_size_for_pipeline(
-        problem_size=matmul_problem_size,
-        pipeline_options_search_space=pipeline_options_space,
-        codegen_pipeline=taf_pipeline,
-    )
-    assert pipeline_options_space.prefetch_shared_memory == [True]
-    assert pipeline_options_space.no_reduce_shared_memory_bank_conflicts == [
-        True,
-        False,
-    ]
-    assert pipeline_options_space.use_igemm_convolution == [None]
-    assert matmul_problem_size.matmul_size.M == [32]
-    assert matmul_problem_size.matmul_size.N == [64]
-    assert matmul_problem_size.matmul_size.K == [128]
-    assert matmul_problem_size.matmul_size.B == [2]
-    assert matmul_problem_size.contraction_dims.m == [1]
-    assert matmul_problem_size.contraction_dims.n == [2]
-    assert matmul_problem_size.contraction_dims.k == [3]
-    assert matmul_problem_size.contraction_dims.batch == [0]
-
-    # Test Conv VectorDistribute. Expect no change.
-    conv_size = common.ContractionSizes(
-        M=[2, 32, 32],
-        N=[256],
-        K=[3, 3, 512],
-    )
-    contraction_dims = common.ContractionDimensions(
-        m=[0, 1, 2],
-        n=[3],
-        k=[4, 5, 6],
-    )
-    lhs_type = common.ShapedType([2, 34, 34, 512], tuner_ctx.type.f16)
-    rhs_type = common.ShapedType([3, 3, 512, 256], tuner_ctx.type.f16)
-    res_type = common.ShapedType([2, 32, 32, 256], tuner_ctx.type.f32)
-    conv_problem_size = common.ProblemSize(
-        conv_size,
-        lhs_type,
-        rhs_type,
-        res_type,
-        common.DispatchKind.conv,
-        contraction_dims,
-    )
-    vec_dist_pipeline = (
-        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
-    )
-    dispatch_constraints.adjust_problem_size_for_pipeline(
-        problem_size=conv_problem_size,
-        pipeline_options_search_space=pipeline_options_space,
-        codegen_pipeline=vec_dist_pipeline,
-    )
-    assert pipeline_options_space.prefetch_shared_memory == [True]
-    assert pipeline_options_space.no_reduce_shared_memory_bank_conflicts == [
-        True,
-        False,
-    ]
-    assert pipeline_options_space.use_igemm_convolution == [None]
-    assert conv_problem_size.matmul_size.M == [2, 32, 32]
-    assert conv_problem_size.matmul_size.N == [256]
-    assert conv_problem_size.matmul_size.K == [3, 3, 512]
-    assert conv_problem_size.matmul_size.B == []
-    assert conv_problem_size.contraction_dims.m == [0, 1, 2]
-    assert conv_problem_size.contraction_dims.n == [3]
-    assert conv_problem_size.contraction_dims.k == [4, 5, 6]
-    assert conv_problem_size.contraction_dims.batch == []
-
-    # Test Conv TileAndFuse. Expect flat K dims and use_igemm_convolution True.
-    dispatch_constraints.adjust_problem_size_for_pipeline(
-        problem_size=conv_problem_size,
-        pipeline_options_search_space=pipeline_options_space,
-        codegen_pipeline=taf_pipeline,
-    )
-    assert pipeline_options_space.prefetch_shared_memory == [True]
-    assert pipeline_options_space.no_reduce_shared_memory_bank_conflicts == [
-        True,
-        False,
-    ]
-    assert pipeline_options_space.use_igemm_convolution == [True]
-    assert conv_problem_size.matmul_size.M == [2, 32, 32]
-    assert conv_problem_size.matmul_size.N == [256]
-    assert conv_problem_size.matmul_size.K == [4608]
-    assert conv_problem_size.matmul_size.B == []
-    assert conv_problem_size.contraction_dims.m == [0, 1, 2]
-    assert conv_problem_size.contraction_dims.n == [3]
-    assert conv_problem_size.contraction_dims.k == [4]
-    assert conv_problem_size.contraction_dims.batch == []
 
 
 def test_generate_tile_and_fuse_constraints_valid_input(
@@ -327,23 +65,16 @@ def test_generate_tile_and_fuse_constraints_valid_input(
         K=[128],
         B=[2],
     )
-    contraction_dims = common.ContractionDimensions(
-        m=[1],
-        n=[2],
-        k=[3],
-        batch=[0],
-    )
+    # contraction_dims = common.ContractionDimensions(
+    #     m=[1],
+    #     n=[2],
+    #     k=[3],
+    #     batch=[0],
+    # )
     lhs_type = common.ShapedType([2, 32, 128], tuner_ctx.type.f16)
     rhs_type = common.ShapedType([2, 64, 128], tuner_ctx.type.f16)
     res_type = common.ShapedType([2, 32, 64], tuner_ctx.type.f32)
-    problem_size = common.ProblemSize(
-        matmul_size,
-        lhs_type,
-        rhs_type,
-        res_type,
-        common.DispatchKind.contraction,
-        contraction_dims,
-    )
+
     # Define input parameters as z3 Ints
     m, n, k = (
         [z3.Int("m0")],
@@ -354,6 +85,8 @@ def test_generate_tile_and_fuse_constraints_valid_input(
         [z3.Int("subgroup_m0")],
         [z3.Int("subgroup_n0")],
     )
+    tile_sizes = [m, n, k, subgroup_m, subgroup_n]
+
     subgroup_size = z3.Int("subgroup_size")
     intrinsic_mn = z3.Int("intrinsic_mn")
     intrinsic_k = z3.Int("intrinsic_k")
@@ -362,19 +95,24 @@ def test_generate_tile_and_fuse_constraints_valid_input(
         z3.Int("wg_y"),
         z3.Int("wg_z"),
     )
+    wg_size = [wg_x, wg_y, wg_z]
+
     sg_m_cnt = z3.Int("sg_m_cnt")
     sg_n_cnt = z3.Int("sg_n_cnt")
 
     constraints = dispatch_constraints.generate_tile_and_fuse_constraints(
-        problem_size,
-        [m, n, k, subgroup_m, subgroup_n],
-        4,
-        subgroup_size,
-        [intrinsic_mn, intrinsic_k],
-        [wg_x, wg_y, wg_z],
-        sg_m_cnt,
-        sg_n_cnt,
-        [
+        matmul_size=matmul_size,
+        lhs_type=lhs_type,
+        rhs_type=rhs_type,
+        res_type=res_type,
+        tile_sizes=tile_sizes,
+        num_subgroups=4,
+        subgroup_size=subgroup_size,
+        intrinsic_size=[intrinsic_mn, intrinsic_k],
+        workgroup_size=wg_size,
+        subgroup_m_count=sg_m_cnt,
+        subgroup_n_count=sg_n_cnt,
+        mma_intrinsics=[
             iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
             iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
             iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
@@ -408,14 +146,14 @@ def test_generate_tile_and_fuse_constraints_invalid_input(
     lhs_type = common.ShapedType([2, 32, 128], tuner_ctx.type.f16)
     rhs_type = common.ShapedType([2, 64, 128], tuner_ctx.type.f16)
     res_type = common.ShapedType([2, 32, 64], tuner_ctx.type.f32)
-    problem_size = common.ProblemSize(
-        matmul_size,
-        lhs_type,
-        rhs_type,
-        res_type,
-        common.DispatchKind.contraction,
-        contraction_dims,
-    )
+    # problem_size = common.ProblemSize(
+    #     matmul_size,
+    #     lhs_type,
+    #     rhs_type,
+    #     res_type,
+    #     common.DispatchKind.contraction,
+    #     contraction_dims,
+    # )
     # Define input parameters as z3 Ints
     m, n, k = (
         [z3.Int("m0")],
@@ -436,17 +174,21 @@ def test_generate_tile_and_fuse_constraints_invalid_input(
     )
     sg_m_cnt = z3.Int("sg_m_cnt")
     sg_n_cnt = z3.Int("sg_n_cnt")
+    tile_sizes = [m, n, k, subgroup_m, subgroup_n]
 
     constraints = dispatch_constraints.generate_tile_and_fuse_constraints(
-        problem_size,
-        [m, n, k, subgroup_m, subgroup_n],
-        4,
-        subgroup_size,
-        [intrinsic_mn, intrinsic_k],
-        [wg_x, wg_y, wg_z],
-        sg_m_cnt,
-        sg_n_cnt,
-        [
+        matmul_size=matmul_size,
+        lhs_type=lhs_type,
+        rhs_type=rhs_type,
+        res_type=res_type,
+        tile_sizes=tile_sizes,
+        num_subgroups=4,
+        subgroup_size=subgroup_size,
+        intrinsic_size=[intrinsic_mn, intrinsic_k],
+        workgroup_size=[wg_x, wg_y, wg_z],
+        subgroup_m_count=sg_m_cnt,
+        subgroup_n_count=sg_n_cnt,
+        mma_intrinsics=[
             iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
             iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
             iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
@@ -466,18 +208,19 @@ def test_generate_vector_distribute_constraints_valid_input(
     tuner_ctx: common.TunerContext,
 ) -> None:
     matmul_size = common.ContractionSizes([1024], [1024], [1024])
-    contraction_dims = common.ContractionDimensions([0], [1], [2])
     lhs_type = common.ShapedType([1024, 1024], tuner_ctx.type.f16)
     rhs_type = common.ShapedType([1024, 1024], tuner_ctx.type.f16)
     res_type = common.ShapedType([1024, 1024], tuner_ctx.type.f32)
-    problem_size = common.ProblemSize(
-        matmul_size,
-        lhs_type,
-        rhs_type,
-        res_type,
-        common.DispatchKind.contraction,
-        contraction_dims,
-    )
+    dispatch_kind = common.DispatchKind.contraction
+
+    # problem_size = common.ProblemSize(
+    #     matmul_size,
+    #     lhs_type,
+    #     rhs_type,
+    #     res_type,
+    #     common.DispatchKind.contraction,
+    #     contraction_dims,
+    # )
     # Define input parameters as z3 Ints
     m, n, k = (
         [z3.Int("m")],
@@ -496,20 +239,24 @@ def test_generate_vector_distribute_constraints_valid_input(
     sg_n_cnt = z3.Int("sg_n_cnt")
 
     constraints = dispatch_constraints.generate_vector_distribute_constraints(
-        problem_size,
-        [m, n, k],
-        4,
-        subgroup_size,
-        [intrinsic_mn, intrinsic_k],
-        [wg_x, wg_y, wg_z],
-        sg_m_cnt,
-        sg_n_cnt,
-        [
+        matmul_size=matmul_size,
+        lhs_type=lhs_type,
+        rhs_type=rhs_type,
+        res_type=res_type,
+        tile_sizes=[m, n, k],
+        num_subgroups=4,
+        subgroup_size=subgroup_size,
+        intrinsic_size=[intrinsic_mn, intrinsic_k],
+        workgroup_size=[wg_x, wg_y, wg_z],
+        subgroup_m_count=sg_m_cnt,
+        subgroup_n_count=sg_n_cnt,
+        mma_intrinsics=[
             iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
             iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
             iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
             iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
         ],
+        dispatch_kind=dispatch_kind,
     )
 
     solver = z3.Solver()
@@ -524,18 +271,20 @@ def test_generate_vector_distribute_constraints_invalid_input(
 ) -> None:
     # Define input parameters that should lead to unsatisfiable constraints
     matmul_size = common.ContractionSizes([1024], [1024], [1024])
-    contraction_dims = common.ContractionDimensions([0], [1], [2])
+    # contraction_dims = common.ContractionDimensions([0], [1], [2])
     lhs_type = common.ShapedType([1024, 1024], tuner_ctx.type.f16)
     rhs_type = common.ShapedType([1024, 1024], tuner_ctx.type.f16)
     res_type = common.ShapedType([1024, 1024], tuner_ctx.type.f32)
-    problem_size = common.ProblemSize(
-        matmul_size,
-        lhs_type,
-        rhs_type,
-        res_type,
-        common.DispatchKind.contraction,
-        contraction_dims,
-    )
+    dispatch_kind = common.DispatchKind.contraction
+
+    # problem_size = common.ProblemSize(
+    #     matmul_size,
+    #     lhs_type,
+    #     rhs_type,
+    #     res_type,
+    #     common.DispatchKind.contraction,
+    #     contraction_dims,
+    # )
     m, n, k = (
         [z3.Int("m")],
         [z3.Int("n")],
@@ -553,20 +302,24 @@ def test_generate_vector_distribute_constraints_invalid_input(
     sg_n_cnt = z3.Int("sg_n_cnt")
 
     constraints = dispatch_constraints.generate_vector_distribute_constraints(
-        problem_size,
-        [m, n, k],
-        4,
-        subgroup_size,
-        [intrinsic_mn, intrinsic_k],
-        [wg_x, wg_y, wg_z],
-        sg_m_cnt,
-        sg_n_cnt,
-        [
+        matmul_size=matmul_size,
+        lhs_type=lhs_type,
+        rhs_type=rhs_type,
+        res_type=res_type,
+        tile_sizes=[m, n, k],
+        num_subgroups=4,
+        subgroup_size=subgroup_size,
+        intrinsic_size=[intrinsic_mn, intrinsic_k],
+        workgroup_size=[wg_x, wg_y, wg_z],
+        subgroup_m_count=sg_m_cnt,
+        subgroup_n_count=sg_n_cnt,
+        mma_intrinsics=[
             iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
             iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
             iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
             iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
         ],
+        dispatch_kind=dispatch_kind,
     )
     constraints.append(m[0] > 1000)  # Adding an additional unsatisfiable constraint
 

--- a/sharktuner/tests/dispatch_parser_test.py
+++ b/sharktuner/tests/dispatch_parser_test.py
@@ -72,17 +72,6 @@ def test_get_contraction_operation(tuner_ctx: common.TunerContext) -> None:
     assert len(root_op_list) == 1
     root_op = root_op_list[0]
     parser = dispatch_parser.ContractionOpInterfaceParser(root_op)
-    shapes: common.ProblemSize = parser.get_problem_size()
-    assert shapes.matmul_size.B == []
-    assert shapes.matmul_size.M == [16]
-    assert shapes.matmul_size.N == [32]
-    assert shapes.matmul_size.K == [64]
-    assert shapes.lhs_type.shape == [16, 64]
-    assert isinstance(shapes.lhs_type.element_type, ir.F16Type)
-    assert shapes.rhs_type.shape == [32, 64]
-    assert isinstance(shapes.rhs_type.element_type, ir.F16Type)
-    assert shapes.res_type.shape == [16, 32]
-    assert isinstance(shapes.res_type.element_type, ir.F32Type)
 
     with ir.Location.unknown():
         bmm_transposed_inputs_str = GENERIC_TEMPLATE.format(
@@ -99,11 +88,6 @@ def test_get_contraction_operation(tuner_ctx: common.TunerContext) -> None:
     assert len(root_op_list) == 1
     root_op = root_op_list[0]
     parser = dispatch_parser.ContractionOpInterfaceParser(root_op)
-    shapes = parser.get_problem_size()
-    assert shapes.matmul_size.B == [5]
-    assert shapes.matmul_size.M == [8]
-    assert shapes.matmul_size.N == [40]
-    assert shapes.matmul_size.K == [128]
 
     with ir.Location.unknown():
         bmm_transposed_inputs_str = GENERIC_TEMPLATE.format(
@@ -125,11 +109,6 @@ def test_get_contraction_operation(tuner_ctx: common.TunerContext) -> None:
     root_op = root_op_list[0]
     parser = dispatch_parser.ContractionOpInterfaceParser(root_op)
     assert parser.get_root_op_func_name() == "match_test"
-    shapes = parser.get_problem_size()
-    assert shapes.matmul_size.B == [16, 16]
-    assert shapes.matmul_size.M == [8, 64]
-    assert shapes.matmul_size.N == [9, 128]
-    assert shapes.matmul_size.K == [15, 256]
 
 
 def test_get_matmul_named_op(tuner_ctx: common.TunerContext) -> None:
@@ -167,18 +146,6 @@ def test_get_matmul_named_op(tuner_ctx: common.TunerContext) -> None:
 
         parser = dispatch_parser.ContractionOpInterfaceParser(root_op)
         assert parser.get_root_op_func_name() == "match_named_matmul"
-        shapes = parser.get_problem_size()
-
-        assert shapes.matmul_size.B == []
-        assert shapes.matmul_size.M == [16]
-        assert shapes.matmul_size.N == [32]
-        assert shapes.matmul_size.K == [64]
-        assert shapes.lhs_type.shape == [16, 64]
-        assert isinstance(shapes.lhs_type.element_type, ir.F16Type)
-        assert shapes.rhs_type.shape == [64, 32]
-        assert isinstance(shapes.rhs_type.element_type, ir.F16Type)
-        assert shapes.res_type.shape == [16, 32]
-        assert isinstance(shapes.res_type.element_type, ir.F32Type)
 
 
 def test_get_named_contraction_op():
@@ -215,15 +182,6 @@ def test_get_named_contraction_op():
 
         parser = dispatch_parser.ContractionOpInterfaceParser(root_op)
         assert parser.get_root_op_func_name() == "match_named_contraction"
-        shape = parser.get_problem_size()
-
-        assert shape.matmul_size.B == []
-        assert shape.matmul_size.M == [5]
-        assert shape.matmul_size.N == [7]
-        assert shape.matmul_size.K == [3]
-        assert shape.lhs_type.shape == [5, 3]
-        assert shape.rhs_type.shape == [7, 3]
-        assert shape.res_type.shape == [5, 7]
 
 
 def test_get_conv_nhwc_hwcf_operation(tuner_ctx: common.TunerContext) -> None:
@@ -250,16 +208,6 @@ def test_get_conv_nhwc_hwcf_operation(tuner_ctx: common.TunerContext) -> None:
         parser.has_valid_root_op()
     ), f"ConvolutionOpInterfaceParser does not support the op: {root_op.name}"
 
-    problem_size = parser.get_problem_size()
-    assert problem_size.contraction_dims.batch == []
-    assert problem_size.contraction_dims.m == [0, 1, 2]
-    assert problem_size.contraction_dims.n == [3]
-    assert problem_size.contraction_dims.k == [4, 5, 6]
-    assert problem_size.matmul_size.B == []
-    assert problem_size.matmul_size.M == [2, 32, 32]
-    assert problem_size.matmul_size.N == [16]
-    assert problem_size.matmul_size.K == [3, 3, 16]
-
 
 def test_get_group_conv_operation(tuner_ctx: common.TunerContext) -> None:
     context = tuner_ctx.mlir_ctx
@@ -283,16 +231,6 @@ def test_get_group_conv_operation(tuner_ctx: common.TunerContext) -> None:
     assert parser.get_root_op_func_name() == "match_test"
     assert parser.has_valid_root_op() is False, "group convs aren't supported yet"
 
-    problem_size = parser.get_problem_size()
-    assert problem_size.contraction_dims.batch == [3]
-    assert problem_size.contraction_dims.m == [0, 1, 2]
-    assert problem_size.contraction_dims.n == [4]
-    assert problem_size.contraction_dims.k == [5, 6, 7]
-    assert problem_size.matmul_size.B == [7]
-    assert problem_size.matmul_size.M == [2, 8, 8]
-    assert problem_size.matmul_size.N == [16]
-    assert problem_size.matmul_size.K == [3, 3, 4]
-
 
 def test_get_generic_conv_operation(tuner_ctx: common.TunerContext) -> None:
     context = tuner_ctx.mlir_ctx
@@ -314,16 +252,6 @@ def test_get_generic_conv_operation(tuner_ctx: common.TunerContext) -> None:
     parser = dispatch_parser.ConvolutionOpInterfaceParser(root_op)
     assert parser.get_root_op_func_name() == "match_test"
     assert parser.has_valid_root_op()
-
-    problem_size = parser.get_problem_size()
-    assert problem_size.contraction_dims.batch == []
-    assert problem_size.contraction_dims.m == [0, 1, 2]
-    assert problem_size.contraction_dims.n == [3]
-    assert problem_size.contraction_dims.k == [4, 5, 6]
-    assert problem_size.matmul_size.B == []
-    assert problem_size.matmul_size.M == [2, 5, 5]
-    assert problem_size.matmul_size.N == [64]
-    assert problem_size.matmul_size.K == [3, 3, 32]
 
 
 def test_get_mmt_tile_sizes(tuner_ctx: common.TunerContext) -> None:


### PR DESCRIPTION
This PR creates interface for constrain generation and retire the data class `ProblemSize` fully. More details can be found in #1442. 