### PR TITLE
[shortfin] Fix extra fiber appends in FiberPool.return_fiber

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/fiber_pool.py
+++ b/shortfin/python/shortfin_apps/llm/components/fiber_pool.py
@@ -78,11 +78,10 @@ class FiberPool:
             assert idx < self.size()
             self.__index_queue.put_nowait(idx)
 
-    def return_fiber(self, fibers: tuple[int, sf.Fiber] | list[tuple[int, sf.Fiber]]):
-        if not isinstance(fibers, list):
-            fibers = [fibers]
-        for idx, fiber in fibers:
-            self.__fiber_pool.append(fiber)
+    def return_fiber(self, indices: int | list[int]):
+        if not isinstance(indices, list):
+            indices = [indices]
+        for idx in indices:
             self.__index_queue.put_nowait(idx)
 
     def size(self) -> int:

--- a/shortfin/python/shortfin_apps/llm/components/generate.py
+++ b/shortfin/python/shortfin_apps/llm/components/generate.py
@@ -208,7 +208,7 @@ class ClientGenerateBatchProcess(sf.Process):
             )
             return
 
-        fibers = []
+        indices = []
         try:
             streaming = self.gen_req.stream
             self.responder.start_response()
@@ -256,12 +256,7 @@ class ClientGenerateBatchProcess(sf.Process):
                     return
 
                 idx, fiber = await self.service.main_fiber_pool.get()
-                fibers.append(
-                    (
-                        idx,
-                        fiber,
-                    )
-                )
+                indices.append(idx)
                 gen_process = GenerateItemProcess(
                     self,
                     self.gen_req,
@@ -286,7 +281,7 @@ class ClientGenerateBatchProcess(sf.Process):
         finally:
             # Remove request from queue when done
             self.service.remove_from_queue(self.decode_config.num_beams)
-            self.service.main_fiber_pool.return_fiber(fibers)
+            self.service.main_fiber_pool.return_fiber(indices)
             self.responder.ensure_response()
 
         # Remove request from queue when done


### PR DESCRIPTION
The function `FiberPool.return_fiber()` incorrectly pushed the returned fiber into the fibers list, which could make its size grow unintentionally.

This patch removes the extra appends and cleans up the usage of the function in other files.