### PR TITLE
Add a cacheing allocator for avoiding reallocations

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/batcher.py
+++ b/shortfin/python/shortfin_apps/llm/components/batcher.py
@@ -16,6 +16,7 @@ import shortfin.array as sfnp
 
 from shortfin import Fiber
 
+from .cacheing_allocator import CacheingAllocator, WrappedAllocation
 from .scheduler import Scheduler
 from ...utils import BatcherProcess
 
@@ -65,12 +66,18 @@ class LlmBatcherProcess(BatcherProcess):
         self.ideal_batch_size: int = ideal_batch_size
         self.page_seq_stride = self.model_params.paged_kv_cache.block_seq_stride
         self.scheduler = Scheduler(ideal_batch_size=self.ideal_batch_size)
+        self.allocator = CacheingAllocator(fiber.device(0))
 
         self.program_isolation = program_isolation
 
     def handle_inference_request(self, request):
         """Handle an inference request."""
         self.pending.add(request)
+
+    def shutdown(self):
+        """Shutdown the batcher process."""
+        super().shutdown()
+        self.allocator.free()
 
     async def process_batches(self):
         """Process batches of requests."""
@@ -119,11 +126,9 @@ class LlmBatcherProcess(BatcherProcess):
         pending = set(pending) - set(scheduled)
         self.pending = self.pending | pending
 
-    def make_process(self, cache: BasePagedAttentionCache, fiber: Fiber):
-        ...
+    def make_process(self, cache: BasePagedAttentionCache, fiber: Fiber): ...
 
-    def board_request(self, cache, request: LlmInferenceExecRequest):
-        ...
+    def board_request(self, cache, request: LlmInferenceExecRequest): ...
 
     def board(self, cache: BasePagedAttentionCache, fiber: Fiber, to_schedule: set):
         # Fill prefill flights.
@@ -175,6 +180,7 @@ class PrefillBatcherProcess(LlmBatcherProcess):
     def make_process(self, cache: BasePagedAttentionCache, fiber: Fiber):
         return PrefillExecutorProcess(
             fiber,
+            self.allocator,
             self.functions,
             self.page_seq_stride,
             cache.page_pool.page_tables,
@@ -230,6 +236,7 @@ class DecodeBatcherProcess(LlmBatcherProcess):
     def make_process(self, cache: BasePagedAttentionCache, fiber: Fiber):
         return DecodeExecutorProcess(
             fiber,
+            self.allocator,
             self.functions,
             self.page_seq_stride,
             cache.page_pool.page_tables,
@@ -255,6 +262,7 @@ class LlmExecutorProcess(sf.Process):
         self,
         name: str,
         fiber: Fiber,
+        allocator,
         functions: dict[int, sf.ProgramFunction],
         seq_stride: int,
         page_tables,
@@ -268,8 +276,10 @@ class LlmExecutorProcess(sf.Process):
         self.functions = functions
         self.program_isolation = program_isolation
 
-    async def get_args(self, bs, device0):
-        ...
+        self.device0 = fiber.device(0)
+        self.allocator = allocator
+
+    async def get_args(self, bs): ...
 
     async def get_results(
         self,
@@ -277,8 +287,7 @@ class LlmExecutorProcess(sf.Process):
         indices: sfnp.device_array | None,
         req_count: int,
         device0: sf.ScopedDevice,
-    ):
-        ...
+    ): ...
 
     async def _transfer_buffer(self, req_count, device0, buffers):
         transfer = any(
@@ -314,7 +323,7 @@ class LlmExecutorProcess(sf.Process):
             else:
                 raise RuntimeError(f"No available entry point for bs {req_bs}")
 
-            args, req_count = await self.get_args(bs, device0)
+            args, req_count = await self.get_args(bs)
 
             logger.debug(
                 "INVOKE %r: %s",
@@ -343,7 +352,8 @@ class LlmExecutorProcess(sf.Process):
                 )
 
             # Invoke VMFB. Logits are of shape [bs, bsl, d].
-            result = await fn(*args, fiber=self.fiber)
+            args_device = [arg.device for arg in args]
+            result = await fn(*args_device, fiber=self.fiber)
 
             indices = None
             logits = result[0]
@@ -359,6 +369,8 @@ class LlmExecutorProcess(sf.Process):
             logits, indices = await self._transfer_buffer(
                 req_count=req_count, device0=device0, buffers=(logits, indices)
             )
+
+            [arg.release() for arg in args]
 
             # Return results.
             await self.get_results(logits, indices, req_count)
@@ -378,6 +390,7 @@ class PrefillExecutorProcess(LlmExecutorProcess):
     def __init__(
         self,
         fiber: Fiber,
+        allocator,
         functions: dict[int, sf.ProgramFunction],
         seq_stride: int,
         page_tables,
@@ -386,13 +399,14 @@ class PrefillExecutorProcess(LlmExecutorProcess):
         super().__init__(
             name="prefill_process",
             fiber=fiber,
+            allocator=allocator,
             functions=functions,
             seq_stride=seq_stride,
             page_tables=page_tables,
             program_isolation=program_isolation,
         )
 
-    async def get_args(self, bs, device0):
+    async def get_args(self, bs):
         seq_stride = self.seq_stride
 
         # Compute block sequence length as maximum sequence length, rounded
@@ -409,37 +423,34 @@ class PrefillExecutorProcess(LlmExecutorProcess):
         # Prepare inputs.
         # TODO: Better support in shortfin for h2d. The best way to do it is
         # device dependent.
+        allocator = self.allocator
         int_dtype = sfnp.int64
-        tokens = sfnp.device_array.for_device(device0, [bs, bsl], int_dtype)
-        seq_lens = sfnp.device_array.for_device(device0, [bs], int_dtype)
-        seq_block_ids = sfnp.device_array.for_device(
-            device0, [bs, block_count], int_dtype
-        )
+        tokens = allocator.allocate([bs, bsl], int_dtype)
+        seq_lens = allocator.allocate([bs], int_dtype)
+        seq_block_ids = allocator.allocate([bs, block_count], int_dtype)
 
         # Populate tokens.
-        tokens_host = tokens.for_transfer()
         for i in range(bs):
-            with tokens_host.view(i).map(discard=True) as m:
+            with tokens.host.view(i).map(discard=True) as m:
                 m.fill(0)
                 if i < req_count:
                     m.items = self.exec_requests[i].input_token_ids
-        tokens_host.copy_to(tokens)
 
         # Populate seq_lens
-        seq_lens_host = seq_lens.for_transfer()
-        with seq_lens_host.map(discard=True) as m:
+        with seq_lens.host.map(discard=True) as m:
             m.fill(1)
             m.items = [len(req.input_token_ids) for req in self.exec_requests]
-        seq_lens_host.copy_to(seq_lens)
 
         # Populate cache pages.
-        seq_block_ids_host = seq_block_ids.for_transfer()
         for i in range(bs):
-            with seq_block_ids_host.view(i).map(discard=True) as m:
+            with seq_block_ids.host.view(i).map(discard=True) as m:
                 m.fill(0)
                 if i < req_count:
                     m.items = self.exec_requests[i].cache_page_indices(block_count)
-        seq_block_ids_host.copy_to(seq_block_ids)
+
+        tokens.transfer_to_device()
+        seq_lens.transfer_to_device()
+        seq_block_ids.transfer_to_device()
 
         # V1 args:
         #  prefill:
@@ -449,7 +460,7 @@ class PrefillExecutorProcess(LlmExecutorProcess):
         #    cache_slabs: ...
         args = [tokens, seq_lens, seq_block_ids]
         for page_table in self.page_tables:
-            args.append(sfnp.disable_barrier(page_table))
+            args.append(WrappedAllocation(sfnp.disable_barrier(page_table)))
 
         return args, req_count
 
@@ -479,6 +490,7 @@ class DecodeExecutorProcess(LlmExecutorProcess):
     def __init__(
         self,
         fiber: Fiber,
+        allocator,
         functions: dict[int, sf.ProgramFunction],
         seq_stride: int,
         page_tables,
@@ -487,13 +499,14 @@ class DecodeExecutorProcess(LlmExecutorProcess):
         super().__init__(
             name="decode_process",
             fiber=fiber,
+            allocator=allocator,
             functions=functions,
             seq_stride=seq_stride,
             page_tables=page_tables,
             program_isolation=isolation,
         )
 
-    async def get_args(self, bs, device0):
+    async def get_args(self, bs):
         # Compute block sequence length as maximum sequence length, rounded
         # up to the seq_stride.
         seq_stride = self.seq_stride
@@ -506,22 +519,17 @@ class DecodeExecutorProcess(LlmExecutorProcess):
         # Prepare inputs.
         # TODO: Better support in shortfin for h2d. The best way to do it is
         # device dependent.
-        int_dtype = sfnp.int64
-        tokens = sfnp.device_array.for_device(device0, [bs, 1], int_dtype)
-        start_positions = sfnp.device_array.for_device(device0, [bs], int_dtype)
-        seq_lens = sfnp.device_array.for_device(device0, [bs], int_dtype)
-        seq_block_ids = sfnp.device_array.for_device(
-            device0, [bs, block_count], int_dtype
-        )
 
-        # Setup host buffers for transfer:
-        tokens_host = tokens.for_transfer()
-        seq_lens_host = seq_lens.for_transfer()
-        start_positions_host = start_positions.for_transfer()
-        seq_block_ids_host = seq_block_ids.for_transfer()
+        allocator = self.allocator
+        int_dtype = sfnp.int64
+
+        tokens = allocator.allocate([bs, 1], int_dtype)
+        start_positions = allocator.allocate([bs], int_dtype)
+        seq_lens = allocator.allocate([bs], int_dtype)
+        seq_block_ids = allocator.allocate([bs, block_count], int_dtype)
 
         # Populate tokens.
-        with tokens_host.map(discard=True) as m:
+        with tokens.host.map(discard=True) as m:
             m.fill(0)
             vals = []
             for i in range(bs):
@@ -530,11 +538,11 @@ class DecodeExecutorProcess(LlmExecutorProcess):
             m.items = vals
 
         # For decode, populate start_positions and seq_lens.
-        with start_positions_host.map(discard=True) as m:
+        with start_positions.host.map(discard=True) as m:
             m.fill(0)
             m.items = [req.start_position for req in self.exec_requests]
 
-        with seq_lens_host.map(discard=True) as m:
+        with seq_lens.host.map(discard=True) as m:
             # Pad unused requests.
             m.fill(
                 1  # Must pad with a nonzero value because a division by 0 during softmax floods clobber page (page 0) in cache with NaN values.
@@ -542,7 +550,7 @@ class DecodeExecutorProcess(LlmExecutorProcess):
             m.items = [req.start_position + 1 for req in self.exec_requests]
 
         # Populate cache pages.
-        with seq_block_ids_host.map(discard=True) as m:
+        with seq_block_ids.host.map(discard=True) as m:
             m.fill(0)
             block_ids = []
             for i in range(bs):
@@ -553,10 +561,10 @@ class DecodeExecutorProcess(LlmExecutorProcess):
             m.items = block_ids
 
         # Transfer to device memory:
-        tokens_host.copy_to(tokens)
-        start_positions_host.copy_to(start_positions)
-        seq_lens_host.copy_to(seq_lens)
-        seq_block_ids_host.copy_to(seq_block_ids)
+        tokens.transfer_to_device()
+        start_positions.transfer_to_device()
+        seq_lens.transfer_to_device()
+        seq_block_ids.transfer_to_device()
 
         # V1 args:
         #  decode:
@@ -567,7 +575,7 @@ class DecodeExecutorProcess(LlmExecutorProcess):
         #    cache_slabs: ...
         args = [tokens, seq_lens, start_positions, seq_block_ids]
         for page_table in self.page_tables:
-            args.append(sfnp.disable_barrier(page_table))
+            args.append(WrappedAllocation(sfnp.disable_barrier(page_table)))
 
         return args, req_count
 

--- a/shortfin/python/shortfin_apps/llm/components/cacheing_allocator.py
+++ b/shortfin/python/shortfin_apps/llm/components/cacheing_allocator.py
@@ -1,0 +1,116 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import shortfin.array as sfnp
+
+
+class Allocation:
+    def __init__(self, device, host, allocator):
+        self._device = device
+        self._host = host
+        self._allocator = allocator
+
+    @property
+    def device(self):
+        return self._device
+
+    @property
+    def host(self):
+        return self._host
+
+    @property
+    def shape(self):
+        return self._host.shape
+
+    @property
+    def dtype(self):
+        return self._host.dtype
+
+    @property
+    def wrapped(self):
+        return False
+
+    def release(self):
+        self._allocator.release(self)
+
+    def transfer_to_device(self):
+        self.host.copy_to(self.device)
+
+
+class WrappedAllocation:
+    def __init__(self, device):
+        self._device = device
+
+    @property
+    def device(self):
+        return self._device
+
+    @property
+    def host(self):
+        return None
+
+    @property
+    def shape(self):
+        return (
+            self._device.delegate().shape
+            if isinstance(self._device, sfnp.disable_barrier)
+            else self._device.shape
+        )
+
+    @property
+    def dtype(self):
+        return (
+            self._device.delegate().dtype
+            if isinstance(self._device, sfnp.disable_barrier)
+            else self._device.dtype
+        )
+
+    @property
+    def wrapped(self):
+        return True
+
+    def transfer_to_device(self):
+        assert False
+
+    def release(self):
+        pass
+
+
+def _shape_matches(a, b):
+    if len(a) != len(b):
+        return False
+
+    return all([_a == _b for _a, _b in zip(a, b)])
+
+
+class CacheingAllocator:
+    def __init__(self, device, *, max_allocations=100):
+        self._device = device
+        self._cache = []
+        self._max_allocations = max_allocations
+
+    def allocate(self, shape, dtype):
+        for i, allocation in enumerate(self._cache):
+            if _shape_matches(allocation.shape, shape) and (allocation.dtype == dtype):
+                return self._cache.pop(i)
+
+        if len(self._cache) > self._max_allocations:
+            diff = len(self._cache) - self._max_allocations
+            to_del = self._cache[:diff]
+            self._cache = self._cache[diff:]
+            del to_del
+
+        device = sfnp.device_array.for_device(self._device, shape, dtype)
+        host = device.for_transfer()
+
+        return Allocation(device, host, self)
+
+    def release(self, allocation):
+        self._cache.append(allocation)
+
+    def free(self):
+        del self._cache
+        self._cache = []

--- a/shortfin/tests/apps/llm/components/cacheing_allocator_test.py
+++ b/shortfin/tests/apps/llm/components/cacheing_allocator_test.py
@@ -1,0 +1,97 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from shortfin_apps.llm.components.cacheing_allocator import CacheingAllocator
+
+import shortfin.array as sfnp
+
+
+def test_allocate(generic_device):
+    allocator = CacheingAllocator(generic_device)
+    allocation0 = allocator.allocate((1, 2, 3), sfnp.int64)
+
+    assert allocation0.shape[0] == 1
+    assert allocation0.shape[1] == 2
+    assert allocation0.shape[2] == 3
+    assert allocation0.dtype == sfnp.int64
+
+
+def test_release_allocate(generic_device):
+    allocator = CacheingAllocator(generic_device)
+    allocation0 = allocator.allocate((1, 2, 3), sfnp.int64)
+
+    allocator.release(allocation0)
+    allocation1 = allocator.allocate((1, 2, 3), sfnp.int64)
+
+    assert allocation0.device == allocation1.device
+    assert allocation0.host == allocation1.host
+
+    assert allocation1.shape[0] == 1
+    assert allocation1.shape[1] == 2
+    assert allocation1.shape[2] == 3
+    assert allocation1.dtype == sfnp.int64
+
+
+def test_release_allocate_diff(generic_device):
+    allocator = CacheingAllocator(generic_device)
+    allocation0 = allocator.allocate((1, 2, 3), sfnp.int64)
+
+    allocator.release(allocation0)
+    allocation1 = allocator.allocate((1, 2, 4), sfnp.int64)
+
+    assert allocation0.device != allocation1.device
+    assert allocation0.host != allocation1.host
+
+
+def test_release_allocate_multiple(generic_device):
+    allocator = CacheingAllocator(generic_device)
+    allocation0 = []
+    allocation1 = []
+
+    for i in range(10):
+        allocation0.append(allocator.allocate((1, 2, 3), sfnp.int64))
+
+    for allocation in allocation0[::-1]:
+        allocator.release(allocation)
+
+    for i in range(10):
+        allocation1.append(allocator.allocate((1, 2, 3), sfnp.int64))
+
+    allocation1.reverse()
+
+    for a, b in zip(allocation0, allocation1):
+        assert a.device == b.device
+        assert a.host == b.host
+
+    for i in range(10):
+        for j in range(10):
+            if i == j:
+                continue
+
+            assert allocation0[i].device != allocation1[j].device
+            assert allocation0[i].host != allocation1[j].host
+
+
+def test_release_allocate_limit(generic_device):
+    allocator = CacheingAllocator(generic_device, max_allocations=1)
+
+    allocation0 = allocator.allocate((1, 2, 3), sfnp.int64)
+    allocation1 = allocator.allocate((1, 2, 3), sfnp.int64)
+
+    allocator.release(allocation0)
+    allocator.release(allocation1)
+
+    # An uncached allocation is used to flush the cache.
+    flush = allocator.allocate((1, 2, 4), sfnp.int64)
+
+    allocation2 = allocator.allocate((1, 2, 3), sfnp.int64)
+    allocation3 = allocator.allocate((1, 2, 3), sfnp.int64)
+
+    assert allocation0.device != allocation3.device
+    assert allocation0.host != allocation3.host
+
+    assert allocation1.device == allocation2.device
+    assert allocation1.host == allocation2.host


### PR DESCRIPTION
We can avoid reallocating at the hip level by cacheing allocations between invocations. This is particularly useful for decode which sees sets of 32 decode steps with the same dimensions and dtypes.