### PR TITLE
[sharktank] xfail with support for regex matching in the error message

### DIFF
--- a/sharktank/tests/utils/testing_test.py
+++ b/sharktank/tests/utils/testing_test.py
@@ -1,0 +1,40 @@
+# Copyright 2025 Advanced Micro Devices, Inc
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+
+from sharktank.utils.testing import xfail, XfailMatchError
+
+
+def test_xfail_with_successful_match():
+    @xfail(raises=RuntimeError, strict=True, match="test_xfail_with_successful_match")
+    def f():
+        raise RuntimeError("test_xfail_with_successful_match")
+
+    with pytest.raises(RuntimeError, match="test_xfail_with_successful_match"):
+        f()
+
+
+def test_xfail_with_failed_match():
+    @xfail(raises=RuntimeError, strict=True, match="string_that_can_not_be_found")
+    def f():
+        raise RuntimeError("test_xfail_with_failed_match")
+
+    with pytest.raises(
+        XfailMatchError,
+        match='Failed to match error "test_xfail_with_failed_match" '
+        'against expected match "string_that_can_not_be_found"',
+    ):
+        f()
+
+
+def test_xfail_without_match():
+    @xfail(raises=RuntimeError, strict=True)
+    def f():
+        raise RuntimeError("test_xfail_without_match")
+
+    with pytest.raises(RuntimeError, match="test_xfail_without_match"):
+        f()


### PR DESCRIPTION
This wraps the pytest.mark.xfail decorator into a new decorator. pytest.mark.xfail does not support matching on the error message, but sometimes we need to be more precise on why we expect a failure. One example is when specifying what compiler error is expected. Just the exception type is not enough.

```
@xfail(raises=MyError, strict=True, match="my message")
@test_something():
    raise MyError("my message")
```