### PR TITLE
[sharktank] add to/form properties methods in LlamaModelConfig

### DIFF
--- a/sharktank/sharktank/examples/sharding/shard_llm_dataset.py
+++ b/sharktank/sharktank/examples/sharding/shard_llm_dataset.py
@@ -37,15 +37,13 @@ def main(raw_args=None):
             f"Expect sharding greater than 1 found {args.tensor_parallelism_size}"
         )
 
-    hp = LlamaHParams.from_gguf_props(dataset.properties)
-    llama_config = LlamaModelConfig(
-        hp, tensor_parallelism_size=args.tensor_parallelism_size
-    )
+    llama_config = LlamaModelConfig.from_properties(dataset.properties)
+    llama_config.tensor_parallelism_size = args.tensor_parallelism_size
 
     sharded_theta = shard_theta(dataset.root_theta, llama_config)
     sharded_theta.rename_tensors_to_paths()
     dataset.root_theta = sharded_theta
-    dataset.properties["tensor_parallelism_size"] = args.tensor_parallelism_size
+    dataset.properties = llama_config.to_properties()
     dataset.save(args.output_irpa_file, io_report_callback=print)
 
 

--- a/sharktank/sharktank/types/theta.py
+++ b/sharktank/sharktank/types/theta.py
@@ -35,6 +35,7 @@ __all__ = [
     "Dataset",
     "flat_to_nested_dict",
     "load_properties",
+    "PropertyValueType",
     "Theta",
     "torch_module_to_theta",
     "mark_export_external_theta",

--- a/sharktank/tests/layers/configs_test.py
+++ b/sharktank/tests/layers/configs_test.py
@@ -4,7 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from sharktank.layers.configs import LlamaHParams
+import torch
+
+from sharktank.layers.configs import LlamaHParams, LlamaModelConfig
 
 
 def test_llama_hp_params_to_from_gguf_props_roundtrip():
@@ -26,3 +28,51 @@ def test_llama_hp_params_to_from_gguf_props_roundtrip():
     )
     roundtripped_params = LlamaHParams.from_gguf_props(params.to_gguf_props())
     assert params == roundtripped_params
+
+
+def test_llama_model_config_to_from_properties_roundtrip():
+    hp = LlamaHParams(
+        model_arch="llama",
+        context_length=1,
+        embedding_length=2,
+        block_count=3,
+        feed_forward_length=3,
+        rope_dimension_count=4,
+        rope_freq_base=5.0,
+        attention_head_count=6,
+        attn_head_dim=4,
+        attention_layer_norm_rms_epsilon=8.0,
+        attention_head_count_kv=9,
+        expert_count=10,
+        expert_used_count=11,
+        n_dense_layers=0,
+    )
+    config = LlamaModelConfig(
+        hp=hp,
+        block_seq_stride=12,
+        kv_cache_type="custom_kv_cache",
+        kv_cache_dtype=torch.float8_e4m3fnuz,
+        activation_dtype=torch.float16,
+        attention_dtype=torch.float32,
+        fake_quant=False,
+        tensor_parallelism_size=13,
+        pipeline_parallelism_size=14,
+        block_to_pipeline_map=(
+            15,
+            16,
+        ),
+        pipeline_to_device_map=(
+            (
+                17,
+                18,
+            ),
+            (19,),
+        ),
+        attention_kernel="custom_attention_kernel",
+        use_hf=True,
+        static_tables=False,
+        attention_chunk_size=20,
+        chunked_attention_layers=set([21, 22]),
+    )
+    roundtripped_config = LlamaModelConfig.from_properties(config.to_properties())
+    assert config == roundtripped_config


### PR DESCRIPTION
We don't record the full range of config options when saving models. This makes available the whole config.