### PR TITLE
[sharktank] move and rename get_iree_compiler_flags

### DIFF
--- a/sharktank/sharktank/utils/iree.py
+++ b/sharktank/sharktank/utils/iree.py
@@ -40,6 +40,47 @@ halelementtype_map = {
 }
 
 
+def get_iree_compiler_flags(
+    iree_hal_target_device: str,
+    iree_hal_local_target_device_backends: list[str] | None = None,
+    iree_hip_target: str | None = None,
+    device_count: int = 1,
+) -> list[str]:
+    """Retrieve compiler flags driven by the test configuration."""
+    res = []
+    if device_count == 1:
+        res += [f"--iree-hal-target-device={iree_hal_target_device}"]
+    else:
+        res += [
+            f"--iree-hal-target-device={iree_hal_target_device}[{i}]"
+            for i in range(device_count)
+        ]
+    if iree_hal_target_device.startswith("local"):
+        res += [
+            f"--iree-hal-local-target-device-backends={v}"
+            for v in iree_hal_local_target_device_backends
+        ]
+        res += ["--iree-llvmcpu-target-cpu=host"]
+    elif iree_hal_target_device.startswith("hip"):
+        res += [f"--iree-hip-target={iree_hip_target}"]
+    return res
+
+
+def get_iree_compiler_flags_from_object(o: Any, device_count: int = 1) -> list[str]:
+    kwargs = {
+        "iree_hal_target_device": o.iree_hal_target_device,
+        "device_count": device_count,
+    }
+    if hasattr(o, "iree_hal_local_target_device_backends"):
+        kwargs[
+            "iree_hal_local_target_device_backends"
+        ] = o.iree_hal_local_target_device_backends
+    if hasattr(o, "iree_hip_target"):
+        kwargs["iree_hip_target"] = o.iree_hip_target
+
+    return get_iree_compiler_flags(**kwargs)
+
+
 def with_iree_device_context(
     fn: Callable[[list[iree.runtime.HalDevice]], Any],
     devices: list[iree.runtime.HalDevice],

--- a/sharktank/sharktank/utils/iree.py
+++ b/sharktank/sharktank/utils/iree.py
@@ -55,6 +55,7 @@ def get_iree_compiler_flags(
             f"--iree-hal-target-device={iree_hal_target_device}[{i}]"
             for i in range(device_count)
         ]
+
     if iree_hal_target_device.startswith("local"):
         res += [
             f"--iree-hal-local-target-device-backends={v}"
@@ -63,6 +64,11 @@ def get_iree_compiler_flags(
         res += ["--iree-llvmcpu-target-cpu=host"]
     elif iree_hal_target_device.startswith("hip"):
         res += [f"--iree-hip-target={iree_hip_target}"]
+    else:
+        raise ValueError(
+            f'"{iree_hal_target_device}" is not a supported IREE HAL target device'
+        )
+
     return res
 
 

--- a/sharktank/sharktank/utils/testing.py
+++ b/sharktank/sharktank/utils/testing.py
@@ -70,27 +70,6 @@ def is_iree_hal_target_device_cpu(v: str, /) -> bool:
     return v.startswith("local") or v == "llvm-cpu"
 
 
-def get_iree_compiler_flags(o: Any, device_count: int = 1) -> list[str]:
-    """Retrieve compiler flags driven by the test configuration."""
-    res = []
-    if device_count == 1:
-        res += [f"--iree-hal-target-device={o.iree_hal_target_device}"]
-    else:
-        res += [
-            f"--iree-hal-target-device={o.iree_hal_target_device}[{i}]"
-            for i in range(device_count)
-        ]
-    if o.iree_hal_target_device.startswith("local"):
-        res += [
-            f"--iree-hal-local-target-device-backends={v}"
-            for v in o.iree_hal_local_target_device_backends
-        ]
-        res += ["--iree-llvmcpu-target-cpu=host"]
-    elif o.iree_hal_target_device.startswith("hip"):
-        res += [f"--iree-hip-target={o.iree_hip_target}"]
-    return res
-
-
 # Range of torch.rand() is [0,1)
 # Range of torch.rand() * 2 - 1 is [-1, 1), includes negative values
 def make_rand_torch(shape: list[int], dtype: Optional[torch.dtype] = torch.float32):

--- a/sharktank/tests/models/flux/flux_test.py
+++ b/sharktank/tests/models/flux/flux_test.py
@@ -29,13 +29,13 @@ from sharktank.models.flux.flux import FluxModelV1, FluxParams
 from sharktank.models.flux.compile import iree_compile_flags
 from sharktank.utils.testing import (
     TempDirTestBase,
-    get_iree_compiler_flags,
     skip,
     is_mi300x,
     is_cpu,
     is_cpu_condition,
 )
 from sharktank.utils.iree import (
+    get_iree_compiler_flags_from_object,
     with_iree_device_context,
     load_iree_module,
     run_iree_module_function,
@@ -116,7 +116,7 @@ class FluxTest(TempDirTestBase):
         iree_module_path = self._temp_dir / "model.vmfb"
         logger.info("Compiling MLIR file...")
 
-        iree_device_flags = get_iree_compiler_flags(self)
+        iree_device_flags = get_iree_compiler_flags_from_object(self)
         compile_flags = iree_compile_flags + iree_device_flags
         iree.compiler.compile_file(
             str(mlir_path),

--- a/sharktank/tests/models/llama/sharded_llama_test.py
+++ b/sharktank/tests/models/llama/sharded_llama_test.py
@@ -22,12 +22,12 @@ import sharktank.ops as ops
 
 from sharktank.utils.testing import (
     assert_cosine_similarity_close,
-    get_iree_compiler_flags,
     is_hip_condition,
 )
 from sharktank.utils.math import round_up_to_multiple_of
 from sharktank.utils import iterables_equal
 from sharktank.utils.iree import (
+    get_iree_compiler_flags_from_object,
     with_iree_device_context,
     get_iree_devices,
     load_iree_module,
@@ -333,7 +333,7 @@ class ShardedLlamaTest(unittest.TestCase):
             if dump_enabled:
                 output.save_mlir(f"{path_prefix}program.mlir")
             output.session.set_flags(
-                *get_iree_compiler_flags(
+                *get_iree_compiler_flags_from_object(
                     self, self.sharded_config.tensor_parallelism_size
                 )
             )

--- a/sharktank/tests/models/t5/t5_test.py
+++ b/sharktank/tests/models/t5/t5_test.py
@@ -48,7 +48,6 @@ from sharktank.models.t5.testing import (
     make_t5_encoder_random_theta,
 )
 from sharktank.utils.testing import (
-    get_iree_compiler_flags,
     assert_text_encoder_state_close,
     make_rand_torch,
     make_random_mask,
@@ -58,6 +57,7 @@ from sharktank.utils.testing import (
 )
 from sharktank.utils.hf_datasets import get_dataset
 from sharktank.utils.iree import (
+    get_iree_compiler_flags_from_object,
     with_iree_device_context,
     get_iree_devices,
     load_iree_module,
@@ -387,7 +387,7 @@ class T5EncoderIreeTest(TempDirTestBase):
             iree.compiler.compile_file(
                 mlir_path,
                 output_file=iree_module_path,
-                extra_args=get_iree_compiler_flags(self),
+                extra_args=get_iree_compiler_flags_from_object(self),
             )
 
         iree_devices = get_iree_devices(driver=self.iree_device, device_count=1)

--- a/sharktank/tests/models/vae/vae_test.py
+++ b/sharktank/tests/models/vae/vae_test.py
@@ -28,6 +28,7 @@ from sharktank.models.vae.tools.run_vae import export_vae
 from sharktank.models.vae.tools.sample_data import get_random_inputs
 from sharktank.tools.import_hf_dataset import import_hf_dataset
 from sharktank.utils.iree import (
+    get_iree_compiler_flags_from_object,
     with_iree_device_context,
     get_iree_devices,
     load_iree_module,
@@ -38,7 +39,6 @@ from sharktank.utils.iree import (
 )
 from sharktank.utils.testing import (
     TempDirTestBase,
-    get_iree_compiler_flags,
     is_cpu_condition,
     is_cpu_win,
     is_mi300x,
@@ -153,7 +153,7 @@ class VaeSDXLDecoderTest(TempDirTestBase):
             "--iree-codegen-llvmgpu-use-vector-distribution=true",
             "--iree-execution-model=async-external",
             "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics)",
-        ] + get_iree_compiler_flags(self)
+        ] + get_iree_compiler_flags_from_object(self)
 
         iree.compiler.compile_file(
             f"{self._temp_dir}/vae_f16.mlir",
@@ -241,7 +241,7 @@ class VaeFluxDecoderTest(TempDirTestBase):
             "--iree-codegen-llvmgpu-use-vector-distribution=true",
             "--iree-execution-model=async-external",
             "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics)",
-        ] + get_iree_compiler_flags(self)
+        ] + get_iree_compiler_flags_from_object(self)
 
     @pytest.mark.expensive
     @with_vae_data


### PR DESCRIPTION
Rename to get_iree_compiler_flags_from_object for a more descriptive name.