### PR TITLE
[mlir_kernel] Use mlir_kernel for injecting Wave kernels

### DIFF
--- a/sharktank/sharktank/kernels/base.py
+++ b/sharktank/sharktank/kernels/base.py
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from typing import Optional, Sequence, Tuple
+from typing import Optional, Sequence, Tuple, List
 
 import logging
 from pathlib import Path
@@ -105,8 +105,13 @@ def call_function(target_function: Operation, *operands: Value) -> Sequence[Valu
     target_symbol = FlatSymbolRefAttr.get(target_function.attributes["sym_name"].value)
     ftype = FunctionType(TypeAttr(target_function.attributes["function_type"]).value)
     operands = [i for i in operands if i is not None]
+    op_name = (
+        "func.call" if target_function.operation.name == "func.func" else "util.call"
+    )
+    target_function.attributes["sym_visibility"] = StringAttr.get("private")
+
     return Operation.create(
-        "util.call",
+        op_name,
         results=ftype.results,
         operands=operands,
         attributes={

--- a/sharktank/sharktank/kernels/mlir_kernel.py
+++ b/sharktank/sharktank/kernels/mlir_kernel.py
@@ -142,7 +142,7 @@ class MLIRTensor:
 
 class MLIRSpec:
     """
-    A class representing a MLIR Jinja2 template.
+    A class representing a MLIR Jinja2 template or a MLIR asm.
 
     The `subs` dictionary contains additional substitutions passed to the jinja
     template generator.
@@ -153,11 +153,15 @@ class MLIRSpec:
     """
 
     mlir: str
+    target_kernel_name: str
     subs: dict
+    use_jinja: bool
 
-    def __init__(self, mlir: str, subs: dict = {}):
+    def __init__(self, mlir: str, target_kernel_name: str = None, subs: dict = {}, use_jinja: bool = True):
         self.mlir = mlir
+        self.target_kernel_name = target_kernel_name
         self.subs = subs
+        self.use_jinja = use_jinja
 
 
 def mlir_kernel(
@@ -353,17 +357,21 @@ def mlir_kernel(
                 # the mlir spec.
                 if symbol_name is None:
                     # Generate the MLIR spec using jinja.
-                    asm = (
-                        _get_jinja2_env()
-                        .from_string(mlir)
-                        .render(
-                            {
-                                "kernel_name": kernel_name,
-                                **self._get_additional_aliases(dims),
-                                **mlir_spec.subs,
-                            }
+                    if mlir_spec.use_jinja:
+                        asm = (
+                            _get_jinja2_env()
+                            .from_string(mlir)
+                            .render(
+                                {
+                                    "kernel_name": kernel_name,
+                                    **self._get_additional_aliases(dims),
+                                    **mlir_spec.subs,
+                                }
+                            )
                         )
-                    )
+                    else:
+                        asm = mlir_spec.mlir
+                        kernel_name = mlir_spec.target_kernel_name
                     try:
                         module_op = Operation.parse(asm, context=kb.context)
                     except MLIRError as e:

--- a/sharktank/sharktank/kernels/wave/attention.py
+++ b/sharktank/sharktank/kernels/wave/attention.py
@@ -1,0 +1,137 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from sharktank.kernels.base import *
+from iree.turbine.kernel.wave.templates.vanilla_attention import (
+    get_bhsd_attention_kernel,
+)
+from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
+from iree.turbine.kernel.wave.compile import wave_compile, WaveCompileOptions
+from iree.turbine.kernel.wave.templates.attention_common import AttentionShape
+from iree.turbine.kernel.wave.constraints import MMAType
+from iree.turbine.kernel.wave.utils.general_utils import (
+    get_default_scheduling_params,
+)
+from iree.turbine.kernel.wave.utils.run_utils import (
+    set_default_run_config,
+)
+from sharktank.kernels.mlir_kernel import *
+
+__all__ = [
+    "get_wave_flash_attention_asm"
+    "wave_bhsd_flash_attention",
+]
+
+def get_wave_flash_attention_asm(target_function_name: str, shape: AttentionShape, mfma_variant: list[MMAType], dynamic_dims: bool, is_causal: bool = False, is_custom_mask: bool = False,) -> str:
+    (
+        base_attention_func,
+        hyperparams,
+        dynamic_symbols,
+        dynamic_symbols_map,
+    ) = get_bhsd_attention_kernel(
+        shape,
+        mfma_variant,
+        dynamic_dims,
+        is_causal=is_causal,
+        is_custom_mask=is_custom_mask,
+    )
+    hyperparams.update(get_default_scheduling_params())
+    options = WaveCompileOptions(
+        subs=hyperparams,
+        schedule=SchedulingType.NONE,
+        dynamic_symbols=dynamic_symbols,
+        dynamic_symbols_map=dynamic_symbols_map,
+        waves_per_eu=2,
+        denorm_fp_math_f32="preserve-sign",
+        func_name=target_function_name,
+        compile_to_mlir=True,
+    )
+    options = set_default_run_config(options)
+    base_attention = wave_compile(options, base_attention_func)
+
+    asm = base_attention.asm
+    return asm
+
+# Wave Attention Kernels
+# Each kernel is put into its own class to create a namespace for it
+B = StaticDim.B # batch_size
+H = StaticDim.H # num_query_heads
+M = StaticDim.M # query_seq_len
+N = StaticDim.N # head_size_kv
+K1 = StaticDim.K1 # head_size
+K2 = StaticDim.K2 # kv_seq_len
+
+F16 = Dtype.F16
+F32 = Dtype.F32
+
+@mlir_kernel(
+    inputs=(
+        MLIRTensor[
+            B,
+            H,
+            M,
+            K1,
+            F16
+        ],
+        MLIRTensor[
+            B,
+            H,
+            K2,
+            K1,
+            F16
+        ],
+        MLIRTensor[
+            B,
+            H,
+            K2,
+            N,
+            F16
+        ],
+        MLIRTensor[
+            B,
+            H,
+            M,
+            N,
+            F32
+        ],
+    ),
+    results=(
+        MLIRTensor[B, H, M, N, F32],
+    ),
+)
+def wave_bhsd_flash_attention(
+    q, k, v, c, result=None
+):
+    batch_size, num_heads, q_s, q_d = q.type.shape
+    v_batch_size, num_heads_kv, v_s, v_d = v.type.shape
+    shape = AttentionShape(
+        batch_size=batch_size,
+        num_query_heads=num_heads,
+        num_kv_heads=num_heads_kv,
+        query_seq_len=q_s,
+        head_size_kv=v_d,
+        head_size=q_d,
+        kv_seq_len=v_s,
+    )
+    mfma_variant = (MMAType.F32_32x32x8_F16, MMAType.F32_32x32x8_F16)
+    dynamic_dims = False
+    is_causal = True
+    is_custom_mask = False
+    i_type_str = "f16"
+    o_type_str = "f32"
+
+    target_function_name = f"wave_flash_attention_{batch_size}_{num_heads}_{q_s}_{v_d}_{i_type_str}_{o_type_str}"
+
+    asm = get_wave_flash_attention_asm(
+        target_function_name,
+        shape,
+        mfma_variant,
+        dynamic_dims,
+        is_causal=is_causal,
+        is_custom_mask=is_custom_mask,
+    )
+
+    return MLIRSpec(asm, target_kernel_name=target_function_name, use_jinja=False)

--- a/sharktank/tests/kernels/attention_wave_test.py
+++ b/sharktank/tests/kernels/attention_wave_test.py
@@ -1,0 +1,48 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+import unittest
+from parameterized import parameterized
+
+import torch
+
+from iree.turbine import aot
+from sharktank.kernels.wave.attention import wave_bhsd_flash_attention
+from sharktank.types import layout_utils
+from sharktank.utils import debugging
+from sharktank import ops
+from iree.turbine.kernel.wave.common.utils import scaled_dot_product_attention_bhsd
+
+
+class wave_attention(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(42)
+
+    @parameterized.expand(
+        [
+            (1e-3, 1e-3),
+        ]
+    )
+    def testWaveAttentionCausal(self, atol, rtol):
+        dtype = torch.float16
+        accum_dtype = torch.float32
+        q = torch.randn([4, 32, 128, 128], device="cuda", dtype=dtype)
+        k = torch.randn([4, 32, 128, 128], device="cuda", dtype=dtype)
+        v = torch.randn([4, 32, 128, 128], device="cuda", dtype=dtype)
+        output = torch.zeros([4, 32, 128, 128], device="cuda", dtype=accum_dtype)
+        result = wave_bhsd_flash_attention(q, k, v, output)
+
+        # Tolerances are empirical and results are not expected to match exactly.
+        ref = scaled_dot_product_attention_bhsd(q, k, v, is_causal=True)
+        torch.testing.assert_close(result, ref, atol=atol, rtol=rtol)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a Wave sdpa kernel invocation and uses the existing sharktank `mlir_kernel` decorator to inject the Wave asm that is generated from the `wave_compile` API. The tests passing depend on https://github.com/iree-org/iree-turbine/pull/787 being merged first.

It is a refactor of https://github.com/nod-ai/shark-ai/pull/1378.