### PR TITLE
Revert "[RoPE] Cleanup RoPE implementation (#1514)"

### DIFF
--- a/sharktank/sharktank/layers/rotary_embedding.py
+++ b/sharktank/sharktank/layers/rotary_embedding.py
@@ -107,6 +107,50 @@ class RotaryEmbeddingLayer(BaseLayer):
             f"Rotary embedding layer not implemented for input tensor type {type(xt)}"
         )
 
+    def _create_interleaved_tensor(_, dim):
+        """Creates a tensor which indexes an tensor such that
+        it alternates between elements of its first and second
+        half. Intended for use for HuggingFace's rotation
+        implementation.
+
+        Args:
+          dim: Size of tensor
+
+        Returns:
+          Interleaved indexing tensor
+        """
+        first_half = torch.arange(dim // 2)
+        second_half = torch.arange(dim // 2, dim)
+
+        interleaved_tensor = torch.empty(dim, dtype=torch.long)
+        interleaved_tensor[0::2] = first_half
+        interleaved_tensor[1::2] = second_half
+
+        return interleaved_tensor
+
+    def _create_ordering_tensor(_, dim):
+        """Creates a tensor which indexes an tensor such that
+        it reverses the alternation induced by create_interleaved_tesnor.
+        Intended for use for HuggingFace's rotation implementation.
+
+        Args:
+          dim: Size of tensor
+
+        Returns:
+          Ordering indexing tensor
+        """
+        order_tensor = torch.empty(dim, dtype=torch.long)
+        order_tensor[: dim // 2] = torch.arange(0, dim, 2)
+        order_tensor[dim // 2 :] = torch.arange(1, dim, 2)
+        return order_tensor
+
+    @staticmethod
+    def rotate_half(x):
+        """Rotates half the hidden dims of the input."""
+        x1 = x[..., : x.shape[-1] // 2]
+        x2 = x[..., x.shape[-1] // 2 :]
+        return torch.cat((-x2, x1), dim=-1)
+
     def forward_unsharded(
         self,
         *,
@@ -116,7 +160,8 @@ class RotaryEmbeddingLayer(BaseLayer):
     ):
         # freqs_cis shape: max_sl, dim
         # xq_, xk_ shape: bs, sl, _, dim
-        _, sl, _, dim = xt.shape
+        xt_ = xt
+        _, sl, _, _ = xt_.shape
 
         if self.use_hf:
             freqs_cis = rotary_embed_table
@@ -125,11 +170,9 @@ class RotaryEmbeddingLayer(BaseLayer):
             # expand to 1, sl, 1, dim and repeat per bs
             cos = cos[None, :, None, :].repeat(xt.shape[0], 1, 1, 1)
             sin = sin[None, :, None, :].repeat(xt.shape[0], 1, 1, 1)
-            xt_real = xt[..., : dim // 2]
-            xt_imag = xt[..., dim // 2 :]
-            x1 = xt_real * cos - xt_imag * sin
-            x2 = xt_imag * cos + xt_real * sin
-            return torch.cat((x1, x2), dim=-1)
+            xt = xt.transpose(1, 2)
+            xt_out = (xt_ * cos) + (self.rotate_half(xt_) * sin)
+            return xt_out
 
         # Offset the table based on starting position.
         if self.use_table:
@@ -143,8 +186,8 @@ class RotaryEmbeddingLayer(BaseLayer):
             freqs_cis.shape[0] >= sl
         ), f"Sequence length longer than embedding table ({sl} vs {freqs_cis.shape[0]})"
 
-        freqs_cis = ops.repeat(freqs_cis[None, :, :], (xt.shape[0], 1, 1))
-        xt_out = kernels.apply_rotary_embedding(xt.to(freqs_cis.dtype), freqs_cis)
+        freqs_cis = ops.repeat(freqs_cis[None, :, :], (xt_.shape[0], 1, 1))
+        xt_out = kernels.apply_rotary_embedding(xt_.to(freqs_cis.dtype), freqs_cis)
 
         return ops.to(xt_out, xt.dtype)
 
@@ -219,15 +262,11 @@ class RotaryEmbeddingLayer(BaseLayer):
         # xq_, xk_ shape: bs, sl, _, dim
         # freqs_cis shape: max_sl, dim
 
-        _, sl, _, dim = xt.shape
-
         if self.use_hf:
             cos, sin = mask
-            xt_real = xt[..., : dim // 2]
-            xt_imag = xt[..., dim // 2 :]
-            x1 = xt_real * cos - xt_imag * sin
-            x2 = xt_imag * cos + xt_real * sin
-            return torch.cat((x1, x2), dim=-1)
+            xt = xt.transpose(1, 2)
+            xt_out = (xt * cos) + (self.rotate_half(xt) * sin)
+            return xt_out.transpose(1, 2)
 
         xt_out = kernels.apply_rotary_embedding(xt.to(mask.dtype), mask)
 
@@ -237,47 +276,39 @@ class RotaryEmbeddingLayer(BaseLayer):
         dim = self.rope_dimension_count
         if self.use_hf:
 
-            # The original paper creates a d/2 dimensional space to represent
-            # the polar coordinates.
-            #
-            # From the original paper:
-            #   theta = 10000^{-2 (i - 1) / d}, i \in [1, 2, ..., d/2]
-            # which is a convoluted way of saying
-            #   theta = (1/base)^{i / d}, i \in range(0, dim, 2)
-            rope_rcp_theta = 1.0 / self.rope_freq_base
-            freqs = rope_rcp_theta ** (torch.arange(0, dim, 2).float() / dim)
+            freqs = 1.0 / (
+                self.rope_freq_base
+                ** (torch.arange(0, dim, 2, dtype=torch.int64).float() / dim)
+            )
+            ### from llama3 embedding changes
+            # TODO: get these values from Dataset
+            factor = 8  # in the original implementation
+            low_freq_factor = 1  # in the original implementation
+            high_freq_factor = 4
+            old_context_len = 8192
 
-            if self.rope_scaling_type == "llama3":
-                # llama3.1 introduced rope scaling to normalize the theta better.
-                # The theory is based on the original llama3.1 implementation:
-                # https://github.com/meta-llama/llama-models/blob/709a61fd810157f75fbb314e7287089eec06d9c3/models/llama3_1/api/model.py#L41
-                # TODO: Not all models use rope scaling, fix this.
-                # TODO: get these values from Dataset. Current values are derived
-                # from llama3.1 reference link above.
-                rope_factor = 8
-                low_freq_factor = 1
-                high_freq_factor = 4
-                old_context_len = 8192
+            low_freq_wavelen = old_context_len / low_freq_factor
+            high_freq_wavelen = old_context_len / high_freq_factor
 
-                # The reference implementation is based on flash-infer. This
-                # implementation uses clamping instead of conditionals which is
-                # much better for a tensor compiler:
-                # https://github.com/flashinfer-ai/flashinfer/commit/4c89decadc8ae9f261cae97c350064156e66bc09#diff-e797f0f37e32a5e08c50ef190459c873fcb33ef6334333cef1e4e2d931308fa3
-                smooth_a = old_context_len / (
-                    2 * torch.pi * (high_freq_factor - low_freq_factor)
-                )
-                smooth_b = -1.0 / (high_freq_factor / low_freq_factor - 1.0)
+            inv_freq = freqs
+            wavelen = 2 * torch.pi / inv_freq
+            inv_freq_llama = torch.where(
+                wavelen > low_freq_wavelen, inv_freq / factor, inv_freq
+            )
 
-                rope_rcp_scale = 1.0 / rope_factor
+            smooth_factor = (old_context_len / wavelen - low_freq_factor) / (
+                high_freq_factor - low_freq_factor
+            )
+            smoothed_inv_freq = (
+                1 - smooth_factor
+            ) * inv_freq_llama / factor + smooth_factor * inv_freq_llama
+            is_medium_freq = ~(wavelen < high_freq_wavelen) * ~(
+                wavelen > low_freq_wavelen
+            )
+            freqs = torch.where(is_medium_freq, smoothed_inv_freq, inv_freq_llama)
 
-                smooth = freqs * smooth_a + smooth_b
-                # Clamp to [0, 1]
-                smooth = torch.clamp(smooth, 0.0, 1.0)
-                freqs = (1 - smooth) * (freqs * rope_rcp_scale) + smooth * freqs
-            elif self.rope_scaling_type is not None:
-                raise ValueError(f"{self.rope_scaling_type} NYI")
-
-            emb = torch.outer(t, freqs)
+            freqs = torch.cat((freqs, freqs), dim=-1).to(device=self.device)
+            emb = t.unsqueeze(1).float() * freqs.unsqueeze(0).float()
 
             cos = torch.cos(emb).to(self.dtype)
             sin = torch.sin(emb).to(self.dtype)

--- a/sharktank/tests/models/llama/attention_test.py
+++ b/sharktank/tests/models/llama/attention_test.py
@@ -1,0 +1,176 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import unittest
+
+import torch
+
+from sharktank.layers.configs.llm_configs import *
+from sharktank.layers.rotary_embedding import RotaryEmbeddingLayer
+from sharktank.layers.paged_attention import PagedAttention
+from sharktank.models.llm import AttentionFFNBlock
+from sharktank.models.llama.testing import *
+
+from transformers.models.llama.modeling_llama import (
+    LlamaAttention,
+    LlamaMLP,
+    LlamaRMSNorm,
+    LlamaDecoderLayer,
+)
+from transformers.models.llama.configuration_llama import LlamaConfig
+
+
+class AttentionBlockTest(unittest.TestCase):
+    def test(self):
+        torch.manual_seed(1234567)
+        torch.set_default_dtype(torch.float32)
+        block_index = 0
+        seq_len = 13
+        head_count = 32
+        head_dim = 100
+        hidden_size = 3200
+        ffn_dim = 8640
+        head_count_kv = 32
+        block_seq_stride = 1
+        rms_epsilon = 0.01
+        rope_dimension_count = 100
+        rope_freq_base = 10000.0
+        max_seq_len = 2048
+        attention_block_theta = make_attention_block_theta(
+            feature_dim=head_count * head_dim, ffn_dim=ffn_dim, dtype=torch.float32
+        )
+
+        hp = LlamaHParams(
+            model_arch="llama",
+            context_length=max_seq_len,
+            embedding_length=head_count * head_dim,
+            block_count=1,
+            feed_forward_length=ffn_dim,
+            attention_head_count=head_count,
+            attention_layer_norm_rms_epsilon=rms_epsilon,
+            attention_head_count_kv=head_count_kv,
+            attn_head_dim=head_dim,
+            rope_dimension_count=rope_dimension_count,
+            rope_freq_base=rope_freq_base,
+        )
+
+        llama_config = LlamaModelConfig(
+            hp,
+            attention_kernel="torch",
+            block_seq_stride=block_seq_stride,
+        )
+
+        paged_kv_cache = PagedAttention(
+            transformer_block_count=head_count,
+            attn_head_count=head_count,
+            attn_head_dim=head_dim,
+            cache_partition_count=2,  # One for each of K/V.
+            block_seq_stride=block_seq_stride,
+            device="cpu",
+            cache_dtype=torch.float32,
+            attn_dtype=torch.float32,
+        )
+        attention_block = AttentionFFNBlock(
+            theta=attention_block_theta,
+            block_index=block_index,
+            cache=paged_kv_cache,
+            config=llama_config,
+        )
+        attention_embedding = RotaryEmbeddingLayer(
+            rope_dimension_count=rope_dimension_count,
+            rope_freq_base=rope_freq_base,
+            max_seqlen=max_seq_len,
+            device="cpu",
+            use_hf=True,
+        )
+        position_embeddings = attention_embedding.rotary_embed_table
+        input_tensor = make_rand_torch(
+            (1, seq_len, head_count * head_dim), dtype=torch.float32
+        )
+
+        sharktank_output = attention_block(
+            input_tensor,
+            embedding=attention_embedding,
+            attention_mask=torch.zeros(1, seq_len, seq_len, dtype=torch.float32),
+            start_index=0,
+            cache_state=paged_kv_cache.allocate(128),
+            seq_block_ids=torch.arange(seq_len).view(1, -1),
+        )
+
+        llama_config = LlamaConfig(
+            hidden_size=hidden_size,
+            num_attention_heads=head_count,
+            num_key_value_heads=head_count_kv,
+            max_position_embeddings=max_seq_len,
+            rms_norm_eps=rms_epsilon,
+            rope_theta=10000,
+        )
+        llama_attention_block = LlamaAttention(
+            config=llama_config, layer_idx=block_index
+        )
+
+        llama_attention_block.q_proj.weight = torch.nn.Parameter(
+            attention_block_theta("attn_q.weight").as_torch(),
+            requires_grad=True,
+        )
+        llama_attention_block.k_proj.weight = torch.nn.Parameter(
+            attention_block_theta("attn_k.weight").as_torch(),
+            requires_grad=True,
+        )
+        llama_attention_block.v_proj.weight = torch.nn.Parameter(
+            attention_block_theta("attn_v.weight").as_torch(),
+            requires_grad=True,
+        )
+        llama_attention_block.o_proj.weight = torch.nn.Parameter(
+            attention_block_theta("attn_output.weight").as_torch(),
+            requires_grad=True,
+        )
+
+        llama_mlp = LlamaMLP(config=llama_config)
+        llama_mlp.gate_proj.weight = torch.nn.Parameter(
+            attention_block_theta("ffn_gate.weight").as_torch(), requires_grad=True
+        )
+        llama_mlp.up_proj.weight = torch.nn.Parameter(
+            attention_block_theta("ffn_up.weight").as_torch(), requires_grad=True
+        )
+        llama_mlp.down_proj.weight = torch.nn.Parameter(
+            attention_block_theta("ffn_down.weight").as_torch(), requires_grad=True
+        )
+
+        llama_input_layernorm = LlamaRMSNorm(hidden_size=hidden_size, eps=rms_epsilon)
+        llama_input_layernorm.weight = torch.nn.Parameter(
+            attention_block_theta("attn_norm.weight").as_torch(),
+            requires_grad=True,
+        )
+
+        llama_post_attention_layernorm = LlamaRMSNorm(
+            hidden_size=hidden_size, eps=rms_epsilon
+        )
+        llama_post_attention_layernorm.weight = torch.nn.Parameter(
+            attention_block_theta("ffn_norm.weight").as_torch(),
+            requires_grad=True,
+        )
+
+        llama_decoder_layer = LlamaDecoderLayer(
+            config=llama_config, layer_idx=block_index
+        )
+        llama_decoder_layer.self_attn = llama_attention_block
+        llama_decoder_layer.mlp = llama_mlp
+        llama_decoder_layer.input_layernorm = llama_input_layernorm
+        llama_decoder_layer.post_attention_layernorm = llama_post_attention_layernorm
+        position_embeddings = [x[:seq_len, :].unsqueeze(0) for x in position_embeddings]
+        huggingface_output = llama_decoder_layer(
+            input_tensor,
+            position_embeddings=position_embeddings,
+        )[0]
+        assert sharktank_output.shape == huggingface_output.shape
+        torch.testing.assert_close(
+            sharktank_output, huggingface_output, atol=1e-5, rtol=5e-1
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This reverts commit 6f3f3504d5e4a3e1c259d899316979e867516c4f.

We were seeing an issue in the Shortfin server, while running mistral and tracked it down to a regression in accuracy. Bisecting led to this commit as being the culprit.

Initially, this presented itself as a numpy NaN error in the server:

```bash
/shark-ai/shortfin/src/shortfin/support/iree_helpers.h:315: UNKNOWN; Unhandled exception: Traceback (most recent call last):
  File "numpy/random/mtrand.pyx", line 990, in numpy.random.mtrand.RandomState.choice
RuntimeError: Async exception on <Worker 'default-fiber-pool-init-worker-0'>): probabilities contain NaN
```

Was able to track this down to being caused by NaNs in the logits, directly after decode invocation. Those NaNs eventually get passed to the `Sampler.sample_top_p` function.

When error wasn't thrown, this issue would also present itself with inaccurate or empty output:

```bash
curl http://localhost:8001/generate -H "Content-Type: application/json" -d '{ "return_text_in_logprobs": "False", "stream": "False", "text":  "life is amazing, is it not? ", "sampling_params": {"max_completion_tokens": 64, "b_of_n":1}}'
{"responses": [{"prompt": "life is amazing, is it not? ", "responses": [{"text": ""}, {"text": ""}, {"text": ""}, {"text": ""}, {"text": ""}, {"text": ""}, {"text": ""}, {"text": ""}]}]}%
```

After bisecting, was able to rule out IREE side, by re-compiling a golden MLIR that still worked. Bisecting through sharktank side showed this commit to be the issue. **Reverting fixes the accuracy issues and the numpy NaN issue**.

Still need to track down why this was able to slip through our CIs. This may be something specific to Mistral, as PPL tests, Llama based smoke tests, etc. don't show an error.