### PR TITLE
Remove `argmax` and `topk` functions from `PagedLlmModelV1`

### DIFF
--- a/sharktank/sharktank/models/llm/llm.py
+++ b/sharktank/sharktank/models/llm/llm.py
@@ -142,29 +142,6 @@ class PagedLlmModelV1(BaseCausalLMModel):
         )
         return x.clone(ts=shards, devices=next_devices)
 
-    def argmax(
-        self,
-        logits: torch.Tensor,
-        chunk_size: int,
-    ):
-        indices = ops.argmax(logits, -1, chunk_size=chunk_size)
-        indices_expanded = indices.unsqueeze(-1)
-
-        max_logits = ops.gather(logits, dim=-1, index=indices_expanded)
-        max_logits = max_logits.squeeze(-1)
-
-        return max_logits, indices
-
-    def topk(
-        self,
-        logits: torch.Tensor,
-        k: int,
-        chunk_size: int,
-    ):
-        return ops.topk(
-            logits, k=k, dim=-1, largest=True, sorted=True, chunk_size=chunk_size
-        )
-
     def prefill(
         self,
         # [bs, batch_seq_len]


### PR DESCRIPTION
Cleanup based on [this feedback](https://github.com/nod-ai/shark-ai/pull/1474#discussion_r2111794321).

Makes more sense to have the `topk` and `argmax` function defined and called in the export script itself, instead of in `PagedLlmModelV1`