### PR TITLE
Add --use-attention-mask flag to eager mode

### DIFF
--- a/sharktank/sharktank/evaluate/perplexity_torch.py
+++ b/sharktank/sharktank/evaluate/perplexity_torch.py
@@ -45,8 +45,8 @@ class PerplexityTorch:
     For more information, see https://huggingface.co/docs/transformers/perplexity
     """
 
-    def __init__(self):
-        pass
+    def __init__(self, use_attention_mask: bool = True):
+        self.use_attention_mask = use_attention_mask
 
     def print_token_comparison(self, i: int):
         if i <= self.max_prompt_length:
@@ -119,6 +119,7 @@ class PerplexityTorch:
             token_ids=token_batch,
             seq_lens=seq_lens_batch,
             page_cache_size=self.page_cache_size,
+            use_attention_mask=self.use_attention_mask,
         )
 
         return token_batch
@@ -245,6 +246,7 @@ def run_perplexity_torch(
                 use_hf=args.use_hf,
                 fake_quant=args.fake_quant,
                 skip_decode=args.skip_decode,
+                use_attention_mask=args.use_attention_mask,
             )
         )
 
@@ -278,9 +280,10 @@ def perplexity_torch(
     use_hf,
     fake_quant,
     skip_decode,
+    use_attention_mask: bool,
 ):
 
-    perplexity = PerplexityTorch()
+    perplexity = PerplexityTorch(use_attention_mask=use_attention_mask)
 
     perplexity.load_model(
         dataset=dataset,

--- a/sharktank/sharktank/examples/paged_llm_v1.py
+++ b/sharktank/sharktank/examples/paged_llm_v1.py
@@ -77,6 +77,7 @@ def main():
         seq_lens=seq_lens,
         dump_path=args.dump_path,
         dump_decode_steps=args.dump_decode_steps,
+        use_attention_mask=args.use_attention_mask,
     )
     results = batch.prefill()
     batch.print_current_results()

--- a/sharktank/sharktank/models/llm/llm.py
+++ b/sharktank/sharktank/models/llm/llm.py
@@ -171,13 +171,14 @@ class PagedLlmModelV1(BaseCausalLMModel):
         tokens: Union[torch.Tensor, ReplicatedTensor],
         *,
         # [[bs|1, 1, batch_seq_len, batch_seq_len] x self.config.pipeline_parallelism_size]
-        attention_mask: list[Union[torch.Tensor, ReplicatedTensor]],
+        attention_mask: list[Union[torch.Tensor, ReplicatedTensor, None]],
         # [bs, batch_seq_len // block_seq_stride]
         seq_block_ids: list[Union[torch.Tensor, ReplicatedTensor]],
         cache_state: list[Union[torch.Tensor, SplitPrimitiveTensor]],
     ):
         self._assert_device(tokens)
-        self._assert_device(*attention_mask, dtype=self.activation_dtype)
+        if not all(mask is None for mask in attention_mask):
+            self._assert_device(*attention_mask, dtype=self.activation_dtype)
         self._assert_device(*seq_block_ids)
         self._assert_device(*cache_state, dtype=self.activation_dtype)
 

--- a/sharktank/sharktank/utils/load_llm.py
+++ b/sharktank/sharktank/utils/load_llm.py
@@ -66,6 +66,7 @@ class TorchGenerator:
         page_cache_size: int = None,
         dump_path: Path = None,
         dump_decode_steps: int = None,
+        use_attention_mask: bool = True,
     ) -> "Batch":
         bs = token_ids.shape[0]
 
@@ -86,6 +87,7 @@ class TorchGenerator:
             bs=bs,
             dump_path=dump_path,
             dump_decode_steps=dump_decode_steps,
+            use_attention_mask=use_attention_mask,
         )
 
     def alloc_page(self) -> int:
@@ -105,6 +107,7 @@ class Batch:
         bs: int,
         dump_path: Path,
         dump_decode_steps: int,
+        use_attention_mask: bool,
     ):
         self.bs = bs
         assert seq_lens.shape[0] == self.bs
@@ -118,6 +121,7 @@ class Batch:
         self.dump_path = dump_path
         self.dump_decode_steps = dump_decode_steps
         self.decode_step = 0
+        self.use_attention_mask = use_attention_mask
 
         # Assemble the batch.
         seq_stride = self.parent.block_seq_stride
@@ -206,14 +210,17 @@ class Batch:
 
     def prefill(self):
         model = self.parent.model
-        attention_mask = model.attention_mask(
-            model.input_mask(self.seq_lens, self.token_ids.shape[1])
-        )
         seq_block_ids = self.pad_block_ids()
+        token_ids = self.token_ids
         trace_tensor("prefill.token_ids", self.token_ids)
         trace_tensor("prefill.seq_block_ids", seq_block_ids)
-        trace_tensor("prefill.attention_mask", attention_mask)
-        token_ids = self.token_ids
+
+        attention_mask = None
+        if self.use_attention_mask:
+            attention_mask = model.attention_mask(
+                model.input_mask(self.seq_lens, self.token_ids.shape[1])
+            )
+            trace_tensor("prefill.attention_mask", attention_mask)
 
         shard_count = model.config.tensor_parallelism_size
         num_pipelines = model.config.pipeline_parallelism_size

--- a/sharktank/tests/evaluate/perplexity_torch_test.py
+++ b/sharktank/tests/evaluate/perplexity_torch_test.py
@@ -40,6 +40,7 @@ class PerplexityTest(unittest.TestCase):
             f"--num-prompts={self.batch_size}",
             f"--device={self.device}",
             f"--tensor-parallelism-size={self.tensor_parallelism_size}",
+            "--use-attention-mask",
         ]
         if extra_args:
             self.argv.extend(extra_args)


### PR DESCRIPTION
IREE version of models could be run with or without the `--use-attention-mask` flag, with the default being without the flag. The eager mode execution could only be run **with** the flag, and there was no way to disable it.

This PR:
- Adds the flag to eager runs
- Sets the default to enabled so that current behaviour is maintained

This is useful for testing differences model results, since the resulting mask is slightly different with or without the flag, as have been observed in the past.