### PR TITLE
[shortfin][WIP] Implement run_in_executor for PyWorkerEventLoop

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/independent_token_selection_strategy.py
+++ b/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/independent_token_selection_strategy.py
@@ -13,6 +13,7 @@ from .beam_group import Beam, BeamGroup
 from .base_token_selection_strategy import (
     BaseTokenSelectionStrategy,
 )
+import asyncio
 
 from ..messages import LlmInferenceExecRequest, InferencePhase
 
@@ -185,7 +186,7 @@ class IndependentTokenSelectionStrategy(BaseTokenSelectionStrategy):
                 config.decode_callback(req)
 
             await beam_group.wait()
-            beam_group.process_beams()
+            await asyncio.to_thread(beam_group.process_beams)
 
             if not beam_group.active_beams:
                 break


### PR DESCRIPTION
All of the CPU work done in the LLM app is *non-async*, which means that it will not allow anything else to be scheduled on the event loop until it completes. While not perfect, a workaround is to offload the blocking functions to a `ThreadPoolExecutor`, which integrated well with other async code.

This patch implements `run_in_executor` for `PyWorkerEventLoop`, which will allow using `asyncio.to_thread` to offload blocking calls in async contexts to a `ThreadPoolExecutor`.

Also uses `asyncio.to_thread` to call `beam_group.process_beams` which includes expensive blocking functions in its call stack.