### PR TITLE
[shortfin] Fix runner label for nightly workflow.

### DIFF
--- a/.github/workflows/ci-shortfin-nightly.yml
+++ b/.github/workflows/ci-shortfin-nightly.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   install-and-test:
     name: Install and test
-    runs-on: linux-mi300-1gpu-ossci
+    runs-on: linux-mi300-1gpu-ossci-nod-ai
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
This workflow has always failed, but two months ago it started failing after 24 hour timeouts trying to find runners, since the runner labels were updated in https://github.com/nod-ai/shark-ai/pull/1163. The workflow was added around the same time, in https://github.com/nod-ai/shark-ai/pull/1162, so that was missed. See the history here: https://github.com/nod-ai/shark-ai/actions/workflows/ci-shortfin-nightly.yml.

Tested here: https://github.com/nod-ai/shark-ai/actions/runs/15396732703/job/43319287710.

> [!IMPORTANT]
> The workflow is still failing, just now due to missing access permissions. 