### PR TITLE
Check input lengths for RotaryEmbeddingLayer.compute_batch_mask

### DIFF
--- a/sharktank/sharktank/layers/rotary_embedding.py
+++ b/sharktank/sharktank/layers/rotary_embedding.py
@@ -209,7 +209,7 @@ class RotaryEmbeddingLayer(BaseLayer):
             0
         ) + start_positions.unsqueeze(1)
         assert not any(
-            position >= self.max_seqlen for position in start_positions
+            position >= self.max_seqlen for position in ops.unshard(positions_seq)
         ), "One or more positions greater than max_seqlen. Prompt too long."
         # Broadcast lookup to [b, ...].
         self.trace_tensor("rope.positions_seq", positions_seq)

--- a/sharktank/sharktank/layers/rotary_embedding.py
+++ b/sharktank/sharktank/layers/rotary_embedding.py
@@ -208,6 +208,9 @@ class RotaryEmbeddingLayer(BaseLayer):
         positions_seq = torch.arange(0, batch_seq_len, device=self.device).unsqueeze(
             0
         ) + start_positions.unsqueeze(1)
+        assert not any(
+            position >= self.max_seqlen for position in start_positions
+        ), "One or more positions greater than max_seqlen. Prompt too long."
         # Broadcast lookup to [b, ...].
         self.trace_tensor("rope.positions_seq", positions_seq)
         if self.use_hf:


### PR DESCRIPTION
This will prevent us from accidentally indexing beyond the end of the RotaryEmbedding table, at least in Eager mode. (See #1549)