### PR TITLE
Hookup `topk` to `iree_linalg_ext.topk`

### DIFF
--- a/sharktank/sharktank/kernels/__init__.py
+++ b/sharktank/sharktank/kernels/__init__.py
@@ -16,3 +16,4 @@ from .conv_2d_nchw_fchw import *
 from .pooling_nchw_sum import *
 from .base import *
 from .bitcast import *
+from .topk import *

--- a/sharktank/sharktank/kernels/templates/topk_dynamic.mlir
+++ b/sharktank/sharktank/kernels/templates/topk_dynamic.mlir
@@ -1,0 +1,44 @@
+// Copyright 2024 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+!input_tensor_type = tensor<?x?x?x{{dtype}}>
+!indices_tensor_type = tensor<?x?x?xi32>
+!values_tensor_type = tensor<?x?x{{k}}x{{dtype}}>
+!indices_out_tensor_type = tensor<?x?x{{k}}xi32>
+
+module {
+  util.func private @sharktank_topk_{{k}}_{{dtype}}(%arg0: !input_tensor_type) -> (!values_tensor_type, !indices_out_tensor_type) {
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant -3.402820e+38 : {{dtype}}  // Minimum float32 value
+
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+
+
+    %dim0 = tensor.dim %arg0, %c0 : !input_tensor_type
+    %dim1 = tensor.dim %arg0, %c1 : !input_tensor_type
+    %dim2 = tensor.dim %arg0, %c2 : !input_tensor_type
+    %0 = tensor.empty(%dim0, %dim1, %dim2) : !indices_tensor_type
+    %1 = tensor.empty(%dim0, %dim1) : !values_tensor_type
+    %2 = tensor.empty(%dim0, %dim1) : !indices_out_tensor_type
+    %3 = linalg.fill ins(%cst : {{dtype}}) outs(%1 : !values_tensor_type) -> !values_tensor_type
+    %4 = linalg.fill ins(%c0_i32 : i32) outs(%2 : !indices_out_tensor_type) -> !indices_out_tensor_type
+    %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} outs(%0 : !indices_tensor_type) {
+    ^bb0(%out: i32):
+      %7 = linalg.index 2 : index
+      %8 = arith.index_cast %7 : index to i32
+      linalg.yield %8 : i32
+    } -> !indices_tensor_type
+    %6:2 = iree_linalg_ext.topk dimension(2) ins(%arg0, %5 : !input_tensor_type, !indices_tensor_type) outs(%3, %4 : !values_tensor_type, !indices_out_tensor_type) {
+    ^bb0(%arg1: {{dtype}}, %arg2: {{dtype}}):
+      // Sort in descending order like PyTorch
+      %7 = arith.cmpf ogt, %arg1, %arg2 : {{dtype}}
+      iree_linalg_ext.yield %7 : i1
+    } -> !values_tensor_type, !indices_out_tensor_type
+    util.return %6#0, %6#1 : !values_tensor_type, !indices_out_tensor_type
+  }
+}

--- a/sharktank/sharktank/kernels/topk.py
+++ b/sharktank/sharktank/kernels/topk.py
@@ -1,0 +1,71 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from sharktank.kernels.base import *
+import torch
+
+__all__ = [
+    "iree_topk",
+]
+
+
+@CustomOp.register(library=LIBRARY)
+class iree_topk(CustomOp):
+
+    signature = "iree_topk(Tensor input, int k) -> (Tensor values, Tensor indices)"
+
+    def select(self, ksel: KernelSelection):
+        inputs_desc = ksel.arg_tensor(0)
+        k = ksel.attr_int(1).v
+        values_desc = ksel.return_new_tensor(
+            [inputs_desc.t.shape[0], inputs_desc.t.shape[1], k],
+            dtype=inputs_desc.t.dtype,
+        )
+        indices_desc = ksel.return_new_tensor(
+            [inputs_desc.t.shape[0], inputs_desc.t.shape[1], k], dtype=torch.int32
+        )
+        # specialize_all_known_dims(inputs_desc)
+        # specialize_all_known_dims(values_desc)
+        # specialize_all_known_dims(indices_desc)
+
+    def generate(self, ksel: KernelSelection, kb: KernelBuilder):
+        input = kb.arg_value(0)
+
+        result_desc = ksel.result_descs[0]
+        result_shape = result_desc.t.shape
+        k = result_shape[-1]
+
+        input_tensor_type = RankedTensorType(input.type)
+        input_asm_type, input_ident, input_dtype = unpack_tensor_type(input.type)
+
+        # Generate specialization signature and types.
+        bs = input.type.shape[0]
+        sl = input.type.shape[1]
+        sl = "?" if sl < 0 else sl  # Use ? for dynamic dimensions in MLIR
+
+        template_file = "topk_dynamic.mlir"
+        target_function_name = f"sharktank_topk_{k}_{input_dtype}"
+
+        # Template params
+        input_tensor_type = input_asm_type
+        indices_tensor_type = f"tensor<?x?x?xi32>"
+        values_tensor_type = f"tensor<?x?x{k}x{input_dtype}>"
+        indices_out_tensor_type = f"tensor<?x?x{k}xi32>"
+
+        target_function = inline_template_function(
+            kb,
+            template_file,
+            target_function_name,
+            input_tensor_type=input_tensor_type,
+            indices_tensor_type=indices_tensor_type,
+            values_tensor_type=values_tensor_type,
+            indices_out_tensor_type=indices_out_tensor_type,
+            bs=bs,
+            sl=sl,
+            k=k,
+            dtype=str(input_dtype),
+        )
+        kb.yield_results(*call_function(target_function, *kb.arg_bindings))

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -22,6 +22,9 @@ from sharktank.types import (
     BlockScaledI4Layout,
     TensorScaledLayout,
 )
+
+from sharktank.kernels.topk import iree_topk
+
 from sharktank.types.tensors import unbox_tensor, AnyTensor
 from ._registry import AllOfType, AllOfExprs, AllOfExprsVariadic, IsOfType
 from .signatures import *
@@ -727,6 +730,9 @@ def topk_default(
     sorted: bool,
     chunk_size: Optional[int] = None,
 ) -> tuple[Tensor, Tensor]:
+    if largest:
+        return iree_topk(tensor, k=k)
+
     if chunk_size is None:
         result = torch.topk(
             unbox_tensor(tensor), k=k, dim=dim, largest=largest, sorted=sorted

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -730,16 +730,16 @@ def topk_default(
     sorted: bool,
     chunk_size: Optional[int] = None,
 ) -> tuple[Tensor, Tensor]:
+    if chunk_size is not None:
+        return _split_topk(tensor, k, dim, largest, sorted, chunk_size)
+
     if largest:
-        return iree_topk(tensor, k=k)
+        return iree_topk(unbox_tensor(tensor), k=k)
 
-    if chunk_size is None:
-        result = torch.topk(
-            unbox_tensor(tensor), k=k, dim=dim, largest=largest, sorted=sorted
-        )
-        return result.values, result.indices
-
-    return _split_topk(tensor, k, dim, largest, sorted, chunk_size)
+    result = torch.topk(
+        unbox_tensor(tensor), k=k, dim=dim, largest=largest, sorted=sorted
+    )
+    return result.values, result.indices
 
 
 def _split_topk(

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -782,7 +782,7 @@ def _split_topk(
     tensor_unflattened = unflatten(tensor, dim, (n_chunks, chunk_size))
 
     vals_local, idx_local = topk(
-        tensor_unflattened, k, dim=dim + 1, largest=largest, sorted=False
+        tensor_unflattened, k, dim=dim + 1, largest=largest, sorted=sorted
     )
 
     vals_flat = flatten(vals_local, start_dim=dim, end_dim=dim + 1)

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -733,7 +733,7 @@ def topk_default(
     if chunk_size is not None:
         return _split_topk(tensor, k, dim, largest, sorted, chunk_size)
 
-    if largest and len(tensor.shape) == 3 and dim == 2:
+    if largest and not sorted and len(tensor.shape) == 3 and dim == 2:
         values, indices = iree_topk(unbox_tensor(tensor), k=k)
         return values, indices.to(torch.int64)
 

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -782,7 +782,7 @@ def _split_topk(
     tensor_unflattened = unflatten(tensor, dim, (n_chunks, chunk_size))
 
     vals_local, idx_local = topk(
-        tensor_unflattened, k, dim=dim + 1, largest=largest, sorted=sorted
+        tensor_unflattened, k, dim=dim + 1, largest=largest, sorted=False
     )
 
     vals_flat = flatten(vals_local, start_dim=dim, end_dim=dim + 1)

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -733,8 +733,9 @@ def topk_default(
     if chunk_size is not None:
         return _split_topk(tensor, k, dim, largest, sorted, chunk_size)
 
-    if largest:
-        return iree_topk(unbox_tensor(tensor), k=k)
+    if largest and len(tensor.shape) == 3 and dim == 2:
+        values, indices = iree_topk(unbox_tensor(tensor), k=k)
+        return values, indices.to(torch.int64)
 
     result = torch.topk(
         unbox_tensor(tensor), k=k, dim=dim, largest=largest, sorted=sorted

--- a/sharktank/tests/kernels/topk_test.py
+++ b/sharktank/tests/kernels/topk_test.py
@@ -1,0 +1,66 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+import torch
+import unittest
+
+from sharktank import kernels
+from sharktank import ops
+
+
+class topk_test(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(42)
+
+    def test_topk(self):
+        dtype = torch.float32
+        # Create input tensor with shape [8, 1, 128] (batch_size=8, seq_len=1, dim=128)
+        x = torch.rand([8, 2, 10], dtype=dtype)
+
+        # Add some known values to verify topk behavior
+        x[0, 0, :4] = torch.tensor([10.0, 5.0, 8.0, 3.0], dtype=dtype)
+
+        # Get reference result using torch.topk
+        ref_values, ref_indices = torch.topk(x, k=4, dim=-1)
+
+        # Get result from our kernel
+        result = kernels.iree_topk(x, 4)
+        result_values, result_indices = result[0], result[1]
+
+        # Convert indices to match PyTorch's dtype
+        result_indices = result_indices.to(torch.int64)
+
+        # Compare results
+        torch.testing.assert_close(result_values, ref_values)
+        torch.testing.assert_close(result_indices, ref_indices)
+
+    # def test_topk_dynamic_dim(self):
+    #     dtype = torch.float32
+    #     # Test with different last dimension sizes
+    #     for dim in [64, 128, 256]:
+    #         x = torch.rand([8, 1, dim], dtype=dtype)
+
+    #         # Get reference result
+    #         ref_values, ref_indices = torch.topk(x, k=4, dim=-1)
+
+    #         # Get result from our kernel
+    #         result = kernels.apply_topk(x)
+    #         result_values, result_indices = result[0], result[1]
+
+    #         # Convert indices to match PyTorch's dtype
+    #         result_indices = result_indices.to(torch.int64)
+
+    #         # Compare results
+    #         torch.testing.assert_close(
+    #             result_values, ref_values, msg=f"Failed for dim={dim}"
+    #         )
+    #         torch.testing.assert_close(
+    #             result_indices, ref_indices, msg=f"Failed for dim={dim}"
+    #         )

--- a/sharktank/tests/kernels/topk_test.py
+++ b/sharktank/tests/kernels/topk_test.py
@@ -41,26 +41,26 @@ class topk_test(unittest.TestCase):
         torch.testing.assert_close(result_values, ref_values)
         torch.testing.assert_close(result_indices, ref_indices)
 
-    # def test_topk_dynamic_dim(self):
-    #     dtype = torch.float32
-    #     # Test with different last dimension sizes
-    #     for dim in [64, 128, 256]:
-    #         x = torch.rand([8, 1, dim], dtype=dtype)
+    def test_topk_dynamic_dim(self):
+        dtype = torch.float32
+        # Test with different last dimension sizes
+        for dim in [64, 128, 256]:
+            x = torch.rand([8, 1, dim], dtype=dtype)
 
-    #         # Get reference result
-    #         ref_values, ref_indices = torch.topk(x, k=4, dim=-1)
+            # Get reference result
+            ref_values, ref_indices = torch.topk(x, k=4, dim=-1)
 
-    #         # Get result from our kernel
-    #         result = kernels.apply_topk(x)
-    #         result_values, result_indices = result[0], result[1]
+            # Get result from our kernel
+            result = kernels.iree_topk(x, k=4)
+            result_values, result_indices = result[0], result[1]
 
-    #         # Convert indices to match PyTorch's dtype
-    #         result_indices = result_indices.to(torch.int64)
+            # Convert indices to match PyTorch's dtype
+            result_indices = result_indices.to(torch.int64)
 
-    #         # Compare results
-    #         torch.testing.assert_close(
-    #             result_values, ref_values, msg=f"Failed for dim={dim}"
-    #         )
-    #         torch.testing.assert_close(
-    #             result_indices, ref_indices, msg=f"Failed for dim={dim}"
-    #         )
+            # Compare results
+            torch.testing.assert_close(
+                result_values, ref_values, msg=f"Failed for dim={dim}"
+            )
+            torch.testing.assert_close(
+                result_indices, ref_indices, msg=f"Failed for dim={dim}"
+            )

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -452,11 +452,7 @@ class TestTopK(unittest.TestCase):
             (-1, 8, True, True, (1, 1, 256), 16),
             (-1, 4, False, True, (1, 1, 256), 16),
             (-1, 4, False, False, (1, 1, 256), 16),
-            (-1, 4, True, True, (1, 1, 131072), 1024),
             (-1, 2, True, True, (2, 1, 6), 3),
-            (-1, 4, True, True, (1, 32, 131072), 1024),
-            (-1, 4, True, True, (4, 32, 131072), 1024),
-            (-1, 4, True, True, (32, 1, 131072), 1024),
         ]
     )
     def testSplitTopKLastDim(self, dim, k, largest, _sorted, shape, chunk_size):

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -6,6 +6,7 @@
 
 import unittest
 
+import math
 import numpy as np
 import pytest
 import torch
@@ -456,7 +457,11 @@ class TestTopK(unittest.TestCase):
         ]
     )
     def testSplitTopKLastDim(self, dim, k, largest, _sorted, shape, chunk_size):
-        tensor = torch.rand(shape, dtype=torch.float32)
+        numels = math.prod(shape)
+        tensor = torch.arange(numels) * 173 + 129
+        tensor = tensor % numels
+        tensor = tensor.to(torch.float16).view(shape)
+
         values_expected, index_expected = torch.topk(tensor, k, dim, largest, _sorted)
 
         values, index = ops.topk(
@@ -483,16 +488,20 @@ class TestTopK(unittest.TestCase):
 
     @parameterized.expand(
         [
-            (0, 2, True, True, (4, 1, 32), 2),
-            (0, 2, False, True, (4, 1, 32), 2),
-            (0, 2, False, False, (4, 1, 32), 2),
-            (0, 2, True, False, (4, 1, 32), 2),
-            (0, 3, True, True, (6, 2, 64), 3),
-            (0, 4, True, True, (8, 3, 128), 4),
+            (0, 2, True, True, (4, 1, 8), 2),
+            (0, 2, False, True, (4, 1, 8), 2),
+            (0, 2, False, False, (4, 1, 8), 2),
+            (0, 2, True, False, (4, 1, 8), 2),
+            (0, 3, True, True, (6, 2, 12), 3),
+            (0, 4, True, True, (8, 3, 24), 4),
         ]
     )
     def testSplitTopKDim0(self, dim, k, largest, _sorted, shape, chunk_size):
-        tensor = torch.rand(shape, dtype=torch.float16)
+        numels = math.prod(shape)
+        tensor = torch.arange(numels) * 173 + 129
+        tensor = tensor % numels
+        tensor = tensor.to(torch.float16).view(shape)
+
         values_expected, index_expected = torch.topk(tensor, k, dim, largest, _sorted)
 
         values, index = ops.topk(

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -485,46 +485,46 @@ class TestTopK(unittest.TestCase):
 
         torch.testing.assert_close(values_from_indices, values_from_indices_expected)
 
-    # @parameterized.expand(
-    #     [
-    #         (0, 2, True, True, (4, 1, 32), 2),
-    #         (0, 2, False, True, (4, 1, 32), 2),
-    #         (0, 2, False, False, (4, 1, 32), 2),
-    #         (0, 2, True, False, (4, 1, 32), 2),
-    #         (0, 3, True, True, (6, 2, 64), 3),
-    #         (0, 4, True, True, (8, 3, 128), 4),
-    #     ]
-    # )
-    # def testSplitTopKDim0(self, dim, k, largest, _sorted, shape, chunk_size):
-    #     tensor = torch.rand(shape, dtype=torch.float16)
-    #     values_expected, index_expected = torch.topk(tensor, k, dim, largest, _sorted)
+    @parameterized.expand(
+        [
+            (0, 2, True, True, (4, 1, 32), 2),
+            (0, 2, False, True, (4, 1, 32), 2),
+            (0, 2, False, False, (4, 1, 32), 2),
+            (0, 2, True, False, (4, 1, 32), 2),
+            (0, 3, True, True, (6, 2, 64), 3),
+            (0, 4, True, True, (8, 3, 128), 4),
+        ]
+    )
+    def testSplitTopKDim0(self, dim, k, largest, _sorted, shape, chunk_size):
+        tensor = torch.rand(shape, dtype=torch.float16)
+        values_expected, index_expected = torch.topk(tensor, k, dim, largest, _sorted)
 
-    #     values, index = ops.topk(
-    #         tensor, k, dim, largest, _sorted, chunk_size=chunk_size, use_topk_kernel=True
-    #     )
+        values, index = ops.topk(
+            tensor, k, dim, largest, _sorted, chunk_size=chunk_size
+        )
 
-    #     if not _sorted:
-    #         values = torch.sort(values, dim=dim).values
-    #         values_expected = torch.sort(values_expected, dim=dim).values
+        if not _sorted:
+            values = torch.sort(values, dim=dim).values
+            values_expected = torch.sort(values_expected, dim=dim).values
 
-    #     torch.testing.assert_close(values, values_expected)
+        torch.testing.assert_close(values, values_expected)
 
-    #     # Duplicate values may cause differences in indices
-    #     index_slices = [slice(None)] * tensor.ndim
-    #     index_slices[dim] = index[0, 0]
-    #     values_from_indices = tensor[tuple(index_slices)]
+        # Duplicate values may cause differences in indices
+        index_slices = [slice(None)] * tensor.ndim
+        index_slices[dim] = index[0, 0]
+        values_from_indices = tensor[tuple(index_slices)]
 
-    #     index_slices_expected = [slice(None)] * tensor.ndim
-    #     index_slices_expected[dim] = index_expected[0, 0]
-    #     values_from_indices_expected = tensor[tuple(index_slices_expected)]
+        index_slices_expected = [slice(None)] * tensor.ndim
+        index_slices_expected[dim] = index_expected[0, 0]
+        values_from_indices_expected = tensor[tuple(index_slices_expected)]
 
-    #     if not _sorted:
-    #         values_from_indices = torch.sort(values_from_indices, dim=dim).values
-    #         values_from_indices_expected = torch.sort(
-    #             values_from_indices_expected, dim=dim
-    #         ).values
+        if not _sorted:
+            values_from_indices = torch.sort(values_from_indices, dim=dim).values
+            values_from_indices_expected = torch.sort(
+                values_from_indices_expected, dim=dim
+            ).values
 
-    #     torch.testing.assert_close(values_from_indices, values_from_indices_expected)
+        torch.testing.assert_close(values_from_indices, values_from_indices_expected)
 
 
 class TestTraceTensors(TempDirTestBase):

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -460,7 +460,7 @@ class TestTopK(unittest.TestCase):
         ]
     )
     def testSplitTopKLastDim(self, dim, k, largest, _sorted, shape, chunk_size):
-        tensor = torch.rand(shape, dtype=torch.float16)
+        tensor = torch.rand(shape, dtype=torch.float32)
         values_expected, index_expected = torch.topk(tensor, k, dim, largest, _sorted)
 
         values, index = ops.topk(
@@ -472,6 +472,7 @@ class TestTopK(unittest.TestCase):
             values_expected = torch.sort(values_expected).values
 
         torch.testing.assert_close(values, values_expected)
+        index = index.to(torch.int64)
 
         values_from_indices = torch.gather(tensor, -1, index=index)
         values_from_indices_expected = torch.gather(tensor, -1, index=index_expected)
@@ -484,46 +485,46 @@ class TestTopK(unittest.TestCase):
 
         torch.testing.assert_close(values_from_indices, values_from_indices_expected)
 
-    @parameterized.expand(
-        [
-            (0, 2, True, True, (4, 1, 32), 2),
-            (0, 2, False, True, (4, 1, 32), 2),
-            (0, 2, False, False, (4, 1, 32), 2),
-            (0, 2, True, False, (4, 1, 32), 2),
-            (0, 3, True, True, (6, 2, 64), 3),
-            (0, 4, True, True, (8, 3, 128), 4),
-        ]
-    )
-    def testSplitTopKDim0(self, dim, k, largest, _sorted, shape, chunk_size):
-        tensor = torch.rand(shape, dtype=torch.float16)
-        values_expected, index_expected = torch.topk(tensor, k, dim, largest, _sorted)
+    # @parameterized.expand(
+    #     [
+    #         (0, 2, True, True, (4, 1, 32), 2),
+    #         (0, 2, False, True, (4, 1, 32), 2),
+    #         (0, 2, False, False, (4, 1, 32), 2),
+    #         (0, 2, True, False, (4, 1, 32), 2),
+    #         (0, 3, True, True, (6, 2, 64), 3),
+    #         (0, 4, True, True, (8, 3, 128), 4),
+    #     ]
+    # )
+    # def testSplitTopKDim0(self, dim, k, largest, _sorted, shape, chunk_size):
+    #     tensor = torch.rand(shape, dtype=torch.float16)
+    #     values_expected, index_expected = torch.topk(tensor, k, dim, largest, _sorted)
 
-        values, index = ops.topk(
-            tensor, k, dim, largest, _sorted, chunk_size=chunk_size
-        )
+    #     values, index = ops.topk(
+    #         tensor, k, dim, largest, _sorted, chunk_size=chunk_size, use_topk_kernel=True
+    #     )
 
-        if not _sorted:
-            values = torch.sort(values, dim=dim).values
-            values_expected = torch.sort(values_expected, dim=dim).values
+    #     if not _sorted:
+    #         values = torch.sort(values, dim=dim).values
+    #         values_expected = torch.sort(values_expected, dim=dim).values
 
-        torch.testing.assert_close(values, values_expected)
+    #     torch.testing.assert_close(values, values_expected)
 
-        # Duplicate values may cause differences in indices
-        index_slices = [slice(None)] * tensor.ndim
-        index_slices[dim] = index[0, 0]
-        values_from_indices = tensor[tuple(index_slices)]
+    #     # Duplicate values may cause differences in indices
+    #     index_slices = [slice(None)] * tensor.ndim
+    #     index_slices[dim] = index[0, 0]
+    #     values_from_indices = tensor[tuple(index_slices)]
 
-        index_slices_expected = [slice(None)] * tensor.ndim
-        index_slices_expected[dim] = index_expected[0, 0]
-        values_from_indices_expected = tensor[tuple(index_slices_expected)]
+    #     index_slices_expected = [slice(None)] * tensor.ndim
+    #     index_slices_expected[dim] = index_expected[0, 0]
+    #     values_from_indices_expected = tensor[tuple(index_slices_expected)]
 
-        if not _sorted:
-            values_from_indices = torch.sort(values_from_indices, dim=dim).values
-            values_from_indices_expected = torch.sort(
-                values_from_indices_expected, dim=dim
-            ).values
+    #     if not _sorted:
+    #         values_from_indices = torch.sort(values_from_indices, dim=dim).values
+    #         values_from_indices_expected = torch.sort(
+    #             values_from_indices_expected, dim=dim
+    #         ).values
 
-        torch.testing.assert_close(values_from_indices, values_from_indices_expected)
+    #     torch.testing.assert_close(values_from_indices, values_from_indices_expected)
 
 
 class TestTraceTensors(TempDirTestBase):


### PR DESCRIPTION
For greater topk we can directly emit a `iree_linalg_ext.topk` operator then rely on codegen for generating the kernel. This avoids having torch accidentally emit `torch.sort` and `torch.slice`.