### PR TITLE
Change perplexity logit padding to align logits with tokens

### DIFF
--- a/sharktank/sharktank/evaluate/perplexity_iree.py
+++ b/sharktank/sharktank/evaluate/perplexity_iree.py
@@ -420,13 +420,22 @@ class PerplexityIree:
                     out_logits.append(decode_logits)
 
             out_logits = ops.cat(out_logits, dim=1)
+
             pad_logits_shape = self.token_ids.shape[1] - out_logits.shape[1]
+
             pad_logits = torch.zeros(
                 out_logits.shape[0], pad_logits_shape, out_logits.shape[2]
             )
 
             self.cache_state = None  # Remove saved reference to iree.runtime.DeviceArray before leaving function
-            return ops.cat((out_logits, pad_logits), 1).to(self.torch_device)
+            return ops.cat(
+                (
+                    pad_logits[:, : self.start + 1],
+                    out_logits,
+                    pad_logits[:, self.start + 1 :],
+                ),
+                dim=1,
+            ).to(self.device)
 
         return with_iree_device_context(run_iree_module, devices)
 

--- a/sharktank/sharktank/evaluate/perplexity_iree.py
+++ b/sharktank/sharktank/evaluate/perplexity_iree.py
@@ -435,7 +435,7 @@ class PerplexityIree:
                     pad_logits[:, self.start + 1 :],
                 ),
                 dim=1,
-            ).to(self.device)
+            ).to(self.torch_device)
 
         return with_iree_device_context(run_iree_module, devices)
 

--- a/sharktank/sharktank/evaluate/perplexity_torch.py
+++ b/sharktank/sharktank/evaluate/perplexity_torch.py
@@ -239,9 +239,14 @@ class PerplexityTorch:
             device=self.device,
         )
 
-        out_logits = ops.cat((out_logits, pad_logits), dim=1).to(self.device)
-
-        return out_logits
+        return ops.cat(
+            (
+                pad_logits[:, : self.start + 1],
+                out_logits,
+                pad_logits[:, self.start + 1 :],
+            ),
+            dim=1,
+        ).to(self.device)
 
     @timeit
     def get_perplexity(

--- a/sharktank/sharktank/utils/evaluate.py
+++ b/sharktank/sharktank/utils/evaluate.py
@@ -30,7 +30,7 @@ def compute_perplexity(
 
     attention_mask = (token_ids != 0).int().detach().clone().to(token_ids.device)
 
-    logits = logits[..., : -(start + 1), :].contiguous()
+    logits = logits[..., start + 1 :, :].contiguous()
     token_ids = token_ids[..., start + 1 :].contiguous()
     attention_mask = attention_mask[..., start + 1 :].contiguous()
 


### PR DESCRIPTION
Logits need to be padded to keep them the same length as token_ids since we don't start with token_ids[:, 0], we instead prefil will a range of tokens to give better context to the model.

Previously the logits were right padded based on the difference between in length between their size and that of token_ids. This causes token_ids[:, i] and logits[:, i] to no longer line up requiring special indexing further down.

This PR cleans up that padding approach to make the indexing consistent.