### PR TITLE
Rework kernels to include per indices mapping

### DIFF
--- a/sharktank/hip_kernels/CMakeLists.txt
+++ b/sharktank/hip_kernels/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.13)
 project(HIP_KERNELS LANGUAGES C CXX)
 
 # Set ROCm and IREE build paths
-set(IREE_BUILD_DIR $ENV{IREE_BUILD_DIR})
 set(ROCM_PATH /opt/rocm)
 
+set(IREE_BUILD_DIR OFF CACHE STRING "iree build directory")
 set(TARGET_ARCH "gfx942" CACHE STRING "Target architecture for ROCM GPU")
 
 # Find all kernel source files in the kernels subdirectory

--- a/sharktank/hip_kernels/specs/topk_f16_spec.mlir
+++ b/sharktank/hip_kernels/specs/topk_f16_spec.mlir
@@ -9,18 +9,23 @@
 #rocm_target = #hal.executable.target<"rocm", "rocm-hsaco-fb", {target_arch = "{{HIP_ARCH}}", ukernels = "none"}>
 
 module attributes {transform.with_named_sequence} {
-  util.func private @topk_3d_f16_entry_point(%arg0: tensor<?x?xf16>) -> (tensor<?x8xf16>, tensor<?x8xi32>) {
+  util.func private @topk_3d_f16_entry_point(%arg0: tensor<?x?xf16>, %arg1: tensor<?x?xi32>) -> (tensor<?x8xf16>, tensor<?x8xi32>) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %dim0 = tensor.dim %arg0, %c0 : tensor<?x?xf16>
     %dim1 = tensor.dim %arg0, %c1 : tensor<?x?xf16>
+
+    %dim2 = tensor.dim %arg1, %c0 : tensor<?x?xi32>
+    %dim3 = tensor.dim %arg1, %c1 : tensor<?x?xi32>
+
     %dim1_i32 = arith.index_cast %dim1 : index to i32
-    %4:2 = hal.dispatch.extern "topk_F16I32"[%dim0](%dim1_i32, %arg0) : (i32, tensor<?x?xf16>{%dim0, %dim1}) -> tensor<?x8xf16>{%dim0}, tensor<?x8xi32>{%dim0}
+    %4:2 = hal.dispatch.extern "topk_F16I32"[%dim0](%dim1_i32, %arg0, %arg1) : (i32, tensor<?x?xf16>{%dim0, %dim1}, tensor<?x?xi32>{%dim2, %dim3}) -> tensor<?x8xf16>{%dim0}, tensor<?x8xi32>{%dim0}
       count(%device: !hal.device, %batchSize: index) -> (index, index, index) {
         %c1_0 = arith.constant 1 : index
         hal.return %batchSize, %c1_0, %c1_0 : index, index, index
       }
       layout(#hal.pipeline.layout<constants = 1, bindings = [
+        #hal.pipeline.binding<storage_buffer, ReadOnly>,
         #hal.pipeline.binding<storage_buffer, ReadOnly>,
         #hal.pipeline.binding<storage_buffer>,
         #hal.pipeline.binding<storage_buffer>
@@ -41,6 +46,9 @@ module attributes {transform.with_named_sequence} {
     %in0 = transform.get_operand %linalg[0] : (!transform.any_op) -> !transform.any_value
     transform.iree.match.cast_compatible_type %in0 = tensor<?x?xf16> : !transform.any_value
     transform.iree.match.dim_is_multiple_of %in0[1], 64 : !transform.any_value
+    %in1 = transform.get_operand %linalg[1] : (!transform.any_op) -> !transform.any_value
+    transform.iree.match.cast_compatible_type %in0 = tensor<?x?xi32> : !transform.any_value
+    transform.iree.match.dim_is_multiple_of %in1[1], 64 : !transform.any_value
     %out0 = transform.get_operand %linalg[2] : (!transform.any_op) -> !transform.any_value
     transform.iree.match.cast_compatible_type %out0 = tensor<?x8xf16> : !transform.any_value
     %out1 = transform.get_operand %linalg[3] : (!transform.any_op) -> !transform.any_value
@@ -51,7 +59,7 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @cast_and_call_topk(%topk: !transform.any_op {transform.readonly}) {
     %module = transform.util.get_nearest_symbol_table %topk : (!transform.any_op) -> !transform.any_op
     %func = transform.util.import_symbol @topk_3d_f16_entry_point into %module if undefined : (!transform.any_op) -> !transform.any_op
-    %ins = transform.get_operand %topk[0] : (!transform.any_op) -> !transform.any_value
+    %ins = transform.get_operand %topk[all] : (!transform.any_op) -> !transform.any_value
     %outs = transform.get_result %topk[all] : (!transform.any_op) -> !transform.any_value
     transform.util.cast_and_call %func(%ins) -> %outs before %topk {
       transform.type_conversion.tensor.cast_shape_dynamic_dims

--- a/sharktank/hip_kernels/specs/topk_f32_spec.mlir
+++ b/sharktank/hip_kernels/specs/topk_f32_spec.mlir
@@ -9,18 +9,23 @@
 #rocm_target = #hal.executable.target<"rocm", "rocm-hsaco-fb", {target_arch = "{{HIP_ARCH}}", ukernels = "none"}>
 
 module attributes {transform.with_named_sequence} {
-  util.func private @topk_3d_f32_entry_point(%arg0: tensor<?x?xf32>) -> (tensor<?x8xf32>, tensor<?x8xi32>) {
+  util.func private @topk_3d_f32_entry_point(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32>) -> (tensor<?x8xf32>, tensor<?x8xi32>) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %dim0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
     %dim1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
+
+    %dim2 = tensor.dim %arg1, %c0 : tensor<?x?xi32>
+    %dim3 = tensor.dim %arg1, %c1 : tensor<?x?xi32>
+
     %dim1_i32 = arith.index_cast %dim1 : index to i32
-    %4:2 = hal.dispatch.extern "topk_F32I32"[%dim0](%dim1_i32, %arg0) : (i32, tensor<?x?xf32>{%dim0, %dim1}) -> tensor<?x8xf32>{%dim0}, tensor<?x8xi32>{%dim0}
+    %4:2 = hal.dispatch.extern "topk_F32I32"[%dim0](%dim1_i32, %arg0, %arg1) : (i32, tensor<?x?xf32>{%dim0, %dim1}, tensor<?x?xi32>{%dim2, %dim3}) -> tensor<?x8xf32>{%dim0}, tensor<?x8xi32>{%dim0}
       count(%device: !hal.device, %batchSize: index) -> (index, index, index) {
         %c1_0 = arith.constant 1 : index
         hal.return %batchSize, %c1_0, %c1_0 : index, index, index
       }
       layout(#hal.pipeline.layout<constants = 1, bindings = [
+        #hal.pipeline.binding<storage_buffer, ReadOnly>,
         #hal.pipeline.binding<storage_buffer, ReadOnly>,
         #hal.pipeline.binding<storage_buffer>,
         #hal.pipeline.binding<storage_buffer>
@@ -41,6 +46,9 @@ module attributes {transform.with_named_sequence} {
     %in0 = transform.get_operand %linalg[0] : (!transform.any_op) -> !transform.any_value
     transform.iree.match.cast_compatible_type %in0 = tensor<?x?xf32> : !transform.any_value
     transform.iree.match.dim_is_multiple_of %in0[1], 64 : !transform.any_value
+    %in1 = transform.get_operand %linalg[1] : (!transform.any_op) -> !transform.any_value
+    transform.iree.match.cast_compatible_type %in0 = tensor<?x?xi32> : !transform.any_value
+    transform.iree.match.dim_is_multiple_of %in1[1], 64 : !transform.any_value
     %out0 = transform.get_operand %linalg[2] : (!transform.any_op) -> !transform.any_value
     transform.iree.match.cast_compatible_type %out0 = tensor<?x8xf32> : !transform.any_value
     %out1 = transform.get_operand %linalg[3] : (!transform.any_op) -> !transform.any_value
@@ -51,7 +59,7 @@ module attributes {transform.with_named_sequence} {
   transform.named_sequence @cast_and_call_topk(%topk: !transform.any_op {transform.readonly}) {
     %module = transform.util.get_nearest_symbol_table %topk : (!transform.any_op) -> !transform.any_op
     %func = transform.util.import_symbol @topk_3d_f32_entry_point into %module if undefined : (!transform.any_op) -> !transform.any_op
-    %ins = transform.get_operand %topk[0] : (!transform.any_op) -> !transform.any_value
+    %ins = transform.get_operand %topk[all] : (!transform.any_op) -> !transform.any_value
     %outs = transform.get_result %topk[all] : (!transform.any_op) -> !transform.any_value
     transform.util.cast_and_call %func(%ins) -> %outs before %topk {
       transform.type_conversion.tensor.cast_shape_dynamic_dims

--- a/sharktank/hip_kernels/tests/topk_f16.cpp
+++ b/sharktank/hip_kernels/tests/topk_f16.cpp
@@ -17,13 +17,23 @@ constexpr int ARGMAX_LABEL = 7; // Will still be top-1 here
 constexpr int k = 8;
 
 template <typename DataT>
-static inline void fillIndex(DataT *mat, uint32_t m, uint32_t n, int k) {
+static inline void fillValues(DataT *mat, uint32_t m, uint32_t n, int k) {
   for (int i = 0; i < m; ++i) {
     for (int j = 0; j < n; j++) {
       // Fill top-K largest values at known locations
       mat[i * n + j] = (j >= ARGMAX_LABEL && j < ARGMAX_LABEL + k)
                            ? static_cast<DataT>(250.0 - (j - ARGMAX_LABEL))
                            : static_cast<DataT>(0.0);
+    }
+  }
+}
+
+template <typename DataT>
+static inline void fillIndices(DataT *mat, uint32_t m, uint32_t n, int k) {
+  for (int i = 0; i < m; ++i) {
+    for (int j = 0; j < n; j++) {
+      // Fill top-K largest values at known locations
+      mat[i * n + j] = j;
     }
   }
 }
@@ -47,26 +57,33 @@ std::vector<char> readFileIntoVector(const std::string &filename) {
 void benchmark_module(size_t reductionSize) {
   int batchSize = 1;
 
-  std::vector<INPUT_TY> inputBuffer(batchSize * reductionSize);
-  std::vector<OUTPUT_TY> outputIndices(k);
-  std::vector<INPUT_TY> outputValues(k);
+  std::vector<INPUT_TY> inputValues(batchSize * reductionSize);
+  std::vector<OUTPUT_TY> inputIndices(batchSize * reductionSize);
+  std::vector<OUTPUT_TY> outputIndices(batchSize * k);
+  std::vector<INPUT_TY> outputValues(batchSize * k);
 
-  fillIndex(inputBuffer.data(), batchSize, reductionSize, k);
+  fillValues(inputValues.data(), batchSize, reductionSize, k);
+  fillIndices(inputIndices.data(), batchSize, reductionSize, k);
 
   std::cout << "Initializing device data..." << std::endl;
   INPUT_TY *d_input;
+  OUTPUT_TY *d_indices;
   OUTPUT_TY *d_outputIndices;
   INPUT_TY *d_outputValues;
 
-  size_t bytesInput = inputBuffer.size() * sizeof(INPUT_TY);
+  size_t bytesInput = inputValues.size() * sizeof(INPUT_TY);
+  size_t bytesIdx = inputIndices.size() * sizeof(OUTPUT_TY);
   size_t bytesOutIdx = outputIndices.size() * sizeof(OUTPUT_TY);
   size_t bytesOutVal = outputValues.size() * sizeof(INPUT_TY);
 
   CHECK_HIP_ERROR(hipMalloc(&d_input, bytesInput));
+  CHECK_HIP_ERROR(hipMalloc(&d_indices, bytesIdx));
   CHECK_HIP_ERROR(hipMalloc(&d_outputIndices, bytesOutIdx));
   CHECK_HIP_ERROR(hipMalloc(&d_outputValues, bytesOutVal));
 
-  CHECK_HIP_ERROR(hipMemcpy(d_input, inputBuffer.data(), bytesInput,
+  CHECK_HIP_ERROR(hipMemcpy(d_input, inputValues.data(), bytesInput,
+                            hipMemcpyHostToDevice));
+  CHECK_HIP_ERROR(hipMemcpy(d_indices, inputIndices.data(), bytesIdx,
                             hipMemcpyHostToDevice));
 
   hipModule_t module;
@@ -97,10 +114,11 @@ void benchmark_module(size_t reductionSize) {
   }
 
   *((hipDeviceptr_t *)kernelParam[0]) = d_input;
-  *((hipDeviceptr_t *)kernelParam[1]) = d_outputValues;
-  *((hipDeviceptr_t *)kernelParam[2]) = d_outputIndices;
-  *((uint32_t *)kernelParam[3]) = static_cast<uint32_t>(reductionSize);
-  *((uint32_t *)kernelParam[4]) = static_cast<uint32_t>(k);
+  *((hipDeviceptr_t *)kernelParam[1]) = d_indices;
+  *((hipDeviceptr_t *)kernelParam[2]) = d_outputValues;
+  *((hipDeviceptr_t *)kernelParam[3]) = d_outputIndices;
+  *((uint32_t *)kernelParam[4]) = static_cast<uint32_t>(reductionSize);
+  *((uint32_t *)kernelParam[5]) = static_cast<uint32_t>(k);
 
   // Launch
   std::cout << "Launching Topk kernel..." << std::endl;

--- a/sharktank/sharktank/kernels/templates/topk_dynamic.mlir
+++ b/sharktank/sharktank/kernels/templates/topk_dynamic.mlir
@@ -6,11 +6,11 @@
 
 !input_tensor_type = tensor<?x?x{{dtype}}>
 !indices_tensor_type = tensor<?x?xi32>
-!values_tensor_type = tensor<?x{{k}}x{{dtype}}>
+!values_out_tensor_type = tensor<?x{{k}}x{{dtype}}>
 !indices_out_tensor_type = tensor<?x{{k}}xi32>
 
 module {
-  util.func private @sharktank_topk_{{k}}_{{dtype}}(%arg0: !input_tensor_type) -> (!values_tensor_type, !indices_out_tensor_type) {
+  util.func private @sharktank_topk_{{k}}_{{dtype}}(%arg0: !input_tensor_type, %arg0_0: !indices_tensor_type) -> (!values_out_tensor_type, !indices_out_tensor_type) {
     %c0_i32 = arith.constant 0 : i32
     %cst = arith.constant -3.402820e+38 : {{dtype}}  // Minimum float32 value
 
@@ -21,23 +21,17 @@ module {
 
     %dim0 = tensor.dim %arg0, %c0 : !input_tensor_type
     %dim1 = tensor.dim %arg0, %c1 : !input_tensor_type
-    %0 = tensor.empty(%dim0, %dim1) : !indices_tensor_type
-    %1 = tensor.empty(%dim0) : !values_tensor_type
+    %1 = tensor.empty(%dim0) : !values_out_tensor_type
     %2 = tensor.empty(%dim0) : !indices_out_tensor_type
-    %3 = linalg.fill ins(%cst : {{dtype}}) outs(%1 : !values_tensor_type) -> !values_tensor_type
+    %3 = linalg.fill ins(%cst : {{dtype}}) outs(%1 : !values_out_tensor_type) -> !values_out_tensor_type
     %4 = linalg.fill ins(%c0_i32 : i32) outs(%2 : !indices_out_tensor_type) -> !indices_out_tensor_type
-    %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} outs(%0 : !indices_tensor_type) {
-    ^bb0(%out: i32):
-      %7 = linalg.index 1 : index
-      %8 = arith.index_cast %7 : index to i32
-      linalg.yield %8 : i32
-    } -> !indices_tensor_type
-    %6:2 = iree_linalg_ext.topk dimension(1) ins(%arg0, %5 : !input_tensor_type, !indices_tensor_type) outs(%3, %4 : !values_tensor_type, !indices_out_tensor_type) {
+
+    %6:2 = iree_linalg_ext.topk dimension(1) ins(%arg0, %arg0_0 : !input_tensor_type, !indices_tensor_type) outs(%3, %4 : !values_out_tensor_type, !indices_out_tensor_type) {
     ^bb0(%arg1: {{dtype}}, %arg2: {{dtype}}):
       // Sort in descending order like PyTorch
       %7 = arith.cmpf ogt, %arg1, %arg2 : {{dtype}}
       iree_linalg_ext.yield %7 : i1
-    } -> !values_tensor_type, !indices_out_tensor_type
-    util.return %6#0, %6#1 : !values_tensor_type, !indices_out_tensor_type
+    } -> !values_out_tensor_type, !indices_out_tensor_type
+    util.return %6#0, %6#1 : !values_out_tensor_type, !indices_out_tensor_type
   }
 }

--- a/sharktank/sharktank/kernels/topk.py
+++ b/sharktank/sharktank/kernels/topk.py
@@ -15,11 +15,12 @@ __all__ = [
 @CustomOp.register(library=LIBRARY)
 class iree_topk(CustomOp):
 
-    signature = "iree_topk(Tensor input, int k) -> (Tensor values, Tensor indices)"
+    signature = "iree_topk(Tensor input, Tensor indices, int k) -> (Tensor values, Tensor indices)"
 
     def select(self, ksel: KernelSelection):
         inputs_desc = ksel.arg_tensor(0)
-        k = ksel.attr_int(1).v
+        indices_desc = ksel.arg_tensor(1)
+        k = ksel.attr_int(2).v
         values_desc = ksel.return_new_tensor(
             [inputs_desc.t.shape[0], k],
             dtype=inputs_desc.t.dtype,
@@ -27,12 +28,10 @@ class iree_topk(CustomOp):
         indices_desc = ksel.return_new_tensor(
             [inputs_desc.t.shape[0], k], dtype=torch.int32
         )
-        # specialize_all_known_dims(inputs_desc)
-        # specialize_all_known_dims(values_desc)
-        # specialize_all_known_dims(indices_desc)
 
     def generate(self, ksel: KernelSelection, kb: KernelBuilder):
         input = kb.arg_value(0)
+        indices = kb.arg_value(1)
 
         result_desc = ksel.result_descs[0]
         result_shape = result_desc.t.shape
@@ -42,13 +41,13 @@ class iree_topk(CustomOp):
         input_asm_type, input_ident, input_dtype = unpack_tensor_type(input.type)
 
         # Generate specialization signature and types.
-        template_file = "topk_dynamic.mlir"
+        template_file =  "topk_dynamic.mlir"
         target_function_name = f"sharktank_topk_{k}_{input_dtype}"
 
         # Template params
         input_tensor_type = input_asm_type
         indices_tensor_type = f"tensor<?x?xi32>"
-        values_tensor_type = f"tensor<?x{k}x{input_dtype}>"
+        values_out_tensor_type = f"tensor<?x{k}x{input_dtype}>"
         indices_out_tensor_type = f"tensor<?x{k}xi32>"
 
         target_function = inline_template_function(
@@ -57,7 +56,7 @@ class iree_topk(CustomOp):
             target_function_name,
             input_tensor_type=input_tensor_type,
             indices_tensor_type=indices_tensor_type,
-            values_tensor_type=values_tensor_type,
+            values_out_tensor_type=values_out_tensor_type,
             indices_out_tensor_type=indices_out_tensor_type,
             k=k,
             dtype=str(input_dtype),

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -731,23 +731,40 @@ def topk_default(
     chunk_size: Optional[int] = None,
     use_linalgext_topk: bool = False,
 ) -> tuple[Tensor, Tensor]:
-    if chunk_size is not None:
-        return _split_topk(
-            tensor, k, dim, largest, sorted, chunk_size, use_linalgext_topk
-        )
 
     if use_linalgext_topk:
         assert largest
         assert not sorted
-        assert dim == len(tensor.shape) - 1
+        assert dim == len(tensor.shape) - 1 or dim == -1
         bs_shape = tensor.shape[:-1]
-        tensor = tensor.flatten(0, -2)
 
-        values, indices = iree_topk(unbox_tensor(tensor), k=k)
+        tensor = unbox_tensor(tensor.flatten(0, -2))
+        flat_bs = tensor.shape[0]
+
+        indices = torch.arange(tensor.shape[1], dtype=torch.int32)[None, :].repeat(tensor.shape[0], 1)
+
+        if chunk_size:
+            tensor = tensor.unflatten(dim, (chunk_size, tensor.shape[-1] // chunk_size))
+            tensor = tensor.flatten(0, 1)
+            indices = indices.unflatten(dim, (chunk_size, indices.shape[-1] // chunk_size))
+            indices = indices.flatten(0, 1)
+
+
+        values, indices = iree_topk(tensor, indices, k=k)
+
+        if chunk_size:
+            values = values.unflatten(0, (flat_bs, chunk_size)).flatten(1)
+            indices = indices.unflatten(0, (flat_bs, chunk_size)).flatten(1)
+            values, indices = iree_topk(values, indices, k=k)
 
         values = unflatten(values, 0, bs_shape)
         indices = unflatten(indices, 0, bs_shape)
         return values, indices.to(torch.int64)
+
+    if chunk_size is not None:
+        return _split_topk(
+            tensor, k, dim, largest, sorted, chunk_size, use_linalgext_topk
+        )
 
     result = torch.topk(
         unbox_tensor(tensor), k=k, dim=dim, largest=largest, sorted=sorted

--- a/sharktank/tests/kernels/topk_test.py
+++ b/sharktank/tests/kernels/topk_test.py
@@ -31,7 +31,8 @@ class topk_test(unittest.TestCase):
         ref_values, ref_indices = torch.topk(x, k=4, dim=-1)
 
         # Get result from our kernel
-        result = kernels.iree_topk(x, 4)
+        y = torch.arange(10)[None, :].repeat(8, 1).to(torch.int32)
+        result = kernels.iree_topk(x, indices=y, k=4)
         result_values, result_indices = result[0], result[1]
 
         # Convert indices to match PyTorch's dtype
@@ -51,7 +52,8 @@ class topk_test(unittest.TestCase):
             ref_values, ref_indices = torch.topk(x, k=4, dim=-1)
 
             # Get result from our kernel
-            result = kernels.iree_topk(x, k=4)
+            y = torch.arange(dim)[None, :].repeat(8, 1).to(torch.int32)
+            result = kernels.iree_topk(x, indices=y, k=4)
             result_values, result_indices = result[0], result[1]
 
             # Convert indices to match PyTorch's dtype

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -448,15 +448,16 @@ class TestScatterAdd(unittest.TestCase):
 class TestTopK(unittest.TestCase):
     @parameterized.expand(
         [
-            (-1, 4, True, True, (1, 1, 256), 16),
-            (-1, 4, True, True, (1, 1, 256), 8),
-            (-1, 8, True, True, (1, 1, 256), 16),
-            (-1, 4, False, True, (1, 1, 256), 16),
-            (-1, 4, False, False, (1, 1, 256), 16),
-            (-1, 2, True, True, (2, 1, 6), 3),
+            (-1, 4, True, True, (1, 1, 256), 16, False),
+            (-1, 4, True, True, (1, 1, 256), 8 , False),
+            (-1, 8, True, True, (1, 1, 256), 16, False),
+            (-1, 4, False, True, (1, 1, 256), 16, False),
+            (-1, 4, False, False, (1, 1, 256), 16, False),
+            (-1, 2, True, True, (2, 1, 6), 3, False),
+            (-1, 4, True, False, (1, 1, 64), 8, True),
         ]
     )
-    def testSplitTopKLastDim(self, dim, k, largest, _sorted, shape, chunk_size):
+    def testSplitTopKLastDim(self, dim, k, largest, _sorted, shape, chunk_size, use_linalgext_topk):
         numels = math.prod(shape)
         tensor = torch.arange(numels) * 173 + 129
         tensor = tensor % numels
@@ -465,7 +466,7 @@ class TestTopK(unittest.TestCase):
         values_expected, index_expected = torch.topk(tensor, k, dim, largest, _sorted)
 
         values, index = ops.topk(
-            tensor, k, dim, largest, _sorted, chunk_size=chunk_size
+            tensor, k, dim, largest, _sorted, chunk_size=chunk_size, use_linalgext_topk=use_linalgext_topk
         )
 
         if _sorted is False:


### PR DESCRIPTION
`linalg_ext.scatter` provides its input indices. Having the inputs invoke in a chained fashion optimizes back-to-back top-ks for split-k.