### PR TITLE
Revert "Update transformers version to 4.52.4"

### DIFF
--- a/sharktank/requirements.txt
+++ b/sharktank/requirements.txt
@@ -7,7 +7,7 @@ numpy
 
 # Model deps.
 huggingface-hub
-transformers==4.52.4
+transformers==4.50.0
 datasets
 einops
 


### PR DESCRIPTION
Reverts nod-ai/shark-ai#1581

Originally added for a toy tests that have not been merged yet, but it causes issues with several issues (e.g. nightly T5 test) since we are on torch 2.5.1. 

We should bump this back, and update torch, after our next release.