### PR TITLE
[tuner] build td spec using config list

### DIFF
--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -85,8 +85,11 @@ class ContractionOpInterfaceTuner(
     ) -> ir.Module:
         contraction_op = self.get_root_op()
         func_name = self.get_root_op_func_name()
+
+        # Wrap the single CompilationInfoAttr in a list of (str, Attribute).
+        config_list = [("compilation_info", compilation_info)]
         return spec_builder.build_td_spec(
-            contraction_op.context, contraction_op, compilation_info, func_name
+            contraction_op.context, contraction_op, config_list, func_name
         )
 
 
@@ -107,8 +110,11 @@ class ConvolutionOpInterfaceTuner(
     ) -> ir.Module:
         conv_op = self.get_root_op()
         func_name = self.get_root_op_func_name()
+
+        # Wrap the single CompilationInfoAttr in a list of (str, Attribute).
+        config_list = [("compilation_info", compilation_info)]
         return spec_builder.build_td_spec(
-            conv_op.context, conv_op, compilation_info, func_name
+            conv_op.context, conv_op, config_list, func_name
         )
 
 

--- a/sharktuner/sharktuner/spec_builder.py
+++ b/sharktuner/sharktuner/spec_builder.py
@@ -35,7 +35,7 @@ def get_placeholder_spec(context: ir.Context) -> ir.Module:
 def build_td_spec(
     context: ir.Context,
     op: ir.Operation,
-    compilation_info: iree_codegen.CompilationInfoAttr,
+    config_list: list[tuple[str, ir.Attribute]],
     func_name: str,
 ) -> ir.Module:
     bbargs = []
@@ -76,35 +76,50 @@ def build_td_spec(
         bbargs.append(f"{ssa_name}: {operand_type}")
         captured_values.add(operand)
     bbargs_str = ", ".join(bbargs)
+
+    config_lines = []
+    yield_vars = []
+    for i, (key, attr) in enumerate(config_list):
+        config_var = f"%{key}_{i}"
+        config_lines.append(
+            f"{config_var} = transform.param.constant {attr} -> !transform.any_param"
+        )
+        yield_vars.append(config_var)
+    config_block = "\n                ".join(config_lines)
+    yield_list = ", ".join(["%cont"] + yield_vars)
+    yield_types = ", ".join(
+        ["!transform.any_op"] + ["!transform.any_param"] * len(yield_vars)
+    )
+
     spec_text = f"""
-        module attributes {{ transform.with_named_sequence, iree_codegen.tuning_spec_with_default_entrypoint }} {{
-            // Annotation Transform
-            transform.named_sequence @apply_op_config(%op: !transform.any_op {{transform.readonly}},
-                                                        %config: !transform.any_param {{transform.readonly}}) {{
-                transform.annotate %op "compilation_info" = %config : !transform.any_op, !transform.any_param
-                transform.yield
-            }}
-
-            // Custom Op Matcher
-            transform.named_sequence @{func_name}(%cont: !transform.any_op {{transform.readonly}})
-                -> (!transform.any_op, !transform.any_param) {{
-                %ins, %outs = transform.iree.match.cast_compatible_dag_from_root %cont {{
-                ^bb0({bbargs_str}):
-                {root_operation}
-                }} : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
-                %config = transform.param.constant {compilation_info} -> !transform.any_param
-                transform.yield %cont, %config : !transform.any_op, !transform.any_param
-            }}
-
-            // Entry Point
-            transform.named_sequence
-            @__kernel_config(%variant_op: !transform.any_op {{transform.consumed}}) -> !transform.any_op
-                attributes {{ iree_codegen.tuning_spec_entrypoint }} {{
-                %res = transform.foreach_match in %variant_op
-                    @{func_name} -> @apply_op_config
-                : (!transform.any_op) -> !transform.any_op
-                transform.yield %res : !transform.any_op
-            }}
+    module attributes {{ transform.with_named_sequence, iree_codegen.tuning_spec_with_default_entrypoint }} {{
+        // Annotation Transform
+        transform.named_sequence @apply_op_config(%op: !transform.any_op {{transform.readonly}},
+                                                    {", ".join(f"%cfg_{i}: !transform.any_param {{transform.readonly}}" for i in range(len(config_list)))}) {{
+{"".join([f"                transform.annotate %op \"{key}\" = %cfg_{i} : !transform.any_op, !transform.any_param\n" for i, (key, _) in enumerate(config_list)])}
+            transform.yield
         }}
-        """
+
+        // Custom Op Matcher
+        transform.named_sequence @{func_name}(%cont: !transform.any_op {{transform.readonly}})
+            -> ({yield_types}) {{
+            %ins, %outs = transform.iree.match.cast_compatible_dag_from_root %cont {{
+            ^bb0({bbargs_str}):
+            {root_operation}
+            }} : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
+            {config_block}
+            transform.yield {yield_list} : {yield_types}
+        }}
+
+        // Entry Point
+        transform.named_sequence
+        @__kernel_config(%variant_op: !transform.any_op {{transform.consumed}}) -> !transform.any_op
+            attributes {{ iree_codegen.tuning_spec_entrypoint }} {{
+            %res = transform.foreach_match in %variant_op
+                @{func_name} -> @apply_op_config
+            : (!transform.any_op) -> !transform.any_op
+            transform.yield %res : !transform.any_op
+        }}
+    }}
+    """
     return ir.Module.parse(spec_text, context)


### PR DESCRIPTION
This PR is the first step toward supporting attention in the tuner.

- Generalizes build_td_spec to accept a config_list argument, allowing multiple configuration attributes to be applied.
Example usage for attention tuning:
```
config_list = [
    ("compilation_info", compilation_info_attr),
    ("decomposition_config", decomposition_config_attr),
] 
```
- For existing contraction/conv ops, the function remains compatible:

```
config_list = [("compilation_info", compilation_info_attr)]
```