### PR TITLE
[shortfin][LLM] Optimize d2h transfers and tune strobe delays

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/batcher.py
+++ b/shortfin/python/shortfin_apps/llm/components/batcher.py
@@ -31,6 +31,7 @@ from .service_debug_dumper import SERVICE_DEBUG_DUMPER
 
 logger = logging.getLogger(__name__)
 
+STROBE_DELAY_COEFF = 4
 
 ########################################################################################
 # Batcher
@@ -42,8 +43,8 @@ import math
 class LlmBatcherProcess(BatcherProcess):
     """This batcher provides a high-level mechanism for dispatching LLM tasks."""
 
-    STROBE_SHORT_DELAY = 0.065
-    STROBE_LONG_DELAY = 0.065
+    STROBE_SHORT_DELAY = 0.065 // STROBE_DELAY_COEFF
+    STROBE_LONG_DELAY = 0.065 * STROBE_DELAY_COEFF
 
     def __init__(
         self,
@@ -158,8 +159,8 @@ class PrefillBatcherProcess(LlmBatcherProcess):
     committed cache state).
     """
 
-    STROBE_SHORT_DELAY = 0.065
-    STROBE_LONG_DELAY = 0.065
+    STROBE_SHORT_DELAY = 0.065 // STROBE_DELAY_COEFF
+    STROBE_LONG_DELAY = 0.065 * STROBE_DELAY_COEFF
 
     def __init__(
         self,
@@ -214,8 +215,8 @@ class DecodeBatcherProcess(LlmBatcherProcess):
     committed cache state).
     """
 
-    STROBE_SHORT_DELAY = 0.0006
-    STROBE_LONG_DELAY = 0.0006
+    STROBE_SHORT_DELAY = 0.0006 // STROBE_DELAY_COEFF
+    STROBE_LONG_DELAY = 0.0006 * STROBE_DELAY_COEFF
 
     def __init__(
         self,
@@ -302,6 +303,7 @@ class LlmExecutorProcess(sf.Process):
             return buffers
 
         new_buffers = []
+        await device0
         for buffer in buffers:
             if buffer is None:
                 new_buffers.append(None)
@@ -311,7 +313,6 @@ class LlmExecutorProcess(sf.Process):
             host_buffer.copy_from(buffer)
             new_buffers.append(host_buffer)
 
-        await device0
         return tuple(new_buffers)
 
     async def run(self):

--- a/shortfin/python/shortfin_apps/llm/components/service.py
+++ b/shortfin/python/shortfin_apps/llm/components/service.py
@@ -55,13 +55,12 @@ class LlmGenerateService(GenerateService):
         self.server_params = server_params
         self.max_queue_size = max_queue_size
         self.current_queue_size = 0
-        self.main_fiber_pool = FiberPool(
-            self.sysman, self.max_queue_size, resizable=True
-        )
-
         self.set_isolation(program_isolation)
         self._initialize_worker_and_fiber()
         self._initialize_queues()
+        self.main_fiber_pool = FiberPool(
+            self.sysman, self.max_queue_size, resizable=True
+        )
         self._initialize_page_cache()
         self._lock = Lock()
 


### PR DESCRIPTION
This patch moves `await device0` in `_transfer_buffer()` to before the d2h transfer starts. This ensures that the transfer does not happen simultaneously with kernel invocations, which can stall both the GPU and the CPU as the work is happening, reducing overall throughput.

Also tunes the values of `STROBE_SHORT_DELAY` and `STROBE_LONG_DELAY` for the batchers, as it does not make sense to wait for  the same amount of time when requests are available as when they are not.