### PR TITLE
Update Python versions in developer guide to 3.11

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -16,7 +16,7 @@ sudo apt update && sudo apt install -y clang lld
 Install:
 
 ```bash
-sudo apt install python-is-python3 python3-venv python3-dev
+sudo apt install python-is-python3 python3.11-venv python3.11-dev
 ```
 
 <details>
@@ -62,7 +62,7 @@ The project is configured to ignore `.venv` directories, and editors like
 VSCode pick them up by default.
 
 ```bash
-python -m venv .venv
+python3.11 -m venv .venv
 source .venv/bin/activate
 ```
 


### PR DESCRIPTION
This makes the developer guide consistent with the user guide: https://github.com/nod-ai/shark-ai/blob/main/docs/user_guide.md

> Officially we support Python versions: 3.11, 3.12, 3.13
The rest of this guide assumes you are using Python 3.11.

Without this, it installed python3.10 on my system and I got into version related errors.