### PR TITLE
[sharktank] allow for different dtypes and sort by file modification time in assert_close_safetensors

### DIFF
--- a/sharktank/sharktank/utils/testing.py
+++ b/sharktank/sharktank/utils/testing.py
@@ -186,6 +186,7 @@ def assert_close_safetensors(
     rtol: Optional[float] = None,
     atol: Optional[float] = None,
     fail_fast: bool = True,
+    allow_different_dtype: bool = False,
 ):
     """Asserts that actual and reference safetensors files are within tolerances.
 
@@ -196,21 +197,25 @@ def assert_close_safetensors(
 
     print(f"Asserting tensors close: actual={actual_path}, ref={ref_path}")
 
-    not_close_list: list[tuple[str, str]] = []
+    ref_path = Path(ref_path)
+    actual_path = Path(actual_path)
 
-    if os.path.isdir(ref_path):
-        assert os.path.isdir(actual_path)
-        actual_path = os.path.abspath(actual_path)
-        ref_path = os.path.abspath(ref_path)
-        ref_paths = [
-            Path(root) / file
-            for root, dirs, files in os.walk(ref_path)
-            for file in files
+    if not ref_path.is_file():
+        # Get all files in ref_path recursively.
+        ref_file_paths: list[Path] = [
+            file_path for file_path in Path(ref_path).rglob("*") if file_path.is_file()
         ]
-        for ref_file_path in ref_paths:
-            actual_file_path = Path(
-                f"{actual_path}{str(ref_file_path).removeprefix(ref_path)}"
-            )
+
+        # Sort by timestamp. When we compare traces we want to order by time.
+        ref_file_paths.sort(key=lambda file_path: os.stat(file_path).st_mtime_ns)
+
+        ref_actual_file_path_map: dict[Path, Path] = {
+            ref_file_path: Path(actual_path) / ref_file_path.relative_to(ref_path)
+            for ref_file_path in ref_file_paths
+        }
+
+        not_close_list: list[tuple[Path, Path]] = []
+        for ref_file_path, actual_file_path in ref_actual_file_path_map.items():
             try:
                 assert os.path.isfile(actual_file_path)
                 assert_close_safetensors(
@@ -218,33 +223,35 @@ def assert_close_safetensors(
                     ref_file_path,
                     rtol=rtol,
                     atol=atol,
-                    fail_fast=fail_fast,
+                    allow_different_dtype=allow_different_dtype,
                 )
             except Exception as ex:
                 if fail_fast:
                     raise
                 not_close_list.append((actual_file_path, ref_file_path))
                 print(ex)
+
         if len(not_close_list) > 0:
             print("Not close:")
             for actual, ref in not_close_list:
                 print(f"{actual} != {ref}")
             assert False, "Tensors are not close."
+        return
 
-    def print_stats(label, t):
-        t = t.to(dtype=torch.float32)
-        std, mean = torch.std_mean(t)
+    def print_stats(label: str, t: torch.Tensor):
+        t_f32 = t.to(dtype=torch.float32)
+        std, mean = torch.std_mean(t_f32)
         print(
             f"    {label}: "
-            f"MIN={torch.min(t)}, "
-            f"MAX={torch.max(t)}, "
-            f"MEAN={mean}, STD={std}"
+            f"MIN={torch.min(t_f32)}, "
+            f"MAX={torch.max(t_f32)}, "
+            f"MEAN={mean}, STD={std}, "
+            f"DTYPE={t.dtype}"
         )
 
     with safe_open(actual_path, framework="pt") as actual_f, safe_open(
         ref_path, framework="pt"
     ) as ref_f:
-        is_close = True
         # Print all first.
         for name in ref_f.keys():
             actual = actual_f.get_tensor(name)
@@ -257,16 +264,10 @@ def assert_close_safetensors(
         # Then assert.
         for name in ref_f.keys():
             actual = actual_f.get_tensor(name)
+            if allow_different_dtype:
+                actual = actual.to(dtype=ref.dtype)
             ref = ref_f.get_tensor(name)
-            try:
-                torch.testing.assert_close(actual, ref, rtol=rtol, atol=atol)
-            except Exception as ex:
-                if fail_fast:
-                    raise
-                is_close = False
-                print(ex)
-
-        assert is_close, "Tensors are not close."
+            torch.testing.assert_close(actual, ref, rtol=rtol, atol=atol)
 
 
 def assert_iterables_equal(
@@ -473,3 +474,10 @@ def get_test_prompts():
             num_prompts=16, min_prompt_length=50
         )
     return _test_prompts
+
+
+def _globe_matching_file_paths(
+    target: PathLike,
+    source: PathLike,
+):
+    """Recurse into subdirectories of target and align"""


### PR DESCRIPTION
Sometimes when comparing traces the reference may be of higher precision. Here a flag is added to allow for this auto promotion.

Sort by file modification time to try and get an order closer to the reference execution order. When we trace, tensors are written in order as the module is executed and we want to preserve this order when doing the comparison. It would be ideal if we could have a global trace tensor counter. Then we would be able to do a lexicographical sort, but this does not play nice during torch export.