### PR TITLE
[docs] Use '--run-nightly-tests' instead of '--run-nightly-llama-tests'

### DIFF
--- a/sharktank/sharktank/evaluate/README.md
+++ b/sharktank/sharktank/evaluate/README.md
@@ -28,7 +28,7 @@ pytest -n 8 -v -s sharktank/tests/evaluate/perplexity_torch_test.py -k test_llam
   --llama3-8b-tokenizer-path=tokenizer_config.json \
   --bs=4 \
   --device='cuda:0' \
-  --run-nightly-llama-tests
+  --run-nightly-tests
 ```
 
 ##### IREE mode
@@ -40,7 +40,7 @@ pytest -n 8 -v -s sharktank/tests/evaluate/perplexity_iree_test.py -k test_llama
   --iree-device=hip://0 \
   --iree-hip-target=gfx942 \
   --iree-hal-target-device=hip \
-  --run-nightly-llama-tests
+  --run-nightly-tests
 ```
 
 For a new model:

--- a/sharktank/tests/docs/llama_benchmarking_instructions.md
+++ b/sharktank/tests/docs/llama_benchmarking_instructions.md
@@ -14,7 +14,7 @@ wanted to only run the Llama 3.1 70B F16 Decomposed test:
 pytest sharktank/tests/models/llama/benchmark_amdgpu_test.py \
     -v -s \
     -m "expensive" \
-    --run-nightly-llama-tests \
+    --run-nightly-tests \
     -k 'testBenchmark70B_f16_TP8_Decomposed' \
     --iree-hip-target=gfx942 \
     --iree-device=hip://0


### PR DESCRIPTION
`--run-nightly-llama-tests` is not a valid flag anymore and `--run-nightly-tests` should be used instead.