### PR TITLE
Pass correct attn_type from create_paged_kv_cache

### DIFF
--- a/sharktank/sharktank/layers/paged_llama_attention_block.py
+++ b/sharktank/sharktank/layers/paged_llama_attention_block.py
@@ -67,6 +67,9 @@ class PagedLlamaAttentionBlock(ThetaLayer):
             "deepseek2": "mla",
         }
         self.attn_type = self.attn_type_map[self.model_arch]
+        assert (
+            self.attn_type == self.paged_attention.attn_type
+        ), f"Attention type mismatch: {self.attn_type} != {self.paged_attention.attn_type}"
 
         self.k_quantizer = None
         self.v_quantizer = None

--- a/sharktank/sharktank/utils/create_cache.py
+++ b/sharktank/sharktank/utils/create_cache.py
@@ -11,6 +11,12 @@ def create_paged_kv_cache(config: LlamaModelConfig) -> PagedAttention:
     if config.kv_cache_type != "paged":
         raise ValueError("Model does not use paged kv cache, cannot create kv cache")
 
+    attn_type_map = {
+        "llama": "gqa",
+        "grok": "gqa",
+        "deepseek2": "mla",
+    }
+
     hp = config.hp
     dtype = config.kv_cache_dtype or config.attention_dtype
     return PagedAttention(
@@ -19,6 +25,7 @@ def create_paged_kv_cache(config: LlamaModelConfig) -> PagedAttention:
         pipeline_to_device_map=config.pipeline_to_device_map,
         attn_head_count=hp.attention_head_count_kv,
         attn_head_dim=hp.attn_head_dim,
+        attn_type=attn_type_map[hp.model_arch],
         cache_partition_count=2,  # One for each of K/V.
         block_seq_stride=config.block_seq_stride,
         device=config.device,


### PR DESCRIPTION
Currently `create_paged_kv_cache` creates all kv_caches with the same attn_type (gqa) since it relies on the default.

`attn_type_map` should probably be refactored out to a central place so we don't have multiple of them sitting around, that or placed into `LlamaModelConfig`.