### PR TITLE
Add --iree-stream-affinity-solver-max-iterations=1024 for llama compile

### DIFF
--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -52,6 +52,7 @@ class BaseBenchmarkTest(unittest.TestCase):
             "--iree-hal-indirect-command-buffers=true",
             "--iree-stream-resource-memory-model=discrete",
             "--iree-hal-memoization=true",
+            "--iree-stream-affinity-solver-max-iterations=1024",
         ]
 
     def save_benchmarks(


### PR DESCRIPTION
Quick fix from https://github.com/nod-ai/shark-ai/pull/1612 to bring the nightly llama test back to normal.
Issue from iree-compile https://github.com/iree-org/iree/issues/21068
Temp fix is to add --iree-stream-affinity-solver-max-iterations=1024 in iree-compile.