### PR TITLE
Move attn_type_map to a single location

### DIFF
--- a/sharktank/sharktank/layers/__init__.py
+++ b/sharktank/sharktank/layers/__init__.py
@@ -6,7 +6,7 @@
 
 from .base import *
 from .conv import Conv2DLayer, Conv3DLayer, Conv1DLayer
-from .paged_attention import PagedAttention
+from .paged_attention import PagedAttention, attn_type_map
 from .causal_llm import BaseCausalLMModel
 from .linear import LinearLayer
 from .norm import RMSNormLayer, LayerNorm

--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -11,7 +11,6 @@ tightly coupled transformer blocks a bit less "stringy" with loose tensors
 and dims floating around everywhere.
 """
 
-from itertools import accumulate
 from typing import Optional, Union, List
 
 import math
@@ -32,7 +31,16 @@ from sharktank.types import (
 from sharktank import ops, kernels
 from sharktank.kernels.mlir_kernel import *
 
-__all__ = ["PagedAttention"]
+__all__ = ["PagedAttention", "attn_type_map"]
+
+
+attn_type_map = {
+    "llama": "gqa",
+    "grok": "gqa",
+    "deepseek2": "mla",
+    "llama4": "gqa",
+}
+
 
 # Paged Attention Kernels
 #

--- a/sharktank/sharktank/layers/paged_llama_attention_block.py
+++ b/sharktank/sharktank/layers/paged_llama_attention_block.py
@@ -14,7 +14,7 @@ from .linear import LinearLayer
 from .norm import RMSNormLayer, L2Norm
 from .rotary_embedding import RotaryEmbeddingLayer
 from .latent_attention_block import LatentAttentionBlock
-from .paged_attention import PagedAttention
+from .paged_attention import PagedAttention, attn_type_map
 from sharktank import ops
 
 __all__ = [
@@ -71,13 +71,7 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         self.floor_scale = floor_scale
         self.attn_scale = attn_scale
 
-        self.attn_type_map = {
-            "llama": "gqa",
-            "grok": "gqa",
-            "deepseek2": "mla",
-            "llama4": "gqa",
-        }
-        self.attn_type = self.attn_type_map[self.model_arch]
+        self.attn_type = attn_type_map[self.model_arch]
         assert (
             self.attn_type == self.paged_attention.attn_type
         ), f"Attention type mismatch: {self.attn_type} != {self.paged_attention.attn_type}"

--- a/sharktank/sharktank/utils/create_cache.py
+++ b/sharktank/sharktank/utils/create_cache.py
@@ -11,13 +11,6 @@ def create_paged_kv_cache(config: LlamaModelConfig) -> PagedAttention:
     if config.kv_cache_type != "paged":
         raise ValueError("Model does not use paged kv cache, cannot create kv cache")
 
-    attn_type_map = {
-        "llama": "gqa",
-        "grok": "gqa",
-        "deepseek2": "mla",
-        "llama4": "gqa",
-    }
-
     hp = config.hp
     dtype = config.kv_cache_dtype or config.attention_dtype
     return PagedAttention(


### PR DESCRIPTION
One copy is easier to maintain and means we can't forget about updating both.