### PR TITLE
[tuner] use config list for constraint generators

### DIFF
--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -50,9 +50,6 @@ class DispatchTuner(dispatch_parser.DispatchParser):
         Each TuningConfiguration specifies a name (e.g., "compilation_info") and
         its corresponding MLIR attribute (e.g., CompilationInfoAttr) to be applied
         to the dispatch root operation.
-
-        Example:
-            TuningConfiguration(name="compilation_info", configuration=CompilationInfoAttr(...))
         """
         pass
 

--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -42,9 +42,13 @@ class DispatchTuner(dispatch_parser.DispatchParser):
     @abstractmethod
     def get_td_spec(
         self,
-        compilation_info: iree_codegen.CompilationInfoAttr,
+        config: list[tuple[str, ir.Attribute]],
     ) -> ir.Module:
-        """Generate a transform dialect spec that applies the compilation info attr."""
+        """
+        Generate a transform dialect spec from a config list.
+        The config is a list of (str, Attribute) tuples, such as:
+            [("compilation_info", CompilationInfoAttr), ...]
+        """
         pass
 
     @abstractmethod
@@ -81,15 +85,12 @@ class ContractionOpInterfaceTuner(
 
     def get_td_spec(
         self,
-        compilation_info: iree_codegen.CompilationInfoAttr,
+        config: list[tuple[str, ir.Attribute]],
     ) -> ir.Module:
         contraction_op = self.get_root_op()
         func_name = self.get_root_op_func_name()
-
-        # Wrap the single CompilationInfoAttr in a list of (str, Attribute).
-        config_list = [("compilation_info", compilation_info)]
         return spec_builder.build_td_spec(
-            contraction_op.context, contraction_op, config_list, func_name
+            contraction_op.context, contraction_op, config, func_name
         )
 
 
@@ -106,16 +107,11 @@ class ConvolutionOpInterfaceTuner(
 
     def get_td_spec(
         self,
-        compilation_info: iree_codegen.CompilationInfoAttr,
+        config: list[tuple[str, ir.Attribute]],
     ) -> ir.Module:
         conv_op = self.get_root_op()
         func_name = self.get_root_op_func_name()
-
-        # Wrap the single CompilationInfoAttr in a list of (str, Attribute).
-        config_list = [("compilation_info", compilation_info)]
-        return spec_builder.build_td_spec(
-            conv_op.context, conv_op, config_list, func_name
-        )
+        return spec_builder.build_td_spec(conv_op.context, conv_op, config, func_name)
 
 
 def get_default_output_dir() -> str:

--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -45,7 +45,7 @@ class DispatchTuner(dispatch_parser.DispatchParser):
         config: list[tuple[str, ir.Attribute]],
     ) -> ir.Module:
         """
-        Generate a transform dialect spec from a config list.
+        Generates a transform dialect spec from a config list.
         The config is a list of (str, Attribute) tuples, such as:
             [("compilation_info", CompilationInfoAttr), ...]
         """

--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -42,12 +42,17 @@ class DispatchTuner(dispatch_parser.DispatchParser):
     @abstractmethod
     def get_td_spec(
         self,
-        config: list[tuple[str, ir.Attribute]],
+        config_list: list[common.TuningConfiguration],
     ) -> ir.Module:
         """
-        Generates a transform dialect spec from a config list.
-        The config is a list of (str, Attribute) tuples, such as:
-            [("compilation_info", CompilationInfoAttr), ...]
+        Generates a transform dialect spec from a list of TuningConfiguration objects.
+
+        Each TuningConfiguration specifies a name (e.g., "compilation_info") and
+        its corresponding MLIR attribute (e.g., CompilationInfoAttr) to be applied
+        to the dispatch root operation.
+
+        Example:
+            TuningConfiguration(name="compilation_info", configuration=CompilationInfoAttr(...))
         """
         pass
 
@@ -85,12 +90,12 @@ class ContractionOpInterfaceTuner(
 
     def get_td_spec(
         self,
-        config: list[tuple[str, ir.Attribute]],
+        config_list: list[common.TuningConfiguration],
     ) -> ir.Module:
         contraction_op = self.get_root_op()
         func_name = self.get_root_op_func_name()
         return spec_builder.build_td_spec(
-            contraction_op.context, contraction_op, config, func_name
+            contraction_op.context, contraction_op, config_list, func_name
         )
 
 
@@ -107,11 +112,13 @@ class ConvolutionOpInterfaceTuner(
 
     def get_td_spec(
         self,
-        config: list[tuple[str, ir.Attribute]],
+        config_list: list[common.TuningConfiguration],
     ) -> ir.Module:
         conv_op = self.get_root_op()
         func_name = self.get_root_op_func_name()
-        return spec_builder.build_td_spec(conv_op.context, conv_op, config, func_name)
+        return spec_builder.build_td_spec(
+            conv_op.context, conv_op, config_list, func_name
+        )
 
 
 def get_default_output_dir() -> str:

--- a/sharktuner/sharktuner/common.py
+++ b/sharktuner/sharktuner/common.py
@@ -62,6 +62,19 @@ class TunerContext:
         return self.mlir_ctx.__exit__(exc_type, exc_value, traceback)
 
 
+@dataclass
+class TuningConfiguration:
+    """
+    A TuningConfiguration contains an attribute that will be set on an op as a
+    result of running a tuning spec, along with its name. For example, a common
+    tuning configuration would have "compilation_info" as its name, and an
+    `iree_codegen.CompilationInfoAttr` as the configuration.
+    """
+
+    name: str
+    configuration: ir.Attribute
+
+
 class DispatchKind(Enum):
     conv = 0
     contraction = 1

--- a/sharktuner/sharktuner/common.py
+++ b/sharktuner/sharktuner/common.py
@@ -69,6 +69,9 @@ class TuningConfiguration:
     result of running a tuning spec, along with its name. For example, a common
     tuning configuration would have "compilation_info" as its name, and an
     `iree_codegen.CompilationInfoAttr` as the configuration.
+
+    Example:
+        TuningConfiguration(name="compilation_info", configuration=CompilationInfoAttr(...))
     """
 
     name: str

--- a/sharktuner/sharktuner/constraint_generator.py
+++ b/sharktuner/sharktuner/constraint_generator.py
@@ -52,7 +52,7 @@ def generate_generic_contraction_solutions(
     mma_intrinsics: list[iree_gpu.MMAIntrinsic] = [],
     allowed_waves_per_eu: list[int] = [2],
     pipeline_options_search_space: dispatch_constraints.PipelineOptionsSearchSpace = dispatch_constraints.PipelineOptionsSearchSpace(),
-) -> Iterator[iree_codegen.CompilationInfoAttr]:
+) -> Iterator[list[tuple[str, ir.Attribute]]]:
     adjust_problem_size_for_pipeline(
         contraction_dims,
         matmul_size,
@@ -239,7 +239,7 @@ def generate_generic_contraction_solutions(
         i += 1
 
         for compilation_info in compilation_infos:
-            yield compilation_info
+            yield [("compilation_info", compilation_info)]
 
 
 class ConstraintGenerator(ABC):
@@ -252,8 +252,10 @@ class ConstraintGenerator(ABC):
     and using that information to generate valid configurations that satisfy the
     constraints imposed by the codegen pipeline and target architecture.
 
-    The `generate_solutions` method produces a stream of CompilationInfoAttr
-    candidates, each representing a viable tuning configuration for the given problem.
+    The `generate_solutions` method produces a stream of configuration tuples.
+    Each item is a list of (str, Attribute) pairs representing a viable tuning configuration.
+    The example entry is:
+        [("compilation_info", CompilationInfoAttr)].
     """
 
     @abstractmethod
@@ -262,10 +264,9 @@ class ConstraintGenerator(ABC):
         tuner_context: common.TunerContext,
         codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline,
         **pipeline_constraint_options,
-    ) -> Iterator[iree_codegen.CompilationInfoAttr]:
+    ) -> Iterator[list[tuple[str, ir.Attribute]]]:
         """
-        Generate a sequence of CompilationInfoAttr candidates based on the
-        tuning constraints for the given codegen pipeline.
+        Generate a sequence of tuning configuration entries for the specified pipeline.
         """
         pass
 
@@ -314,7 +315,7 @@ class ContractionOpInterfaceConstraintGenerator(ConstraintGenerator):
         tuner_context: common.TunerContext,
         codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline,
         **pipeline_constraint_options,
-    ) -> Iterator[iree_codegen.CompilationInfoAttr]:
+    ) -> Iterator[list[tuple[str, ir.Attribute]]]:
         return generate_generic_contraction_solutions(
             tuner_ctx=tuner_context,
             contraction_dims=self.dims,
@@ -371,7 +372,7 @@ class ConvolutionOpInterfaceConstraintGenerator(ConstraintGenerator):
         tuner_context: common.TunerContext,
         codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline,
         **pipeline_constraint_options,
-    ) -> Iterator[iree_codegen.CompilationInfoAttr]:
+    ) -> Iterator[list[tuple[str, ir.Attribute]]]:
         return generate_generic_contraction_solutions(
             tuner_ctx=tuner_context,
             contraction_dims=self.dims,

--- a/sharktuner/sharktuner/spec_builder.py
+++ b/sharktuner/sharktuner/spec_builder.py
@@ -35,7 +35,7 @@ def get_placeholder_spec(context: ir.Context) -> ir.Module:
 def build_td_spec(
     context: ir.Context,
     op: ir.Operation,
-    config_list: list[tuple[str, ir.Attribute]],
+    config_list: list[common.TuningConfiguration],
     func_name: str,
 ) -> ir.Module:
     bbargs = []
@@ -79,10 +79,10 @@ def build_td_spec(
 
     config_lines = []
     yield_vars = []
-    for i, (key, attr) in enumerate(config_list):
-        config_var = f"%{key}_{i}"
+    for i, config in enumerate(config_list):
+        config_var = f"%{config.name}_{i}"
         config_lines.append(
-            f"{config_var} = transform.param.constant {attr} -> !transform.any_param"
+            f"{config_var} = transform.param.constant {config.configuration} -> !transform.any_param"
         )
         yield_vars.append(config_var)
     config_block = "\n                ".join(config_lines)
@@ -96,8 +96,8 @@ def build_td_spec(
         for i in range(len(config_list))
     )
     annotation_lines = "\n".join(
-        f'                transform.annotate %op "{key}" = %cfg_{i} : !transform.any_op, !transform.any_param'
-        for i, (key, _) in enumerate(config_list)
+        f'                transform.annotate %op "{config.name}" = %cfg_{i} : !transform.any_op, !transform.any_param'
+        for i, config in enumerate(config_list)
     )
 
     spec_text = f"""\

--- a/sharktuner/tests/candidate_gen_test.py
+++ b/sharktuner/tests/candidate_gen_test.py
@@ -96,7 +96,9 @@ def test_get_td_spec_contraction(tuner_ctx: common.TunerContext) -> None:
     root_op = root_op_list[0]
 
     tuner = candidate_gen.ContractionOpInterfaceTuner(root_op)
-    td_spec_module = tuner.get_td_spec([("compilation_info", compilation_info)])
+    td_spec_module = tuner.get_td_spec(
+        [common.TuningConfiguration("compilation_info", compilation_info)]
+    )
     assert td_spec_module
 
     named_sequence_ops: list[transform.NamedSequenceOp] = get_ops_from_module(
@@ -178,7 +180,9 @@ def test_get_td_spec_convolution(tuner_ctx: common.TunerContext) -> None:
     assert len(root_op_list) == 1
     root_op = root_op_list[0]
     tuner = candidate_gen.ConvolutionOpInterfaceTuner(root_op)
-    td_spec_module = tuner.get_td_spec([("compilation_info", compilation_info)])
+    td_spec_module = tuner.get_td_spec(
+        [common.TuningConfiguration("compilation_info", compilation_info)]
+    )
     assert td_spec_module
 
     named_sequence_ops: list[transform.NamedSequenceOp] = get_ops_from_module(

--- a/sharktuner/tests/candidate_gen_test.py
+++ b/sharktuner/tests/candidate_gen_test.py
@@ -96,7 +96,7 @@ def test_get_td_spec_contraction(tuner_ctx: common.TunerContext) -> None:
     root_op = root_op_list[0]
 
     tuner = candidate_gen.ContractionOpInterfaceTuner(root_op)
-    td_spec_module = tuner.get_td_spec(compilation_info)
+    td_spec_module = tuner.get_td_spec([("compilation_info", compilation_info)])
     assert td_spec_module
 
     named_sequence_ops: list[transform.NamedSequenceOp] = get_ops_from_module(
@@ -178,7 +178,7 @@ def test_get_td_spec_convolution(tuner_ctx: common.TunerContext) -> None:
     assert len(root_op_list) == 1
     root_op = root_op_list[0]
     tuner = candidate_gen.ConvolutionOpInterfaceTuner(root_op)
-    td_spec_module = tuner.get_td_spec(compilation_info)
+    td_spec_module = tuner.get_td_spec([("compilation_info", compilation_info)])
     assert td_spec_module
 
     named_sequence_ops: list[transform.NamedSequenceOp] = get_ops_from_module(

--- a/sharktuner/tests/constraint_generator_test.py
+++ b/sharktuner/tests/constraint_generator_test.py
@@ -199,11 +199,7 @@ def test_generate_solutions_tile_and_fuse_contraction_padding(
                 lowering_config
             ), f"Missing padding in lowering config: {lowering_config}"
             promote = [int(x) for x in lowering_config.attributes["promote_operands"]]
-            assert promote == [
-                0,
-                1,
-                2,
-            ], f"Expected promote_operands = [0, 1, 2], got: {promote}"
+            assert promote == [0, 1, 2]
 
 
 def test_generate_solutions_tile_and_fuse_conv_padding(
@@ -278,11 +274,7 @@ def test_generate_solutions_tile_and_fuse_conv_padding(
                 lowering_config
             ), f"Missing padding in lowering config: {lowering_config}"
             promote = [int(x) for x in lowering_config.attributes["promote_operands"]]
-            assert promote == [
-                0,
-                1,
-                2,
-            ], f"Expected promote_operands = [0, 1, 2], got: {promote}"
+            assert promote == [0, 1, 2]
 
 
 def test_adjust_problem_size_for_pipeline(

--- a/sharktuner/tests/constraint_generator_test.py
+++ b/sharktuner/tests/constraint_generator_test.py
@@ -181,17 +181,21 @@ def test_generate_solutions_tile_and_fuse_contraction_padding(
 
         assert len(solutions) > 0, "No solutions generated with TileAndFuse pipeline."
         assert all(
-            isinstance(sol, iree_codegen.CompilationInfoAttr) for sol in solutions
-        )
+            len(pair) == 1 and pair[0][0] == "compilation_info" for pair in solutions
+        ), "Each solution must be a single-item list with key 'compilation_info'"
 
+        compilation_infos = [pair[0][1] for pair in solutions]
         assert all(
-            "padding =" in str(sol.lowering_config) for sol in solutions
+            isinstance(sol, iree_codegen.CompilationInfoAttr)
+            for sol in compilation_infos
+        )
+        assert all(
+            "padding =" in str(sol.lowering_config) for sol in compilation_infos
         ), "Not all lowering configs have padding option."
-
         assert all(
             [int(x) for x in sol.lowering_config.attributes["promote_operands"]]
             == [0, 1, 2]
-            for sol in solutions
+            for sol in compilation_infos
         ), "Not all lowering configs have promote_operands = [0, 1, 2]."
 
 
@@ -249,15 +253,21 @@ def test_generate_solutions_tile_and_fuse_conv_padding(
 
         assert len(solutions) > 0, "No solutions generated with TileAndFuse pipeline."
         assert all(
-            isinstance(sol, iree_codegen.CompilationInfoAttr) for sol in solutions
+            len(pair) == 1 and pair[0][0] == "compilation_info" for pair in solutions
+        ), "Each solution must be a single-item list with key 'compilation_info'"
+
+        compilation_infos = [pair[0][1] for pair in solutions]
+        assert all(
+            isinstance(sol, iree_codegen.CompilationInfoAttr)
+            for sol in compilation_infos
         )
         assert all(
-            "padding =" in str(sol.lowering_config) for sol in solutions
+            "padding =" in str(sol.lowering_config) for sol in compilation_infos
         ), "Not all lowering configs have padding option"
         assert all(
             [int(x) for x in sol.lowering_config.attributes["promote_operands"]]
             == [0, 1, 2]
-            for sol in solutions
+            for sol in compilation_infos
         ), "Not all lowering configs have promote_operands = [0, 1, 2]"
 
 

--- a/sharktuner/tests/constraint_generator_test.py
+++ b/sharktuner/tests/constraint_generator_test.py
@@ -182,16 +182,19 @@ def test_generate_solutions_tile_and_fuse_contraction_padding(
         assert len(solutions) > 0, "No solutions generated with TileAndFuse pipeline."
         for solution in solutions:
             assert len(solution) == 1, f"Expected a single-item list, got: {solution}"
-            config_name, compilation_info_attr = solution[0]
+            config = solution[0]
+            assert isinstance(
+                config, common.TuningConfiguration
+            ), f"Expected TuningConfiguration, got: {type(config)}"
 
             assert (
-                config_name == "compilation_info"
-            ), f"Expected key 'compilation_info', got: {config_name}"
+                config.name == "compilation_info"
+            ), f"Expected key 'compilation_info', got: {config.name}"
             assert isinstance(
-                compilation_info_attr, iree_codegen.CompilationInfoAttr
-            ), f"Expected CompilationInfoAttr, got: {type(compilation_info_attr)}"
+                config.configuration, iree_codegen.CompilationInfoAttr
+            ), f"Expected CompilationInfoAttr, got: {type(config.configuration)}"
 
-            lowering_config = compilation_info_attr.lowering_config
+            lowering_config = config.configuration.lowering_config
             assert "padding =" in str(
                 lowering_config
             ), f"Missing padding in lowering config: {lowering_config}"
@@ -258,16 +261,19 @@ def test_generate_solutions_tile_and_fuse_conv_padding(
         assert len(solutions) > 0, "No solutions generated with TileAndFuse pipeline."
         for solution in solutions:
             assert len(solution) == 1, f"Expected a single-item list, got: {solution}"
-            config_name, compilation_info_attr = solution[0]
+            config = solution[0]
+            assert isinstance(
+                config, common.TuningConfiguration
+            ), f"Expected TuningConfiguration, got: {type(config)}"
 
             assert (
-                config_name == "compilation_info"
-            ), f"Expected key 'compilation_info', got: {config_name}"
+                config.name == "compilation_info"
+            ), f"Expected key 'compilation_info', got: {config.name}"
             assert isinstance(
-                compilation_info_attr, iree_codegen.CompilationInfoAttr
-            ), f"Expected CompilationInfoAttr, got: {type(compilation_info_attr)}"
+                config.configuration, iree_codegen.CompilationInfoAttr
+            ), f"Expected CompilationInfoAttr, got: {type(config.configuration)}"
 
-            lowering_config = compilation_info_attr.lowering_config
+            lowering_config = config.configuration.lowering_config
             assert "padding =" in str(
                 lowering_config
             ), f"Missing padding in lowering config: {lowering_config}"

--- a/sharktuner/tests/constraint_generator_test.py
+++ b/sharktuner/tests/constraint_generator_test.py
@@ -180,23 +180,27 @@ def test_generate_solutions_tile_and_fuse_contraction_padding(
         )
 
         assert len(solutions) > 0, "No solutions generated with TileAndFuse pipeline."
-        assert all(
-            len(pair) == 1 and pair[0][0] == "compilation_info" for pair in solutions
-        ), "Each solution must be a single-item list with key 'compilation_info'"
+        for solution in solutions:
+            assert len(solution) == 1, f"Expected a single-item list, got: {solution}"
+            config_name, compilation_info_attr = solution[0]
 
-        compilation_infos = [pair[0][1] for pair in solutions]
-        assert all(
-            isinstance(sol, iree_codegen.CompilationInfoAttr)
-            for sol in compilation_infos
-        )
-        assert all(
-            "padding =" in str(sol.lowering_config) for sol in compilation_infos
-        ), "Not all lowering configs have padding option."
-        assert all(
-            [int(x) for x in sol.lowering_config.attributes["promote_operands"]]
-            == [0, 1, 2]
-            for sol in compilation_infos
-        ), "Not all lowering configs have promote_operands = [0, 1, 2]."
+            assert (
+                config_name == "compilation_info"
+            ), f"Expected key 'compilation_info', got: {config_name}"
+            assert isinstance(
+                compilation_info_attr, iree_codegen.CompilationInfoAttr
+            ), f"Expected CompilationInfoAttr, got: {type(compilation_info_attr)}"
+
+            lowering_config = compilation_info_attr.lowering_config
+            assert "padding =" in str(
+                lowering_config
+            ), f"Missing padding in lowering config: {lowering_config}"
+            promote = [int(x) for x in lowering_config.attributes["promote_operands"]]
+            assert promote == [
+                0,
+                1,
+                2,
+            ], f"Expected promote_operands = [0, 1, 2], got: {promote}"
 
 
 def test_generate_solutions_tile_and_fuse_conv_padding(
@@ -252,23 +256,27 @@ def test_generate_solutions_tile_and_fuse_conv_padding(
         )
 
         assert len(solutions) > 0, "No solutions generated with TileAndFuse pipeline."
-        assert all(
-            len(pair) == 1 and pair[0][0] == "compilation_info" for pair in solutions
-        ), "Each solution must be a single-item list with key 'compilation_info'"
+        for solution in solutions:
+            assert len(solution) == 1, f"Expected a single-item list, got: {solution}"
+            config_name, compilation_info_attr = solution[0]
 
-        compilation_infos = [pair[0][1] for pair in solutions]
-        assert all(
-            isinstance(sol, iree_codegen.CompilationInfoAttr)
-            for sol in compilation_infos
-        )
-        assert all(
-            "padding =" in str(sol.lowering_config) for sol in compilation_infos
-        ), "Not all lowering configs have padding option"
-        assert all(
-            [int(x) for x in sol.lowering_config.attributes["promote_operands"]]
-            == [0, 1, 2]
-            for sol in compilation_infos
-        ), "Not all lowering configs have promote_operands = [0, 1, 2]"
+            assert (
+                config_name == "compilation_info"
+            ), f"Expected key 'compilation_info', got: {config_name}"
+            assert isinstance(
+                compilation_info_attr, iree_codegen.CompilationInfoAttr
+            ), f"Expected CompilationInfoAttr, got: {type(compilation_info_attr)}"
+
+            lowering_config = compilation_info_attr.lowering_config
+            assert "padding =" in str(
+                lowering_config
+            ), f"Missing padding in lowering config: {lowering_config}"
+            promote = [int(x) for x in lowering_config.attributes["promote_operands"]]
+            assert promote == [
+                0,
+                1,
+                2,
+            ], f"Expected promote_operands = [0, 1, 2], got: {promote}"
 
 
 def test_adjust_problem_size_for_pipeline(

--- a/sharktuner/tests/spec_builder_test.py
+++ b/sharktuner/tests/spec_builder_test.py
@@ -100,7 +100,11 @@ def test_spec_builder(tuner_ctx: common.TunerContext) -> None:
     spec_module = spec_builder.build_td_spec(
         tuner_ctx.mlir_ctx,
         root_op,
-        [("compilation_info", compilation_info)],
+        [
+            common.TuningConfiguration(
+                name="compilation_info", configuration=compilation_info
+            )
+        ],
         "match_matmul",
     )
     assert spec_module
@@ -140,8 +144,12 @@ def test_spec_builder(tuner_ctx: common.TunerContext) -> None:
         }
     )
     config_list = [
-        ("compilation_info", compilation_info),
-        ("decomposition_config", decomposition_config),
+        common.TuningConfiguration(
+            name="compilation_info", configuration=compilation_info
+        ),
+        common.TuningConfiguration(
+            name="decomposition_config", configuration=decomposition_config
+        ),
     ]
 
     spec_module = spec_builder.build_td_spec(


### PR DESCRIPTION
This PR mainly about using config list ( replace `Iterator[iree_codegen.CompilationInfoAttr]` with `Iterator[list[tuple[str, ir.Attribute]]]`  ) for constraint generators per comments in https://github.com/nod-ai/shark-ai/pull/1602#discussion_r2138003453. All relevant tests have been updated accordingly.