### PR TITLE
Add unit tests for Llm Batcher classes,

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/batcher.py
+++ b/shortfin/python/shortfin_apps/llm/components/batcher.py
@@ -6,9 +6,7 @@
 
 import logging
 import os
-
-from dataclasses import dataclass
-from typing import List
+from typing import List, Optional, Tuple, Union
 
 
 import shortfin as sf
@@ -16,7 +14,7 @@ import shortfin.array as sfnp
 
 from shortfin import Fiber
 
-from .device_array_cache import DeviceArrayCache, WrappedAllocation
+from .device_array_cache import DeviceArrayCache, WrappedAllocation, Allocation
 from .scheduler import Scheduler
 from ...utils import BatcherProcess
 
@@ -26,7 +24,7 @@ from .kvcache.base_attention_cache import (
     CacheAllocationFailure,
 )
 
-from .messages import LlmInferenceExecRequest, InferencePhase
+from .messages import LlmInferenceExecRequest
 from .service_debug_dumper import SERVICE_DEBUG_DUMPER
 
 logger = logging.getLogger(__name__)
@@ -57,7 +55,7 @@ class LlmBatcherProcess(BatcherProcess):
     ):
         super().__init__(fiber=fiber)
         self.name = name
-        self.page_cache = page_cache
+        self.page_cache: BasePagedAttentionCache = page_cache
         self.model_params = model_params
         self.functions = functions
         self.pending: set[LlmInferenceExecRequest] = set()
@@ -66,7 +64,7 @@ class LlmBatcherProcess(BatcherProcess):
         self.ideal_batch_size: int = ideal_batch_size
         self.page_seq_stride = self.model_params.paged_kv_cache.block_seq_stride
         self.scheduler = Scheduler(ideal_batch_size=self.ideal_batch_size)
-        self.cache = DeviceArrayCache(fiber.device(0))
+        self.cache: DeviceArrayCache = DeviceArrayCache(fiber.device(0))
 
         self.program_isolation = program_isolation
 
@@ -96,9 +94,7 @@ class LlmBatcherProcess(BatcherProcess):
         super().custom_message(msg)
 
     async def board_flights(self):
-        await super().board_flights()
-
-    async def board_flights(self):
+        """Make, schedule, and launch a batch of pending requests."""
         # TODO: Add lock on self.pending
         pending = self.pending
         self.pending = set()
@@ -133,6 +129,13 @@ class LlmBatcherProcess(BatcherProcess):
         ...
 
     def board(self, cache: BasePagedAttentionCache, fiber: Fiber, to_schedule: set):
+        """Create and launch an LlmExecutorProcess for the given requests.
+
+        Args:
+            cache (BasePagedAttentionCache): KVCache to use for this flight.
+            fiber (Fiber): Fiber to use for invocation.
+            to_schedule (set): Scheduled requests to be invoked in this flight.
+        """
         # Fill prefill flights.
         assert len(to_schedule) > 0
         assert len(to_schedule) <= self.ideal_batch_size
@@ -264,7 +267,7 @@ class LlmExecutorProcess(sf.Process):
         self,
         name: str,
         fiber: Fiber,
-        cache,
+        cache: DeviceArrayCache,
         functions: dict[int, sf.ProgramFunction],
         seq_stride: int,
         page_tables,
@@ -293,7 +296,24 @@ class LlmExecutorProcess(sf.Process):
     ):
         ...
 
-    async def _transfer_buffer(self, req_count, device0, buffers):
+    async def _transfer_buffer(
+        self,
+        req_count: int,
+        device0: sf.ScopedDevice,
+        buffers: Tuple[sfnp.device_array, Optional[sfnp.device_array]],
+    ) -> Tuple[sfnp.device_array, Optional[sfnp.device_array]]:
+        """Transfer buffer data from device to host after invocation.
+
+        Args:
+            req_count (int): The number of requests in this batch.
+            device0 (sf.ScopedDevice): The device used for invocation.
+            buffers (Tuple[sfnp.device_array, Optional[sfnp.device_array]]): The buffers to be transferred.
+                - The 0th buffer should be the `logits`
+                - The 1st buffer should be the `indices`
+
+        Returns:
+            Tuple[sfnp.device_array, Optional[sfnp.device_array]]: A host-side copy of the given buffers.
+        """
         transfer = any(
             [self.exec_requests[i].return_host_array for i in range(req_count)]
         )
@@ -314,11 +334,51 @@ class LlmExecutorProcess(sf.Process):
         await device0
         return tuple(new_buffers)
 
+    async def _post_run(
+        self,
+        args: List[Union[Allocation, WrappedAllocation]],
+        req_count: int,
+        result: Tuple[sfnp.device_array, Optional[sfnp.device_array]],
+    ):
+        """Process the results after a run.
+
+        Args:
+            args (list[sfnp.device_array]): The arguments used in the run.
+            req_count (int): The number of requests in the batch.
+            result (Tuple[sfnp.device_array, Optional[sfnp.device_array]]): The results of the run.
+        """
+        seq_stride = self.seq_stride
+        device0 = self.fiber.device(0)
+
+        indices = None
+        logits = result[0]
+        if len(result) > 1:
+            indices = result[1]
+
+        # publish cache pages
+        for r in self.exec_requests:
+            total_tokens = r.start_position + len(r.input_token_ids)
+            number_of_complete_pages = total_tokens // seq_stride
+            r.publish_allocated_pages(number_of_complete_pages)
+
+        logits, indices = await self._transfer_buffer(
+            req_count=req_count, device0=device0, buffers=(logits, indices)
+        )
+
+        [arg.release() for arg in args]
+
+        # Return results.
+        await self.get_results(logits, indices, req_count)
+
     async def run(self):
+        """Invoke `prefill` or `decode` function, with IREE, on a batch of requests.
+
+        Raises:
+            RuntimeError: No available entry point for given batch size.
+        """
         try:
             req_bs = len(self.exec_requests)
-            seq_stride = self.seq_stride
-            device0 = self.fiber.device(0)
+
             # Select an entrypoint for the batch.
             entrypoints = self.functions
             for bs, fn in entrypoints.items():
@@ -358,26 +418,7 @@ class LlmExecutorProcess(sf.Process):
             # Invoke VMFB. Logits are of shape [bs, bsl, d].
             args_device = [arg.device for arg in args]
             result = await fn(*args_device, fiber=self.fiber)
-
-            indices = None
-            logits = result[0]
-            if len(result) > 1:
-                indices = result[1]
-
-            # publish cache pages
-            for r in self.exec_requests:
-                total_tokens = r.start_position + len(r.input_token_ids)
-                number_of_complete_pages = total_tokens // seq_stride
-                r.publish_allocated_pages(number_of_complete_pages)
-
-            logits, indices = await self._transfer_buffer(
-                req_count=req_count, device0=device0, buffers=(logits, indices)
-            )
-
-            [arg.release() for arg in args]
-
-            # Return results.
-            await self.get_results(logits, indices, req_count)
+            await self._post_run(args, req_count, result)
 
         except Exception:
             logger.exception("Fatal error in prefetch invocation")
@@ -394,7 +435,7 @@ class PrefillExecutorProcess(LlmExecutorProcess):
     def __init__(
         self,
         fiber: Fiber,
-        cache,
+        cache: DeviceArrayCache,
         functions: dict[int, sf.ProgramFunction],
         seq_stride: int,
         page_tables,
@@ -410,7 +451,19 @@ class PrefillExecutorProcess(LlmExecutorProcess):
             program_isolation=program_isolation,
         )
 
-    async def get_args(self, bs):
+    async def get_args(
+        self, bs
+    ) -> Tuple[List[Union[Allocation, WrappedAllocation]], int]:
+        """Get the arguments for the prefill invocation.
+
+        Args:
+            bs (int): The batch size.
+
+        Returns:
+            Tuple[List[Union[Allocation, WrappedAllocation]], int]: A tuple containing:
+                - A list of arguments for the invocation.
+                - The number of requests in the batch.
+        """
         seq_stride = self.seq_stride
 
         # Compute block sequence length as maximum sequence length, rounded
@@ -469,6 +522,13 @@ class PrefillExecutorProcess(LlmExecutorProcess):
         return args, req_count
 
     async def get_results(self, logits, indices, req_count):
+        """Get the results after a prefill invocation.
+
+        Args:
+            logits (sfnp.device_array): The logits output from the invocation.
+            indices (sfnp.device_array | None): The indices output from the invocation, if any.
+            req_count (int): The number of requests in the batch.
+        """
         for i in range(req_count):
             req = self.exec_requests[i]
             sl = len(req.input_token_ids)
@@ -494,11 +554,11 @@ class DecodeExecutorProcess(LlmExecutorProcess):
     def __init__(
         self,
         fiber: Fiber,
-        cache,
+        cache: DeviceArrayCache,
         functions: dict[int, sf.ProgramFunction],
         seq_stride: int,
         page_tables,
-        isolation: sf.ProgramIsolation,
+        program_isolation: sf.ProgramIsolation,
     ):
         super().__init__(
             name="decode_process",
@@ -507,10 +567,22 @@ class DecodeExecutorProcess(LlmExecutorProcess):
             functions=functions,
             seq_stride=seq_stride,
             page_tables=page_tables,
-            program_isolation=isolation,
+            program_isolation=program_isolation,
         )
 
-    async def get_args(self, bs):
+    async def get_args(
+        self, bs
+    ) -> Tuple[List[Union[Allocation, WrappedAllocation]], int]:
+        """Get the arguments for the decode invocation.
+
+        Args:
+            bs (int): The batch size.
+
+        Returns:
+            Tuple[List[Union[Allocation, WrappedAllocation]], int]: A tuple containing:
+                - A list of arguments for the invocation.
+                - The number of requests in the batch.
+        """
         # Compute block sequence length as maximum sequence length, rounded
         # up to the seq_stride.
         seq_stride = self.seq_stride
@@ -584,7 +656,13 @@ class DecodeExecutorProcess(LlmExecutorProcess):
         return args, req_count
 
     async def get_results(self, logits, indices, req_count):
+        """Get the results after a decode invocation.
 
+        Args:
+            logits (sfnp.device_array): The logits output from the invocation.
+            indices (sfnp.device_array | None): The indices output from the invocation, if any.
+            req_count (int): The number of requests in the batch.
+        """
         # Return results.
         for i in range(req_count):
             req = self.exec_requests[i]

--- a/shortfin/tests/apps/llm/components/batcher_test.py
+++ b/shortfin/tests/apps/llm/components/batcher_test.py
@@ -1,0 +1,645 @@
+import asyncio
+from uuid import uuid4
+import pytest
+
+import shortfin.array as sfnp
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from shortfin import ProgramIsolation
+
+from shortfin_apps.llm.components.batcher import (
+    PrefillExecutorProcess,
+    DecodeExecutorProcess,
+    LlmBatcherProcess,
+    LlmExecutorProcess,
+)
+
+from shortfin_apps.llm.components.config_struct import ModelParams, PagedKVCacheParams
+from shortfin_apps.llm.components.device_array_cache import (
+    Allocation as DeviceArrayAllocation,
+    WrappedAllocation as DeviceArrayWrappedAllocation,
+)
+from shortfin_apps.llm.components.messages import (
+    LlmInferenceExecRequest,
+    InferencePhase,
+)
+
+
+@pytest.fixture
+def model_params():
+    return ModelParams(
+        max_seq_len=42,
+        transformer_block_count=42,
+        attn_head_dim=42,
+        prefill_batch_sizes=[4],
+        decode_batch_sizes=[4],
+        paged_kv_cache=PagedKVCacheParams(
+            block_seq_stride=42,
+            attention_head_count_kv=42,
+            device_block_count=256,
+            kv_cache_dtype=sfnp.float16,
+        ),
+    )
+
+
+@pytest.fixture
+def llm_batcher_process(model_params, fiber, cache):
+    return LlmBatcherProcess(
+        name="test-batcher",
+        fiber=fiber,
+        page_cache=cache,
+        model_params=model_params,
+        functions=None,
+        ideal_batch_size=4,
+        program_isolation=ProgramIsolation.PER_CALL.value,
+    )
+
+
+@pytest.fixture
+def llm_executor_process(model_params, fiber, device_array_cache):
+    return LlmExecutorProcess(
+        name="test-executor",
+        fiber=fiber,
+        cache=device_array_cache,
+        functions=None,
+        seq_stride=42,
+        page_tables=None,
+        program_isolation=ProgramIsolation.PER_CALL.value,
+    )
+
+
+@pytest.fixture
+def prefill_executor_process(model_params, fiber, device_array_cache):
+    return PrefillExecutorProcess(
+        fiber=fiber,
+        cache=device_array_cache,
+        functions=None,
+        seq_stride=model_params.paged_kv_cache.block_seq_stride,
+        page_tables=None,
+        program_isolation=ProgramIsolation.PER_CALL.value,
+    )
+
+
+@pytest.fixture(scope="function")
+def decode_executor_process(model_params, fiber, device_array_cache):
+    return DecodeExecutorProcess(
+        fiber=fiber,
+        cache=device_array_cache,
+        functions=None,
+        seq_stride=model_params.paged_kv_cache.block_seq_stride,
+        page_tables=None,
+        program_isolation=ProgramIsolation.PER_CALL.value,
+    )
+
+
+class MockVoidFuture:
+    def __init__(self):
+        self._event = asyncio.Event()
+
+    def set_success(self):
+        self._event.set()
+
+    def __await__(self):
+        return self._event.wait().__await__()
+
+
+@pytest.fixture()
+def exec_req_list():
+    with patch(
+        "shortfin_apps.llm.components.messages.sf.VoidFuture", new=MockVoidFuture
+    ):
+        input_tokens = [0, 1, 2, 3, 4, 5]
+
+        exec_reqs = []
+        for _ in range(4):
+            exec_req = LlmInferenceExecRequest(
+                phase=InferencePhase.PREFILL,
+                input_token_ids=input_tokens,
+                rid=str(uuid4()),
+                status_tracker=None,
+            )
+            exec_reqs.append(exec_req)
+            input_tokens = [val + 1 for val in input_tokens]
+
+        yield exec_reqs
+
+
+class TestLlmBatcherProcess:
+    @pytest.mark.asyncio
+    async def test_board_flights(
+        self, llm_batcher_process: LlmBatcherProcess, exec_req_list
+    ):
+        llm_batcher_process.board = MagicMock()
+
+        ## Empty
+        llm_batcher_process.pending = set()
+        await llm_batcher_process.board_flights()
+        assert llm_batcher_process.board.call_count == 0
+        llm_batcher_process.board.reset_mock()
+
+        assert llm_batcher_process.pending == set()
+
+        ## Non-empty
+        to_schedule = set(exec_req_list)
+        llm_batcher_process.pending = to_schedule
+        await llm_batcher_process.board_flights()
+
+        assert llm_batcher_process.board.call_count == 1
+        call_args = llm_batcher_process.board.call_args.args
+        assert len(call_args) == 3
+        assert call_args[0] == llm_batcher_process.page_cache
+        assert call_args[1] == llm_batcher_process.fiber
+        assert set(call_args[2]) == set(exec_req_list)
+
+        assert llm_batcher_process.pending == set()
+
+    @patch("shortfin_apps.llm.components.batcher.LlmExecutorProcess")
+    def test_board(self, mock_executor_cls, llm_batcher_process: LlmBatcherProcess):
+        """Test that the board method correctly schedules requests.
+
+        Args:
+            mock_executor_cls (MagicMock): Mocked LlmExecutorProcess class.
+            llm_batcher_process (LlmBatcherProcess): Instance of LlmBatcherProcess for testing.
+        """
+        to_schedule = {1, 2, 3, 4}
+
+        mock_executor = MagicMock()
+        mock_executor.exec_requests = []
+        mock_executor.launch = MagicMock()
+        mock_executor_cls.return_value = mock_executor
+
+        llm_batcher_process.make_process = MagicMock(return_value=mock_executor)
+        llm_batcher_process.board_request = MagicMock(side_effect=lambda _, x: x)
+
+        llm_batcher_process.board(
+            llm_batcher_process.cache,
+            llm_batcher_process.fiber,
+            to_schedule,
+        )
+
+        assert llm_batcher_process.board_request.call_count == len(to_schedule)
+        assert mock_executor.launch.call_count == 1
+
+
+class DummyDeviceArrayAllocation:
+    def __init__(self, device_array: sfnp.device_array):
+        self.device = device_array
+        self.shape = device_array.shape
+        self.released = False
+
+    def release(self):
+        self.released = True
+
+
+class TestLlmExecutorProcess:
+    def test__transfer_buffer_none_indices(
+        self, lsys, llm_executor_process: LlmExecutorProcess, exec_req_list
+    ):
+        async def test_none_indices():
+            llm_executor_process.exec_requests = exec_req_list
+            device0 = llm_executor_process.fiber.device(0)
+
+            data = [1, 2, 3]
+
+            buffer0 = sfnp.device_array(device0, [1, 2, 3], dtype=sfnp.float16)
+            buffer1 = None
+
+            with buffer0.map(discard=True) as m:
+                m.items = data
+
+            logits, indices = await llm_executor_process._transfer_buffer(
+                1, device0, [buffer0, buffer1]
+            )
+
+            assert isinstance(logits, sfnp.device_array)
+            assert indices is None
+            assert logits.items.tolist() == [1, 2, 3, 0, 0, 0]
+
+        lsys.run(test_none_indices())
+
+    def test__transfer_buffer_with_indices(
+        self, lsys, llm_executor_process: LlmExecutorProcess, exec_req_list
+    ):
+        async def test_with_indices():
+            llm_executor_process.exec_requests = exec_req_list
+            device0 = llm_executor_process.fiber.device(0)
+
+            buffer0 = sfnp.device_array(device0, [1, 2, 3], dtype=sfnp.float16)
+            buffer1 = sfnp.device_array(device0, [1, 2, 3], dtype=sfnp.int32)
+
+            with buffer0.map(discard=True) as m:
+                m.items = [1, 2, 3]
+
+            with buffer1.map(discard=True) as m:
+                m.items = [4, 5, 6]
+
+            logits, indices = await llm_executor_process._transfer_buffer(
+                1, device0, [buffer0, buffer1]
+            )
+
+            assert isinstance(logits, sfnp.device_array)
+            assert isinstance(indices, sfnp.device_array)
+            assert logits.items.tolist() == [1, 2, 3, 0, 0, 0]
+            assert indices.items.tolist() == [4, 5, 6, 0, 0, 0]
+
+        lsys.run(test_with_indices())
+
+    def test_run(self, lsys, llm_executor_process: LlmExecutorProcess, exec_req_list):
+        async def test_run_none_indices(*args, **kwargs):
+            device0 = llm_executor_process.fiber.device(0)
+
+            async def _dummy_invocation():
+                logits = sfnp.device_array(device0, [1, 2, 3], dtype=sfnp.float16)
+                indices = None
+
+                with logits.map(discard=True) as m:
+                    m.items = [1, 2, 3]
+                return logits, indices
+
+            dummy_invocation = AsyncMock(side_effect=_dummy_invocation)
+
+            # Test will fail if it selects the wrong entrypoint
+            entrypoints = {
+                1: None,
+                2: None,
+                4: dummy_invocation,
+                8: None,
+            }
+
+            dummy_arg_input = DummyDeviceArrayAllocation(
+                sfnp.device_array(device0, [1, 2, 3], dtype=sfnp.float16)
+            )
+
+            llm_executor_process._post_run = AsyncMock()
+            llm_executor_process.get_args = AsyncMock(
+                return_value=([dummy_arg_input], None)
+            )
+            llm_executor_process.functions = entrypoints
+            llm_executor_process.exec_requests = exec_req_list
+
+            await llm_executor_process.run()
+            dummy_invocation.assert_called_once()
+
+        lsys.run(test_run_none_indices())
+
+    def test__post_run_none_indices(
+        self, lsys, llm_executor_process: LlmExecutorProcess, exec_req_list
+    ):
+        async def test_post_run():
+            device0 = llm_executor_process.fiber.device(0)
+            logits = sfnp.device_array(device0, [1, 2, 3], dtype=sfnp.float16)
+            indices = None
+
+            with logits.map(discard=True) as m:
+                m.items = [1, 2, 3]
+
+            dummy_arg_input = DummyDeviceArrayAllocation(logits)
+
+            with patch.object(
+                LlmInferenceExecRequest, "publish_allocated_pages"
+            ) as mock_publish:
+                transfered_buffers = []
+
+                llm_executor_process.get_results = AsyncMock(
+                    side_effect=lambda logits, indices, count: transfered_buffers.append(
+                        (logits, indices)
+                    )
+                )
+                llm_executor_process.exec_requests = exec_req_list
+
+                await llm_executor_process._post_run(
+                    [dummy_arg_input], len(exec_req_list), (logits, indices)
+                )
+
+                llm_executor_process.get_results.assert_called_once()
+                host_logits = transfered_buffers[0][0]
+                host_indices = transfered_buffers[0][1]
+
+                assert host_logits.items.tolist() == logits.items.tolist()
+                assert host_indices is None
+
+                assert mock_publish.call_count == len(exec_req_list)
+
+        lsys.run(test_post_run())
+
+    def test__post_run_with_indices(
+        self, lsys, llm_executor_process: LlmExecutorProcess, exec_req_list
+    ):
+        async def test_post_run_with_indices():
+            device0 = llm_executor_process.fiber.device(0)
+            logits = sfnp.device_array(device0, [1, 2, 3], dtype=sfnp.float16)
+            indices = sfnp.device_array(device0, [4, 5, 6], dtype=sfnp.int32)
+
+            with logits.map(discard=True) as m:
+                m.items = [1, 2, 3]
+
+            with indices.map(discard=True) as m:
+                m.items = [4, 5, 6]
+
+            dummy_arg_input = DummyDeviceArrayAllocation(logits)
+
+            with patch.object(
+                LlmInferenceExecRequest, "publish_allocated_pages"
+            ) as mock_publish:
+                transfered_buffers = []
+
+                llm_executor_process.get_results = AsyncMock(
+                    side_effect=lambda logits, indices, count: transfered_buffers.append(
+                        (logits, indices)
+                    )
+                )
+                llm_executor_process.exec_requests = exec_req_list
+
+                await llm_executor_process._post_run(
+                    [dummy_arg_input], len(exec_req_list), (logits, indices)
+                )
+
+                llm_executor_process.get_results.assert_called_once()
+                host_logits = transfered_buffers[0][0]
+                host_indices = transfered_buffers[0][1]
+
+                assert host_logits.items.tolist() == logits.items.tolist()
+                assert host_indices.items.tolist() == indices.items.tolist()
+
+                assert mock_publish.call_count == len(exec_req_list)
+
+        lsys.run(test_post_run_with_indices())
+
+
+class TestPrefillExecutorProcess:
+    def test_get_args(
+        self, lsys, prefill_executor_process: PrefillExecutorProcess, exec_req_list
+    ):
+        async def _test_get_args():
+            prefill_executor_process.exec_requests = exec_req_list
+
+            page_tables = [
+                sfnp.device_array(
+                    prefill_executor_process.fiber.device(0),
+                    [1, 256],
+                    dtype=sfnp.float16,
+                )
+            ]
+            data = [i for i in range(256)]
+            with page_tables[0].map(discard=True) as m:
+                m.items = data
+
+            prefill_executor_process.page_tables = page_tables
+
+            args, req_count = await prefill_executor_process.get_args(
+                len(exec_req_list)
+            )
+            await prefill_executor_process.fiber.device(0)
+
+            assert len(args) == 4
+            assert req_count == len(exec_req_list)
+
+            tokens, seq_lens, seq_block_ids, page_table = args
+
+            for val in [tokens, seq_lens, seq_block_ids]:
+                assert isinstance(val, DeviceArrayAllocation)
+
+            assert isinstance(page_table, DeviceArrayWrappedAllocation)
+            disable_barrier = page_table.device
+            assert isinstance(disable_barrier, sfnp.disable_barrier)
+
+            page_table = disable_barrier.delegate()
+
+            token_device_array = tokens.device
+            for i in range(len(exec_req_list)):
+                input_tokens = token_device_array.view(i).items.tolist()
+                expected_tokens = exec_req_list[i].input_token_ids
+                assert input_tokens[0 : len(expected_tokens)] == expected_tokens
+
+            seq_lens = seq_lens.device.items.tolist()
+            seq_block_ids = seq_block_ids.device.items.tolist()
+            page_table = page_table.items.tolist()
+
+            assert seq_lens == [6, 6, 6, 6]
+            assert seq_block_ids == [0, 0, 0, 0]
+            assert page_table == data
+
+        lsys.run(_test_get_args())
+
+    def test_get_results_none_indices(
+        self,
+        lsys,
+        prefill_executor_process: PrefillExecutorProcess,
+        exec_req_list: list[LlmInferenceExecRequest],
+    ):
+        async def _test_get_results():
+            sl = len(exec_req_list[0].input_token_ids)
+
+            logits = sfnp.device_array(
+                prefill_executor_process.fiber.device(0),
+                [4, sl, 16],
+                dtype=sfnp.float16,
+            )
+
+            data = [i for i in range(16)]
+            for i in range(len(exec_req_list)):
+                with logits.view(i, sl - 1).map(discard=True) as m:
+                    m.items = data
+
+            indices = None
+            prefill_executor_process.exec_requests = exec_req_list
+            await prefill_executor_process.get_results(
+                logits, indices, len(exec_req_list)
+            )
+            await prefill_executor_process.fiber.device(0)
+
+            for req in exec_req_list:
+                logits = req.result_logits.items.tolist()
+                assert logits == [i for i in range(16)]
+
+                assert req.result_indices is None
+                assert req.done
+
+        lsys.run(_test_get_results())
+
+    def test_get_results_with_indices(
+        self,
+        lsys,
+        prefill_executor_process: PrefillExecutorProcess,
+        exec_req_list: list[LlmInferenceExecRequest],
+    ):
+        async def _test_get_results():
+            sl = len(exec_req_list[0].input_token_ids)
+
+            logits = sfnp.device_array(
+                prefill_executor_process.fiber.device(0),
+                [4, sl, 16],
+                dtype=sfnp.float16,
+            )
+            indices = sfnp.device_array(
+                prefill_executor_process.fiber.device(0),
+                [4, sl, 16],
+                dtype=sfnp.int64,
+            )
+
+            data = [i for i in range(16)]
+            for i in range(len(exec_req_list)):
+                with logits.view(i, sl - 1).map(discard=True) as m:
+                    m.items = data
+                with indices.view(i, sl - 1).map(discard=True) as m:
+                    m.items = data
+
+            prefill_executor_process.exec_requests = exec_req_list
+            await prefill_executor_process.get_results(
+                logits, indices, len(exec_req_list)
+            )
+            await prefill_executor_process.fiber.device(0)
+
+            for req in exec_req_list:
+                logits = req.result_logits.items.tolist()
+                indices = req.result_indices.items.tolist()
+
+                assert logits == [i for i in range(16)]
+                assert indices == [i for i in range(16)]
+
+                assert req.done
+
+        lsys.run(_test_get_results())
+
+
+class TestDecodeExecutorProcess:
+    def test_get_args(
+        self,
+        lsys,
+        decode_executor_process: DecodeExecutorProcess,
+        exec_req_list: list[LlmInferenceExecRequest],
+    ):
+        async def _test_get_args():
+            for req in exec_req_list:
+                req.start_position = len(req.input_token_ids) - 1
+
+            decode_executor_process.exec_requests = exec_req_list
+
+            page_tables = [
+                sfnp.device_array(
+                    decode_executor_process.fiber.device(0),
+                    [1, 256],
+                    dtype=sfnp.float16,
+                )
+            ]
+            data = [i for i in range(256)]
+            with page_tables[0].map(discard=True) as m:
+                m.items = data
+
+            decode_executor_process.page_tables = page_tables
+
+            args, req_count = await decode_executor_process.get_args(len(exec_req_list))
+            await decode_executor_process.fiber.device(0)
+
+            assert len(args) == 5
+            assert req_count == len(exec_req_list)
+
+            tokens, start_positions, seq_lens, seq_block_ids, page_table = args
+
+            for val in [tokens, start_positions, seq_lens, seq_block_ids]:
+                assert isinstance(val, DeviceArrayAllocation)
+
+            assert isinstance(page_table, DeviceArrayWrappedAllocation)
+            disable_barrier = page_table.device
+            assert isinstance(disable_barrier, sfnp.disable_barrier)
+
+            page_table = disable_barrier.delegate()
+
+            token_device_array = tokens.device
+            for i in range(len(exec_req_list)):
+                input_tokens = token_device_array.view(i).items.tolist()
+                expected_tokens = exec_req_list[i].input_token_ids[-1]
+                assert input_tokens == [expected_tokens]
+
+            start_positions = start_positions.device.items.tolist()
+            seq_lens = seq_lens.device.items.tolist()
+            seq_block_ids = seq_block_ids.device.items.tolist()
+            page_table = page_table.items.tolist()
+
+            assert start_positions == [6, 6, 6, 6]
+            assert seq_lens == [5, 5, 5, 5]
+            assert seq_block_ids == [0, 0, 0, 0]
+            assert page_table == data
+
+        lsys.run(_test_get_args())
+
+    def test_get_results_none_indices(
+        self,
+        lsys,
+        decode_executor_process: DecodeExecutorProcess,
+        exec_req_list: list[LlmInferenceExecRequest],
+    ):
+        async def _test_get_results():
+            sl = len(exec_req_list[0].input_token_ids)
+
+            logits_input = sfnp.device_array(
+                decode_executor_process.fiber.device(0),
+                [4, sl, 16],
+                dtype=sfnp.float16,
+            )
+
+            data = [i for i in range(16)]
+            for i in range(len(exec_req_list)):
+                with logits_input.view(i, 0).map(discard=True) as m:
+                    m.items = data
+
+            indices = None
+            decode_executor_process.exec_requests = exec_req_list
+            await decode_executor_process.get_results(
+                logits_input, indices, len(exec_req_list)
+            )
+            await decode_executor_process.fiber.device(0)
+
+            for req in exec_req_list:
+                logits = req.result_logits.items.tolist()
+                assert logits == data
+
+                assert req.result_indices is None
+                assert req.done._event.is_set()
+
+        lsys.run(_test_get_results())
+
+    def test_get_results_with_indices(
+        self,
+        lsys,
+        decode_executor_process: DecodeExecutorProcess,
+        exec_req_list: list[LlmInferenceExecRequest],
+    ):
+        async def _test_get_results():
+            sl = 1
+
+            logits = sfnp.device_array(
+                decode_executor_process.fiber.device(0),
+                [4, sl, 16],
+                dtype=sfnp.float16,
+            )
+            indices = sfnp.device_array(
+                decode_executor_process.fiber.device(0),
+                [4, sl, 16],
+                dtype=sfnp.int64,
+            )
+
+            data = [i for i in range(16)]
+            for i in range(len(exec_req_list)):
+                with logits.view(i, 0).map(discard=True) as m:
+                    m.items = data
+                with indices.view(i, 0).map(discard=True) as m:
+                    m.items = data
+
+            decode_executor_process.exec_requests = exec_req_list
+            await decode_executor_process.get_results(
+                logits, indices, len(exec_req_list)
+            )
+            await decode_executor_process.fiber.device(0)
+
+            for req in exec_req_list:
+                logits = req.result_logits.items.tolist()
+                indices = req.result_indices.items.tolist()
+
+                assert logits == data
+                assert indices == data
+
+                assert req.done
+
+        lsys.run(_test_get_results())

--- a/shortfin/tests/apps/llm/conftest.py
+++ b/shortfin/tests/apps/llm/conftest.py
@@ -22,13 +22,14 @@ def require_deps():
 import shortfin as sf
 import shortfin.array as sfnp
 
+from shortfin_apps.llm.components.device_array_cache import DeviceArrayCache
 from shortfin_apps.llm.components.kvcache.base_attention_cache import (
     BasePagedAttentionCache,
 )
 from shortfin_apps.llm.components.kvcache.page_pool import PagePool, PageInfo
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def lsys():
     sc = sf.host.CPUSystemBuilder()
     lsys = sc.create_system()
@@ -36,14 +37,25 @@ def lsys():
     lsys.shutdown()
 
 
-@pytest.fixture(scope="module")
-def fiber(lsys):
-    return lsys.create_fiber()
+@pytest.fixture(scope="function")
+def worker(lsys):
+    worker = lsys.create_worker("test-worker")
+    yield worker
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
+def fiber(lsys, worker):
+    return lsys.create_fiber(worker)
+
+
+@pytest.fixture(scope="function")
 def device(fiber):
     return fiber.device(0)
+
+
+@pytest.fixture(scope="function")
+def device_array_cache(device):
+    return DeviceArrayCache(device=device)
 
 
 TEST_PAGE_SIZE = 16


### PR DESCRIPTION
# Description

1. Unit tests for Batcher classes
2. Very small change to make `LlmExecutorProcess` more testable by moving the post-processing calls to a `_post_run` function.
3. Removes the `xfails` that we previously had on the `fork_pages` test. I spent annoying amount of time trying to figure out how to let a test wait on the device. It was obvious once I found it, and same trick fixes `fork_pages`.

The batcher is likely the most critical component in the `Shortfin Llm Server`, but we were lacking a set of unit tests for it.
We do have some `direct_to_batcher` tests that runs an integration test in a simulated decode loop. However, it's better that we have a more robust wall.

For the most part, I only test public functions that have non-trivial logic. I did specifically chose to test two private functions:

- _transfer_buffers
- _post_run

Added a test for _transfer_buffers, because I've seen a couple PRs attempt to refactor this specific spot incorrectly. So, it seems like the easiest function to get wrong, but also the most enticing to change haha.

Added a test for _post_run, because I really just created that function to make the tests a little easier. Still includes important logic that we want a guard around.