### PR TITLE
Fix topk kernel for large cases

### DIFF
--- a/sharktank/hip_kernels/kernels/topk_fp16_ukernel.c
+++ b/sharktank/hip_kernels/kernels/topk_fp16_ukernel.c
@@ -28,8 +28,13 @@ extern "C" __global__ void topk_F16I32(const _Float16 *__restrict__ inputValues,
   uint laneID = threadIdx.x;
 
   int linearIndex = groupID;
-  const _Float16 *batchInput = inputValues + linearIndex * reductionSize;
-  const int32_t *batchIndices = inputIndices + linearIndex * reductionSize;
+
+  int64_t linearIndex64 = linearIndex;
+  int64_t reductionSize64 = reductionSize;
+  int64_t reductionOffset = linearIndex64 * reductionSize64;
+
+  const _Float16 *batchInput = inputValues + reductionOffset;
+  const int32_t *batchIndices = inputIndices + reductionOffset;
   _Float16 *batchOutputValues = outputValues + linearIndex * k;
   int32_t *batchOutputIndices = outputIndices + linearIndex * k;
 

--- a/sharktank/hip_kernels/kernels/topk_fp32_ukernel.c
+++ b/sharktank/hip_kernels/kernels/topk_fp32_ukernel.c
@@ -28,8 +28,12 @@ extern "C" __global__ void topk_F32I32(const float *__restrict__ inputValues,
   uint laneID = threadIdx.x;
 
   int linearIndex = groupID;
-  const float *batchInput = inputValues + linearIndex * reductionSize;
-  const int32_t *batchIndices = inputIndices + linearIndex * reductionSize;
+  int64_t linearIndex64 = linearIndex;
+  int64_t reductionSize64 = reductionSize;
+  int64_t reductionOffset = linearIndex64 * reductionSize64;
+
+  const float *batchInput = inputValues + reductionOffset;
+  const int32_t *batchIndices = inputIndices + reductionOffset;
   float *batchOutputValues = outputValues + linearIndex * k;
   int32_t *batchOutputIndices = outputIndices + linearIndex * k;
 


### PR DESCRIPTION
When doing reductions across long sequence lengths its possible to exceed a 2 GB intermediate buffer. These cases need ensure pointer arithmetic occurs in 32-bits or it will incorrectly offset.