### PR TITLE
Support returning only the final logits from prefill

### DIFF
--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -303,6 +303,13 @@ def main():
             if args.logits_normalization == "log_softmax":
                 logits = ops.elementwise(torch.log, ops.softmax(logits, dim=-1))
 
+            if args.prefill_final_logits:
+                last_seq_lens = seq_lens
+                bsi = torch.tensor(list(range(logits.shape[0])))
+
+                logits = logits[bsi, last_seq_lens - 1]
+                logits = logits.unsqueeze(1)
+
             top_k = args.top_k
             if top_k is None:
                 return logits

--- a/sharktank/sharktank/utils/cli.py
+++ b/sharktank/sharktank/utils/cli.py
@@ -165,6 +165,11 @@ def add_model_options(parser: argparse.ArgumentParser):
         help="Return the log softmax of the logits",
         choices=["none", "softmax", "log_softmax"],
     )
+    parser.add_argument(
+        "--prefill-final-logits",
+        help="Return only the final logits",
+        action="store_true",
+    )
 
 
 def add_model_input_options(parser: argparse.ArgumentParser):


### PR DESCRIPTION
Prefill logits often only require the final logits for performing the first decode step. By optionally returning only the final logits we can minimize data transfer and reduce compute on earlier stages of the pipeline.