### PR TITLE
[sharktank] enable vae tests for nightly ci

### DIFF
--- a/sharktank/tests/models/vae/vae_test.py
+++ b/sharktank/tests/models/vae/vae_test.py
@@ -124,11 +124,6 @@ class VaeSDXLDecoderTest(TempDirTestBase):
 
         torch.testing.assert_close(ref_results, results)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Compile error uses <LARGE_NUM> bytes of shared memory; exceeded the limit of 65536 bytes: "
-        "https://github.com/iree-org/iree/issues/20875",
-    )
     @pytest.mark.expensive
     def testVaeIreeVsHuggingFace(self):
         dtype = getattr(torch, "float32")
@@ -355,11 +350,6 @@ class VaeFluxDecoderTest(TempDirTestBase):
             rtol=rtol,
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Compile error uses <LARGE_NUM> bytes of shared memory; exceeded the limit of 65536 bytes: "
-        "https://github.com/iree-org/iree/issues/20875",
-    )
     @pytest.mark.expensive
     @with_vae_data
     def testVaeIreeVsHuggingFace(self):


### PR DESCRIPTION
Enable SDXL FLux Vae test, compile issue fixed.