### PR TITLE
[sharktank] Fix package having unwanted dependency on pytest

### DIFF
--- a/sharktank/sharktank/models/dummy/dummy.py
+++ b/sharktank/sharktank/models/dummy/dummy.py
@@ -16,7 +16,6 @@ from ...layers import (
     configure_default_export_compile,
 )
 from ...types import Theta, AnyTensor, DefaultPrimitiveTensor
-from ...utils.testing import make_rand_torch
 
 __all__ = [
     "DummyModel",
@@ -47,6 +46,8 @@ class DummyModel(ThetaLayer):
         return DummyModelConfig
 
     def generate_random_theta(self) -> Theta:
+        from ...utils.testing import make_rand_torch
+
         rng_seed = self.config.rng_seed
         if rng_seed is None:
             rng_seed = 12345
@@ -71,6 +72,8 @@ class DummyModel(ThetaLayer):
     def sample_inputs(
         self, batch_size: int | None = 1, function: str | None = None
     ) -> tuple[tuple[AnyTensor, ...], OrderedDict[str, AnyTensor]]:
+        from ...utils.testing import make_rand_torch
+
         assert batch_size is not None
         assert function == "forward" or function is None
 


### PR DESCRIPTION
Fixes https://github.com/nod-ai/shark-ai/issues/1660.

The dummy model does not require to import the testing utils at the top of the file. The imports can be push into the concrete functions that use them.