### PR TITLE
[sharktank] move functions out of utils.testing to avoid unwanted dependency on pytest

### DIFF
--- a/sharktank/sharktank/export_layer/export_moe.py
+++ b/sharktank/sharktank/export_layer/export_moe.py
@@ -13,7 +13,7 @@ from sharktank.layers.mixture_of_experts_block import MoeBlock
 from sharktank.utils import cli
 from sharktank.types import Theta
 from sharktank.layers.testing import make_random_moe_block_theta
-from sharktank.utils.testing import make_rand_torch
+from sharktank.utils.random import make_rand_torch
 
 
 def main():

--- a/sharktank/sharktank/layers/testing.py
+++ b/sharktank/sharktank/layers/testing.py
@@ -7,7 +7,7 @@
 import torch
 from sharktank.types.theta import Theta
 from sharktank.types.tensors import DefaultPrimitiveTensor, unbox_tensor
-from sharktank.utils.testing import make_rand_torch
+from sharktank.utils.random import make_rand_torch
 from sharktank.types.sharding import *
 
 

--- a/sharktank/sharktank/models/deepseek/testing.py
+++ b/sharktank/sharktank/models/deepseek/testing.py
@@ -9,7 +9,7 @@ import torch
 
 from sharktank.types.tensors import *
 from sharktank.types.theta import Theta
-from sharktank.utils.testing import make_rand_torch
+from sharktank.utils.random import make_rand_torch
 from sharktank.layers.testing import (
     make_latent_attention_block_theta,
     make_ffn_block_theta,

--- a/sharktank/sharktank/models/dummy/dummy.py
+++ b/sharktank/sharktank/models/dummy/dummy.py
@@ -16,6 +16,7 @@ from ...layers import (
     configure_default_export_compile,
 )
 from ...types import Theta, AnyTensor, DefaultPrimitiveTensor
+from sharktank.utils.random import make_rand_torch
 
 __all__ = [
     "DummyModel",
@@ -46,8 +47,6 @@ class DummyModel(ThetaLayer):
         return DummyModelConfig
 
     def generate_random_theta(self) -> Theta:
-        from ...utils.testing import make_rand_torch
-
         rng_seed = self.config.rng_seed
         if rng_seed is None:
             rng_seed = 12345
@@ -72,8 +71,6 @@ class DummyModel(ThetaLayer):
     def sample_inputs(
         self, batch_size: int | None = 1, function: str | None = None
     ) -> tuple[tuple[AnyTensor, ...], OrderedDict[str, AnyTensor]]:
-        from ...utils.testing import make_rand_torch
-
         assert batch_size is not None
         assert function == "forward" or function is None
 

--- a/sharktank/sharktank/models/flux/flux.py
+++ b/sharktank/sharktank/models/flux/flux.py
@@ -20,7 +20,7 @@ import torch.nn as nn
 from sharktank.layers import *
 from sharktank.types import *
 from sharktank.utils.create_cache import *
-from sharktank.utils.testing import make_rand_torch
+from sharktank.utils.random import make_rand_torch
 from sharktank import ops
 
 __all__ = [

--- a/sharktank/sharktank/models/flux/testing.py
+++ b/sharktank/sharktank/models/flux/testing.py
@@ -13,10 +13,10 @@ from .flux import FluxParams, FluxModelV1
 from .export import export_flux_transformer, flux_transformer_default_batch_sizes
 from sharktank.types import DefaultPrimitiveTensor, Theta
 from sharktank.layers.testing import (
-    make_rand_torch,
     make_mmdit_double_block_random_theta,
     make_mmdit_single_block_random_theta,
 )
+from sharktank.utils.random import make_rand_torch
 
 
 def convert_flux_transformer_input_for_hugging_face_model(

--- a/sharktank/sharktank/models/grok/testing.py
+++ b/sharktank/sharktank/models/grok/testing.py
@@ -8,7 +8,7 @@ import torch
 
 from sharktank.types.tensors import *
 from sharktank.types.theta import Theta
-from sharktank.utils.testing import make_rand_torch
+from sharktank.utils.random import make_rand_torch
 from sharktank.layers.testing import make_llama_attention_block_theta
 from sharktank.layers.configs import LlamaModelConfig
 

--- a/sharktank/sharktank/models/llama/testing.py
+++ b/sharktank/sharktank/models/llama/testing.py
@@ -10,7 +10,7 @@ import torch
 from sharktank.types.tensors import *
 from sharktank.types.theta import Theta
 from sharktank.layers.configs import LlamaModelConfig
-from sharktank.utils.testing import make_rand_torch
+from sharktank.utils.random import make_rand_torch
 from sharktank.layers.testing import (
     make_llama_attention_block_theta,
     make_ffn_block_theta,

--- a/sharktank/sharktank/models/punet/testing.py
+++ b/sharktank/sharktank/models/punet/testing.py
@@ -14,7 +14,7 @@ from sharktank.types.tensors import *
 from sharktank.types.theta import Theta, Dataset
 from sharktank.utils.export import export
 from sharktank.utils.iree import flatten_for_iree_signature
-from sharktank.utils.testing import make_rand_torch
+from sharktank.utils.random import make_rand_torch
 from typing import Any, List
 
 import functools

--- a/sharktank/sharktank/testing/example_builder.py
+++ b/sharktank/sharktank/testing/example_builder.py
@@ -13,7 +13,7 @@ import torch
 from sharktank.layers import ThetaLayer, ModelConfig, LinearLayer
 from sharktank.types import Theta, DefaultPrimitiveTensor
 from sharktank.build import export_model
-from sharktank.utils.testing import make_rand_torch
+from sharktank.utils.random import make_rand_torch
 
 
 @dataclass(kw_only=True)

--- a/sharktank/sharktank/utils/random.py
+++ b/sharktank/sharktank/utils/random.py
@@ -1,0 +1,20 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Optional
+import torch
+
+
+# Range of torch.rand() is [0,1)
+# Range of torch.rand() * 2 - 1 is [-1, 1), includes negative values
+def make_rand_torch(shape: list[int], dtype: Optional[torch.dtype] = torch.float32):
+    return (torch.rand(shape) * 2 - 1).to(dtype=dtype)
+
+
+def make_random_mask(shape: tuple[int], dtype: Optional[torch.dtype] = None):
+    mask = make_rand_torch(shape=shape, dtype=dtype)
+    mask = (mask >= 0).to(dtype=dtype)
+    return mask

--- a/sharktank/sharktank/utils/testing.py
+++ b/sharktank/sharktank/utils/testing.py
@@ -64,18 +64,6 @@ def is_iree_hal_target_device_cpu(v: str, /) -> bool:
     return v.startswith("local") or v == "llvm-cpu"
 
 
-# Range of torch.rand() is [0,1)
-# Range of torch.rand() * 2 - 1 is [-1, 1), includes negative values
-def make_rand_torch(shape: list[int], dtype: Optional[torch.dtype] = torch.float32):
-    return (torch.rand(shape) * 2 - 1).to(dtype=dtype)
-
-
-def make_random_mask(shape: tuple[int], dtype: Optional[torch.dtype] = None):
-    mask = make_rand_torch(shape=shape, dtype=dtype)
-    mask = (mask >= 0).to(dtype=dtype)
-    return mask
-
-
 class TempDirTestBase(unittest.TestCase):
     def setUp(self):
         self._temp_dir = Path(tempfile.mkdtemp(type(self).__qualname__))

--- a/sharktank/tests/layers/linear_test.py
+++ b/sharktank/tests/layers/linear_test.py
@@ -11,7 +11,7 @@ from parameterized import parameterized
 
 from sharktank.layers import *
 from sharktank.types import *
-from sharktank.utils.testing import make_rand_torch
+from sharktank.utils.random import make_rand_torch
 
 logger = logging.getLogger(__name__)
 

--- a/sharktank/tests/layers/mixture_of_experts_block_test.py
+++ b/sharktank/tests/layers/mixture_of_experts_block_test.py
@@ -11,7 +11,7 @@ from typing import Callable
 import torch
 from iree.turbine.aot import *
 from sharktank.layers.testing import make_random_moe_block_theta
-from sharktank.utils.testing import make_rand_torch
+from sharktank.utils.random import make_rand_torch
 from sharktank.layers.mixture_of_experts_block import MoeBlock
 from sharktank.types.sharding import MoeBlockSharding
 from sharktank.ops import reshard, reshard_like, replicate

--- a/sharktank/tests/layers/sharded_paged_llama_attention_block_test.py
+++ b/sharktank/tests/layers/sharded_paged_llama_attention_block_test.py
@@ -10,9 +10,10 @@ from sharktank.layers import (
     PagedAttention,
     RotaryEmbeddingLayer,
 )
-from sharktank.layers.testing import make_llama_attention_block_theta, make_rand_torch
+from sharktank.layers.testing import make_llama_attention_block_theta
 from sharktank.types.sharding import PagedLlamaAttentionBlockSharding
 from sharktank.types import SplitPrimitiveTensor, unbox_tensor
+from sharktank.utils.random import make_rand_torch
 import torch
 from sharktank import ops
 from copy import deepcopy

--- a/sharktank/tests/models/clip/clip_test.py
+++ b/sharktank/tests/models/clip/clip_test.py
@@ -41,11 +41,10 @@ from sharktank.types import (
 )
 from sharktank.transforms.dataset import set_float_dtype
 from sharktank.utils.hf_datasets import get_dataset
+from sharktank.utils.random import make_random_mask, make_rand_torch
 from sharktank.utils.testing import (
     is_cpu_condition,
     assert_text_encoder_state_close,
-    make_rand_torch,
-    make_random_mask,
     TempDirTestBase,
     get_test_prompts,
 )

--- a/sharktank/tests/models/t5/t5_test.py
+++ b/sharktank/tests/models/t5/t5_test.py
@@ -47,10 +47,9 @@ from sharktank.models.t5.testing import (
     covert_t5_encoder_to_hugging_face,
     make_t5_encoder_random_theta,
 )
+from sharktank.utils.random import make_rand_torch, make_random_mask
 from sharktank.utils.testing import (
     assert_text_encoder_state_close,
-    make_rand_torch,
-    make_random_mask,
     skip,
     TempDirTestBase,
     get_test_prompts,


### PR DESCRIPTION
The recent fix https://github.com/nod-ai/shark-ai/pull/1662 was not enough to mitigate the problem.
This change removes all imports of `sharktank.utils.testing` form non-testing code by moving the functions `make_rand_torch` and `make_random_mask` to another location.