### PR TITLE
Fix Llama benchmark

### DIFF
--- a/.github/workflows/ci-llama-large-tests.yaml
+++ b/.github/workflows/ci-llama-large-tests.yaml
@@ -78,7 +78,7 @@ jobs:
             --llama3-8b-f8-model-path="/shark-dev/8b/fp8/native_fp8_e4m3fnuz_llama3_8b.irpa" \
             --llama3-8b-f8-attnf8-model-path="/shark-dev/8b/fp8/attnf8/native_fp8_e4m3fnuz_llama3_8b.irpa" \
             --llama3-70b-f16-model-path="/shark-dev/70b/instruct/weights/llama3.1_70b_instruct_fp16.irpa" \
-            --llama3-70b-f16-tp8-model-path="/shark-dev/70b/instruct/weights/tp8/llama3.1_70b_instruct_fp16_tp8.irpa" \
+            --llama3-70b-f16-tp8-model-path="/shark-dev/70b/instruct/weights/tp8/llama3_70b_instruct_fp16_tp8.irpa" \
             --llama3-70b-f8-model-path="/shark-dev/70b/fp8/llama70b_fp8.irpa" \
             --llama3-405b-f16-tp8-model-path="/shark-dev/405b/instruct/weights/tp8/llama3_405b_instruct_fp16_tp8.irpa" \
             --llama3-405b-f8-tp8-model-path="/shark-dev/405b/f8/tp8/llama3.1_405b_fp8_tp8_parameters.irpa" \

--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -190,6 +190,7 @@ jobs:
             --capture=no \
             --log-cli-level=info \
             -v \
+            -k "not benchmark" \
             --iree-hal-target-device=hip \
             --iree-hip-target=gfx942 \
             --iree-device=hip://0 \

--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -190,11 +190,9 @@ jobs:
             --capture=no \
             --log-cli-level=info \
             -v \
-            -k "not benchmark" \
             --iree-hal-target-device=hip \
             --iree-hip-target=gfx942 \
-            --iree-device=hip://0 \
-            --llama3-8b-f16-model-path="/shark-dev/8b/instruct/weights/llama3.1_8b_instruct_fp16.irpa"
+            --iree-device=hip://0
 
   test_with_data:
     name: "Data-dependent Tests"

--- a/sharktank/sharktank/utils/testing.py
+++ b/sharktank/sharktank/utils/testing.py
@@ -39,7 +39,7 @@ is_nightly = pytest.mark.skipif(
     reason="Run large tests if --run-nightly-tests is passed",
 )
 is_llama_8b = pytest.mark.skipif(
-    'config.getoption("llama3_8b_f16_model_path") is None or config.getoption("llama3_8b_tokenizer_path") is None',
+    'config.getoption("llama3_8b_f16_model_path") is None',
     reason="Run llama tests if --llama3-8b-f16-model-path is passed",
 )
 is_deepseek = pytest.mark.skipif(

--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -187,8 +187,7 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
             ],
         }
 
-    @parameterized.expand((((128,), (2048,))))
-    def test_benchmark8B_f16_tp1(self, input_size: int):
+    def test_benchmark8B_f16_tp1_input_len_128(self):
         self.export_artifact = ExportArtifacts(
             irpa_path=self.llama3_8b_f16_model,
             iree_hip_target=self.iree_hip_target,
@@ -198,11 +197,30 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
             pipeline_parallelism_size=1,
             block_seq_stride=32,
             cwd=self.repo_root,
-            output_name=self.dir_path / f"f16_torch_{input_size}_tp1",
+            output_name=self.dir_path / f"f16_torch_{128}_tp1",
             hip_device_id=self.iree_device,
         )
-        self.prefill_args = self.prefill_args_fp16[input_size]
-        self.decode_args = self.decode_args_fp16[input_size]
+        self.prefill_args = self.prefill_args_fp16[128]
+        self.decode_args = self.decode_args_fp16[128]
+
+        self.export_compile_benchmark()
+
+    @is_nightly
+    def test_benchmark8B_f16_tp1_input_len_2048(self):
+        self.export_artifact = ExportArtifacts(
+            irpa_path=self.llama3_8b_f16_model,
+            iree_hip_target=self.iree_hip_target,
+            iree_hal_target_device=self.iree_hal_target_device,
+            attention_kernel="torch",
+            tensor_parallelism_size=1,
+            pipeline_parallelism_size=1,
+            block_seq_stride=32,
+            cwd=self.repo_root,
+            output_name=self.dir_path / f"f16_torch_{2048}_tp1",
+            hip_device_id=self.iree_device,
+        )
+        self.prefill_args = self.prefill_args_fp16[2048]
+        self.decode_args = self.decode_args_fp16[2048]
 
         self.export_compile_benchmark()
 

--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -91,7 +91,9 @@ class BaseBenchmarkTest(unittest.TestCase):
         return benchmark_args
 
     def export_compile_benchmark(self, skip_decode: bool = False):
-        self.export_artifact.export_and_compile_llm(batch_size=self.batch_size)
+        self.export_artifact.export_and_compile_llm(
+            batch_size=self.batch_size, skip_decode=skip_decode
+        )
 
         benchmark_filename = self.export_artifact.output_name.with_suffix(".txt")
         self.export_artifact.iree_benchmark(

--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -17,6 +17,7 @@ from sharktank.utils.export_artifacts import (
     IreeBenchmarkException,
 )
 from sharktank.utils.testing import (
+    is_llama_8b,
     is_mi300x,
     is_nightly,
 )
@@ -187,6 +188,7 @@ class BenchmarkLlama3_1_8B(BaseBenchmarkTest):
             ],
         }
 
+    @is_llama_8b
     def test_benchmark8B_f16_tp1_input_len_128(self):
         self.export_artifact = ExportArtifacts(
             irpa_path=self.llama3_8b_f16_model,


### PR DESCRIPTION
- 70B fp16 tp8 path seems to have changed
- Fixing unpassed `skip_decode` arg
- Split the 8B fp16 128 & 2048 tests apart so that only the input_len=128 is run on PRs and the 2048 is left for nightlies.