### PR TITLE
[sharktank] Update toy Deepseek eager perplexity after torch bump

### DIFF
--- a/sharktank/tests/evaluate/baseline_perplexity_scores.json
+++ b/sharktank/tests/evaluate/baseline_perplexity_scores.json
@@ -446,12 +446,12 @@
   },
   "deepseek_v3_torch": {
     "perplexities": [
-      1478.516846,
-      5466.473633,
-      3303.35376,
-      290.115479
+      1472.039307,
+      5494.48291,
+      3331.409424,
+      289.678802
     ],
-    "mean_perplexity": 2634.61493
+    "mean_perplexity": 2646.902611
   },
   "deepseek_v3_iree": {
     "perplexities": [

--- a/sharktank/tests/evaluate/perplexity_torch_test.py
+++ b/sharktank/tests/evaluate/perplexity_torch_test.py
@@ -106,7 +106,7 @@ class PerplexityTest(unittest.TestCase):
         self.irpa_file = self.deepseek_v3_tp2_model
         self.tokenizer = self.deepseek_v3_tokenizer
         self.tensor_parallelism_size = 2
-        self.delta = 10
+        self.delta = 11
 
         self.prepare_argv(extra_args=("--use-toy-model",))
         self.run_and_check_perplexity()


### PR DESCRIPTION
Update toy Deepseek eager perplexity after torch bump from torch>=2.5.1 to torch==2.6.0

Depends on: https://github.com/nod-ai/shark-ai/pull/1678
Resolves issue: https://github.com/nod-ai/shark-ai/issues/1690

Note: Unsharded & pp regressed by 10 points. tp's delta increased by ~1 point.
