### PR TITLE
 remove 405 and 70B FP8 model from pull_request run

### DIFF
--- a/.github/workflows/ci_llama_3.1_405b_fp16_tp8.yml
+++ b/.github/workflows/ci_llama_3.1_405b_fp16_tp8.yml
@@ -7,7 +7,6 @@
 name: Llama 3.1 405 FP16 TP8 Benchmarking Tests
 
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     # Weekdays at 11:00 AM UTC = 03:00 AM PST / 04:00 AM PDT

--- a/.github/workflows/ci_llama_3.1_405b_fp8_tp8.yml
+++ b/.github/workflows/ci_llama_3.1_405b_fp8_tp8.yml
@@ -4,10 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-name: Llama 3.1 8B FP8 Benchmarking Tests
+name: Llama 3.1 405B FP8 Benchmarking Tests
 
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     # Weekdays at 11:00 AM UTC = 03:00 AM PST / 04:00 AM PDT

--- a/.github/workflows/ci_llama_3.1_70b_fp8.yml
+++ b/.github/workflows/ci_llama_3.1_70b_fp8.yml
@@ -7,7 +7,6 @@
 name: Llama 3.1 70B FP8 Benchmarking Tests
 
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     # Weekdays at 11:00 AM UTC = 03:00 AM PST / 04:00 AM PDT


### PR DESCRIPTION
disabled 405B and 70B FP8 from running on pull request