### PR TITLE
Separated rotary sharding behavior from rotary layer

### DIFF
--- a/sharktank/sharktank/layers/__init__.py
+++ b/sharktank/sharktank/layers/__init__.py
@@ -10,6 +10,7 @@ from .paged_attention import PagedAttention, attn_type_map
 from .causal_llm import BaseCausalLMModel
 from .linear import LinearLayer
 from .norm import RMSNormLayer, LayerNorm
+from .rotary_embedding import build_rotary_layer
 from .rotary_embedding import RotaryEmbeddingLayer
 from .token_embedding import TokenEmbeddingLayer
 from .paged_llama_attention_block import PagedLlamaAttentionBlock

--- a/sharktank/sharktank/layers/rotary_embedding.py
+++ b/sharktank/sharktank/layers/rotary_embedding.py
@@ -18,6 +18,112 @@ from sharktank.types import (
 )
 
 
+def build_rotary_layer(
+    tensor_parallelism_size: int = 1,
+    pipeline_parallelism: bool = False,
+    devices=None,
+    **kwargs,
+):
+    rotary_layer = RotaryEmbeddingLayer(**kwargs)
+    return ShardedRotaryLayer(
+        tensor_parallelism_size=tensor_parallelism_size,
+        pipeline_parallelism=pipeline_parallelism,
+        rotary_layer=rotary_layer,
+        devices=devices,
+    )
+
+
+# We wrap a shardless rotary layer so the sharding behavior can be handled independently of the numerics.
+class ShardedRotaryLayer(BaseLayer):
+    def __init__(
+        self,
+        *,
+        tensor_parallelism_size: int,
+        pipeline_parallelism: bool,
+        rotary_layer,
+        devices,
+    ):
+        super().__init__()
+        self._pipeline_parallelism = pipeline_parallelism
+        self._tensor_parallelism_size = tensor_parallelism_size
+        self._rotary_layer = rotary_layer
+        self._devices = (
+            devices
+            if devices is not None
+            else tuple(range(self.tensor_parallelism_size))
+        )
+
+
+    def rotary_embed_table(self):
+        t = self._rotary_layer.create_rotary_embed_table()
+        if self._tensor_parallelism_size > 1 or self._pipeline_parallelism:
+            # Replicate across all devices, the data is not a lot and the computation is cheap.
+            t = ops.replicate(t, self._tensor_parallelism_size, devices=self._devices)
+
+        return t
+
+    def forward(
+        self,
+        *,
+        xt: Union[torch.Tensor, ShardedTensor],
+        start_index: int,
+    ):
+        table = self.rotary_embed_table()
+
+        if not isinstance(table, ShardedTensor):
+            return self._rotary_layer(
+                xt=xt, start_index=start_index, rotary_embed_table=table
+            )
+
+        shards = [
+            self._rotary_layer(xt=xs, start_index=start_index, rotary_embed_table=ts)
+            for xs, ts in zip(xt.shards, table.shards)
+        ]
+        return xt.clone(ts=shards)
+
+    def compute_batch_mask(
+        self, start_positions: Union[torch.Tensor, ReplicatedTensor], batch_seq_len: int
+    ) -> torch.Tensor:
+        if isinstance(start_positions, ShardedTensor):
+            shards = []
+            table = self.rotary_embed_table()
+            for s, ts in zip(start_positions.shards, table.shards):
+                shard = self._rotary_layer.compute_batch_mask(
+                    start_positions=s,
+                    batch_seq_len=batch_seq_len,
+                    rotary_embed_table=ts,
+                )
+                shards.append(shard)
+
+            return start_positions.clone(ts=shards)
+
+        return self._rotary_layer.compute_batch_mask(
+            start_positions=start_positions,
+            batch_seq_len=batch_seq_len,
+            rotary_embed_table=self.rotary_embed_table(),
+        )
+
+    def apply_batched_mask(
+        self,
+        *,
+        xt: Union[torch.Tensor, SplitPrimitiveTensor, ReplicatedTensor],
+        mask: Union[torch.Tensor, ReplicatedTensor],
+    ) -> Union[SplitPrimitiveTensor, ReplicatedTensor]:
+
+        if not isinstance(xt, ShardedTensor):
+            return self._rotary_layer.apply_batched_mask(xt=xt, mask=mask)
+
+        assert isinstance(mask, ReplicatedTensor) and mask.shard_count == xt.shard_count
+        xt_shards = [
+            self._rotary_layer.apply_batched_mask(
+                xt=unbox_tensor(xt_shard),
+                mask=unbox_tensor(mask_shard),
+            )
+            for xt_shard, mask_shard in zip(xt.shards, mask.shards)
+        ]
+        return xt.clone(ts=xt_shards)
+
+
 class RotaryEmbeddingLayer(BaseLayer):
     """Computes a rotary embedding in the style popularized by llama (RoPE)."""
 
@@ -31,10 +137,7 @@ class RotaryEmbeddingLayer(BaseLayer):
         use_hf: bool = False,
         rope_scaling_type: Optional[str] = None,
         use_table: bool = True,
-        tensor_parallelism_size: int = 1,
-        pipeline_parallelism: bool = False,
         dtype: torch.dtype = torch.float32,
-        devices: tuple[int, ...] | None = None,
         model_arch: Optional[str] = None,
     ):
         super().__init__()
@@ -46,105 +149,7 @@ class RotaryEmbeddingLayer(BaseLayer):
         self.use_table = use_table
         self.dtype = dtype
         self.rope_freq_base = rope_freq_base if rope_freq_base is not None else 10000.0
-        self.tensor_parallelism_size = tensor_parallelism_size
-        self.pipeline_parallelism = pipeline_parallelism
-        self.devices = (
-            devices
-            if devices is not None
-            else tuple(range(self.tensor_parallelism_size))
-        )
         self.model_arch = model_arch
-
-    @property
-    def rotary_embed_table(self):
-        return self._create_rotary_embed_table()
-
-    def forward(
-        self,
-        *,
-        xt: Union[torch.Tensor, ShardedTensor],
-        start_index: int,
-    ):
-        table = self.rotary_embed_table
-        if isinstance(xt, ReplicatedTensor):
-            return ReplicatedTensor(
-                ts=[
-                    self.forward_unsharded(
-                        xt=unbox_tensor(s),
-                        start_index=start_index,
-                        rotary_embed_table=unbox_tensor(t),
-                    )
-                    for s, t in zip(xt.shards, table.shards)
-                ],
-                devices=table.devices,
-            )
-
-        if not isinstance(xt, ShardedTensor):
-            return self.forward_unsharded(
-                xt=xt,
-                start_index=start_index,
-                rotary_embed_table=table,
-            )
-
-        if isinstance(xt, SplitPrimitiveTensor):
-            assert (
-                not self.use_hf or xt.shard_dim == len(xt.shape) - 1
-            ), "We rotate the last dim in that case causing awkwardness, so sharding it is disallowed"
-            assert (
-                isinstance(table, ShardedTensor) and xt.shard_count == table.shard_count
-            )
-            rotary_shards = [unbox_tensor(shard) for shard in table.shards]
-
-            xt_shards = [
-                self.forward_unsharded(
-                    xt=unbox_tensor(xt_shard),
-                    start_index=start_index,
-                    rotary_embed_table=rotary_shard,
-                )
-                for xt_shard, rotary_shard in zip(xt.shards, rotary_shards)
-            ]
-            return xt.clone(ts=xt_shards)
-
-        raise NotImplementedError(
-            f"Rotary embedding layer not implemented for input tensor type {type(xt)}"
-        )
-
-    def _create_interleaved_tensor(_, dim):
-        """Creates a tensor which indexes an tensor such that
-        it alternates between elements of its first and second
-        half. Intended for use for HuggingFace's rotation
-        implementation.
-
-        Args:
-          dim: Size of tensor
-
-        Returns:
-          Interleaved indexing tensor
-        """
-        first_half = torch.arange(dim // 2)
-        second_half = torch.arange(dim // 2, dim)
-
-        interleaved_tensor = torch.empty(dim, dtype=torch.long)
-        interleaved_tensor[0::2] = first_half
-        interleaved_tensor[1::2] = second_half
-
-        return interleaved_tensor
-
-    def _create_ordering_tensor(_, dim):
-        """Creates a tensor which indexes an tensor such that
-        it reverses the alternation induced by create_interleaved_tesnor.
-        Intended for use for HuggingFace's rotation implementation.
-
-        Args:
-          dim: Size of tensor
-
-        Returns:
-          Ordering indexing tensor
-        """
-        order_tensor = torch.empty(dim, dtype=torch.long)
-        order_tensor[: dim // 2] = torch.arange(0, dim, 2)
-        order_tensor[dim // 2 :] = torch.arange(1, dim, 2)
-        return order_tensor
 
     @staticmethod
     def rotate_half(x):
@@ -153,7 +158,7 @@ class RotaryEmbeddingLayer(BaseLayer):
         x2 = x[..., x.shape[-1] // 2 :]
         return torch.cat((-x2, x1), dim=-1)
 
-    def forward_unsharded(
+    def forward(
         self,
         *,
         xt: torch.Tensor,
@@ -198,7 +203,7 @@ class RotaryEmbeddingLayer(BaseLayer):
             freqs_cis = freqs_cis[0:sl, :]
         else:
             freqs_cis = torch.arange(sl, device=xt.device) + start_index
-            freqs_cis = self._compute_rotary_embed_table(freqs_cis)
+            freqs_cis = self.compute_rotary_embed_table(freqs_cis)
 
         assert (
             freqs_cis.shape[0] >= sl
@@ -210,7 +215,10 @@ class RotaryEmbeddingLayer(BaseLayer):
         return ops.to(xt_out, xt.dtype)
 
     def compute_batch_mask(
-        self, start_positions: Union[torch.Tensor, ReplicatedTensor], batch_seq_len: int
+        self,
+        start_positions: Union[torch.Tensor, ReplicatedTensor],
+        batch_seq_len: int,
+        rotary_embed_table: torch.Tensor,
     ) -> torch.Tensor:
         # TODO: I'm pretty sure this function is only correct because batch_seq_len is always 1
         """Computes a mask for a batch that can be repeatedly applied.
@@ -230,46 +238,19 @@ class RotaryEmbeddingLayer(BaseLayer):
         self.trace_tensor("rope.positions_seq", positions_seq)
         if self.use_hf:
             assert self.use_table, "use_hf requires use_table"
-            freqs_cis = self.rotary_embed_table
+            freqs_cis = rotary_embed_table
             cos, sin = [x[positions_seq.flatten(), :] for x in freqs_cis]
             freqs_cis = (cos[:, None, None, :], sin[:, None, None, :])
             return freqs_cis
 
         if self.use_table:
-            freqs_cis = self.rotary_embed_table[positions_seq.flatten()]
+            freqs_cis = rotary_embed_table[positions_seq.flatten()]
         else:
-            shape = positions_seq.shape
-            if isinstance(positions_seq, ReplicatedTensor):
-                ts = [
-                    self._compute_rotary_embed_table(s.flatten()).unflatten(0, shape)
-                    for s in positions_seq.shards
-                ]
-                freqs_cis = ReplicatedTensor(ts=ts)
-            else:
-                freqs_cis = self._compute_rotary_embed_table(positions_seq.flatten())
+            freqs_cis = self.compute_rotary_embed_table(positions_seq.flatten())
 
         return freqs_cis.unsqueeze(1)
 
-    def apply_batched_mask(
-        self,
-        *,
-        xt: Union[torch.Tensor, SplitPrimitiveTensor, ReplicatedTensor],
-        mask: Union[torch.Tensor, ReplicatedTensor],
-    ) -> Union[SplitPrimitiveTensor, ReplicatedTensor]:
-        if not isinstance(xt, ShardedTensor):
-            return self.apply_batched_mask_unsharded(xt=xt, mask=mask)
-
-        assert isinstance(mask, ReplicatedTensor) and mask.shard_count == xt.shard_count
-        xt_shards = [
-            self.apply_batched_mask_unsharded(
-                xt=unbox_tensor(xt_shard),
-                mask=unbox_tensor(mask_shard),
-            )
-            for xt_shard, mask_shard in zip(xt.shards, mask.shards)
-        ]
-        return xt.clone(ts=xt_shards)
-
-    def apply_batched_mask_unsharded(self, *, xt: torch.Tensor, mask: torch.Tensor):
+    def apply_batched_mask(self, *, xt: torch.Tensor, mask: torch.Tensor):
         """Applies the embedding to a ragged batch of queries and keys.
 
         This does a more complicated indexing operation for cases when the each
@@ -290,7 +271,7 @@ class RotaryEmbeddingLayer(BaseLayer):
 
         return xt_out.type_as(xt)
 
-    def _compute_rotary_embed_table(self, t):
+    def compute_rotary_embed_table(self, t):
         dim = self.rope_dimension_count
         if self.use_hf:
 
@@ -338,14 +319,6 @@ class RotaryEmbeddingLayer(BaseLayer):
         freqs = (t.unsqueeze(1) * freqs.unsqueeze(0)).float()
         return freqs
 
-    def _create_rotary_embed_table(self):
+    def create_rotary_embed_table(self):
         t = torch.arange(self.max_seqlen, device=self.device)
-        freqs_cis = self._compute_rotary_embed_table(t)
-        return self._replicate(freqs_cis)
-
-    def _replicate(self, t):
-        if self.tensor_parallelism_size > 1 or self.pipeline_parallelism:
-            # Replicate across all devices, the data is not a lot and the computation is cheap.
-            t = ops.replicate(t, self.tensor_parallelism_size, devices=self.devices)
-
-        return t
+        return self.compute_rotary_embed_table(t)

--- a/sharktank/sharktank/models/llm/llm.py
+++ b/sharktank/sharktank/models/llm/llm.py
@@ -84,7 +84,7 @@ class PagedLlmModelV1(BaseCausalLMModel):
         )
         self.attention_embedding = nn.ModuleList(
             [
-                RotaryEmbeddingLayer(
+                build_rotary_layer(
                     rope_dimension_count=self.hp.rope_dimension_count,
                     rope_freq_base=self.hp.rope_freq_base,
                     max_seqlen=self.hp.context_length,

--- a/sharktank/tests/layers/paged_llama_attention_block_test.py
+++ b/sharktank/tests/layers/paged_llama_attention_block_test.py
@@ -18,7 +18,7 @@ from iree.turbine import aot
 from sharktank.layers import (
     PagedLlamaAttentionBlock,
     PagedAttention,
-    RotaryEmbeddingLayer,
+    build_rotary_layer,
 )
 from sharktank.layers.testing import make_llama_attention_block_theta
 from sharktank.types.tensors import DefaultPrimitiveTensor
@@ -91,7 +91,7 @@ class PagedLlamaAttentionBlockTest(unittest.TestCase):
             self.batch_size, -1
         )
 
-        embedding_module = RotaryEmbeddingLayer(
+        embedding_module = build_rotary_layer(
             rope_dimension_count=self.rope_dimension_count,
             max_seqlen=self.max_seqlen,
             rope_freq_base=self.rope_freq_base,

--- a/sharktank/tests/layers/rotary_test.py
+++ b/sharktank/tests/layers/rotary_test.py
@@ -7,7 +7,7 @@
 import math
 import torch
 
-from sharktank.layers import RotaryEmbeddingLayer
+from sharktank.layers.rotary_embedding import build_rotary_layer
 
 
 def validate(xq, em, rope_dims, rope_freq_base, interleaved):
@@ -73,7 +73,7 @@ def test_sharded_rotary_table_interleaved():
 
     # First we setup and get the default rotary embedding layer
     xq = torch.rand((bs, max_seqlen, heads, rope_dims), dtype=torch.float)
-    default_layer = RotaryEmbeddingLayer(
+    default_layer = build_rotary_layer(
         rope_dimension_count=rope_dims,
         max_seqlen=max_seqlen,
         rope_freq_base=rope_freq_base,
@@ -98,7 +98,7 @@ def test_sharded_rotary_table_concatted():
 
     # First we setup and get the default rotary embedding layer
     xq = torch.rand((bs, max_seqlen, heads, rope_dims), dtype=torch.float)
-    default_layer = RotaryEmbeddingLayer(
+    default_layer = build_rotary_layer(
         rope_dimension_count=rope_dims,
         max_seqlen=max_seqlen,
         rope_freq_base=rope_freq_base,

--- a/sharktank/tests/layers/sharded_paged_latent_attention_block_test.py
+++ b/sharktank/tests/layers/sharded_paged_latent_attention_block_test.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 import torch
 
 from sharktank.layers.paged_llama_attention_block import PagedLlamaAttentionBlock
-from sharktank.layers.rotary_embedding import RotaryEmbeddingLayer
+from sharktank.layers.rotary_embedding import build_rotary_layer
 from sharktank.layers.testing import make_rand_torch
 
 from sharktank.models.deepseek.toy_deepseek import generate
@@ -117,7 +117,7 @@ class ShardedPagedLatentAttentionBlockTest(unittest.TestCase):
             sharded_cache_state,
         ) = make_unsharded_and_sharded_equal_cache_states()
 
-        embedding = RotaryEmbeddingLayer(
+        embedding = build_rotary_layer(
             rope_dimension_count=hp.rope_dimension_count,
             rope_freq_base=hp.rope_freq_base,
             max_seqlen=hp.context_length,
@@ -144,7 +144,7 @@ class ShardedPagedLatentAttentionBlockTest(unittest.TestCase):
             cache_state=cache_state,
         )
 
-        sharded_embedding = RotaryEmbeddingLayer(
+        sharded_embedding = build_rotary_layer(
             rope_dimension_count=hp.rope_dimension_count,
             rope_freq_base=hp.rope_freq_base,
             max_seqlen=hp.context_length,

--- a/sharktank/tests/layers/sharded_paged_llama_attention_block_test.py
+++ b/sharktank/tests/layers/sharded_paged_llama_attention_block_test.py
@@ -8,7 +8,7 @@ import unittest
 from sharktank.layers import (
     PagedLlamaAttentionBlock,
     PagedAttention,
-    RotaryEmbeddingLayer,
+    build_rotary_layer,
 )
 from sharktank.layers.testing import make_llama_attention_block_theta
 from sharktank.types.sharding import PagedLlamaAttentionBlockSharding
@@ -134,7 +134,7 @@ class ShardedPagedLlamaAttentionBlockTest(unittest.TestCase):
         seq_block_ids = torch.arange(self.batch_size * self.block_seqlen).view(
             self.batch_size, -1
         )
-        embedding_module = RotaryEmbeddingLayer(
+        embedding_module = build_rotary_layer(
             rope_dimension_count=self.rope_dimension_count,
             max_seqlen=self.max_seqlen,
             rope_freq_base=self.rope_freq_base,

--- a/sharktank/tests/layers/sharded_rotary_embedding_test.py
+++ b/sharktank/tests/layers/sharded_rotary_embedding_test.py
@@ -7,7 +7,7 @@
 
 import torch
 
-from sharktank.layers import RotaryEmbeddingLayer
+from sharktank.layers.rotary_embedding import build_rotary_layer
 from sharktank import ops
 from sharktank.types import (
     ShardedTensor,
@@ -30,7 +30,7 @@ def test_sharded_rotary_table():
     # First we setup and get the default rotary embedding layer
     xq = torch.rand((bs, max_seqlen, heads, rope_dims), dtype=torch.float)
     xk = torch.rand((bs, max_seqlen, heads, rope_dims), dtype=torch.float)
-    default_layer = RotaryEmbeddingLayer(
+    default_layer = build_rotary_layer(
         rope_dimension_count=rope_dims,
         max_seqlen=max_seqlen,
         rope_freq_base=rope_freq_base,
@@ -41,7 +41,7 @@ def test_sharded_rotary_table():
     # Then we can shard the same inputs and layer
     xq = SplitPrimitiveTensor(ts=xq, shard_dim=2, shard_count=4)
     xk = SplitPrimitiveTensor(ts=xk, shard_dim=2, shard_count=4)
-    shard_layer = RotaryEmbeddingLayer(
+    shard_layer = build_rotary_layer(
         rope_dimension_count=rope_dims,
         max_seqlen=max_seqlen,
         rope_freq_base=rope_freq_base,

--- a/sharktank/tests/models/llama/attention_test.py
+++ b/sharktank/tests/models/llama/attention_test.py
@@ -9,7 +9,7 @@ import unittest
 import torch
 
 from sharktank.layers.configs.llm_configs import *
-from sharktank.layers.rotary_embedding import RotaryEmbeddingLayer
+from sharktank.layers.rotary_embedding import build_rotary_layer
 from sharktank.layers.paged_attention import PagedAttention
 from sharktank.models.llm import AttentionFFNBlock
 from sharktank.models.llama.testing import *
@@ -79,7 +79,7 @@ class AttentionBlockTest(unittest.TestCase):
             cache=paged_kv_cache,
             config=llama_config,
         )
-        attention_embedding = RotaryEmbeddingLayer(
+        attention_embedding = build_rotary_layer(
             rope_dimension_count=rope_dimension_count,
             rope_freq_base=rope_freq_base,
             max_seqlen=max_seq_len,

--- a/sharktank/tests/models/llama/rot_emb_test.py
+++ b/sharktank/tests/models/llama/rot_emb_test.py
@@ -6,7 +6,7 @@
 
 import torch
 
-from sharktank.layers.rotary_embedding import RotaryEmbeddingLayer
+from sharktank.layers.rotary_embedding import build_rotary_layer
 from transformers.models.llama.modeling_llama import (
     LlamaRotaryEmbedding,
     apply_rotary_pos_emb,
@@ -46,7 +46,7 @@ class HFRotaryComparisonTest(unittest.TestCase):
                 xt = xt.transpose(1, 2)
                 return apply_rotary_pos_emb(xt, xt, cos, sin)[0].transpose(1, 2)
 
-        st_rotary = RotaryEmbeddingLayer(
+        st_rotary = build_rotary_layer(
             rope_dimension_count=dims,
             max_seqlen=2048,
             rope_freq_base=500000,
@@ -64,9 +64,7 @@ class HFRotaryComparisonTest(unittest.TestCase):
         mask = st_rotary.compute_batch_mask(
             start_positions=torch.arange(0, bs), batch_seq_len=1
         )
-        st_results = st_rotary.apply_batched_mask_unsharded(
-            xt=decode_example, mask=mask
-        )
+        st_results = st_rotary.apply_batched_mask(xt=decode_example, mask=mask)
         hf_results = hf_rotary.forward(
             xt=decode_example, positions=torch.arange(0, bs).unsqueeze(1)
         )


### PR DESCRIPTION
Rotary layer should have sharding behavior split away from the main implementation. This avoids handling the desharding - resharding of the rotary embedding table.