### PR TITLE
Add `write_range` function to `KVCache`

### DIFF
--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -352,6 +352,79 @@ class KVCache:
             else:
                 page_table.index_put_(indices=(index,), values=values)
 
+    def write_range(
+        self,
+        *,
+        state: List[torch.Tensor],
+        cache_partitions: List[torch.Tensor],
+        transformer_block_index: int,
+        seq_positions: torch.Tensor,
+        page_ids: Union[torch.Tensor, ReplicatedTensor],
+    ):
+        """Writes a range of cache partitions to the page table.
+        Similar function to `write_timestep`, but generalized for writing
+        cache partitions with seq_len > 1.
+        Args:
+            state (List[torch.Tensor]): Current state of the KV cache allocation.
+            cache_partitions (List[torch.Tensor]): K and V cache partitions.
+            transformer_block_index (int): Transformer block index to write to.
+            seq_positions (torch.Tensor): Positions denoting the starting index to write for a given sequence.
+            page_ids (Union[torch.Tensor, ReplicatedTensor]): Page IDs to write to.
+        """
+        assert len(state) == 1
+        assert len(cache_partitions) == self.cache_partition_count
+
+        page_table = self.unflatten_page_table(state)[0]
+        page_table = page_table.flatten(0, 4)
+
+        device = self.device
+        bs, seq_len, *_ = cache_partitions[0].shape
+
+        positions = torch.arange(seq_len, device=device, dtype=torch.int64).unsqueeze(
+            0
+        ) + seq_positions.unsqueeze(
+            1
+        )  # [bs, seq_len]
+
+        # Compute the logical page indices from `seq_positions`
+        logical_page_index = positions // self.block_seq_stride  # [bs, seq_len]
+
+        # Obtain the real page ids from the page table.
+        real_page_ids = ops.gather(page_ids, dim=1, index=logical_page_index).view(
+            bs, seq_len, 1
+        )
+
+        # Compute the page offsets within the block sequence stride.
+        page_offset = (positions % self.block_seq_stride).view(bs, seq_len, 1)
+
+        # Compute the head offsets.
+        head_offset = torch.arange(self.attn_head_count, device=device).view(
+            (1, 1, self.attn_head_count)
+        )
+
+        # Loop over the cache partitions and write them to the page table.
+        for cache_partition_id, cache_partition in enumerate(cache_partitions):
+            partitions = torch.tensor(cache_partition_id, device=device).view(1, 1, 1)
+
+            # Compute the flat index for the page table.
+            index = real_page_ids
+            index = index * self.transformer_block_count + transformer_block_index
+            index = index * self.cache_partition_count + partitions
+            index = index * self.attn_head_count + head_offset
+            index = index * self.block_seq_stride + page_offset
+
+            # Prepare the values to write.
+            values = ops.to(cache_partition, dtype=page_table.dtype)
+
+            if page_table.dtype == torch.float8_e4m3fnuz:
+                # Workaround for Torch not supporting torch.Tensor.index_copy_ for f8.
+                page_table_as_int8 = page_table.view(dtype=torch.int8)
+                values_int8 = values.view(dtype=torch.int8)
+                page_table_as_int8.index_put_(indices=(index,), values=values_int8)
+
+            else:
+                page_table.index_put_(indices=(index,), values=values)
+
 
 class ShardedCache:
     def __init__(
@@ -521,6 +594,28 @@ class ShardedCache:
         for i in range(self.shard_count):
             cache_partition_shards = [p.shards[i] for p in cache_partitions]
             self.caches[i].write_timestep(
+                state=[state[0].shards[i]],
+                cache_partitions=cache_partition_shards,
+                transformer_block_index=transformer_block_index,
+                seq_positions=seq_positions.shards[i],
+                page_ids=page_ids.shards[i],
+            )
+
+    def write_range(
+        self,
+        *,
+        state: List[SplitPrimitiveTensor],
+        cache_partitions: List[SplitPrimitiveTensor],
+        transformer_block_index: int,
+        seq_positions: SplitPrimitiveTensor,
+        page_ids: ReplicatedTensor,
+    ):
+        assert len(state) == 1
+        assert state[0].shard_count == self.shard_count
+
+        for i in range(self.shard_count):
+            cache_partition_shards = [p.shards[i] for p in cache_partitions]
+            self.caches[i].write_range(
                 state=[state[0].shards[i]],
                 cache_partitions=cache_partition_shards,
                 transformer_block_index=transformer_block_index,
@@ -782,6 +877,38 @@ class PipelinedCache:
             seq_positions=seq_positions,
         )
 
+    def write_range(
+        self,
+        *,
+        state: List[ReplicatedTensor | SplitPrimitiveTensor],
+        cache_partitions: List[SplitPrimitiveTensor],
+        transformer_block_index: int,
+        seq_positions: SplitPrimitiveTensor,
+        page_ids: ReplicatedTensor,
+    ):
+        pipeline = self.block_to_pipeline_map[transformer_block_index]
+        block = self.transformer_block_map[transformer_block_index]
+
+        # Select the right pipeline:
+        pipeline_state = [state[pipeline]]
+
+        # Remove pipelining from the args:
+        page_ids = self.unwrap_like(page_ids, pipeline_state)
+
+        # If device pipelined we need to unwrap:
+        pipeline_state = self.unwrap_pipelining(pipeline_state)
+        page_ids = self.unwrap_pipelining(page_ids)
+        cache_partitions = self.unwrap_pipelining(cache_partitions)
+        seq_positions = self.unwrap_pipelining(seq_positions)
+
+        return self.caches[pipeline].write_range(
+            state=pipeline_state,
+            cache_partitions=cache_partitions,
+            transformer_block_index=block,
+            seq_positions=seq_positions,
+            page_ids=page_ids,
+        )
+
 
 def build_cache(
     shard_count: int,
@@ -943,6 +1070,22 @@ class PagedAttention:
         page_ids: Union[torch.Tensor, ReplicatedTensor],
     ):
         self.kv_cache.write_timestep(
+            state=state,
+            cache_partitions=cache_partitions,
+            transformer_block_index=transformer_block_index,
+            seq_positions=seq_positions,
+            page_ids=page_ids,
+        )
+
+    def write_range(
+        self,
+        state: List[torch.Tensor | SplitPrimitiveTensor | ReplicatedTensor],
+        cache_partitions: List[torch.Tensor | SplitPrimitiveTensor | ReplicatedTensor],
+        transformer_block_index: int,
+        seq_positions: Optional[torch.Tensor],
+        page_ids: Union[torch.Tensor, ReplicatedTensor],
+    ):
+        self.kv_cache.write_range(
             state=state,
             cache_partitions=cache_partitions,
             transformer_block_index=transformer_block_index,

--- a/sharktank/tests/layers/kv_cache_test.py
+++ b/sharktank/tests/layers/kv_cache_test.py
@@ -128,6 +128,88 @@ def test_paged(dtype: torch.dtype):
     torch.testing.assert_close(check_concat_1, read_back[1])
 
 
+@pytest.mark.parametrize(
+    "dtype,write_seq_len",
+    [
+        # Test all relevant dtypes
+        (torch.float8_e4m3fnuz, 8),
+        (torch.bfloat16, 8),
+        (torch.float16, 8),
+        # Test edge cases
+        (torch.float32, 0),
+        (torch.float32, 4),
+        (torch.float32, 8),
+        (torch.float32, 24),
+    ],
+)
+def test_write_range(dtype: torch.dtype, write_seq_len: int):
+    bs = 4
+    seq_length = 24
+    # write_seq_len = 8
+    attn_head_count = 8
+    attn_head_dim = 16
+    transformer_block_count = 4
+    block_seq_stride = 4
+
+    cache = PagedAttention(
+        block_seq_stride=block_seq_stride,
+        transformer_block_count=transformer_block_count,
+        attn_head_count=attn_head_count,
+        attn_head_dim=attn_head_dim,
+        cache_dtype=torch.float32,
+        attn_dtype=torch.float32,
+        device=None,
+    )
+
+    # Allocate cache
+    page_count = bs * seq_length // block_seq_stride
+    page_ids = torch.arange(page_count, dtype=torch.int64).view(
+        bs, seq_length // block_seq_stride
+    )
+    allocation = cache.allocate(page_count=page_count)
+
+    for t in allocation:
+        t[...] = torch.full(t.shape, 0.0).to(dtype=dtype)
+
+    # Create data to write
+    shape = (bs, write_seq_len, attn_head_count, attn_head_dim)
+    write_ones = torch.rand(*shape)
+    write_twos = torch.rand(*shape)
+
+    cache_partitions = [write_ones, write_twos]
+    start_positions = torch.full((bs,), seq_length - write_seq_len, dtype=torch.int64)
+
+    write_page_ids = page_ids[:, : seq_length // block_seq_stride]
+
+    # Write the full range starting at start_positions
+    cache.write_range(
+        state=allocation,
+        cache_partitions=cache_partitions,
+        transformer_block_index=1,
+        seq_positions=start_positions,
+        page_ids=page_ids,
+    )
+
+    # Read back and check
+    read_back = cache.read(
+        allocation,
+        transformer_block_index=1,
+        page_ids=write_page_ids,
+    )
+
+    # Check that the correct slice was written
+    check_1 = read_back[0][:, seq_length - write_seq_len :]
+    torch.testing.assert_close(
+        check_1,
+        write_ones,
+    )
+    check_2 = read_back[1][:, seq_length - write_seq_len :]
+    torch.testing.assert_close(
+        check_2,
+        write_twos,
+    )
+
+
 def test_sharded_paged():
     bs = 4
     seq_length = 24


### PR DESCRIPTION
This is part of the preparation work for enabling `partial_prefill` (prefill with `start_positions` >= 0).

It's similar to `write_timestep`, except extends the functionality to be able to write to kvcache for `seq_len` > 1. During partial_prefill, we will use this function to write the `k` and `v` tensors corresponding to `sequence(i)[start_position(i):]` for each sequence in a batch.

Afterwards, we'll read from the cache, avoiding a recomputation of already cache `k` and `v` tensors corresponding to `sequence(i)[:start_position(i)]`