### PR TITLE
Add extra iterations flag to Llama 405b and 70b perplexity tests

### DIFF
--- a/sharktank/sharktank/utils/export_artifacts.py
+++ b/sharktank/sharktank/utils/export_artifacts.py
@@ -407,6 +407,12 @@ class ExportArtifacts:
             "--iree-hal-memoization=true",
         ]
 
+        # TODO: https://github.com/iree-org/iree/issues/21068
+        if any(
+            llama_size in str(self.irpa_path) for llama_size in ["405", "70"]
+        ) and all("max-iterations" not in arg for arg in compile_args):
+            compile_args += "--iree-stream-affinity-solver-max-iterations=1024"
+
         # Append optional arguments if provided
         if extra_args:
             compile_args += extra_args

--- a/sharktank/tests/evaluate/perplexity_iree_test.py
+++ b/sharktank/tests/evaluate/perplexity_iree_test.py
@@ -60,9 +60,10 @@ class PerplexityTest(unittest.TestCase):
         self.argv.extend(f"--iree-device={device}" for device in self.iree_devices)
 
         # TODO: https://github.com/iree-org/iree/issues/21068
-        self.argv.append(
-            "--extra-compile-arg=--iree-stream-affinity-solver-max-iterations=1024"
-        )
+        if any(llama_size in self._testMethodName for llama_size in ["405", "70"]):
+            self.argv.append(
+                "--extra-compile-arg=--iree-stream-affinity-solver-max-iterations=1024"
+            )
 
         if self.tensor_parallelism_size * self.pipeline_parallelism_size > 1:
             self.argv.append(f"--use-attention-mask")

--- a/sharktank/tests/evaluate/perplexity_iree_test.py
+++ b/sharktank/tests/evaluate/perplexity_iree_test.py
@@ -59,6 +59,11 @@ class PerplexityTest(unittest.TestCase):
         ]
         self.argv.extend(f"--iree-device={device}" for device in self.iree_devices)
 
+        # TODO: https://github.com/iree-org/iree/issues/21068
+        self.argv.append(
+            "--extra-compile-arg=--iree-stream-affinity-solver-max-iterations=1024"
+        )
+
         if self.tensor_parallelism_size * self.pipeline_parallelism_size > 1:
             self.argv.append(f"--use-attention-mask")
         if extra_args:

--- a/sharktank/tests/evaluate/perplexity_iree_test.py
+++ b/sharktank/tests/evaluate/perplexity_iree_test.py
@@ -59,12 +59,6 @@ class PerplexityTest(unittest.TestCase):
         ]
         self.argv.extend(f"--iree-device={device}" for device in self.iree_devices)
 
-        # TODO: https://github.com/iree-org/iree/issues/21068
-        if any(llama_size in self._testMethodName for llama_size in ["405", "70"]):
-            self.argv.append(
-                "--extra-compile-arg=--iree-stream-affinity-solver-max-iterations=1024"
-            )
-
         if self.tensor_parallelism_size * self.pipeline_parallelism_size > 1:
             self.argv.append(f"--use-attention-mask")
         if extra_args:


### PR DESCRIPTION
Needed because of: https://github.com/iree-org/iree/issues/21068.