### PR TITLE
[LLM Server] Fix issue with batch `input_id` requests

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/generate.py
+++ b/shortfin/python/shortfin_apps/llm/components/generate.py
@@ -298,15 +298,6 @@ class ClientGenerateBatchProcess(sf.Process):
             await asyncio.gather(*gen_processes)
             if not self.responder.is_disconnected():
                 self.generate_response(gen_processes, streaming)
-        except Exception as e:
-            logger.exception("Error in ClientGenerateBatchProcess: %s", e)
-            if not self.responder.is_disconnected():
-                self._return_error_response(
-                    status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    error_message=str(e),
-                    code=ResponseErrorCodes.INTERNAL_ERROR,
-                    extra_fields={},
-                )
         finally:
             self.service.main_fiber_pool.return_fiber(indices)
             self.responder.ensure_response()


### PR DESCRIPTION
## Description

We were hitting an issue when attempting to send batch requests through the `mlperf harness`, where we specify `input_ids` instead of text.

Simple fix here, we weren't checking if the request was pre-tokenized or not, so we were attempting to index into a `None` value, which causes the error.

Seeing some gaps in the CI regarding requests that supply `input_token_ids` instead of `text`. Will follow up with coverage PR + any fixes that unearths.