### PR TITLE
[sharktank] Make IREE flags pytest fixture work at function scope

### DIFF
--- a/sharktank/conftest.py
+++ b/sharktank/conftest.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 from pytest import FixtureRequest
 from typing import Optional, Any
+from dataclasses import dataclass
 
 
 # Tests under each top-level directory will get a mark.
@@ -305,6 +306,7 @@ def set_fixture(request: FixtureRequest, name: str, value: Any):
         return value
     else:
         setattr(request.cls, name, value)
+        return value
 
 
 def set_fixture_from_cli_option(
@@ -368,7 +370,7 @@ def batch_size(request: FixtureRequest) -> Optional[str]:
 
 
 @pytest.fixture(scope="class")
-def get_model_artifacts(request: FixtureRequest):
+def model_artifacts(request: FixtureRequest) -> dict[str, str]:
     model_path = {}
     model_path["llama3_8b_tokenizer_path"] = set_fixture_from_cli_option(
         request, "--llama3-8b-tokenizer-path", "llama3_8b_tokenizer"
@@ -427,23 +429,36 @@ def get_model_artifacts(request: FixtureRequest):
     return model_path
 
 
+@dataclass
+class IreeFlags:
+    iree_device: str
+    iree_hip_target: str
+    iree_hal_target_device: str
+    iree_hal_local_target_device_backends: str
+
+
 @pytest.fixture(scope="class")
-def get_iree_flags(request: FixtureRequest):
-    model_path = {}
+def iree_flags(request: FixtureRequest) -> IreeFlags:
     iree_device = request.config.getoption("iree_device")
     if not isinstance(iree_device, str) and len(iree_device) == 1:
         iree_device = iree_device[0]
     set_fixture(request, "iree_device", iree_device)
-    model_path["iree_hip_target"] = set_fixture_from_cli_option(
+    iree_hip_target = set_fixture_from_cli_option(
         request, "--iree-hip-target", "iree_hip_target"
     )
-    model_path["iree_hal_target_device"] = set_fixture_from_cli_option(
+    iree_hal_target_device = set_fixture_from_cli_option(
         request, "--iree-hal-target-device", "iree_hal_target_device"
     )
-    model_path["iree_hal_local_target_device_backends"] = set_fixture_from_cli_option(
+    iree_hal_local_target_device_backends = set_fixture_from_cli_option(
         request,
         "--iree-hal-local-target-device-backends",
         "iree_hal_local_target_device_backends",
+    )
+    return IreeFlags(
+        iree_device=iree_device,
+        iree_hip_target=iree_hip_target,
+        iree_hal_target_device=iree_hal_target_device,
+        iree_hal_local_target_device_backends=iree_hal_local_target_device_backends,
     )
 
 

--- a/sharktank/tests/evaluate/perplexity_iree_test.py
+++ b/sharktank/tests/evaluate/perplexity_iree_test.py
@@ -25,8 +25,8 @@ from sharktank.utils.testing import (
 
 
 @pytest.mark.usefixtures(
-    "get_model_artifacts",
-    "get_iree_flags",
+    "model_artifacts",
+    "iree_flags",
     "tensor_parallelism_size",
     "baseline_perplexity_scores",
     "batch_size",

--- a/sharktank/tests/evaluate/perplexity_torch_test.py
+++ b/sharktank/tests/evaluate/perplexity_torch_test.py
@@ -21,7 +21,7 @@ from sharktank.utils.testing import (
 
 
 @pytest.mark.usefixtures(
-    "get_model_artifacts",
+    "model_artifacts",
     "tensor_parallelism_size",
     "baseline_perplexity_scores",
     "batch_size",

--- a/sharktank/tests/models/clip/clip_test.py
+++ b/sharktank/tests/models/clip/clip_test.py
@@ -78,7 +78,7 @@ with_clip_data = pytest.mark.skipif("not config.getoption('with_clip_data')")
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.usefixtures("path_prefix", "get_iree_flags")
+@pytest.mark.usefixtures("path_prefix", "iree_flags")
 class ClipTextIreeTest(TempDirTestBase):
     def setUp(self):
         super().setUp()
@@ -331,7 +331,7 @@ class ClipTextIreeTest(TempDirTestBase):
         )
 
 
-@pytest.mark.usefixtures("get_model_artifacts")
+@pytest.mark.usefixtures("model_artifacts")
 class ClipTextEagerTest(TestCase):
     def setUp(self):
         super().setUp()

--- a/sharktank/tests/models/deepseek/test_deepseek.py
+++ b/sharktank/tests/models/deepseek/test_deepseek.py
@@ -60,7 +60,7 @@ class DeepseekCrossEntropyTest(unittest.TestCase):
         assert pytest.approx(9.7477, 1e-4) == cross_entropy
 
 
-@pytest.mark.usefixtures("get_iree_flags", "device")
+@pytest.mark.usefixtures("iree_flags", "device")
 @is_mi300x
 class DeepseekIreeVsEagerTest(TempDirTestBase):
     @xfail(

--- a/sharktank/tests/models/deepseek/test_sharded.py
+++ b/sharktank/tests/models/deepseek/test_sharded.py
@@ -33,7 +33,7 @@ from sharktank.utils.testing import TempDirTestBase, assert_logits_kl_divergence
 from sharktank.examples.sharding import shard_llm_dataset
 
 
-@pytest.mark.usefixtures("get_iree_flags")
+@pytest.mark.usefixtures("iree_flags")
 class DeepseekShardedTest(TempDirTestBase):
     @parameterized.expand(
         [

--- a/sharktank/tests/models/flux/flux_test.py
+++ b/sharktank/tests/models/flux/flux_test.py
@@ -71,7 +71,7 @@ def convert_input_dtype(input: dict[str, torch.Tensor], dtype: torch.dtype):
     )
 
 
-@pytest.mark.usefixtures("path_prefix", "get_iree_flags")
+@pytest.mark.usefixtures("path_prefix", "iree_flags")
 class FluxTest(TempDirTestBase):
     def setUp(self):
         super().setUp()

--- a/sharktank/tests/models/llama/benchmark_amdgpu_test.py
+++ b/sharktank/tests/models/llama/benchmark_amdgpu_test.py
@@ -23,7 +23,7 @@ from sharktank.utils.testing import (
 )
 
 
-@pytest.mark.usefixtures("get_iree_flags", "get_model_artifacts")
+@pytest.mark.usefixtures("iree_flags", "model_artifacts")
 class BaseBenchmarkTest(unittest.TestCase):
     dir_path_suffix = datetime.now().strftime("%Y-%m-%d")
     repo_root = Path(__file__).resolve().parents[4]

--- a/sharktank/tests/models/llama/sharded_llama_test.py
+++ b/sharktank/tests/models/llama/sharded_llama_test.py
@@ -42,7 +42,7 @@ from iree.turbine.aot import FxProgramsBuilder, export
 import iree
 
 
-@pytest.mark.usefixtures("caching", "path_prefix", "get_iree_flags")
+@pytest.mark.usefixtures("caching", "path_prefix", "iree_flags")
 class ShardedLlamaTest(unittest.TestCase):
     def setUp(self):
         torch.random.manual_seed(123456)

--- a/sharktank/tests/models/t5/t5_test.py
+++ b/sharktank/tests/models/t5/t5_test.py
@@ -328,7 +328,7 @@ class T5EncoderEagerTest(TestCase):
         )
 
 
-@pytest.mark.usefixtures("caching", "get_iree_flags", "path_prefix")
+@pytest.mark.usefixtures("caching", "iree_flags", "path_prefix")
 class T5EncoderIreeTest(TempDirTestBase):
     def setUp(self):
         super().setUp()

--- a/sharktank/tests/models/vae/vae_test.py
+++ b/sharktank/tests/models/vae/vae_test.py
@@ -55,7 +55,7 @@ with_vae_data = pytest.mark.skipif("not config.getoption('with_vae_data')")
 
 
 @with_vae_data
-@pytest.mark.usefixtures("get_iree_flags")
+@pytest.mark.usefixtures("iree_flags")
 class VaeSDXLDecoderTest(TempDirTestBase):
     def setUp(self):
         super().setUp()
@@ -224,7 +224,7 @@ class VaeSDXLDecoderTest(TempDirTestBase):
         torch.testing.assert_close(ref_results, iree_result, atol=3e-5, rtol=6e-6)
 
 
-@pytest.mark.usefixtures("get_iree_flags")
+@pytest.mark.usefixtures("iree_flags")
 class VaeFluxDecoderTest(TempDirTestBase):
     def setUp(self):
         super().setUp()

--- a/sharktank/tests/pipelines/flux/flux_pipeline_test.py
+++ b/sharktank/tests/pipelines/flux/flux_pipeline_test.py
@@ -19,7 +19,7 @@ from sharktank.pipelines.flux import FluxPipeline
 with_flux_data = pytest.mark.skipif("not config.getoption('with_flux_data')")
 
 
-@pytest.mark.usefixtures("get_model_artifacts")
+@pytest.mark.usefixtures("model_artifacts")
 class FluxPipelineEagerTest(TestCase):
     def setUp(self):
         super().setUp()

--- a/sharktank/tests/pytest_fixtures_test.py
+++ b/sharktank/tests/pytest_fixtures_test.py
@@ -1,0 +1,38 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+from unittest import TestCase
+
+pytest_plugins = "pytester"
+
+
+def test_function_scope_iree_flags_fixture_smoke(iree_flags):
+    """Make sure fixtures work on function scope, not just class scope."""
+    assert hasattr(iree_flags, "iree_device")
+    assert hasattr(iree_flags, "iree_hip_target")
+    assert hasattr(iree_flags, "iree_hal_target_device")
+    assert hasattr(iree_flags, "iree_hal_local_target_device_backends")
+
+
+def test_function_scope_model_artifacts_fixture_smoke(model_artifacts):
+    """Make sure fixtures work on function scope, not just class scope."""
+    assert "llama3_8b_tokenizer_path" in model_artifacts
+
+
+@pytest.mark.usefixtures("iree_flags", "model_artifacts")
+class TestFixtureOnTestCase(TestCase):
+    """Make sure fixtures work on TestCase classes."""
+
+    def test_iree_flags_smoke(self):
+        assert hasattr(self, "iree_device")
+        assert hasattr(self, "iree_hip_target")
+        assert hasattr(self, "iree_hal_target_device")
+        assert hasattr(self, "iree_hal_local_target_device_backends")
+
+    def test_model_artifacts_smoke(self):
+        # Check one sample value.
+        assert hasattr(self, "llama3_8b_tokenizer")

--- a/sharktank/tests/utils/iree_test.py
+++ b/sharktank/tests/utils/iree_test.py
@@ -73,7 +73,7 @@ def test_trace_model_with_tracy(dummy_model: DummyModel, dummy_model_path: Path)
         assert trace_path.exists()
 
 
-@pytest.mark.usefixtures("get_iree_flags")
+@pytest.mark.usefixtures("iree_flags")
 class TestTensorConversion(TestCase):
     def setUp(self):
         torch.manual_seed(0)


### PR DESCRIPTION
Our fixture get_iree_flags works only on classes and not with individual tests. This causes a bunch of problems like not being able to xfail a parametrized test for particular parameter set. Because tests in unittest.TestCase are not compatible with pytest.param. parameterized.parameterized.expand is not compatible with pytest.mark.xfail.

Resolves https://github.com/nod-ai/shark-ai/issues/1708.

Rename fixtures
get_iree_flags -> iree_flags
get_model_artifacts -> model_artifacts