### PR TITLE
[tuner] add parser for attention op

### DIFF
--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -91,9 +91,6 @@ class ContractionOpInterfaceTuner(
     ) -> ir.Module:
         contraction_op = self.get_root_op()
         func_name = self.get_root_op_func_name()
-
-        # Wrap the single CompilationInfoAttr in a list of (str, Attribute).
-        config_list = [("compilation_info", compilation_info)]
         return spec_builder.build_td_spec(
             contraction_op.context, contraction_op, config_list, func_name
         )
@@ -116,9 +113,6 @@ class ConvolutionOpInterfaceTuner(
     ) -> ir.Module:
         conv_op = self.get_root_op()
         func_name = self.get_root_op_func_name()
-
-        # Wrap the single CompilationInfoAttr in a list of (str, Attribute).
-        config_list = [("compilation_info", compilation_info)]
         return spec_builder.build_td_spec(
             conv_op.context, conv_op, config_list, func_name
         )

--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -91,6 +91,9 @@ class ContractionOpInterfaceTuner(
     ) -> ir.Module:
         contraction_op = self.get_root_op()
         func_name = self.get_root_op_func_name()
+
+        # Wrap the single CompilationInfoAttr in a list of (str, Attribute).
+        config_list = [("compilation_info", compilation_info)]
         return spec_builder.build_td_spec(
             contraction_op.context, contraction_op, config_list, func_name
         )
@@ -113,6 +116,9 @@ class ConvolutionOpInterfaceTuner(
     ) -> ir.Module:
         conv_op = self.get_root_op()
         func_name = self.get_root_op_func_name()
+
+        # Wrap the single CompilationInfoAttr in a list of (str, Attribute).
+        config_list = [("compilation_info", compilation_info)]
         return spec_builder.build_td_spec(
             conv_op.context, conv_op, config_list, func_name
         )

--- a/sharktuner/sharktuner/dispatch_parser.py
+++ b/sharktuner/sharktuner/dispatch_parser.py
@@ -11,6 +11,7 @@ from abc import ABCMeta, abstractmethod
 
 from iree.compiler import ir  # type: ignore
 from iree.compiler.dialects import linalg, func  # type: ignore
+from iree.compiler.dialects import iree_codegen  # type: ignore
 
 from . import common
 
@@ -89,5 +90,4 @@ class AttentionOpInterfaceParser(DispatchParser):
 
     def has_valid_root_op(self) -> bool:
         root_op = self.get_root_op()
-        # TODO(Bangtian): will see whether to use `iree_codegen.isa_attention_op`
-        return root_op.name == "iree_linalg_ext.attention"
+        return iree_codegen.isa_attention_op(root_op)

--- a/sharktuner/sharktuner/dispatch_parser.py
+++ b/sharktuner/sharktuner/dispatch_parser.py
@@ -81,3 +81,13 @@ class ConvolutionOpInterfaceParser(DispatchParser):
         ):
             return False
         return True
+
+
+class AttentionOpInterfaceParser(DispatchParser):
+    def __init__(self, root_op: ir.Operation):
+        super().__init__(root_op)
+
+    def has_valid_root_op(self) -> bool:
+        root_op = self.get_root_op()
+        # TODO(Bangtian): will see whether to use `iree_codegen.isa_attention_op`
+        return root_op.name == "iree_linalg_ext.attention"


### PR DESCRIPTION
After https://github.com/iree-org/iree/pull/21170 and https://github.com/iree-org/iree/pull/21216 exposing python bindings from iree side, This PR adds parser for attention op.