### PR TITLE
Rate Limiting based on available page

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/error_codes.py
+++ b/shortfin/python/shortfin_apps/llm/components/error_codes.py
@@ -4,3 +4,4 @@ from enum import Enum, auto
 class ResponseErrorCodes(Enum):
     QUEUE_FULL = "QUEUE_FULL"
     INVALID_REQUEST_ARGS = "INVALID_REQUEST_ARGS"
+    PAGE_FULL = "PAGE_FULL"

--- a/shortfin/python/shortfin_apps/llm/components/generate.py
+++ b/shortfin/python/shortfin_apps/llm/components/generate.py
@@ -9,6 +9,7 @@ import dataclasses
 import io
 import json
 import logging
+import math
 
 from copy import deepcopy
 from typing import List, Tuple
@@ -283,9 +284,9 @@ class ClientGenerateBatchProcess(sf.Process):
                 )
 
                 # return error reponse if no pages available
-                needed_pages_num = math.ceil(len(request.input_token_ids) / self.service.model_params.paged_kv_cache.block_seq_stride) + total_requested_beams - 1
+                needed_pages_num = math.ceil(len(input_token_ids) / self.service.model_params.paged_kv_cache.block_seq_stride) + total_requested_beams - 1
                 available_pages_num = len(self.service.page_pool.available_pages)
-                if needed_pages > available_pages_num:
+                if needed_pages_num > available_pages_num:
                     self._return_error_response(
                         status.HTTP_400_BAD_REQUEST,
                         error_message="Not enough pages for the new request",
@@ -305,7 +306,7 @@ class ClientGenerateBatchProcess(sf.Process):
                     self.gen_req,
                     index,
                     input_text=input_text,
-                    input_token_ids,
+                    input_token_ids=input_token_ids,
                     eos_token_id=self.tokenizer.eos_token_id,
                     decode_config=decode_config,
                     status_tracker=self.responder.get_status_tracker(),

--- a/shortfin/python/shortfin_apps/llm/components/generate.py
+++ b/shortfin/python/shortfin_apps/llm/components/generate.py
@@ -277,14 +277,17 @@ class ClientGenerateBatchProcess(sf.Process):
                     else self.gen_req.text
                 )
 
-                input_token_ids= (
-                    input_tokens
-                    if is_pretokenized
-                    else input_tokens.ids
-                )
+                input_token_ids = input_tokens if is_pretokenized else input_tokens.ids
 
                 # return error reponse if no pages available
-                needed_pages_num = math.ceil(len(input_token_ids) / self.service.model_params.paged_kv_cache.block_seq_stride) + total_requested_beams - 1
+                needed_pages_num = (
+                    math.ceil(
+                        len(input_token_ids)
+                        / self.service.model_params.paged_kv_cache.block_seq_stride
+                    )
+                    + total_requested_beams
+                    - 1
+                )
                 available_pages_num = len(self.service.page_pool.available_pages)
                 if needed_pages_num > available_pages_num:
                     self._return_error_response(

--- a/shortfin/python/shortfin_apps/llm/components/service.py
+++ b/shortfin/python/shortfin_apps/llm/components/service.py
@@ -102,16 +102,16 @@ class LlmGenerateService(GenerateService):
             alloc_page_count=self.model_params.paged_kv_cache.device_block_count,
             paged_kv_block_size_elements=self.model_params.paged_kv_block_size_elements,
         )
-        page_pool = PagePool(devices=self.devices, config=page_pool_config)
+        self.page_pool = PagePool(devices=self.devices, config=page_pool_config)
 
         if self.server_params.prefix_sharing_algorithm == "trie":
             self.page_cache = TriePagedAttentionCache(
-                page_pool=page_pool,
+                page_pool=self.page_pool,
                 tokens_per_page=self.model_params.paged_kv_cache.block_seq_stride,
             )
         elif self.server_params.prefix_sharing_algorithm == "none":
             self.page_cache = BasePagedAttentionCache(
-                page_pool=page_pool,
+                page_pool=self.page_pool,
                 tokens_per_page=self.model_params.paged_kv_cache.block_seq_stride,
             )
         else:


### PR DESCRIPTION
Why:
When new request coming in, the number of pages needed to be checked to ensure there is enough number of pages.

How:
Use three parameters to predict number of pages needed

1. Length of input tokens
2. Block sequence stride
3. Number of beams