### PR TITLE
[sharktank] Fix and add tests for running models in eager with  paged_llm_v1

### DIFF
--- a/sharktank/sharktank/examples/paged_llm_v1.py
+++ b/sharktank/sharktank/examples/paged_llm_v1.py
@@ -25,6 +25,7 @@ def main(cli_args: list[str] | None = None):
         --prompt-seq-len: int - Generate random token ids for given seq len and bs and save prefill & first decode step input args as npy files
         --dump-path: str - Path to save prefill and decode input args as npy files
         --dump-decode-steps: int - Number of decode steps to dump decode args (defaults to 1 decode step)
+        --max-decode-steps: int - maximum number of decode steps to perform.
         --bs: int - batch size, for custom prompts, bs is number of given prompts (defaults to 4)
         --save_intermediates_path: str - save module forward outputs to safetensors, ex: run_0 will save to run_0_prefill.savetensors"
     """

--- a/sharktank/sharktank/models/llama/toy_llama.py
+++ b/sharktank/sharktank/models/llama/toy_llama.py
@@ -33,6 +33,7 @@ def generate(
 
     config = LlamaModelConfig(
         hp=LlamaHParams(
+            vocab_size=vocabulary_size,
             context_length=block_seq_stride * max_blocks,
             embedding_length=attention_head_count * attn_head_dim,
             block_count=3,

--- a/sharktank/sharktank/utils/cli.py
+++ b/sharktank/sharktank/utils/cli.py
@@ -180,6 +180,12 @@ def add_model_input_options(parser: argparse.ArgumentParser):
         nargs="+",
         help="Custom prompt strings to run LLM or perplexity",
     )
+    parser.add_argument(
+        "--max-decode-steps",
+        type=int,
+        default=None,
+        help="Maximum number of decode steps to perform.",
+    )
 
 
 def add_iree_flags(parser: argparse.ArgumentParser):

--- a/sharktank/sharktank/utils/load_llm.py
+++ b/sharktank/sharktank/utils/load_llm.py
@@ -31,10 +31,15 @@ class TorchGenerator:
         tokenizer: Optional[InferenceTokenizer] = None,
         # Need to look at the model more for this.
         end_token: int = 2,
+        max_decode_steps: int | None = None,
     ):
+        """
+        max_decode_steps: maximum number of decode steps to perform.
+        """
         self.model = model
         self.tokenizer = tokenizer
         self.end_token = end_token
+        self.max_decode_steps = max_decode_steps
 
     @property
     def block_seq_stride(self) -> int:
@@ -56,6 +61,23 @@ class TorchGenerator:
             device=self.model.device,
         )
 
+        return token_ids, seq_lens
+
+    def generate_random_tokens(
+        self, batch_size: int, prompt_seq_len: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        token_ids = torch.randint(
+            low=0,
+            high=self.model.config.hp.vocab_size,
+            size=[batch_size, prompt_seq_len],
+        )
+        # TODO: refactor to not use list[list[int]] as this is not efficient.
+        token_ids = [[int(t) for t in s] for s in token_ids]
+        token_ids, seq_lens = pad_tokens(
+            token_ids, pad_to_multiple_of=self.model.cache.pad_sequence_stride
+        )
+        token_ids = torch.tensor(token_ids, device=self.model.device)
+        seq_lens = torch.tensor(seq_lens, device=self.model.device)
         return token_ids, seq_lens
 
     def begin_batch(
@@ -87,6 +109,7 @@ class TorchGenerator:
             dump_path=dump_path,
             dump_decode_steps=dump_decode_steps,
             use_attention_mask=use_attention_mask,
+            max_decode_steps=self.max_decode_steps,
         )
 
     def alloc_page(self) -> int:
@@ -107,6 +130,7 @@ class Batch:
         dump_path: Path,
         dump_decode_steps: int,
         use_attention_mask: bool,
+        max_decode_steps: int | None = None,
     ):
         self.bs = bs
         assert seq_lens.shape[0] == self.bs
@@ -121,6 +145,7 @@ class Batch:
         self.dump_decode_steps = dump_decode_steps
         self.decode_step = 0
         self.use_attention_mask = use_attention_mask
+        self.max_decode_steps = max_decode_steps
 
         # Assemble the batch.
         seq_stride = self.parent.block_seq_stride
@@ -136,6 +161,11 @@ class Batch:
 
     @property
     def done(self) -> bool:
+        if (
+            self.max_decode_steps is not None
+            and self.max_decode_steps <= self.decode_step
+        ):
+            return True
         return (
             len(self.done_result_indices) == self.bs or len(self.parent.free_pages) == 0
         )
@@ -237,13 +267,17 @@ class Batch:
             )
             _attention_mask, _seq_block_ids = [], []
             for devices in pipeline_to_device_map:
-                _attention_mask.append(
-                    replicate(
-                        attention_mask,
-                        count=shard_count,
-                        devices=devices,
+                if attention_mask is None:
+                    _attention_mask.append(None)
+                else:
+                    _attention_mask.append(
+                        replicate(
+                            attention_mask,
+                            count=shard_count,
+                            devices=devices,
+                        )
                     )
-                )
+
                 _seq_block_ids.append(
                     replicate(
                         seq_block_ids,

--- a/sharktank/sharktank/utils/load_llm.py
+++ b/sharktank/sharktank/utils/load_llm.py
@@ -161,13 +161,13 @@ class Batch:
 
     @property
     def done(self) -> bool:
-        if (
-            self.max_decode_steps is not None
-            and self.max_decode_steps <= self.decode_step
-        ):
-            return True
         return (
-            len(self.done_result_indices) == self.bs or len(self.parent.free_pages) == 0
+            len(self.done_result_indices) == self.bs
+            or len(self.parent.free_pages) == 0
+            or (
+                self.max_decode_steps is not None
+                and self.max_decode_steps <= self.decode_step
+            )
         )
 
     def detokenize(self) -> list[str]:
@@ -379,7 +379,7 @@ class Batch:
                 _decode_attention_mask,
             )
 
-        if self.dump_path is not None:
+        if self.dump_path is not None and self.dump_decode_steps < self.decode_step:
             print(f"\nSaving decode args to {Path(self.dump_path)}\n")
 
             self.dump_args(

--- a/sharktank/sharktank/utils/load_llm.py
+++ b/sharktank/sharktank/utils/load_llm.py
@@ -86,7 +86,7 @@ class TorchGenerator:
         seq_lens: torch.tensor,
         page_cache_size: int = None,
         dump_path: Path = None,
-        dump_decode_steps: int = None,
+        dump_decode_steps: int = 1,
         use_attention_mask: bool = True,
     ) -> "Batch":
         bs = token_ids.shape[0]
@@ -379,7 +379,7 @@ class Batch:
                 _decode_attention_mask,
             )
 
-        if self.dump_path is not None and self.dump_decode_steps < self.decode_step:
+        if self.dump_path is not None and self.decode_step < self.dump_decode_steps:
             print(f"\nSaving decode args to {Path(self.dump_path)}\n")
 
             self.dump_args(

--- a/sharktank/sharktank/utils/testing.py
+++ b/sharktank/sharktank/utils/testing.py
@@ -248,7 +248,9 @@ class IreeVsEagerLLMTester:
             PagedLlmModelV1(theta=theta_for_eager, config=self.config)
         )
         self.eager_batch = generator.begin_batch(
-            token_ids=prefill_token_ids, seq_lens=prefill_seq_lens, dump_path=work_dir
+            token_ids=prefill_token_ids,
+            seq_lens=prefill_seq_lens,
+            dump_path=work_dir,
         )
 
         self.exporter.export_and_compile_llm(

--- a/sharktank/tests/examples/paged_llm_v1_test.py
+++ b/sharktank/tests/examples/paged_llm_v1_test.py
@@ -1,0 +1,42 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+import torch
+
+from pathlib import Path
+from sharktank.models.llama.testing import make_random_llama_theta
+from sharktank.models.llama import toy_llama
+from sharktank.types import Dataset
+from sharktank.examples import paged_llm_v1
+
+
+@pytest.mark.parametrize(
+    "dtype,tensor_parallelism_size",
+    [
+        (torch.float16, 1),
+        (torch.float16, 2),
+        (torch.float32, 1),
+        (torch.float32, 2),
+    ],
+)
+def test_smoke_paged_llm_v1(
+    dtype: torch.dtype, tensor_parallelism_size: int, tmp_path: Path
+):
+    theta, config = toy_llama.generate(seed=0, dtype_rest=dtype, dtype_norm=dtype)
+    dataset = Dataset(root_theta=theta, properties=config.to_properties())
+    dataset_path = tmp_path / "model.irpa"
+    dataset.save(dataset_path)
+    paged_llm_v1.main(
+        [
+            f"--irpa-file={dataset_path}",
+            "--tokenizer-type=fake",
+            "--bs=4",
+            "--prompt-seq-len=2",
+            "--max-decode-steps=1",
+            f"--tensor-parallelism-size={tensor_parallelism_size}",
+        ]
+    )

--- a/sharktank/tests/examples/paged_llm_v1_test.py
+++ b/sharktank/tests/examples/paged_llm_v1_test.py
@@ -8,12 +8,16 @@ import pytest
 import torch
 
 from pathlib import Path
+from sharktank.examples import paged_llm_v1
 from sharktank.models.llama.testing import make_random_llama_theta
 from sharktank.models.llama import toy_llama
 from sharktank.types import Dataset
-from sharktank.examples import paged_llm_v1
+from sharktank.utils.testing import is_mi300x
 
 
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="Run only on GPU for fast execution."
+)
 @pytest.mark.parametrize(
     "dtype,tensor_parallelism_size",
     [
@@ -38,5 +42,6 @@ def test_smoke_paged_llm_v1(
             "--prompt-seq-len=2",
             "--max-decode-steps=1",
             f"--tensor-parallelism-size={tensor_parallelism_size}",
+            "--device=cuda:0",
         ]
     )


### PR DESCRIPTION
We don't have tests for the script.

Expand functionality with
1. Use LlamaModelConfig.from_properties to parse config instead of just the GGUF properties.
2. Actually generate a random prompt with --prompt-seq-len.
3. Add max decode steps option.
