### PR TITLE
Add a flag for converting quark's non-matmul parameters to a provided flag

### DIFF
--- a/sharktank/sharktank/models/llama/tools/import_quark_dataset.py
+++ b/sharktank/sharktank/models/llama/tools/import_quark_dataset.py
@@ -127,8 +127,6 @@ def apply_per_layer_quant(
     output_quant_scale = as_torch_or_none(layer_theta.optional_tensor("output_scale"))
     if output_quant_scale and output_quant_scale.dtype is torch.bfloat16:
         output_quant_scale = output_quant_scale.to(torch.float32)
-
-    # Cast output_scale to specified dtype if provided
     if output_quant_scale is not None and weight_dtype_override is not None:
         output_quant_scale = output_quant_scale.to(weight_dtype_override)
     if weight_quant_scale is None:

--- a/sharktank/sharktank/models/llama/tools/import_quark_dataset.py
+++ b/sharktank/sharktank/models/llama/tools/import_quark_dataset.py
@@ -401,7 +401,7 @@ def main(argv):
 
     # Convert weight_dtype_override string to torch dtype
     weight_dtype_override = (
-        serialized_name_to_dtype.get(args.weight_dtype_override)
+        serialized_name_to_dtype(args.weight_dtype_override)
         if args.weight_dtype_override
         else None
     )


### PR DESCRIPTION
This changes:
- Output scales (output_scale)
- KV cache scales (kv_cache_scale)
- Attention/probability output scales (prob_output_scale/attn_scale)
- All norm layer weights
- Embedding and output weight