### PR TITLE
Remove streaming from shortfin-llm

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/generate.py
+++ b/shortfin/python/shortfin_apps/llm/components/generate.py
@@ -85,8 +85,6 @@ class GenerateItemProcess(sf.Process):
         self.token_selector: TokenSelector = build_token_selector(
             self.token_selector_config,
         )
-        self.is_multi_response = is_multi_response(self.decode_config)
-        self.streamed_tokens_index = 0
         self._status_tracker = status_tracker
 
     async def run(self):
@@ -106,17 +104,8 @@ class GenerateItemProcess(sf.Process):
         finally:
             exec_req.free_cache_pages()
 
-    def results_callback(self, result: int | list[list[int]]):
-        if is_multi_response(self.decode_config):
-            # TODO: Streaming is not supported for multiple responses
-            self.result_token_ids = result
-            return
-
-        self._append_token(result)
-
-    def _append_token(self, token: int):
-        self.result_token_ids.append(token)
-        self.client.stream_results(self)
+    def results_callback(self, result: list[list[int]]):
+        self.result_token_ids = result
 
 
 class ClientGenerateBatchProcess(sf.Process):
@@ -327,18 +316,10 @@ class ClientGenerateBatchProcess(sf.Process):
             self.responder.send_response(out.getvalue())
             return
 
-        response_map = {}
+        response_map = {p.input_text: [] for p in gen_processes}
 
         for p in gen_processes:
-            response_map[p.input_text] = []
-
-        for p in gen_processes:
-            token_ids = p.result_token_ids
-
-            if not p.is_multi_response:
-                token_ids = [token_ids]
-
-            decoded = self.tokenizer.decode(token_ids)
+            decoded = self.tokenizer.decode(p.result_token_ids)
             rs = [GeneratedResponse(d) for d in decoded]
             response_map[p.input_text] += rs
 
@@ -354,30 +335,6 @@ class ClientGenerateBatchProcess(sf.Process):
         out = io.BytesIO()
         out.write(response.encode())
         self.responder.send_response(out.getvalue())
-
-    def stream_results(self, gen_process: GenerateItemProcess):
-        if not self.gen_req.stream:
-            return
-        out = io.BytesIO()
-        result_tokens = gen_process.result_token_ids[
-            gen_process.streamed_tokens_index :
-        ]
-        rid = (
-            gen_process.gen_req.rid
-            if gen_process.gen_req.is_single
-            else gen_process.gen_req.rid[gen_process.index]
-        )
-        if not self.gen_req.return_input_ids:
-            (result_text,) = self.tokenizer.decode([result_tokens])
-            out.write(f"data({rid}): ".encode())
-            out.write(result_text.encode())
-            out.write(b"\n\n")
-        else:
-            out.write(f"data({rid}): ".encode())
-            out.write(str(result_tokens[0]).encode())
-            out.write(b"\n\n")
-        self.responder.stream_part(out.getvalue())
-        gen_process.streamed_tokens_index += len(result_tokens)
 
     def tokenize(self) -> list[Encoding]:
         gen_req = self.gen_req

--- a/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/base_token_selection_strategy.py
+++ b/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/base_token_selection_strategy.py
@@ -89,11 +89,6 @@ class BaseTokenSelectionStrategy(ABC):
             token = sfnp.argmax(exec_req.result_logits)
             token_int = token.items[0]
 
-        decode_config = token_selection_strategy_config.decode_config
-        # TODO: This is only temporary until streaming is enabled for `MultiHypothesis`
-        if not decode_config.use_beam_search and decode_config.num_beams == 1:
-            token_selection_strategy_config.results_callback(token_int)
-
         exec_req.input_token_ids.append(token_int)
         exec_req.start_position = len(exec_req.input_token_ids) - 1
 

--- a/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/scorer.py
+++ b/shortfin/python/shortfin_apps/llm/components/token_selection_strategy/scorer.py
@@ -46,7 +46,7 @@ class BaseBeamScorer(ABC):
         """
 
     @abstractmethod
-    def score_beams(beams: List[BaseBeam]) -> List[BaseBeam]:
+    def score_beams(beams: List[BaseBeam], k: int, normalize: bool) -> List[BaseBeam]:
         """Score a group of beams.
 
         Args:
@@ -108,7 +108,9 @@ class DefaultScorer(BaseBeamScorer):
     def normalize_score(self, beam: DefaultBeam, value: float) -> None:
         pass
 
-    def score_beams(self, beams: List[DefaultBeam]) -> List[DefaultBeam]:
+    def score_beams(
+        self, beams: List[DefaultBeam], k: int, normalize: bool
+    ) -> List[DefaultBeam]:
         return beams
 
     def select_beams(

--- a/shortfin/tests/apps/llm/components/token_selection_strategy/token_selection_strategy_test.py
+++ b/shortfin/tests/apps/llm/components/token_selection_strategy/token_selection_strategy_test.py
@@ -125,7 +125,6 @@ async def test_prefill(
     )
     await dummy_token_selection_strategy.prefill(exec_req)
 
-    assert results_array[0] == 15
     assert exec_req.input_token_ids[-1] == 15
     assert exec_req.start_position == 6
 


### PR DESCRIPTION
Streaming is basically non-functional for beam search. We should be ripping out support so that we can refactor processing layers.