### PR TITLE
Rework responders for error message returning

### DIFF
--- a/shortfin/python/shortfin/support/responder.py
+++ b/shortfin/python/shortfin/support/responder.py
@@ -5,7 +5,13 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 
+from enum import Enum
 from shortfin.support.status_tracker import AbstractStatusTracker
+
+
+class ResponderErrorCodes(Enum):
+    QUEUE_FULL = "QUEUE_FULL"
+    INVALID_REQUEST_ARGS = "INVALID_REQUEST_ARGS"
 
 
 class AbstractResponder:
@@ -18,6 +24,11 @@ class AbstractResponder:
         pass
 
     def ensure_response(self):
+        pass
+
+    def send_error(
+        self, error_message: str, code: ResponderErrorCodes, extra_fields: dict
+    ):
         pass
 
     def send_response(self, response):

--- a/shortfin/python/shortfin_apps/llm/cli.py
+++ b/shortfin/python/shortfin_apps/llm/cli.py
@@ -17,7 +17,7 @@ import numpy as np
 from pathlib import Path
 from typing import Dict, List, Optional
 from shortfin.support.logging_setup import configure_main_logger
-from shortfin.support.responder import AbstractResponder
+from shortfin.support.responder import AbstractResponder, ResponderErrorCodes
 
 from .components.generate import ClientGenerateBatchProcess
 from .components.io_struct import GenerateReqInput, SamplingParams
@@ -166,6 +166,12 @@ class CliResponder(AbstractResponder):
 
     def ensure_response(self):
         self._timer.end()
+
+    def send_error(
+        self, error_message: str, code: ResponderErrorCodes, extra_fields: dict
+    ):
+        self.send_response(f"{code}: {error_message}")
+        self.ensure_response()
 
     def send_response(self, response):
         logger.info(f"{self.name} Sending response")

--- a/shortfin/python/shortfin_apps/llm/components/error_codes.py
+++ b/shortfin/python/shortfin_apps/llm/components/error_codes.py
@@ -1,6 +1,0 @@
-from enum import Enum, auto
-
-
-class ResponseErrorCodes(Enum):
-    QUEUE_FULL = "QUEUE_FULL"
-    INVALID_REQUEST_ARGS = "INVALID_REQUEST_ARGS"

--- a/shortfin/python/shortfin_apps/llm/components/generate.py
+++ b/shortfin/python/shortfin_apps/llm/components/generate.py
@@ -18,9 +18,7 @@ import shortfin.array as sfnp
 
 # TODO: Have a generic "Responder" interface vs just the concrete impl.
 from shortfin.interop.fastapi import RequestStatusTracker
-from shortfin.support.responder import AbstractResponder
-from fastapi.responses import JSONResponse
-from fastapi import status
+from shortfin.support.responder import AbstractResponder, ResponderErrorCodes
 
 from .config_struct import DecodeConfig
 from .io_struct import (
@@ -30,7 +28,6 @@ from .io_struct import (
     PromptResponse,
 )
 from .messages import LlmInferenceExecRequest, InferencePhase
-from .error_codes import ResponseErrorCodes
 from .service import LlmGenerateService
 from .token_selection_strategy import (
     TokenSelector,
@@ -175,20 +172,6 @@ class ClientGenerateBatchProcess(sf.Process):
         )
         return False
 
-    def _return_error_response(
-        self,
-        status_code: int,
-        error_message: str,
-        code: ResponseErrorCodes,
-        extra_fields: dict,
-    ):
-        error_response = JSONResponse(
-            status_code=status_code,
-            content={"error": error_message, "code": code.value, **extra_fields},
-        )
-        self.responder.send_response(error_response)
-        self.responder.ensure_response()
-
     def _pre_processing_sampling_params(self) -> Tuple[List[DecodeConfig], int]:
         """Calculate the total number of beams requested in the generation request."""
         gen_req = self.gen_req
@@ -220,10 +203,9 @@ class ClientGenerateBatchProcess(sf.Process):
         # TODO(@zphoenixrises): Add load testing and integration tests for this.
         added_to_queue = self.service.queue_manager.add_to_queue(total_requested_beams)
         if not added_to_queue:
-            self._return_error_response(
-                status.HTTP_503_SERVICE_UNAVAILABLE,
+            self.responder.send_error(
                 error_message="Server queue is full. Please try again later.",
-                code=ResponseErrorCodes.QUEUE_FULL,
+                code=ResponderErrorCodes.QUEUE_FULL,
                 extra_fields={
                     "current_size": self.service.queue_manager.current_queue_size,
                     "max_size": self.service.max_queue_size,
@@ -260,10 +242,9 @@ class ClientGenerateBatchProcess(sf.Process):
                     exported_topk,
                     requested_topk,
                 ):
-                    self._return_error_response(
-                        status.HTTP_400_BAD_REQUEST,
+                    self.responder.send_error(
                         error_message="Requested top-k larger than exported top-k",
-                        code=ResponseErrorCodes.INVALID_REQUEST_ARGS,
+                        code=ResponderErrorCodes.INVALID_REQUEST_ARGS,
                         extra_fields={
                             "exported_topk": exported_topk,
                             "requested_topk": requested_topk,


### PR DESCRIPTION
Error message handling should be performed by the responder to avoid fastapi dependencies in the core service.