### PR TITLE
[shortfin] Fix license formatting in pyproject.toml

### DIFF
--- a/shortfin/pyproject.toml
+++ b/shortfin/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 description = "SHARK inference library and serving engine"
 readme = "README.md"
-license = "Apache-2.0"
+license = {"text" = "Apache-2.0"}
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Programming Language :: Python :: 3",


### PR DESCRIPTION
As currently implemented I get the following error when running `./dev_me.py`:
```
 ValueError: invalid pyproject.toml config: `project.license`.
  configuration error: `project.license` must be valid exactly by one definition (2 matches found):

      - keys:
          'file': {type: string}
        required: ['file']
      - keys:
          'text': {type: string}
        required: ['text']

  error: subprocess-exited-with-error
  ```