### PR TITLE
Set / increase the minimum setuptools version

### DIFF
--- a/shark-ai/pyproject.toml
+++ b/shark-ai/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = [
+  "setuptools>=77.0.3",
+  "wheel",
+]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/sharktank/pyproject.toml
+++ b/sharktank/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = [
+  "setuptools>=77.0.3",
+  "wheel",
+]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/sharktuner/pyproject.toml
+++ b/sharktuner/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = [
+  "setuptools>=77.0.3",
+  "wheel",
+]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/shortfin/pyproject.toml
+++ b/shortfin/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "cmake>=3.29",
-    "setuptools>=61.0",
+    "setuptools>=77.0.3",
     "wheel",
     "ninja",
     'typing-extensions ; python_version == "3.10" ',

--- a/shortfin/requirements-tests.txt
+++ b/shortfin/requirements-tests.txt
@@ -9,7 +9,7 @@ uvicorn
 scikit-image
 
 # Libraries needed to build in dev setups.
-setuptools
+setuptools>=77.0.3
 wheel
 
 # Deps needed for shortfin_apps.llm


### PR DESCRIPTION
Our projects' configuration specify the used license with the `license` field, following PEP 639. According to [1], "A previous PEP had specified license to be a table with a file or a text key, this format is now deprecated." Therefore, the minimum setuptools version is explicitly set to 77.0.3.

[1] https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files