### PR TITLE
[Sharktank] Do not bitcast f8->i8 for index_copy_ and index_put_ during export to help compiler fusion

### DIFF
--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -297,13 +297,7 @@ class KVCache:
             cache_partition = cache_partition.transpose(1, 2)
 
             part_block = ops.to(cache_partition, dtype=page_table.dtype)
-            if page_table.dtype == torch.float8_e4m3fnuz:
-                # Workaround for Torch not supporting torch.Tensor.index_copy_ for f8.
-                page_table_as_int8 = page_table.view(dtype=torch.int8)
-                part_block_as_int8 = part_block.view(dtype=torch.int8)
-                page_table_as_int8.index_copy_(0, index, part_block_as_int8)
-            else:
-                page_table.index_copy_(0, index, part_block)
+            ops.index_copy_(page_table, 0, index, part_block)
 
     def write_timestep(
         self,
@@ -343,14 +337,7 @@ class KVCache:
 
             cache_partition.transpose(1, 2)
             values = ops.to(cache_partition, dtype=page_table.dtype)
-
-            if page_table.dtype == torch.float8_e4m3fnuz:
-                # Workaround for Torch not supporting torch.Tensor.index_copy_ for f8.
-                page_table_as_int8 = page_table.view(dtype=torch.int8)
-                values_int8 = values.view(dtype=torch.int8)
-                page_table_as_int8.index_put_(indices=(index,), values=values_int8)
-            else:
-                page_table.index_put_(indices=(index,), values=values)
+            ops.index_put_(page_table, indices=(index,), values=values)
 
     def write_range(
         self,
@@ -420,14 +407,7 @@ class KVCache:
             # Prepare the values to write.
             values = ops.to(cache_partition, dtype=page_table.dtype)
 
-            if page_table.dtype == torch.float8_e4m3fnuz:
-                # Workaround for Torch not supporting torch.Tensor.index_copy_ for f8.
-                page_table_as_int8 = page_table.view(dtype=torch.int8)
-                values_int8 = values.view(dtype=torch.int8)
-                page_table_as_int8.index_put_(indices=(index,), values=values_int8)
-
-            else:
-                page_table.index_put_(indices=(index,), values=values)
+            ops.index_put_(page_table, indices=(index,), values=values)
 
 
 class ShardedCache:

--- a/sharktank/sharktank/utils/iree.py
+++ b/sharktank/sharktank/utils/iree.py
@@ -19,6 +19,7 @@ import subprocess
 import gc
 import torch
 
+import iree.compiler
 from sharktank.types.tensors import (
     AnyTensor,
     InferenceTensor,
@@ -27,6 +28,7 @@ from sharktank.types.tensors import (
     unbox_tensor,
     torch_tree_flatten,
 )
+from sharktank.utils import verify_exactly_one_is_not_none
 from .tree import Tree
 from iree.runtime import FileHandle
 import iree.runtime
@@ -60,6 +62,50 @@ torch_dtype_to_numpy_dtype_map = {
     torch.int8: np.int8,
     torch.int16: np.int16,
 }
+
+
+def oneshot_iree_run(
+    module: torch.nn.Module,
+    args: tuple[Any, ...] = tuple(),
+    kwargs: dict[str, Any] = {},
+    function: str = "forward",
+    device: str | list[str] = "local-task",
+    device_count: int | None = None,
+    compile_args: tuple[str, ...] = None,
+) -> tuple[torch.Tensor, ...]:
+    """All in one: export, compile and run."""
+    from iree.turbine import aot
+    from iree.turbine.aot import FxProgramsBuilder
+
+    fxb = FxProgramsBuilder(module)
+
+    @fxb.export_program(name=function, args=args, kwargs=kwargs, strict=False)
+    def _(module, *args, **kwargs):
+        return getattr(module, function)(*args, **kwargs)
+
+    export_output = aot.export(
+        fxb,
+    )
+    if compile_args is not None:
+        export_output.session.set_flags(*compile_args)
+    memory_view: memoryview = export_output.compile(
+        save_to=None, target_backends=None
+    ).map_memory()
+    iree_devices = get_iree_devices(device=device, device_count=device_count)
+
+    def run(iree_devices: list[iree.runtime.HalDevice]):
+        vm_module, vm_context, vm_instance = load_iree_module(
+            module_buff=memory_view, devices=iree_devices
+        )
+        torch_like_iree_module = TorchLikeIreeModule(
+            vm_module, vm_context, iree_devices
+        )
+        results = getattr(torch_like_iree_module, function)(*args, **kwargs)
+        # Clone to avoid leaking IREE-backed torch tensors.
+        results = tuple(t.clone() for t in results)
+        return results
+
+    return with_iree_device_context(run, iree_devices)
 
 
 class TorchLikeIreeModule:
@@ -299,7 +345,9 @@ _same_as_device_count = object()
 
 
 def load_iree_module(
-    module_path: str,
+    *,
+    module_buff: bytearray | None = None,
+    module_path: str | None = None,
     devices: List[iree.runtime.HalDevice],
     parameters_path: Optional[str] = None,
     debug_sink: Optional[iree.runtime.HalModuleDebugSink] = None,
@@ -308,6 +356,8 @@ def load_iree_module(
 ) -> Tuple[iree.runtime.VmModule, iree.runtime.VmContext, iree.runtime.VmInstance]:
     """The VmContext and VmInstance need to outlive the VmModule and any device
     buffers."""
+    verify_exactly_one_is_not_none(module_buff=module_buff, module_path=module_path)
+
     parallel_size = tensor_parallel_size * pipeline_parallel_size
     assert parallel_size == len(devices)
 
@@ -336,7 +386,10 @@ def load_iree_module(
             vm_instance, parameter_provider
         )
         modules.append(parameters_module)
-    vm_module = iree.runtime.VmModule.mmap(vm_instance, module_path)
+    if module_path is not None:
+        vm_module = iree.runtime.VmModule.mmap(vm_instance, module_path)
+    else:
+        vm_module = iree.runtime.VmModule.copy_buffer(vm_instance, module_buff)
     modules.append(vm_module)
     vm_context = iree.runtime.VmContext(instance=vm_instance, modules=modules)
     return vm_module, vm_context, vm_instance

--- a/sharktank/sharktank/utils/misc.py
+++ b/sharktank/sharktank/utils/misc.py
@@ -6,9 +6,19 @@
 
 from typing import Any, Callable, List
 from collections.abc import Iterable
+from collections import Counter
 from operator import eq
 import os
 from contextlib import AbstractContextManager
+
+
+def verify_exactly_one_is_not_none(**kwargs):
+    count = 0
+    for v in kwargs.values():
+        if v is not None:
+            count += 1
+    if count != 1:
+        raise ValueError(f"Exactly one of {kwargs.keys()} must be set.")
 
 
 def longest_equal_range(l1: List[Any], l2: List[Any]) -> int:

--- a/sharktank/sharktank/utils/misc.py
+++ b/sharktank/sharktank/utils/misc.py
@@ -6,7 +6,6 @@
 
 from typing import Any, Callable, List
 from collections.abc import Iterable
-from collections import Counter
 from operator import eq
 import os
 from contextlib import AbstractContextManager


### PR DESCRIPTION
PyTorch Eager CPU does not support index_copy_ and index_put_ for f8. Because of that we need to view as int8.
On the other had the IREE compiler can't fuse these bitcasts.

With this change we are taking different paths during export and eager, such that both limitations are circumvented.
The paged KV cache is adapted to just call `ops.index_copy/put_`.