### PR TITLE
Ensure `key` isn't overwritten, when we cleanup the device_cache

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/device_array_cache.py
+++ b/shortfin/python/shortfin_apps/llm/components/device_array_cache.py
@@ -4,8 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import shortfin.array as sfnp
 import threading
+
+import shortfin.array as sfnp
 
 
 class Allocation:
@@ -122,10 +123,10 @@ class DeviceArrayCache:
                 new_cache = {idx: self._cache[idx] for idx in to_keep}
                 new_table = {}
                 for idx in to_keep:
-                    key = self.create_key(allocation=self._cache[idx])
-                    if key not in new_table:
-                        new_table[key] = []
-                    new_table[key].append(idx)
+                    new_key = self.create_key(allocation=self._cache[idx])
+                    if new_key not in new_table:
+                        new_table[new_key] = []
+                    new_table[new_key].append(idx)
 
                 self._cache = new_cache
                 self._shape_table = new_table


### PR DESCRIPTION
When `device_cache` hits `_max_allocations`, we evict the overflowing items and rebuild the table and cache.

However, we were overwriting the local `key` variable unintentionally, which was causing weirdness down the road.

Eventually, our cache ended up in a state, where there was only a single key in `_cache`, that corresponded to ALL indices in `_table`, regardless of the shape of those indices.

In the specific test case, the last key in the table rebuild loop was 4x132. That meant that we returned a 4x132 allocation, regardless of the shape of the requested allocation.

When the allocation was returned, the incorrect `4x132` key is used (since that's the `Allocation's` key). Overtime, this led to ALL `device_arrays` being stored under said key.

This caused every other shape aside from `4x32` to be a `cache miss`, so we didn't see the result of this error until we hit that last key `4x132`.

This resulted in tons of cache misses, that should have been cache hits. This may have performance implications for our benchmarks.