### PR TITLE
[tuner] add support for attention op

### DIFF
--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -91,6 +91,9 @@ class ContractionOpInterfaceTuner(
     ) -> ir.Module:
         contraction_op = self.get_root_op()
         func_name = self.get_root_op_func_name()
+
+        # Wrap the single CompilationInfoAttr in a list of (str, Attribute).
+        config_list = [("compilation_info", compilation_info)]
         return spec_builder.build_td_spec(
             contraction_op.context, contraction_op, config_list, func_name
         )
@@ -113,6 +116,9 @@ class ConvolutionOpInterfaceTuner(
     ) -> ir.Module:
         conv_op = self.get_root_op()
         func_name = self.get_root_op_func_name()
+
+        # Wrap the single CompilationInfoAttr in a list of (str, Attribute).
+        config_list = [("compilation_info", compilation_info)]
         return spec_builder.build_td_spec(
             conv_op.context, conv_op, config_list, func_name
         )

--- a/sharktuner/sharktuner/common.py
+++ b/sharktuner/sharktuner/common.py
@@ -170,20 +170,6 @@ class AttentionOpInfo:
     k2_dims: list[int]
 
 
-@dataclass
-class GPUMMASchedule:
-    m_size: z3.ArithRef
-    n_size: z3.ArithRef
-    k_size: z3.ArithRef
-
-    m_subgroup_counts: z3.ArithRef
-    n_subgroup_counts: z3.ArithRef
-
-    m_tile_size: z3.ArithRef
-    n_tile_size: z3.ArithRef
-    k_tile_size: z3.ArithRef
-
-
 def get_map_result_dim_positions(map: ir.AffineMap) -> Optional[list[int]]:
     if not map.is_projected_permutation:
         return None

--- a/sharktuner/sharktuner/common.py
+++ b/sharktuner/sharktuner/common.py
@@ -4,6 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import z3  # type: ignore
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass, field
@@ -81,6 +82,7 @@ class TuningConfiguration:
 class DispatchKind(Enum):
     conv = 0
     contraction = 1
+    attention = 2
 
 
 @dataclass
@@ -146,6 +148,40 @@ class ContractionDimensions:
     n: list[int]
     k: list[int]
     batch: list[int] = field(default_factory=list)
+
+
+@dataclass
+class MatmulShapeType:
+    m: int
+    n: int
+    k: int
+    lhs_type: ir.IntegerType | ir.FloatType
+    rhs_type: ir.IntegerType | ir.FloatType
+    acc_type: ir.IntegerType | ir.FloatType
+
+
+@dataclass
+class AttentionOpInfo:
+    domain_rank: int
+    batch_dims: list[int]
+    m_dims: list[int]
+    n_dims: list[int]
+    k1_dims: list[int]
+    k2_dims: list[int]
+
+
+@dataclass
+class GPUMMASchedule:
+    m_size: z3.ArithRef
+    n_size: z3.ArithRef
+    k_size: z3.ArithRef
+
+    m_subgroup_counts: z3.ArithRef
+    n_subgroup_counts: z3.ArithRef
+
+    m_tile_size: z3.ArithRef
+    n_tile_size: z3.ArithRef
+    k_tile_size: z3.ArithRef
 
 
 def get_map_result_dim_positions(map: ir.AffineMap) -> Optional[list[int]]:
@@ -398,3 +434,34 @@ def determine_td_specs_to_link(
 
     # Starter spec is redundant, so skip merging it.
     return [current_td_spec]
+
+
+def get_attention_decomposition_config(
+    tuner_ctx: TunerContext,
+    qk_lowering_config: iree_gpu.LoweringConfigAttr,
+    pv_lowering_config: iree_gpu.LoweringConfigAttr,
+) -> ir.DictAttr:
+    """
+    Constructs the decomposition config for an attention op, embedding
+    separate lowering configs for QK and PV matmuls.
+    """
+
+    ctx = tuner_ctx.mlir_ctx
+    qk_attrs_dict = {
+        "attention_qk_matmul": ir.UnitAttr.get(ctx),
+        "lowering_config": qk_lowering_config,
+    }
+    qk_attr_dict = ir.DictAttr.get(qk_attrs_dict, context=ctx)
+
+    pv_attrs_dict = {
+        "attention_pv_matmul": ir.UnitAttr.get(ctx),
+        "lowering_config": pv_lowering_config,
+    }
+    pv_attr_dict = ir.DictAttr.get(pv_attrs_dict, context=ctx)
+
+    decomposition_config_dict = {
+        "qk_attrs": qk_attr_dict,
+        "pv_attrs": pv_attr_dict,
+    }
+
+    return ir.DictAttr.get(decomposition_config_dict, context=ctx)

--- a/sharktuner/sharktuner/constraint_generator.py
+++ b/sharktuner/sharktuner/constraint_generator.py
@@ -246,6 +246,165 @@ def generate_generic_contraction_solutions(
             ]
 
 
+def generate_attention_solutions(
+    tuner_ctx: common.TunerContext,
+    opinfo: common.AttentionOpInfo,
+    qk_matmul: common.MatmulShapeType,
+    pv_matmul: common.MatmulShapeType,
+    transposed_q: bool,
+    transposed_k: bool,
+    transposed_v: bool,
+    dispatch_kind: common.DispatchKind,
+    codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline = iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute,
+    num_subgroups: int = 4,
+    mma_intrinsics: list[iree_gpu.MMAIntrinsic] = [],
+    allowed_waves_per_eu: list[int] = [2],
+    pipeline_options_search_space: dispatch_constraints.PipelineOptionsSearchSpace = dispatch_constraints.PipelineOptionsSearchSpace(),
+) -> Iterator[list[common.TuningConfiguration]]:
+    if (
+        dispatch_kind != common.DispatchKind.attention
+        or codegen_pipeline
+        != iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
+    ):
+        return []
+
+    m_var = z3.Int("m_tile")
+    n_var = z3.Int("n_tile")
+    k_var = z3.Int("k_tile")
+
+    subgroup_size = z3.Int("subgroup_size")
+    intrinsic_mn = z3.Int("intrinsic_mn")
+    intrinsic_k = z3.Int("intrinsic_k")
+    sg_m_cnt = z3.Int("sg_m_cnt")
+    sg_n_cnt = z3.Int("sg_n_cnt")
+
+    all_vars = (
+        [m_var]
+        + [n_var]
+        + [k_var]
+        + [
+            subgroup_size,
+            intrinsic_mn,
+            intrinsic_k,
+            sg_m_cnt,
+            sg_n_cnt,
+        ]
+    )
+
+    solver = z3.Solver()
+    constraints = dispatch_constraints.generate_attention_vector_distribute_constraints(
+        qk_matmul,
+        pv_matmul,
+        transposed_q,
+        transposed_k,
+        transposed_v,
+        [m_var, n_var, k_var],
+        num_subgroups,
+        subgroup_size,
+        [intrinsic_mn, intrinsic_k],
+        sg_m_cnt,
+        sg_n_cnt,
+        mma_intrinsics,
+    )
+
+    solver.add(z3.simplify(z3.And(constraints)))
+    tuner_ctx.logger.debug(f"Initial constraints: {solver}")
+
+    i = 0
+    while solver.check() == z3.sat:
+        model = solver.model()
+        lookup = lambda var: model[var].as_long()
+        intrinsic_mnk_shape = (
+            lookup(intrinsic_mn),
+            lookup(intrinsic_mn),
+            lookup(intrinsic_k),
+        )
+        mma_attr = dispatch_constraints.getMMAAttr(
+            qk_matmul.acc_type,
+            *intrinsic_mnk_shape,
+            qk_matmul.lhs_type,
+            qk_matmul.rhs_type,
+        )
+
+        # Get workgroup tile sizes.
+        workgroup_tile_sizes = [0] * opinfo.domain_rank
+        reduction_tile_sizes = [0] * opinfo.domain_rank
+
+        m_dim = opinfo.m_dims[-1]
+        n_dim = opinfo.n_dims[-1]
+        k2_dim = opinfo.k2_dims[-1]
+
+        for b in opinfo.batch_dims:
+            workgroup_tile_sizes[b] = 1
+        for m in opinfo.m_dims[:-1]:
+            workgroup_tile_sizes[m] = 1
+        for n in opinfo.n_dims[:-1]:
+            workgroup_tile_sizes[n] = 1
+        for k2 in opinfo.k2_dims[:-1]:
+            reduction_tile_sizes[k2] = 1
+
+        workgroup_tile_sizes[m_dim] = lookup(m_var)
+        workgroup_tile_sizes[n_dim] = lookup(n_var)
+        reduction_tile_sizes[k2_dim] = lookup(k_var)
+
+        qk_config = {
+            "mma_kind": mma_attr,
+            "subgroup_m_count": lookup(sg_m_cnt),
+            "subgroup_n_count": 1,
+            "promote_operands": [0, 1],
+        }
+        qk_lowering_config = common.get_lowering_config(
+            tuner_ctx=tuner_ctx, **qk_config
+        )
+
+        pv_config = {
+            "mma_kind": mma_attr,
+            "subgroup_m_count": lookup(sg_m_cnt),
+            "subgroup_n_count": lookup(sg_n_cnt),
+            "promote_operands": [1],
+        }
+        pv_lowering_config = common.get_lowering_config(
+            tuner_ctx=tuner_ctx, **pv_config
+        )
+
+        decomposition_config = common.get_attention_decomposition_config(
+            tuner_ctx, qk_lowering_config, pv_lowering_config
+        )
+
+        workgroup_size = lookup(sg_m_cnt) * lookup(sg_n_cnt) * lookup(subgroup_size)
+
+        promote_operands = [0, 1, 2]
+        compilation_infos = dispatch_constraints.generate_compilation_infos(
+            tuner_ctx,
+            mma_attr,
+            workgroup_tile_sizes,
+            reduction_tile_sizes,
+            [0, 0, 0],
+            (workgroup_size, 1, 1),
+            lookup(subgroup_size),
+            lookup(sg_m_cnt),
+            lookup(sg_n_cnt),
+            promote_operands,
+            codegen_pipeline,
+            pipeline_options_search_space,
+            allowed_waves_per_eu,
+            padding=None,
+        )
+        solver.add(z3.simplify(z3.Not(z3.And(list(x == model[x] for x in all_vars)))))
+        i += 1
+
+        for compilation_info in compilation_infos:
+            config_list = [
+                common.TuningConfiguration(
+                    name="compilation_info", configuration=compilation_info
+                ),
+                common.TuningConfiguration(
+                    name="decomposition_config", configuration=decomposition_config
+                ),
+            ]
+            yield config_list
+
+
 class ConstraintGenerator(ABC):
     """
     Describes how to generate constraints and produce tuning candidates
@@ -390,6 +549,100 @@ class ConvolutionOpInterfaceConstraintGenerator(ConstraintGenerator):
             rhs_type=self.rhs_type,
             res_type=self.res_type,
             dispatch_kind=common.DispatchKind.conv,
+            codegen_pipeline=codegen_pipeline,
+            **pipeline_constraint_options,
+        )
+
+
+class AttentionOpInterfaceConstraintGenerator(ConstraintGenerator):
+    def __init__(self, root_op: ir.Operation):
+        self.root_op = root_op
+        indexing_maps_attr = root_op.attributes["indexing_maps"]
+        indexing_maps = [attr.value for attr in indexing_maps_attr]
+        q_map = indexing_maps[0]
+        k_map = indexing_maps[1]
+        v_map = indexing_maps[2]
+        o_map = indexing_maps[-1]
+
+        q_dims = common.get_map_result_dim_positions(q_map)
+        k_dims = common.get_map_result_dim_positions(k_map)
+        v_dims = common.get_map_result_dim_positions(v_map)
+
+        raw_opinfo = iree_codegen.get_attention_op_detail(q_map, k_map, v_map, o_map)
+        assert raw_opinfo, "no attention info"
+
+        self.opinfo = common.AttentionOpInfo(
+            domain_rank=raw_opinfo.domain_rank,
+            batch_dims=[attr.value for attr in raw_opinfo.batch_dims],
+            m_dims=[attr.value for attr in raw_opinfo.m_dims],
+            n_dims=[attr.value for attr in raw_opinfo.n_dims],
+            k1_dims=[attr.value for attr in raw_opinfo.k1_dims],
+            k2_dims=[attr.value for attr in raw_opinfo.k2_dims],
+        )
+
+        q_type = ir.RankedTensorType(root_op.operands[0].type)
+        k_type = ir.RankedTensorType(root_op.operands[1].type)
+        v_type = ir.RankedTensorType(root_op.operands[2].type)
+        q_shape = q_type.shape
+        k_shape = k_type.shape
+        v_shape = v_type.shape
+        # Align with IREE's assuption: both QK and PV matmuls produce f32 outputs.
+        f32_type = ir.F32Type.get()
+
+        mDim = self.opinfo.m_dims[-1]
+        k1Dim = self.opinfo.k1_dims[-1]
+        k2Dim = self.opinfo.k2_dims[-1]
+        nDim = self.opinfo.n_dims[-1]
+
+        q_last_expr = q_map.results[-1]
+        k_last_expr = k_map.results[-1]
+        v_last_expr = v_map.results[-1]
+
+        q_dim_expr = ir.AffineDimExpr(q_last_expr)
+        k_dim_expr = ir.AffineDimExpr(k_last_expr)
+        v_dim_expr = ir.AffineDimExpr(v_last_expr)
+
+        self.transposed_k = k1Dim != k_dim_expr.position
+        self.transposed_v = k2Dim != v_dim_expr.position
+        self.transposed_q = k1Dim != q_dim_expr.position
+
+        assert q_dims, "no query dims from attention op"
+        assert k_dims, "no key dims from attention op"
+        assert v_dims, "no value dims from attention op"
+
+        self.qk_matmul = common.MatmulShapeType(
+            m=q_shape[q_dims.index(mDim)],
+            n=k_shape[k_dims.index(k2Dim)],
+            k=q_shape[q_dims.index(k1Dim)],
+            lhs_type=q_type.element_type,
+            rhs_type=k_type.element_type,
+            acc_type=f32_type,
+        )
+
+        self.pv_matmul = common.MatmulShapeType(
+            m=q_shape[q_dims.index(mDim)],
+            n=v_shape[v_dims.index(nDim)],
+            k=v_shape[v_dims.index(k2Dim)],
+            lhs_type=v_type.element_type,
+            rhs_type=v_type.element_type,
+            acc_type=f32_type,
+        )
+
+    def generate_solutions(
+        self,
+        tuner_context: common.TunerContext,
+        codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline,
+        **pipeline_constraint_options,
+    ) -> Iterator[list[common.TuningConfiguration]]:
+        return generate_attention_solutions(
+            tuner_ctx=tuner_context,
+            opinfo=self.opinfo,
+            qk_matmul=self.qk_matmul,
+            pv_matmul=self.pv_matmul,
+            transposed_q=self.transposed_q,
+            transposed_k=self.transposed_k,
+            transposed_v=self.transposed_v,
+            dispatch_kind=common.DispatchKind.attention,
             codegen_pipeline=codegen_pipeline,
             **pipeline_constraint_options,
         )

--- a/sharktuner/sharktuner/constraint_generator.py
+++ b/sharktuner/sharktuner/constraint_generator.py
@@ -603,8 +603,10 @@ class AttentionOpInterfaceConstraintGenerator(ConstraintGenerator):
         q_shape = q_type.shape
         k_shape = k_type.shape
         v_shape = v_type.shape
-        # Align with IREE's assuption: both QK and PV matmuls produce f32 outputs.
+        # QK matmul uses f32 as the accumulator type to match IREE's internal assumption.
+        # PV matmul derives the accumulator type from the output tensor's element type.
         f32_type = ir.F32Type.get()
+        output_type = root_op.results[0].type.element_type
 
         mDim = self.opinfo.m_dims[-1]
         k1Dim = self.opinfo.k1_dims[-1]
@@ -646,7 +648,7 @@ class AttentionOpInterfaceConstraintGenerator(ConstraintGenerator):
             k=v_shape[v_dims.index(k2Dim)],
             lhs_type=v_type.element_type,
             rhs_type=v_type.element_type,
-            acc_type=f32_type,
+            acc_type=output_type,
         )
 
     def generate_solutions(

--- a/sharktuner/sharktuner/dispatch_constraints.py
+++ b/sharktuner/sharktuner/dispatch_constraints.py
@@ -267,6 +267,193 @@ def generate_tile_and_fuse_constraints(
     return constraints
 
 
+def is_valid_mma_schedule(
+    matmul: common.MatmulShapeType,
+    schedule: common.GPUMMASchedule,
+    subgroup_size: z3.ArithRef,
+    transposed_lhs: bool,
+    transposed_rhs: bool,
+) -> list[z3.BoolRef]:
+    wg_threads = subgroup_size * schedule.m_subgroup_counts * schedule.n_subgroup_counts
+
+    # Check alignment between matmul shape and tiling layout.
+    schedule_aligned = z3.And(
+        matmul.m % (schedule.m_subgroup_counts * schedule.m_tile_size * schedule.m_size)
+        == 0,
+        matmul.n % (schedule.n_subgroup_counts * schedule.n_tile_size * schedule.n_size)
+        == 0,
+        matmul.k % (schedule.k_tile_size * schedule.k_size) == 0,
+    )
+
+    kMaxVectorLoadBitWidth = 128
+    bitwidth = matmul.rhs_type.width
+    elems_per_thread = kMaxVectorLoadBitWidth // bitwidth
+
+    m_wg_size = schedule.m_size * schedule.m_tile_size * schedule.m_subgroup_counts
+    n_wg_size = schedule.n_size * schedule.n_tile_size * schedule.n_subgroup_counts
+    k_wg_size = schedule.k_size * schedule.k_tile_size
+
+    inner_lhs_dim = m_wg_size if transposed_lhs else k_wg_size
+    inner_rhs_dim = k_wg_size if transposed_rhs else n_wg_size
+
+    lhs_div = inner_lhs_dim / elems_per_thread
+    rhs_div = inner_rhs_dim / elems_per_thread
+
+    lhs_distributable = z3.Or(lhs_div % wg_threads == 0, wg_threads % lhs_div == 0)
+    rhs_distributable = z3.Or(rhs_div % wg_threads == 0, wg_threads % rhs_div == 0)
+
+    return [schedule_aligned, lhs_distributable, rhs_distributable]
+
+
+def calculate_schedule_operands_shared_memory_usage_in_bytes(
+    schedule: common.GPUMMASchedule,
+    lhs_type: ir.IntegerType | ir.FloatType,
+    rhs_type: ir.IntegerType | ir.FloatType,
+) -> int | z3.ArithRef:
+    tile_m = schedule.m_size * schedule.m_tile_size * schedule.m_subgroup_counts
+    tile_n = schedule.n_size * schedule.n_tile_size * schedule.n_subgroup_counts
+    tile_k = schedule.k_size * schedule.k_tile_size
+
+    lhs_bits = lhs_type.width
+    rhs_bits = rhs_type.width
+
+    lhs_bytes = (tile_m * tile_k * lhs_bits) / 8
+    rhs_bytes = (tile_n * tile_k * rhs_bits) / 8
+
+    total_shared_memory = lhs_bytes + rhs_bytes
+    return total_shared_memory
+
+
+def generate_attention_vector_distribute_constraints(
+    qk_matmul: common.MatmulShapeType,
+    pv_matmul: common.MatmulShapeType,
+    transposed_q: bool,
+    transposed_k: bool,
+    transposed_v: bool,
+    tile_sizes: list[z3.ArithRef],
+    num_subgroups: int,
+    subgroup_size: z3.ArithRef,
+    intrinsic_size: list[z3.ArithRef],
+    subgroup_m_count: z3.ArithRef,
+    subgroup_n_count: z3.ArithRef,
+    mma_intrinsics: list[iree_gpu.MMAIntrinsic],
+):
+    m_tile, n_tile, k_tile = tile_sizes
+    intrinsic_mn, intrinsic_k = intrinsic_size
+    wg_threads = z3.Int("wg_threads")
+
+    constraints = []
+    constraints += [
+        get_mfma_intrinsic_constraints(
+            lhs_type=common.ShapedType([qk_matmul.m, qk_matmul.k], qk_matmul.lhs_type),
+            rhs_type=common.ShapedType([qk_matmul.k, qk_matmul.n], qk_matmul.rhs_type),
+            res_type=common.ShapedType([qk_matmul.m, qk_matmul.n], qk_matmul.acc_type),
+            intrinsic_m=intrinsic_mn,
+            intrinsic_n=intrinsic_mn,
+            intrinsic_k=intrinsic_k,
+            mma_intrinsics=mma_intrinsics,
+        )
+    ]
+
+    constraints += [
+        get_mfma_intrinsic_constraints(
+            lhs_type=common.ShapedType([pv_matmul.m, pv_matmul.k], pv_matmul.lhs_type),
+            rhs_type=common.ShapedType([pv_matmul.k, pv_matmul.n], pv_matmul.rhs_type),
+            res_type=common.ShapedType([pv_matmul.m, pv_matmul.n], pv_matmul.acc_type),
+            intrinsic_m=intrinsic_mn,
+            intrinsic_n=intrinsic_mn,
+            intrinsic_k=intrinsic_k,
+            mma_intrinsics=mma_intrinsics,
+        )
+    ]
+
+    constraints += [
+        qk_matmul.m % intrinsic_mn == 0,
+        qk_matmul.n % intrinsic_mn == 0,
+        qk_matmul.k % intrinsic_k == 0,
+    ]
+    constraints += [
+        pv_matmul.m % intrinsic_mn == 0,
+        pv_matmul.n % intrinsic_mn == 0,
+        pv_matmul.k % intrinsic_k == 0,
+    ]
+
+    constraints += [subgroup_m_count >= 1, subgroup_m_count <= 32]
+    constraints += [subgroup_n_count == 1]
+
+    subgroup_m_tile_count = z3.Int("sg_m_tcnt")
+    subgroup_n_tile_count = z3.Int("sg_n_tcnt")
+    subgroup_k_tile_count = z3.Int("sg_k_tcnt")
+
+    wg_threads = z3.Int("wg_threads")
+    constraints += [subgroup_size == 64, wg_threads <= 1024]
+    constraints += [
+        m_tile >= intrinsic_mn,
+        n_tile >= intrinsic_mn,
+        k_tile >= intrinsic_k,
+    ]
+    constraints += [m_tile == subgroup_m_count * subgroup_m_tile_count * intrinsic_mn]
+    constraints += [n_tile == subgroup_n_count * subgroup_n_tile_count * intrinsic_mn]
+    constraints += [k_tile == subgroup_k_tile_count * intrinsic_k]
+
+    constraints += [n_tile <= 512, k_tile <= 512, m_tile <= 512]
+
+    constraints += [wg_threads == subgroup_m_count * subgroup_n_count * subgroup_size]
+    subgroups = subgroup_m_count * subgroup_n_count
+    if num_subgroups > 0:
+        constraints += [subgroups == num_subgroups]
+    else:
+        constraints += [subgroups >= 1, subgroups <= 10]
+
+    pv_schedule = common.GPUMMASchedule(
+        m_size=intrinsic_mn,
+        n_size=intrinsic_mn,
+        k_size=intrinsic_k,
+        m_subgroup_counts=subgroup_m_count,
+        n_subgroup_counts=subgroup_n_count,
+        m_tile_size=subgroup_m_tile_count,
+        n_tile_size=subgroup_n_tile_count,
+        k_tile_size=subgroup_k_tile_count,
+    )
+
+    qk_schedule = common.GPUMMASchedule(
+        m_size=intrinsic_mn,
+        n_size=intrinsic_k,
+        k_size=intrinsic_k,
+        m_subgroup_counts=subgroup_m_count,
+        n_subgroup_counts=1,
+        m_tile_size=subgroup_m_tile_count,
+        n_tile_size=subgroup_k_tile_count,
+        k_tile_size=qk_matmul.k / intrinsic_k,
+    )
+
+    constraints += is_valid_mma_schedule(
+        matmul=qk_matmul,
+        schedule=qk_schedule,
+        subgroup_size=subgroup_size,
+        transposed_lhs=transposed_q,
+        transposed_rhs=transposed_k,
+    )
+
+    constraints += is_valid_mma_schedule(
+        matmul=pv_matmul,
+        schedule=pv_schedule,
+        subgroup_size=subgroup_size,
+        transposed_lhs=False,
+        transposed_rhs=transposed_v,
+    )
+
+    shared_memory = calculate_schedule_operands_shared_memory_usage_in_bytes(
+        qk_schedule, qk_matmul.lhs_type, qk_matmul.rhs_type
+    ) + calculate_schedule_operands_shared_memory_usage_in_bytes(
+        pv_schedule, pv_matmul.lhs_type, pv_matmul.rhs_type
+    )
+
+    constraints += [shared_memory <= 65536]
+
+    return constraints
+
+
 def getMMAAttr(
     output_type: ir.IntegerType | ir.FloatType,
     m: int,

--- a/sharktuner/sharktuner/dispatch_constraints.py
+++ b/sharktuner/sharktuner/dispatch_constraints.py
@@ -267,7 +267,7 @@ def generate_tile_and_fuse_constraints(
     return constraints
 
 
-def is_valid_mma_schedule(
+def is_valid_vector_distribute_mma_schedule(
     matmul: common.MatmulShapeType,
     schedule: common.GPUMMASchedule,
     subgroup_size: z3.ArithRef,
@@ -427,7 +427,7 @@ def generate_attention_vector_distribute_constraints(
         k_tile_size=qk_matmul.k / intrinsic_k,
     )
 
-    constraints += is_valid_mma_schedule(
+    constraints += is_valid_vector_distribute_mma_schedule(
         matmul=qk_matmul,
         schedule=qk_schedule,
         subgroup_size=subgroup_size,
@@ -435,7 +435,7 @@ def generate_attention_vector_distribute_constraints(
         transposed_rhs=transposed_k,
     )
 
-    constraints += is_valid_mma_schedule(
+    constraints += is_valid_vector_distribute_mma_schedule(
         matmul=pv_matmul,
         schedule=pv_schedule,
         subgroup_size=subgroup_size,

--- a/sharktuner/sharktuner/dispatch_constraints.py
+++ b/sharktuner/sharktuner/dispatch_constraints.py
@@ -305,11 +305,15 @@ def is_valid_vector_distribute_mma_schedule(
     return [schedule_aligned, lhs_distributable, rhs_distributable]
 
 
-def calculate_schedule_operands_shared_memory_usage_in_bytes(
+def calculate_schedule_input_operands_shared_memory_usage_in_bytes(
     schedule: common.GPUMMASchedule,
     lhs_type: ir.IntegerType | ir.FloatType,
     rhs_type: ir.IntegerType | ir.FloatType,
 ) -> int | z3.ArithRef:
+    """
+    Computes the shared memory usage (in bytes) for input operands
+    (LHS and RHS) in the given MMA schedule.
+    """
     tile_m = schedule.m_size * schedule.m_tile_size * schedule.m_subgroup_counts
     tile_n = schedule.n_size * schedule.n_tile_size * schedule.n_subgroup_counts
     tile_k = schedule.k_size * schedule.k_tile_size
@@ -443,9 +447,9 @@ def generate_attention_vector_distribute_constraints(
         transposed_rhs=transposed_v,
     )
 
-    shared_memory = calculate_schedule_operands_shared_memory_usage_in_bytes(
+    shared_memory = calculate_schedule_input_operands_shared_memory_usage_in_bytes(
         qk_schedule, qk_matmul.lhs_type, qk_matmul.rhs_type
-    ) + calculate_schedule_operands_shared_memory_usage_in_bytes(
+    ) + calculate_schedule_input_operands_shared_memory_usage_in_bytes(
         pv_schedule, pv_matmul.lhs_type, pv_matmul.rhs_type
     )
 

--- a/sharktuner/sharktuner/dispatch_constraints.py
+++ b/sharktuner/sharktuner/dispatch_constraints.py
@@ -20,6 +20,20 @@ from iree.compiler.dialects import iree_codegen  # type: ignore
 from . import common
 
 
+@dataclass
+class GPUMMASchedule:
+    m_size: z3.ArithRef
+    n_size: z3.ArithRef
+    k_size: z3.ArithRef
+
+    m_subgroup_counts: z3.ArithRef
+    n_subgroup_counts: z3.ArithRef
+
+    m_tile_size: z3.ArithRef
+    n_tile_size: z3.ArithRef
+    k_tile_size: z3.ArithRef
+
+
 def get_mfma_intrinsic_constraints(
     lhs_type: common.ShapedType,
     rhs_type: common.ShapedType,
@@ -269,7 +283,7 @@ def generate_tile_and_fuse_constraints(
 
 def is_valid_vector_distribute_mma_schedule(
     matmul: common.MatmulShapeType,
-    schedule: common.GPUMMASchedule,
+    schedule: GPUMMASchedule,
     subgroup_size: z3.ArithRef,
     transposed_lhs: bool,
     transposed_rhs: bool,
@@ -306,7 +320,7 @@ def is_valid_vector_distribute_mma_schedule(
 
 
 def calculate_schedule_input_operands_shared_memory_usage_in_bytes(
-    schedule: common.GPUMMASchedule,
+    schedule: GPUMMASchedule,
     lhs_type: ir.IntegerType | ir.FloatType,
     rhs_type: ir.IntegerType | ir.FloatType,
 ) -> int | z3.ArithRef:
@@ -409,7 +423,7 @@ def generate_attention_vector_distribute_constraints(
     else:
         constraints += [subgroups >= 1, subgroups <= 10]
 
-    pv_schedule = common.GPUMMASchedule(
+    pv_schedule = GPUMMASchedule(
         m_size=intrinsic_mn,
         n_size=intrinsic_mn,
         k_size=intrinsic_k,
@@ -420,7 +434,7 @@ def generate_attention_vector_distribute_constraints(
         k_tile_size=subgroup_k_tile_count,
     )
 
-    qk_schedule = common.GPUMMASchedule(
+    qk_schedule = GPUMMASchedule(
         m_size=intrinsic_mn,
         n_size=intrinsic_k,
         k_size=intrinsic_k,

--- a/sharktuner/tests/dispatch_constraints_test.py
+++ b/sharktuner/tests/dispatch_constraints_test.py
@@ -311,7 +311,7 @@ def test_is_valid_mma_schedule(
     )
 
     subgroup_size = z3.Int("subgroup_size")
-    schedule = common.GPUMMASchedule(
+    schedule = dispatch_constraints.GPUMMASchedule(
         m_size=z3.IntVal(16),
         n_size=z3.IntVal(16),
         k_size=z3.IntVal(16),

--- a/sharktuner/tests/dispatch_constraints_test.py
+++ b/sharktuner/tests/dispatch_constraints_test.py
@@ -296,3 +296,121 @@ def test_generate_vector_distribute_constraints_invalid_input(
 
     # Check if the constraints are unsatisfiable
     assert solver.check() == z3.unsat
+
+
+def test_is_valid_mma_schedule(
+    tuner_ctx: common.TunerContext,
+) -> None:
+    matmul = common.MatmulShapeType(
+        m=128,
+        n=128,
+        k=64,
+        lhs_type=tuner_ctx.type.f16,
+        rhs_type=tuner_ctx.type.f16,
+        acc_type=tuner_ctx.type.f32,
+    )
+
+    subgroup_size = z3.Int("subgroup_size")
+    schedule = common.GPUMMASchedule(
+        m_size=z3.IntVal(16),
+        n_size=z3.IntVal(16),
+        k_size=z3.IntVal(16),
+        m_subgroup_counts=z3.IntVal(1),
+        n_subgroup_counts=z3.IntVal(1),
+        m_tile_size=z3.IntVal(2),
+        n_tile_size=z3.IntVal(2),
+        k_tile_size=z3.IntVal(2),
+    )
+
+    constraints = dispatch_constraints.is_valid_mma_schedule(
+        matmul=matmul,
+        schedule=schedule,
+        subgroup_size=subgroup_size,
+        transposed_lhs=False,
+        transposed_rhs=False,
+    )
+
+    solver = z3.Solver()
+    solver.add(subgroup_size == 64)
+    solver.add(constraints)
+
+    assert solver.check() == z3.sat
+
+    matmul = common.MatmulShapeType(
+        m=130,
+        n=128,
+        k=64,
+        lhs_type=tuner_ctx.type.f16,
+        rhs_type=tuner_ctx.type.f16,
+        acc_type=tuner_ctx.type.f32,
+    )
+    constraints = dispatch_constraints.is_valid_mma_schedule(
+        matmul=matmul,
+        schedule=schedule,
+        subgroup_size=subgroup_size,
+        transposed_lhs=False,
+        transposed_rhs=False,
+    )
+
+    solver = z3.Solver()
+    solver.add(subgroup_size == 64)
+    solver.add(constraints)
+
+    assert solver.check() == z3.unsat
+
+
+def test_generate_attention_vector_distribute_constraints(
+    tuner_ctx: common.TunerContext,
+) -> None:
+    f32 = tuner_ctx.type.f32
+    f16 = tuner_ctx.type.f16
+
+    qk_matmul = common.MatmulShapeType(
+        m=128, n=128, k=64, lhs_type=f16, rhs_type=f16, acc_type=f32
+    )
+    pv_matmul = common.MatmulShapeType(
+        m=128, n=128, k=64, lhs_type=f16, rhs_type=f16, acc_type=f32
+    )
+
+    m_tile = z3.Int("m_tile")
+    n_tile = z3.Int("n_tile")
+    k_tile = z3.Int("k_tile")
+    tile_sizes = [m_tile, n_tile, k_tile]
+
+    subgroup_size = z3.IntVal(64)
+    intrinsic_mn = z3.IntVal(16)
+    intrinsic_k = z3.IntVal(16)
+    intrinsic_size = [intrinsic_mn, intrinsic_k]
+
+    subgroup_m_count = z3.Int("subgroup_m_count")
+    subgroup_n_count = z3.Int("subgroup_n_count")
+
+    constraints = dispatch_constraints.generate_attention_vector_distribute_constraints(
+        qk_matmul=qk_matmul,
+        pv_matmul=pv_matmul,
+        transposed_q=False,
+        transposed_k=False,
+        transposed_v=False,
+        tile_sizes=tile_sizes,
+        num_subgroups=4,
+        subgroup_size=subgroup_size,
+        intrinsic_size=intrinsic_size,
+        subgroup_m_count=subgroup_m_count,
+        subgroup_n_count=subgroup_n_count,
+        mma_intrinsics=[
+            iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
+            iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
+            iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
+            iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
+        ],
+    )
+
+    solver = z3.Solver()
+    solver.add(constraints)
+    assert solver.check() == z3.sat
+
+    # Add a conflicting constraint for invalid test.
+    constraints.append(m_tile > 1024)
+    solver = z3.Solver()
+    solver.add(constraints)
+    assert solver.check() == z3.unsat

--- a/sharktuner/tests/dispatch_constraints_test.py
+++ b/sharktuner/tests/dispatch_constraints_test.py
@@ -322,7 +322,7 @@ def test_is_valid_mma_schedule(
         k_tile_size=z3.IntVal(2),
     )
 
-    constraints = dispatch_constraints.is_valid_mma_schedule(
+    constraints = dispatch_constraints.is_valid_vector_distribute_mma_schedule(
         matmul=matmul,
         schedule=schedule,
         subgroup_size=subgroup_size,
@@ -344,7 +344,7 @@ def test_is_valid_mma_schedule(
         rhs_type=tuner_ctx.type.f16,
         acc_type=tuner_ctx.type.f32,
     )
-    constraints = dispatch_constraints.is_valid_mma_schedule(
+    constraints = dispatch_constraints.is_valid_vector_distribute_mma_schedule(
         matmul=matmul,
         schedule=schedule,
         subgroup_size=subgroup_size,


### PR DESCRIPTION
This PR adds initial support for the attention op in the SHARK Tuner.
- Currently supports only the standard attention op, masked attention is not yet handled.
- only about `VectorDistribute `pipeline. 
Attention constraints largely are about two matmul-like patterns along the `VectorDistribute `pipeline.

This PR is implemented mainly through understanding and following the logic of `setAttentionIntrinsicBasedVectorDistributionConfig` from IREE for attention op. 

This PR primarily focuses on adding tuner support for the attention op. It introduces some code redundancy, which I plan to address in a follow-up NFC PR by simplifying and better modularizing the code.

Issue: https://github.com/nod-ai/shark-ai/issues/1769
