### PR TITLE
Change checks to be more generic

### DIFF
--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -1089,10 +1089,10 @@ def _replicate_trampoline(
     devices: tuple[int, ...] | None = None,
 ) -> ShardedTensor:
     tensors = (input,)
-    if isinstance(input, (torch.Tensor, PrimitiveTensor)):
-        devices = devices if devices is not None else tuple(range(count))
-    else:
+    if isinstance(input, ShardedTensor):
         assert devices is None
+    else:
+        devices = devices if devices is not None else tuple(range(count))
 
     for override in d.find_overrides(tensors):
         result = override(input, count=count, devices=devices)

--- a/sharktank/sharktank/types/pipelining.py
+++ b/sharktank/sharktank/types/pipelining.py
@@ -66,7 +66,7 @@ def pipeline_parallelize_theta(
         )
 
     _t = theta.tensor("token_embd")["weight"]
-    shard_count = 1 if isinstance(_t, DefaultPrimitiveTensor) else _t.shard_count
+    shard_count = _t.shard_count if isinstance(_t, ShardedTensor) else 1
 
     block_indices = theta.tensor("blk").keys()
     block_count = len(block_indices)


### PR DESCRIPTION
The checks were always about ShardedTensors, but were operating implicitly by assuming PrimitiveTensors were the only other options. They need to be re-written to allow for QuantizedTensors to be supported.