### PR TITLE
Change def globals() to not assume datatype of underlying shards

### DIFF
--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -887,7 +887,7 @@ class PlanarQuantizedTensor(QuantizedTensor):
         )
 
     def __repr__(self):
-        return f"PlanarQuantized({self.name}, {self.shape}, layout={self.layout})"
+        return f"PlanarQuantizedTensor({self.name}, {self.shape}, layout={self.layout})"
 
 
 ########################################################################################


### PR DESCRIPTION
Current implementation of globals() assumes that the shards are PrimitiveTensors, but we can generalize that work with any InferenceTensor to support Quantized shards.