### PR TITLE
[sharktank] Make our xfail a proper Pytest mark

### DIFF
--- a/sharktank/sharktank/utils/testing.py
+++ b/sharktank/sharktank/utils/testing.py
@@ -723,55 +723,6 @@ def _eval_condition(c: bool | str | None) -> bool:
     )
 
 
-def xfail(
-    condition: bool | None = None,
-    *,
-    match: str | None = None,
-    **kwargs,
-):
-    """xfail a test with support for regex matching against the error message.
-
-    This wraps the pytest.mark.xfail decorator into a new decorator.
-    pytest.mark.xfail does not support matching on the error message, but sometimes we
-    need to be more precise on why we expect a failure.
-    One example is when specifying what compiler error is expected. Just the exception
-    type is not enough.
-
-    ```
-    @xfail(raises=MyError, strict=True, match="my message")
-    @test_something():
-        raise MyError("my message")
-    ```
-
-    *args and **kwargs are passthrough arguments for pytest.mark.xfail.
-    """
-
-    def decorator(test_fn: Callable):
-        if condition is not None:
-            kwargs.update(condition=condition)
-
-        @pytest.mark.xfail(**kwargs)
-        @functools.wraps(test_fn)
-        def wrapper(*args, **kwargs):
-            try:
-                return test_fn(*args, **kwargs)
-            except Exception as ex:
-                if (
-                    not _eval_condition(condition)
-                    or match is None
-                    or re.search(match, str(ex))
-                ):
-                    raise ex
-                else:
-                    raise pytest.fail(
-                        f'Failed to match error "{ex}" against expected match "{match}"'
-                    ) from ex
-
-        return wrapper
-
-    return decorator
-
-
 def get_random_test_text_prompts(
     num_prompts: int, min_prompt_length: int | None = None
 ):

--- a/sharktank/tests/evaluate/perplexity_iree_test.py
+++ b/sharktank/tests/evaluate/perplexity_iree_test.py
@@ -20,7 +20,6 @@ from sharktank.utils.testing import (
     is_deepseek,
     is_llama_8b,
     is_sharded,
-    xfail,
 )
 
 
@@ -156,7 +155,7 @@ class PerplexityTest(unittest.TestCase):
         self.prepare_argv()
         self.run_and_check_perplexity()
 
-    @xfail(
+    @pytest.mark.xfail(
         raises=IreeCompileException,
         reason="https://github.com/iree-org/iree/issues/21068",
         strict=True,
@@ -195,7 +194,7 @@ class PerplexityTest(unittest.TestCase):
         self.prepare_argv(extra_args=(f"--use-toy-model",))
         self.run_and_check_perplexity()
 
-    @xfail(
+    @pytest.mark.xfail(
         raises=IreeCompileException,
         reason="https://github.com/iree-org/iree/issues/20914",
         strict=True,

--- a/sharktank/tests/models/deepseek/test_deepseek.py
+++ b/sharktank/tests/models/deepseek/test_deepseek.py
@@ -21,7 +21,6 @@ from sharktank.utils.testing import (
     is_mi300x,
     IreeVsEagerLLMTester,
     TempDirTestBase,
-    xfail,
 )
 
 
@@ -65,7 +64,7 @@ class DeepseekCrossEntropyTest(unittest.TestCase):
 @is_mi300x
 class DeepseekIreeVsEagerTest(TempDirTestBase):
     @parameterized.expand(product([1, 2], [1, 2]))
-    @xfail(
+    @pytest.mark.xfail(
         raises=AssertionError,
         reason="https://github.com/nod-ai/shark-ai/issues/1758",
         strict=True,

--- a/sharktank/tests/models/llama/test_llama.py
+++ b/sharktank/tests/models/llama/test_llama.py
@@ -20,7 +20,6 @@ from sharktank.utils.testing import (
     is_mi300x,
     IreeVsEagerLLMTester,
     TempDirTestBase,
-    xfail,
 )
 
 
@@ -67,7 +66,7 @@ class CrossEntropyTest(unittest.TestCase):
 @is_mi300x
 class LlamaIreeVsEagerTest(TempDirTestBase):
     @parameterized.expand(product([1, 2], [1, 2]))
-    @xfail(
+    @pytest.mark.xfail(
         raises=AssertionError,
         reason="https://github.com/nod-ai/shark-ai/issues/1758",
         strict=True,

--- a/sharktank/tests/models/punet/sharded_resnet_block_with_iree_test.py
+++ b/sharktank/tests/models/punet/sharded_resnet_block_with_iree_test.py
@@ -4,10 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import gc
 import iree.compiler
 import iree.runtime
-import re
+import pytest
 import sys
 import torch
 
@@ -25,7 +24,6 @@ from sharktank.utils.iree import (
     run_iree_module_function,
     with_iree_device_context,
 )
-from sharktank.utils.testing import xfail
 from typing import List
 
 
@@ -115,7 +113,7 @@ def run_test_toy_size_sharded_resnet_block_with_iree(artifacts_dir: Path):
     torch.testing.assert_close(actual_outputs, expected_results, rtol=0, atol=5e-5)
 
 
-@xfail(
+@pytest.mark.xfail(
     condition=(sys.platform != "win32"),
     raises=iree.compiler.CompilerToolError,
     reason=(
@@ -128,7 +126,7 @@ def run_test_toy_size_sharded_resnet_block_with_iree(artifacts_dir: Path):
     ),
     strict=True,
 )
-@xfail(
+@pytest.mark.xfail(
     condition=(sys.platform == "win32"),
     raises=iree.compiler.CompilerToolError,
     reason=(

--- a/sharktank/tests/ops/sharded_test.py
+++ b/sharktank/tests/ops/sharded_test.py
@@ -9,6 +9,7 @@ from typing import Callable
 import unittest
 import itertools
 import pytest
+import re
 from parameterized import parameterized, parameterized_class
 
 import functools
@@ -1968,7 +1969,7 @@ class TriviallyReplicableTest(unittest.TestCase):
         ),
         strict=True,
         raises=NotImplementedError,
-        match=(
+        match=re.escape(
             "does not have an implementation for argument types:"
             " [<class 'sharktank.types.tensors.ReplicatedTensor'>]"
         ),

--- a/sharktank/tests/utils/testing_test.py
+++ b/sharktank/tests/utils/testing_test.py
@@ -6,17 +6,28 @@
 
 import pytest
 
-from sharktank.utils.testing import xfail
+from pathlib import Path
 
 pytest_plugins = "pytester"
 
 
-def test_strict_xfail_with_successful_match(pytester: pytest.Pytester):
+@pytest.fixture
+def pytester_with_conftest(pytester: pytest.Pytester) -> pytest.Pytester:
+    """Copy our conftest.py into the test dir so that Pytester tests can pick it up."""
+    with open(f"{Path(__file__).parent.parent.parent / 'conftest.py'}", "r") as f:
+        pytester.makeconftest(f.read())
+    return pytester
+
+
+def test_strict_xfail_with_successful_match(pytester_with_conftest: pytest.Pytester):
+    pytester = pytester_with_conftest
     pytester.makepyfile(
         """
-        from sharktank.utils.testing import xfail
+        import pytest
 
-        @xfail(raises=RuntimeError, strict=True, match="test_xfail_with_successful_match")
+        @pytest.mark.xfail(
+            raises=RuntimeError, strict=True, match="test_xfail_with_successful_match"
+        )
         def test_f():
             raise RuntimeError("test_xfail_with_successful_match")
         """
@@ -26,12 +37,15 @@ def test_strict_xfail_with_successful_match(pytester: pytest.Pytester):
     result.assert_outcomes(xfailed=1)
 
 
-def test_strict_xfail_with_failed_match(pytester: pytest.Pytester):
+def test_strict_xfail_with_failed_match(pytester_with_conftest: pytest.Pytester):
+    pytester = pytester_with_conftest
     pytester.makepyfile(
         """
-        from sharktank.utils.testing import xfail
+        import pytest
 
-        @xfail(raises=RuntimeError, strict=True, match="string_that_can_not_be_found")
+        @pytest.mark.xfail(
+            raises=RuntimeError, strict=True, match="string_that_can_not_be_found"
+        )
         def test_f():
             raise RuntimeError("test_xfail_with_failed_match")
         """
@@ -41,12 +55,13 @@ def test_strict_xfail_with_failed_match(pytester: pytest.Pytester):
     result.assert_outcomes(failed=1)
 
 
-def test_non_strict_xfail_with_failed_match(pytester: pytest.Pytester):
+def test_non_strict_xfail_with_failed_match(pytester_with_conftest: pytest.Pytester):
+    pytester = pytester_with_conftest
     pytester.makepyfile(
         """
-        from sharktank.utils.testing import xfail
+        import pytest
 
-        @xfail(raises=RuntimeError, strict=False, match="string_that_can_not_be_found")
+        @pytest.mark.xfail(raises=RuntimeError, strict=False, match="string_that_can_not_be_found")
         def test_f():
             raise RuntimeError("test_xfail_with_failed_match")
         """
@@ -56,12 +71,13 @@ def test_non_strict_xfail_with_failed_match(pytester: pytest.Pytester):
     result.assert_outcomes(failed=1)
 
 
-def test_strict_xfail_without_match(pytester: pytest.Pytester):
+def test_strict_xfail_without_match(pytester_with_conftest: pytest.Pytester):
+    pytester = pytester_with_conftest
     pytester.makepyfile(
         """
-        from sharktank.utils.testing import xfail
+        import pytest
 
-        @xfail(raises=RuntimeError, strict=True)
+        @pytest.mark.xfail(raises=RuntimeError, strict=True)
         def test_f():
             raise RuntimeError("test_xfail_without_match")
         """
@@ -71,12 +87,13 @@ def test_strict_xfail_without_match(pytester: pytest.Pytester):
     result.assert_outcomes(xfailed=1)
 
 
-def test_strict_xfail_with_wrong_exception(pytester: pytest.Pytester):
+def test_strict_xfail_with_wrong_exception(pytester_with_conftest: pytest.Pytester):
+    pytester = pytester_with_conftest
     pytester.makepyfile(
         """
-        from sharktank.utils.testing import xfail
+        import pytest
 
-        @xfail(raises=RuntimeError, strict=True)
+        @pytest.mark.xfail(raises=RuntimeError, strict=True)
         def test_f():
             raise ValueError("")
         """
@@ -87,13 +104,14 @@ def test_strict_xfail_with_wrong_exception(pytester: pytest.Pytester):
 
 
 def test_strict_xfail_match_with_multiple_lines_in_exception_string(
-    pytester: pytest.Pytester,
+    pytester_with_conftest: pytest.Pytester,
 ):
+    pytester = pytester_with_conftest
     pytester.makepyfile(
         """
-        from sharktank.utils.testing import xfail
+        import pytest
 
-        @xfail(raises=RuntimeError, strict=True, match="line2")
+        @pytest.mark.xfail(raises=RuntimeError, strict=True, match="line2")
         def test_f():
             raise RuntimeError("line1\\nline2\\nline3")
         """
@@ -103,12 +121,13 @@ def test_strict_xfail_match_with_multiple_lines_in_exception_string(
     result.assert_outcomes(xfailed=1)
 
 
-def test_xfail_xpass_with_match(pytester: pytest.Pytester):
+def test_xfail_xpass_with_match(pytester_with_conftest: pytest.Pytester):
+    pytester = pytester_with_conftest
     pytester.makepyfile(
         """
-        from sharktank.utils.testing import xfail
+        import pytest
 
-        @xfail(match="match")
+        @pytest.mark.xfail(match="match")
         def test_f():
             pass
         """
@@ -118,13 +137,16 @@ def test_xfail_xpass_with_match(pytester: pytest.Pytester):
     result.assert_outcomes(xpassed=1)
 
 
-def test_multiple_strict_xfails_with_successful_match(pytester: pytest.Pytester):
+def test_multiple_strict_xfails_with_successful_match(
+    pytester_with_conftest: pytest.Pytester,
+):
+    pytester = pytester_with_conftest
     pytester.makepyfile(
         """
-        from sharktank.utils.testing import xfail
+        import pytest
 
-        @xfail(raises=ValueError, strict=True, match="match")
-        @xfail(raises=ValueError, strict=True, match="match")
+        @pytest.mark.xfail(raises=ValueError, strict=True, match="match")
+        @pytest.mark.xfail(raises=ValueError, strict=True, match="match")
         def test_f():
             raise ValueError("match")
         """
@@ -135,13 +157,16 @@ def test_multiple_strict_xfails_with_successful_match(pytester: pytest.Pytester)
 
 
 def test_strict_xfail_with_successful_match_and_false_condition(
-    pytester: pytest.Pytester,
+    pytester_with_conftest: pytest.Pytester,
 ):
+    pytester = pytester_with_conftest
     pytester.makepyfile(
         """
-        from sharktank.utils.testing import xfail
+        import pytest
 
-        @xfail(condition=False, raises=ValueError, reason="", strict=True, match="match")
+        @pytest.mark.xfail(
+            condition=False, raises=ValueError, reason="", strict=True, match="match"
+        )
         def test_f():
             raise ValueError("match")
         """
@@ -151,12 +176,21 @@ def test_strict_xfail_with_successful_match_and_false_condition(
     result.assert_outcomes(failed=1)
 
 
-def test_strict_xfail_with_failed_match_and_true_condition(pytester: pytest.Pytester):
+def test_strict_xfail_with_failed_match_and_true_condition(
+    pytester_with_conftest: pytest.Pytester,
+):
+    pytester = pytester_with_conftest
     pytester.makepyfile(
         """
-        from sharktank.utils.testing import xfail
+        import pytest
 
-        @xfail(condition=True, raises=ValueError, reason="", strict=True, match="not a match")
+        @pytest.mark.xfail(
+            condition=True,
+            raises=ValueError,
+            reason="",
+            strict=True,
+            match="not a match"
+        )
         def test_f():
             raise ValueError("match")
         """
@@ -167,14 +201,23 @@ def test_strict_xfail_with_failed_match_and_true_condition(pytester: pytest.Pyte
 
 
 def test_multiple_strict_xfails_with_failed_match_and_false_condition_in_first_xfail(
-    pytester: pytest.Pytester,
+    pytester_with_conftest: pytest.Pytester,
 ):
+    pytester = pytester_with_conftest
     pytester.makepyfile(
         """
-        from sharktank.utils.testing import xfail
+        import pytest
 
-        @xfail(condition=True, raises=ValueError, reason="", strict=True, match="match")
-        @xfail(condition=False, raises=ValueError, reason="", strict=True, match="not a match")
+        @pytest.mark.xfail(
+            condition=True, raises=ValueError, reason="", strict=True, match="match"
+        )
+        @pytest.mark.xfail(
+            condition=False,
+            raises=ValueError,
+            reason="",
+            strict=True,
+            match="not a match"
+        )
         def test_f():
             raise ValueError("match")
         """
@@ -185,14 +228,23 @@ def test_multiple_strict_xfails_with_failed_match_and_false_condition_in_first_x
 
 
 def test_multiple_strict_xfails_with_failed_match_and_true_condition_in_first_xfail(
-    pytester: pytest.Pytester,
+    pytester_with_conftest: pytest.Pytester,
 ):
+    pytester = pytester_with_conftest
     pytester.makepyfile(
         """
-        from sharktank.utils.testing import xfail
+        import pytest
 
-        @xfail(condition=True, raises=ValueError, reason="", strict=True, match="match")
-        @xfail(condition=True, raises=ValueError, reason="", strict=True, match="not a match")
+        @pytest.mark.xfail(
+            condition=True, raises=ValueError, reason="", strict=True, match="match"
+        )
+        @pytest.mark.xfail(
+            condition=True,
+            raises=ValueError,
+            reason="",
+            strict=True,
+            match="not a match"
+        )
         def test_f():
             raise ValueError("match")
         """
@@ -203,14 +255,15 @@ def test_multiple_strict_xfails_with_failed_match_and_true_condition_in_first_xf
 
 
 def test_multiple_non_strict_xfails_with_false_condition_in_first_xfail(
-    pytester: pytest.Pytester,
+    pytester_with_conftest: pytest.Pytester,
 ):
+    pytester = pytester_with_conftest
     pytester.makepyfile(
         """
-        from sharktank.utils.testing import xfail
+        import pytest
 
-        @xfail(strict=False)
-        @xfail(condition=False, strict=False, raises=ValueError, reason="")
+        @pytest.mark.xfail(strict=False)
+        @pytest.mark.xfail(condition=False, strict=False, raises=ValueError, reason="")
         def test_f():
             raise RuntimeError("")
         """
@@ -221,14 +274,15 @@ def test_multiple_non_strict_xfails_with_false_condition_in_first_xfail(
 
 
 def test_xfail_failed_match_does_not_interfere_with_exception_message_of_failed_previous_match(
-    pytester: pytest.Pytester,
+    pytester_with_conftest: pytest.Pytester,
 ):
+    pytester = pytester_with_conftest
     pytester.makepyfile(
         """
-        from sharktank.utils.testing import xfail
+        import pytest
 
-        @xfail(strict=True, match="This is the exception")
-        @xfail(raises=ValueError, match="not a match")
+        @pytest.mark.xfail(strict=True, match="This is the exception")
+        @pytest.mark.xfail(raises=ValueError, match="not a match")
         def test_f():
             raise ValueError("This is the exception")
         """
@@ -239,15 +293,34 @@ def test_xfail_failed_match_does_not_interfere_with_exception_message_of_failed_
 
 
 def test_xfail_failed_match_does_not_interfere_with_exception_message_of_failed_previous_match(
-    pytester: pytest.Pytester,
+    pytester_with_conftest: pytest.Pytester,
 ):
+    pytester = pytester_with_conftest
     pytester.makepyfile(
         """
-        from sharktank.utils.testing import xfail
+        import pytest
 
-        @xfail(strict=True, match="This is the exception")
-        @xfail(raises=ValueError, match="not a match")
+        @pytest.mark.xfail(strict=True, match="This is the exception")
+        @pytest.mark.xfail(raises=ValueError, match="not a match")
         def test_f():
+            raise ValueError("This is the exception")
+        """
+    )
+
+    result = pytester.runpytest()
+    result.assert_outcomes(failed=1)
+
+
+def test_parametrized_xfail_with_failed_match(pytester_with_conftest: pytest.Pytester):
+    pytester = pytester_with_conftest
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.parametrize(
+            "a", [pytest.param(1, marks=pytest.mark.xfail(match="not a match"))]
+        )
+        def test_f(a: int):
             raise ValueError("This is the exception")
         """
     )


### PR DESCRIPTION
Instead of making a new decorator, extend the pytest.mark.xfail to support exception message matching. Like that it can be used in parametrized tests. E.g.

```
@pytest.mark.parametrize(
    "a", [pytest.param(1, marks=pytest.mark.xfail(match="not a match"))]
)
def test_f(a: int):
    raise ValueError("This is the exception")
```

This is achieved through the pytest hook mechanism.