### PR TITLE
[sharktank] make view op support dtype overload

### DIFF
--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -917,8 +917,18 @@ def _split_topk(
 
 
 @view.override(Tensor)
-def view_default(tensor: Union[Tensor, PrimitiveTensor], shape: List[int]) -> Tensor:
-    return unbox_tensor(tensor).view(*shape)
+def view_default(
+    tensor: Union[Tensor, PrimitiveTensor],
+    shape: List[int] | None,
+    dtype: torch.dtype | None,
+) -> Tensor:
+    assert (shape is None) ^ (
+        dtype is None
+    ), "Exactly one of shape or dtype must be provided"
+    if shape is not None:
+        return unbox_tensor(tensor).view(*shape)
+    else:
+        return unbox_tensor(tensor).view(dtype)
 
 
 @view.override(QuantizedTensor)

--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -1874,7 +1874,10 @@ def unsqueeze_split(tensor: SplitPrimitiveTensor, dim: int) -> SplitPrimitiveTen
 
 
 @view.override(SplitPrimitiveTensor)
-def view_split(tensor: SplitPrimitiveTensor, shape: List[int]) -> SplitPrimitiveTensor:
+def view_split(
+    tensor: SplitPrimitiveTensor, shape: List[int] | None, dtype: torch.Tensor | None
+) -> SplitPrimitiveTensor:
+    assert dtype is None, "Not supported"
     shard_dim = tensor.shard_dim
     mapping = _calculate_view_dimension_mapping(from_shape=tensor.shape, to_shape=shape)
     if len(mapping[shard_dim]) != 1:

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -1698,18 +1698,23 @@ def _topk_trampoline(
 
 
 @overridable
-def view(tensor: AnyTensor, shape: List[int]) -> AnyTensor:
+def view(
+    tensor: AnyTensor, shape: List[int] | None = None, dtype: torch.Tensor | None = None
+) -> AnyTensor:
     """See torch.Tensor.view"""
     ...
 
 
 @view.trampoline
 def _view_trampoline(
-    d: SignatureDispatcher, tensor: AnyTensor, shape: List[int]
+    d: SignatureDispatcher,
+    tensor: AnyTensor,
+    shape: List[int] | None = None,
+    dtype: torch.Tensor | None = None,
 ) -> AnyTensor:
     tensors = (tensor,)
     for override in d.find_overrides(tensors):
-        result = override(tensor, shape)
+        result = override(tensor, shape, dtype)
         if result is not NotImplemented:
             return override, result
     else:


### PR DESCRIPTION
The troch.view op has dtype overload. This aligns our op API with torch.