### PR TITLE
Clean up parameters in server param

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/config_struct.py
+++ b/shortfin/python/shortfin_apps/llm/components/config_struct.py
@@ -231,12 +231,6 @@ class ServerParams:
     # Program isolation configuration
     program_isolation: str = "per_call"
 
-    # Number of shortfin workers to use during generation
-    workers: int = 1
-
-    # Number of fibers to create per worker
-    fibers_per_worker: int = 1
-
     decode_config: DecodeConfig | None = None
 
     # Device configuration

--- a/shortfin/python/shortfin_apps/llm/components/service.py
+++ b/shortfin/python/shortfin_apps/llm/components/service.py
@@ -73,13 +73,6 @@ class LlmGenerateService(GenerateService):
             logger.debug(f"Max queue size: {self.max_queue_size}")
 
     def _initialize_worker_and_fiber(self):
-        num_workers = self.server_params.workers
-        fibers_per_worker = self.server_params.fibers_per_worker
-
-        logger.info(
-            f"Creating {num_workers} workers, with {fibers_per_worker} fibers per worker..."
-        )
-
         self.main_worker = self.sysman.ls.create_worker(f"{self.name}-inference-main-0")
         self.main_fiber = self.sysman.ls.create_fiber(self.main_worker)
 

--- a/shortfin/python/shortfin_apps/llm/server.py
+++ b/shortfin/python/shortfin_apps/llm/server.py
@@ -120,18 +120,6 @@ def add_service_args(parser: argparse.ArgumentParser):
         default=False,
         help="Use beam search for decoding.",
     )
-    parser.add_argument(
-        "--workers",
-        type=int,
-        default=1,
-        help="Number of workers to use when running in `server` mode.",
-    )
-    parser.add_argument(
-        "--fibers_per_worker",
-        type=int,
-        default=1,
-        help="Number of fibers to use per worker.",
-    )
 
 
 def parse_args(argv):

--- a/shortfin/python/shortfin_apps/llm/server.py
+++ b/shortfin/python/shortfin_apps/llm/server.py
@@ -138,30 +138,8 @@ def parse_args(argv):
     )
     return parser.parse_args(argv)
 
-
-def _check_for_per_fiber_bug(args):
-    """This is a temporary check to enable multi-worker and multi-fiber-per-worker
-    for performance benefits.
-
-    TODO: https://github.com/nod-ai/shark-ai/issues/1284
-
-    Raises:
-        NotImplementedError: Raises if per fiber isolation is used with multiple fibers per worker.
-    """
-    isolation = args.program_isolation
-    fibers_per_worker = args.fibers_per_worker
-
-    if isolation == ProgramIsolation.PER_FIBER.name.lower() and fibers_per_worker > 1:
-        raise NotImplementedError(
-            "Per fiber isolation does not currently support multiple fibers per worker. "
-            "Please set `--fibers_per_worker` to 1.\n"
-            "See: https://github.com/nod-ai/shark-ai/issues/1284"
-        )
-
-
 def run_server(argv, log_config=uvicorn.config.LOGGING_CONFIG, port: int | None = None):
     args = parse_args(argv)
-    _check_for_per_fiber_bug(args)
     if args.tokenizer_config_json is None:
         # this is only used for the EOS token
         logging.info("Argument `--tokenizer_config_json` is not provided")

--- a/shortfin/python/shortfin_apps/llm/server.py
+++ b/shortfin/python/shortfin_apps/llm/server.py
@@ -138,6 +138,7 @@ def parse_args(argv):
     )
     return parser.parse_args(argv)
 
+
 def run_server(argv, log_config=uvicorn.config.LOGGING_CONFIG, port: int | None = None):
     args = parse_args(argv)
     if args.tokenizer_config_json is None:


### PR DESCRIPTION
Why:
Worker and fiber are now created dynamically through FiberPool, there is no need to specify number of workers statically

How:
Remove  workers and fibers_per_worker from ServerParams class