### PR TITLE
Remove hardcoded split for top-k=1

### DIFF
--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -9,7 +9,7 @@
 import os
 import logging
 import json
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, Optional
 import torch
 
 from iree.turbine.aot import *
@@ -336,7 +336,7 @@ def main():
                 return logits
 
             if top_k == 1:
-                return argmax_output(logits, chunk_size=hp.context_length // 128)
+                return argmax_output(logits, chunk_size=None)
 
             return topk_output(
                 logits,
@@ -482,7 +482,7 @@ def main():
                 return logits
 
             if top_k == 1:
-                return argmax_output(logits, chunk_size=hp.context_length // 128)
+                return argmax_output(logits, chunk_size=None)
 
             return topk_output(
                 logits,
@@ -492,7 +492,7 @@ def main():
             )
 
     def argmax_output(
-        logits: torch.Tensor, chunk_size: int
+        logits: torch.Tensor, chunk_size: Optional[int]
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Return the max logits and indices for the given logits.
 


### PR DESCRIPTION
Remove hardcoded split for top-k=1. If `--top-k=1` is specified in the export, the dim size will not be a multiple of the chunk size: [command and full stack trace](https://gist.github.com/AmosLewis/ab3d8a5defe96ed79ee570dd22f486d2#file-llama_405b_fp4_pp1_export_bug-md)
```
ValueError: dim's size must be a multiple of chunk_size.
Dim Size: 2
Chunk Size: 1024
```
From my understanding, the compiler will do the split, so we do not need to manually split it in the sharktank export.