### PR TITLE
Change ops.unshard and ops.cat to not unwrap tensor

### DIFF
--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -717,9 +717,7 @@ def to_default(tensor: Tensor, *args, **kwargs) -> PrimitiveTensor:
 def trace_tensor(key: str, *tensors: tuple[AnyTensor, ...]):
     if len(tensors) != 1:
         raise ValueError("Tracing more than one tensor at a time is not supported.")
-    tensor = unshard(tensors[0])
-    if isinstance(tensor, InferenceTensor):
-        tensor = tensor.as_torch()
+    tensor = unbox_tensor(unshard(tensors[0]))
     iree.turbine.ops.iree.trace_tensor(key, tensor)
 
 

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -92,7 +92,10 @@ def _split_argmax(input_tensor, dim, keepdim: bool = False, chunk_size: int = 12
 
 @cat.override(AllOfType(Tensor, PrimitiveTensor))
 def cat_default(tensors: Sequence[Tensor | PrimitiveTensor], dim: int):
-    return torch.cat([unbox_tensor(t) for t in tensors], dim)
+    result = torch.cat([unbox_tensor(t) for t in tensors], dim)
+    if isinstance(tensors[0], PrimitiveTensor):
+        result = DefaultPrimitiveTensor(data=result)
+    return result
 
 
 # conv2d
@@ -714,7 +717,10 @@ def to_default(tensor: Tensor, *args, **kwargs) -> PrimitiveTensor:
 def trace_tensor(key: str, *tensors: tuple[AnyTensor, ...]):
     if len(tensors) != 1:
         raise ValueError("Tracing more than one tensor at a time is not supported.")
-    iree.turbine.ops.iree.trace_tensor(key, unshard(tensors[0]))
+    tensor = unshard(tensors[0])
+    if isinstance(tensor, InferenceTensor):
+        tensor = tensor.as_torch()
+    iree.turbine.ops.iree.trace_tensor(key, tensor)
 
 
 @transfer_to_logical_device.override(Tensor)

--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -1399,16 +1399,16 @@ def scatter_split_split(
 
 
 @sharded_cat.override(SplitPrimitiveTensor)
-def sharded_cat_unsharded(tensor: SplitPrimitiveTensor):
+def sharded_cat_unsharded(tensor: SplitPrimitiveTensor) -> InferenceTensor:
     shard_ts = [
         (
-            transfer_to_logical_device(shard.as_torch(), tensor.devices[0])
+            transfer_to_logical_device(shard, tensor.devices[0])
             if i != 0
-            else barrier_on_logical_device(shard.as_torch(), tensor.devices[0])
+            else barrier_on_logical_device(shard, tensor.devices[0])
         )
         for i, shard in enumerate(tensor.shards)
     ]
-    return torch.cat(shard_ts, dim=tensor.shard_dim)
+    return cat(shard_ts, dim=tensor.shard_dim)
 
 
 @sharded_gather.override(IsOfType(SplitPrimitiveTensor, ReplicatedTensor))
@@ -1654,17 +1654,17 @@ def unflatten_split(
 
 
 @unshard.override(ReplicatedTensor)
-def unshard_replicated(input: ReplicatedTensor) -> Tensor:
-    return input.shards[0].as_torch()
+def unshard_replicated(input: ReplicatedTensor) -> InferenceTensor:
+    return input.shards[0]
 
 
 @unshard.override(SplitPrimitiveTensor)
-def unshard_split(input: SplitPrimitiveTensor) -> Tensor:
+def unshard_split(input: SplitPrimitiveTensor) -> InferenceTensor:
     return sharded_cat(input)
 
 
 @unshard.override(UnreducedTensor)
-def unshard_unreduced(input: UnreducedTensor) -> Tensor:
+def unshard_unreduced(input: UnreducedTensor) -> InferenceTensor:
     shards = input.shards
     shards = [
         (

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -1180,7 +1180,10 @@ class ShardedTensorBase(ShardedTensor):
             return False
         if not self._is_deep_equal(other, compare_name=compare_name):
             return False
-        return all(a.is_deep_equal(b) for a, b in zip(self.shards, other.shards))
+        return all(
+            a.is_deep_equal(b, compare_name=compare_name)
+            for a, b in zip(self.shards, other.shards)
+        )
 
 
 def _is_tuple_of_integral_numbers(x) -> bool:
@@ -1555,7 +1558,7 @@ class ReplicatedTensor(ShardedTensor):
             return False
         if not self._is_deep_equal(other, compare_name=compare_name):
             return False
-        return self.shards[0].is_deep_equal(other.shards[0])
+        return self.shards[0].is_deep_equal(other.shards[0], compare_name=compare_name)
 
 
 @register_inference_tensor

--- a/sharktank/sharktank/utils/load_llm.py
+++ b/sharktank/sharktank/utils/load_llm.py
@@ -216,7 +216,7 @@ class Batch:
         self,
         phase: str,
         arg_name: str,
-        arg: torch.Tensor | ShardedTensor | list[torch.Tensor | ShardedTensor],
+        arg: AnyTensor | list[AnyTensor],
         decode_step: int | None = None,
         rank: int | None = None,
     ):
@@ -230,6 +230,7 @@ class Batch:
                     phase, arg_name, arg.shards[rank]._data, decode_step, rank
                 )
         else:
+            arg = unbox_tensor(arg)
             if arg.dtype in [torch.float8_e4m3fnuz, torch.bfloat16]:
                 arg = arg.to(torch.uint8)
             if phase == "decode":

--- a/sharktank/sharktank/utils/testing.py
+++ b/sharktank/sharktank/utils/testing.py
@@ -700,8 +700,8 @@ def assert_text_encoder_state_close(
 
 
 def assert_logits_kl_divergence_close(
-    actual: torch.Tensor,
-    expected: torch.Tensor,
+    actual: AnyTensor,
+    expected: AnyTensor,
     atol: float,
 ):
     """
@@ -713,8 +713,10 @@ def assert_logits_kl_divergence_close(
         expected: The expected logits tensor.
         atol: The absolute tolerance for the KL divergence loss.
     """
-    actual_probabilities = actual.log_softmax(dim=2, dtype=torch.float32)
-    expected_probabilities = expected.log_softmax(dim=2, dtype=torch.float32)
+    actual_probabilities = unbox_tensor(actual).log_softmax(dim=2, dtype=torch.float32)
+    expected_probabilities = unbox_tensor(expected).log_softmax(
+        dim=2, dtype=torch.float32
+    )
 
     kl_loss = torch.nn.KLDivLoss(reduction="batchmean", log_target=True)
     loss = kl_loss(input=actual_probabilities, target=expected_probabilities)

--- a/sharktank/tests/layers/sharded_paged_kv_cache_test.py
+++ b/sharktank/tests/layers/sharded_paged_kv_cache_test.py
@@ -73,7 +73,7 @@ class ShardedPagedKVCacheTest(unittest.TestCase):
         sharded_state_as_unsharded = self.sharded_cache.unshard_state(
             sharded_cache_state
         )[0]
-        assert sharded_state_as_unsharded.shape == cache_state.shape
+        assert iterables_equal(sharded_state_as_unsharded.shape, cache_state.shape)
         assert ops.equal(
             cache_state,
             sharded_state_as_unsharded,

--- a/sharktank/tests/layers/sharded_paged_latent_attention_block_test.py
+++ b/sharktank/tests/layers/sharded_paged_latent_attention_block_test.py
@@ -19,6 +19,8 @@ from sharktank.types import unbox_tensor, SplitPrimitiveTensor
 from sharktank.types.sharding import shard_theta, LatentAttentionBlockSharding
 from sharktank import ops
 from sharktank.utils.create_cache import *
+from sharktank.utils import iterables_equal
+from sharktank.utils.testing import assert_tensor_close
 
 
 class ShardedPagedLatentAttentionBlockTest(unittest.TestCase):
@@ -79,7 +81,7 @@ class ShardedPagedLatentAttentionBlockTest(unittest.TestCase):
             sharded_state_as_unsharded = sharded_cache.unshard_state(
                 sharded_cache_state
             )[0]
-            assert sharded_state_as_unsharded.shape == cache_state.shape
+            assert iterables_equal(sharded_state_as_unsharded.shape, cache_state.shape)
             assert ops.equal(
                 cache_state,
                 sharded_state_as_unsharded,
@@ -93,10 +95,10 @@ class ShardedPagedLatentAttentionBlockTest(unittest.TestCase):
             sharded_state_as_unsharded = sharded_cache.unshard_state(
                 sharded_cache_state
             )[0]
-            assert sharded_state_as_unsharded.shape == cache_state.shape
-            torch.testing.assert_close(
-                unbox_tensor(cache_state),
-                unbox_tensor(sharded_state_as_unsharded),
+            assert iterables_equal(sharded_state_as_unsharded.shape, cache_state.shape)
+            assert_tensor_close(
+                cache_state,
+                sharded_state_as_unsharded,
                 rtol=rtol,
                 atol=atol,
             )
@@ -172,7 +174,7 @@ class ShardedPagedLatentAttentionBlockTest(unittest.TestCase):
 
         actual_result = unbox_tensor(ops.unshard(sharded_result))
 
-        torch.testing.assert_close(actual_result, expected_result, rtol=rtol, atol=atol)
+        assert_tensor_close(actual_result, expected_result, rtol=rtol, atol=atol)
         assert_close_unsharded_and_sharded_cache_states(
             cache_state, sharded_cache_state
         )

--- a/sharktank/tests/layers/sharded_paged_llama_attention_block_test.py
+++ b/sharktank/tests/layers/sharded_paged_llama_attention_block_test.py
@@ -13,6 +13,7 @@ from sharktank.layers import (
 from sharktank.layers.testing import make_llama_attention_block_theta
 from sharktank.types.sharding import PagedLlamaAttentionBlockSharding
 from sharktank.types import SplitPrimitiveTensor, unbox_tensor
+from sharktank.utils.misc import iterables_equal
 from sharktank.utils.random import make_rand_torch
 import torch
 from sharktank import ops
@@ -85,7 +86,7 @@ class ShardedPagedLlamaAttentionBlockTest(unittest.TestCase):
             sharded_state_as_unsharded = sharded_cache.unshard_state(
                 sharded_cache_state
             )[0]
-            assert sharded_state_as_unsharded.shape == cache_state.shape
+            assert iterables_equal(sharded_state_as_unsharded.shape, cache_state.shape)
             assert ops.equal(
                 cache_state,
                 sharded_state_as_unsharded,
@@ -99,7 +100,7 @@ class ShardedPagedLlamaAttentionBlockTest(unittest.TestCase):
             sharded_state_as_unsharded = sharded_cache.unshard_state(
                 sharded_cache_state
             )[0]
-            assert sharded_state_as_unsharded.shape == cache_state.shape
+            assert iterables_equal(sharded_state_as_unsharded.shape, cache_state.shape)
             torch.testing.assert_close(
                 unbox_tensor(cache_state),
                 unbox_tensor(sharded_state_as_unsharded),

--- a/sharktank/tests/layers/sharded_rotary_embedding_test.py
+++ b/sharktank/tests/layers/sharded_rotary_embedding_test.py
@@ -16,6 +16,8 @@ import unittest
 from typing import List, Optional
 import os
 
+from sharktank.utils.testing import assert_tensor_close
+
 
 def test_sharded_rotary_table():
     bs = 4

--- a/sharktank/tests/models/punet/resnet_test.py
+++ b/sharktank/tests/models/punet/resnet_test.py
@@ -14,6 +14,7 @@ from sharktank.models.punet.layers import ResnetBlock2D
 from sharktank.types import *
 from sharktank.models.punet.sharding import ResnetBlock2DSplitOutputChannelsSharding
 from sharktank import ops
+from sharktank.utils.testing import assert_tensor_close
 
 
 class ResnetBlockTest(unittest.TestCase):
@@ -85,9 +86,7 @@ class ResnetBlockTest(unittest.TestCase):
                 and sharded_result.shard_count == shard_count
             )
             actual_result = ops.unshard(sharded_result)
-            torch.testing.assert_close(
-                expected_result, actual_result, rtol=0, atol=5e-4
-            )
+            assert_tensor_close(expected_result, actual_result, rtol=0, atol=5e-4)
 
 
 if __name__ == "__main__":

--- a/sharktank/tests/models/punet/up_down_block_test.py
+++ b/sharktank/tests/models/punet/up_down_block_test.py
@@ -16,6 +16,7 @@ from sharktank.models.punet.sharding import UpDownBlock2DSplitChannelsSharing
 from sharktank.types import *
 from sharktank import ops
 from sharktank.types.tensors import flatten_tensor_tree
+from sharktank.utils.testing import assert_tensor_close
 
 
 class UpBlock2DTest(unittest.TestCase):
@@ -141,7 +142,7 @@ class UpBlock2DTest(unittest.TestCase):
             actual_result = [ops.unshard(r) for r in sharded_result]
             assert len(expected_result) == len(actual_result)
             for actual, expected in zip(actual_result, expected_result):
-                torch.testing.assert_close(actual, expected, rtol=0, atol=5e-4)
+                assert_tensor_close(actual, expected, rtol=0, atol=5e-4)
 
 
 if __name__ == "__main__":

--- a/sharktank/tests/ops/pipeline_parallelized_test.py
+++ b/sharktank/tests/ops/pipeline_parallelized_test.py
@@ -13,6 +13,7 @@ from sharktank.ops.sharded_impls import assert_on_same_devices
 from sharktank import ops
 from sharktank.types import *
 from sharktank.utils import iterables_equal
+from sharktank.utils.testing import assert_tensor_close
 
 
 class CheckThatOnSameDevicesTest(unittest.TestCase):
@@ -71,9 +72,7 @@ class AllGatherTest(unittest.TestCase):
         actual_result = ops.all_gather(sharded)
 
         for i in range(shard_count):
-            torch.testing.assert_close(
-                actual_result.shards[i].as_torch(), expected_result
-            )
+            assert_tensor_close(actual_result.shards[i], expected_result)
             assert actual_result.devices[i] == devices[i]
 
 
@@ -92,9 +91,7 @@ class AllReduceTest(unittest.TestCase):
         actual_result = ops.all_reduce(sharded)
 
         for i in range(shard_count):
-            torch.testing.assert_close(
-                actual_result.shards[i].as_torch(), expected_result
-            )
+            assert_tensor_close(actual_result.shards[i], expected_result)
             assert actual_result.devices[i] == devices[i]
 
 
@@ -256,7 +253,7 @@ class MatmulTest(unittest.TestCase):
         for i in range(shard_count):
             assert devices[i] == res_sharded.devices[i]
         actual_result = ops.sharded_cat(res_sharded)
-        torch.testing.assert_close(actual_result, expected_result)
+        assert_tensor_close(actual_result, expected_result)
 
 
 class TransposeTest(unittest.TestCase):


### PR DESCRIPTION
- Change ops.cat to not unpack primitive tensors it receives.
- Change unshard to not unwrap all the way to torch.tensor. Especially important once we used sharded quantized tensors. This function should be dequantizing, it should just be unsharding.
- Test fixes by using assert_tensor_close.
- Change is_deep_equals to correctly use `compare_name`.