### PR TITLE
[Fusili] TensorAttr improvements (contiguous check,  uid uniqueness check, use inferred names)

### DIFF
--- a/sharkfuser/README.md
+++ b/sharkfuser/README.md
@@ -83,7 +83,7 @@ Tests and samples that are built with the cmake flag `-DSHARKFUSER_DEBUG_BUILD=O
 ## Project Roadmap
 - [x] Build/test infra, logging, code coverage reporting
 - [x] Graph, tensor, node datastructures / builder API
-- [ ] CI (GHA workflows)
+- [x] CI (GHA workflows)
 - [ ] conv_fprop MLIR ASM emitter
 - [ ] IREE compiler integration
 - [ ] IREE runtime integration

--- a/sharkfuser/README.md
+++ b/sharkfuser/README.md
@@ -23,7 +23,7 @@ ctest --test-dir build
 
 To re-run failed tests verbosely:
 ```shell
-ctest --test-dir build --rerun-failed --output-on-failure --extra-verbose
+ctest --test-dir build --rerun-failed --output-on-failure --verbose
 ```
 
 ### Code coverage (using gcov + lcov):
@@ -90,9 +90,10 @@ Tests and samples that are built with the cmake flag `-DSHARKFUSER_DEBUG_BUILD=O
 - [ ] `g->execute()` (calls IREE compiler/runtime C API)
 - [ ] conv_fprop integration testing
 - [ ] Kernel cache
+- [ ] Shape inference for static dims
+- [ ] Non-contiguous (strided) tensor support
 - [ ] Elementwise ops (relu?)
 - [ ] Op fusion templates
 - [ ] Python bindings
-- [ ] Shape inference for static dims
 - [ ] Serialization
 - [ ] hipDNN integration

--- a/sharkfuser/include/fusili/attributes/tensor_attributes.h
+++ b/sharkfuser/include/fusili/attributes/tensor_attributes.h
@@ -7,6 +7,7 @@
 #ifndef FUSILI_ATTRIBUTES_TENSOR_ATTRIBUTES_H
 #define FUSILI_ATTRIBUTES_TENSOR_ATTRIBUTES_H
 
+#include <algorithm>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -48,6 +49,17 @@ public:
         !scalar_value.has_value() && is_scalar, error_code_t::INVALID_ATTRIBUTE,
         "Tensor '" + name +
             "' is marked as a scalar but does not have a scalar value set");
+
+    // Check if stride is strictly monotonically decreasing
+    FUSILI_RETURN_ERROR_IF(
+        !(std::is_sorted(stride.begin(), stride.end(),
+                         std::greater<int64_t>()) &&
+          stride.back() == 1),
+        error_code_t::NOT_IMPLEMENTED,
+        "Tensor '" + name +
+            "' is not contiguous as defined by its stride; please specify a "
+            "stride {A, B, ... Z} where A > B > ... Z and Z == 1. "
+            "This will be supported in a future release");
 
     return {error_code_t::OK, ""};
   }

--- a/sharkfuser/include/fusili/graph.h
+++ b/sharkfuser/include/fusili/graph.h
@@ -150,6 +150,8 @@ inline error_t Graph::query_tensor_of_uid(int64_t const uid,
           "Tensor with UID " + std::to_string(uid) + " not found"};
 }
 
+// Given a TensorAttr, create a shared pointer and add it to the graph's
+// inputs. This allows the graph to manage the lifetime of the input tensor.
 inline std::shared_ptr<TensorAttr> Graph::tensor(TensorAttr const &tensor) {
   auto tensor_ptr = std::make_shared<TensorAttr>(tensor);
   full_graph_inputs.insert(tensor_ptr);
@@ -160,9 +162,9 @@ inline std::shared_ptr<TensorAttr>
 Graph::conv_fprop(std::shared_ptr<TensorAttr> const &x,
                   std::shared_ptr<TensorAttr> const &w,
                   ConvFPropAttr &conv_attr) {
+  // Populate names when not set
   if (conv_attr.get_name().empty())
     conv_attr.set_name("conv_fprop_" + std::to_string(sub_nodes.size()));
-
   if (x->get_name().empty())
     x->set_name(conv_attr.get_name() + "::X");
   if (w->get_name().empty())
@@ -175,6 +177,7 @@ Graph::conv_fprop(std::shared_ptr<TensorAttr> const &x,
   auto y = output_tensor(conv_attr.get_name() + "::Y");
   conv_attr.set_Y(y);
 
+  // Create node and add to sub_nodes
   sub_nodes.emplace_back(
       std::make_unique<ConvFPropNode>(std::move(conv_attr), context));
 

--- a/sharkfuser/samples/convolution/conv_fprop.cpp
+++ b/sharkfuser/samples/convolution/conv_fprop.cpp
@@ -21,12 +21,12 @@ TEST_CASE("Convolution fprop", "[conv][graph]") {
   auto X = graph->tensor(TensorAttr()
                              .set_name("image")
                              .set_dim({n, c, h, w})
-                             .set_stride({c * h * w, 1, c * w, c}));
+                             .set_stride({c * h * w, h * w, w, 1}));
 
   auto W = graph->tensor(TensorAttr()
                              .set_name("filter")
                              .set_dim({k, c, r, s})
-                             .set_stride({c * r * s, 1, c * s, c}));
+                             .set_stride({c * r * s, r * s, s, 1}));
 
   auto conv_attr = ConvFPropAttr()
                        .set_padding({0, 0})
@@ -36,15 +36,9 @@ TEST_CASE("Convolution fprop", "[conv][graph]") {
 
   auto Y = graph->conv_fprop(X, W, conv_attr);
 
-  Y->set_output(true);
-
-  REQUIRE(Y->get_is_virtual() == false);
-  REQUIRE(Y->get_name() == "conv_fprop::Y");
-
-  // Fails because Y is underspecified (dim/stride inference unimplemented)
-  REQUIRE(graph->validate().is_failure());
-
   // Specify Y's dimensions and strides
   Y->set_dim({n, k, h, w}).set_stride({k * h * w, 1, k * w, k});
+  Y->set_output(true);
+
   REQUIRE(graph->validate().is_ok());
 }

--- a/sharkfuser/samples/convolution/conv_fprop.cpp
+++ b/sharkfuser/samples/convolution/conv_fprop.cpp
@@ -37,7 +37,7 @@ TEST_CASE("Convolution fprop", "[conv][graph]") {
   auto Y = graph->conv_fprop(X, W, conv_attr);
 
   // Specify Y's dimensions and strides
-  Y->set_dim({n, k, h, w}).set_stride({k * h * w, 1, k * w, k});
+  Y->set_dim({n, k, h, w}).set_stride({k * h * w, h * w, w, 1});
   Y->set_output(true);
 
   REQUIRE(graph->validate().is_ok());

--- a/sharkfuser/tests/test_graph.cpp
+++ b/sharkfuser/tests/test_graph.cpp
@@ -87,3 +87,36 @@ TEST_CASE("Graph query_tensor_of_uid finds tensors by UID", "[graph]") {
   REQUIRE(found.get_name() == "conv::Y");
   REQUIRE(g.query_tensor_of_uid(999, found).is_failure());
 }
+
+TEST_CASE("Graph check for UID conflicts failing graph validation", "[graph]") {
+  Graph g;
+  auto x = g.tensor(TensorAttr()
+                        .set_name("X")
+                        .set_dim({1, 3, 8, 8})
+                        .set_stride({192, 1, 24, 3}));
+  auto w = g.tensor(TensorAttr()
+                        .set_name("W")
+                        .set_dim({4, 3, 3, 3})
+                        .set_stride({27, 1, 9, 3}));
+
+  ConvFPropAttr attr;
+  attr.set_padding({0, 0}).set_stride({1, 1}).set_dilation({1, 1}).set_name(
+      "conv");
+  auto y = g.conv_fprop(x, w, attr);
+  y->set_dim({1, 4, 8, 8}).set_stride({256, 1, 32, 4});
+  y->set_output(true);
+
+  // Assign conflicting UIDs
+  x->set_uid(42);
+  w->set_uid(43);
+  y->set_uid(42); // Conflict with x
+
+  // Should fail validation due to UID conflict
+  REQUIRE(g.validate().is_failure());
+
+  // Assign unique UIDs
+  y->set_uid(44);
+
+  // Should pass validation now
+  REQUIRE(g.validate().is_ok());
+}

--- a/sharkfuser/tests/test_graph.cpp
+++ b/sharkfuser/tests/test_graph.cpp
@@ -23,30 +23,33 @@ TEST_CASE("Graph tensor() adds input tensor", "[graph]") {
 TEST_CASE("Graph conv_fprop() adds ConvFPropNode and output tensor",
           "[graph]") {
   Graph g;
-  auto x = g.tensor(TensorAttr()
-                        .set_name("X")
-                        .set_dim({1, 3, 8, 8})
-                        .set_stride({192, 1, 24, 3}));
-  auto w = g.tensor(TensorAttr()
-                        .set_name("W")
-                        .set_dim({4, 3, 3, 3})
-                        .set_stride({27, 1, 9, 3}));
+  auto x =
+      g.tensor(TensorAttr().set_dim({1, 3, 8, 8}).set_stride({192, 1, 24, 3}));
+  auto w =
+      g.tensor(TensorAttr().set_dim({4, 3, 3, 3}).set_stride({27, 1, 9, 3}));
   ConvFPropAttr attr;
   attr.set_padding({0, 0}).set_stride({1, 1}).set_dilation({1, 1});
   auto y = g.conv_fprop(x, w, attr);
-  y->set_output(true);
+
+  // Names for inputs are auto-populated when not set
+  REQUIRE(x->get_name() == "conv_fprop_0::X");
+  REQUIRE(w->get_name() == "conv_fprop_0::W");
   REQUIRE(y->get_name() == "conv_fprop_0::Y");
+
+  // Y is virtual (intermediate tensor) unless specified as output
+  REQUIRE(y->get_is_virtual() == true);
+  y->set_output(true);
   REQUIRE(y->get_is_virtual() == false);
 }
 
 TEST_CASE("Graph validate() returns OK for valid graph", "[graph]") {
   Graph g;
   auto x = g.tensor(TensorAttr()
-                        .set_name("x")
+                        .set_name("X")
                         .set_dim({1, 3, 8, 8})
                         .set_stride({192, 1, 24, 3}));
   auto w = g.tensor(TensorAttr()
-                        .set_name("w")
+                        .set_name("W")
                         .set_dim({4, 3, 3, 3})
                         .set_stride({27, 1, 9, 3}));
   ConvFPropAttr attr;

--- a/sharkfuser/tests/test_graph.cpp
+++ b/sharkfuser/tests/test_graph.cpp
@@ -56,6 +56,11 @@ TEST_CASE("Graph validate() returns OK for valid graph", "[graph]") {
   attr.set_padding({0, 0}).set_stride({1, 1}).set_dilation({1, 1}).set_name(
       "conv");
   auto y = g.conv_fprop(x, w, attr);
+
+  // Fails because y is underspecified (shape/stride inference unimplemented)
+  REQUIRE(g.validate().is_failure());
+
+  // Specify y's shape and strides
   y->set_dim({1, 4, 8, 8}).set_stride({256, 1, 32, 4});
   REQUIRE(g.validate().is_ok());
 }

--- a/sharkfuser/tests/test_graph.cpp
+++ b/sharkfuser/tests/test_graph.cpp
@@ -24,9 +24,9 @@ TEST_CASE("Graph conv_fprop() adds ConvFPropNode and output tensor",
           "[graph]") {
   Graph g;
   auto x =
-      g.tensor(TensorAttr().set_dim({1, 3, 8, 8}).set_stride({192, 1, 24, 3}));
+      g.tensor(TensorAttr().set_dim({1, 8, 8, 3}).set_stride({192, 24, 3, 1}));
   auto w =
-      g.tensor(TensorAttr().set_dim({4, 3, 3, 3}).set_stride({27, 1, 9, 3}));
+      g.tensor(TensorAttr().set_dim({4, 3, 3, 3}).set_stride({27, 9, 3, 1}));
   ConvFPropAttr attr;
   attr.set_padding({0, 0}).set_stride({1, 1}).set_dilation({1, 1});
   auto y = g.conv_fprop(x, w, attr);

--- a/sharkfuser/tests/test_graph.cpp
+++ b/sharkfuser/tests/test_graph.cpp
@@ -46,12 +46,12 @@ TEST_CASE("Graph validate() returns OK for valid graph", "[graph]") {
   Graph g;
   auto x = g.tensor(TensorAttr()
                         .set_name("X")
-                        .set_dim({1, 3, 8, 8})
-                        .set_stride({192, 1, 24, 3}));
+                        .set_dim({1, 8, 8, 3})
+                        .set_stride({192, 24, 3, 1}));
   auto w = g.tensor(TensorAttr()
                         .set_name("W")
                         .set_dim({4, 3, 3, 3})
-                        .set_stride({27, 1, 9, 3}));
+                        .set_stride({27, 9, 3, 1}));
   ConvFPropAttr attr;
   attr.set_padding({0, 0}).set_stride({1, 1}).set_dilation({1, 1}).set_name(
       "conv");
@@ -61,7 +61,7 @@ TEST_CASE("Graph validate() returns OK for valid graph", "[graph]") {
   REQUIRE(g.validate().is_failure());
 
   // Specify y's shape and strides
-  y->set_dim({1, 4, 8, 8}).set_stride({256, 1, 32, 4});
+  y->set_dim({1, 8, 8, 4}).set_stride({256, 32, 4, 1});
   REQUIRE(g.validate().is_ok());
 }
 

--- a/sharkfuser/tests/test_graph.cpp
+++ b/sharkfuser/tests/test_graph.cpp
@@ -69,12 +69,12 @@ TEST_CASE("Graph query_tensor_of_uid finds tensors by UID", "[graph]") {
   Graph g;
   auto x = g.tensor(TensorAttr()
                         .set_name("X")
-                        .set_dim({1, 3, 8, 8})
-                        .set_stride({192, 1, 24, 3}));
+                        .set_dim({1, 8, 8, 3})
+                        .set_stride({192, 24, 3, 1}));
   auto w = g.tensor(TensorAttr()
                         .set_name("W")
                         .set_dim({4, 3, 3, 3})
-                        .set_stride({27, 1, 9, 3}));
+                        .set_stride({27, 9, 3, 1}));
 
   ConvFPropAttr attr;
   attr.set_padding({0, 0}).set_stride({1, 1}).set_dilation({1, 1}).set_name(
@@ -97,18 +97,18 @@ TEST_CASE("Graph check for UID conflicts failing graph validation", "[graph]") {
   Graph g;
   auto x = g.tensor(TensorAttr()
                         .set_name("X")
-                        .set_dim({1, 3, 8, 8})
-                        .set_stride({192, 1, 24, 3}));
+                        .set_dim({1, 8, 8, 3})
+                        .set_stride({192, 24, 3, 1}));
   auto w = g.tensor(TensorAttr()
                         .set_name("W")
                         .set_dim({4, 3, 3, 3})
-                        .set_stride({27, 1, 9, 3}));
+                        .set_stride({27, 9, 3, 1}));
 
   ConvFPropAttr attr;
   attr.set_padding({0, 0}).set_stride({1, 1}).set_dilation({1, 1}).set_name(
       "conv");
   auto y = g.conv_fprop(x, w, attr);
-  y->set_dim({1, 4, 8, 8}).set_stride({256, 1, 32, 4});
+  y->set_dim({1, 8, 8, 4}).set_stride({256, 32, 4, 1});
   y->set_output(true);
 
   // Assign conflicting UIDs

--- a/sharkfuser/tests/test_tensor_attributes.cpp
+++ b/sharkfuser/tests/test_tensor_attributes.cpp
@@ -90,9 +90,19 @@ TEST_CASE("TensorAttr validation edge cases", "[TensorAttr]") {
 
   SECTION("Zero dimension in tensor") {
     TensorAttr t;
-    t.set_name("zero").set_dim({2, 0, 3}).set_stride({0, 0, 1});
+    t.set_name("zero").set_dim({2, 0, 3}).set_stride({6, 3, 1});
     REQUIRE(t.validate().is_ok());
     REQUIRE(t.get_volume() == 0);
+  }
+
+  SECTION("Non-contiguous (strided) tensors fail validation") {
+    TensorAttr t1, t2;
+
+    t1.set_name("contig").set_dim({4, 3}).set_stride({3, 1});
+    REQUIRE(t1.validate().is_ok());
+
+    t2.set_name("non_contig").set_dim({4, 3}).set_stride({1, 4});
+    REQUIRE(t2.validate().is_failure());
   }
 
   SECTION("Virtual and scalar tensors can't coexist") {

--- a/sharkfuser/tests/test_tensor_attributes.cpp
+++ b/sharkfuser/tests/test_tensor_attributes.cpp
@@ -59,13 +59,13 @@ TEST_CASE("TensorAttr method chaining", "[TensorAttr]") {
 TEST_CASE("TensorAttr validation edge cases", "[TensorAttr]") {
   SECTION("Empty dim fails validation") {
     TensorAttr t;
-    t.set_stride({1});
+    t.set_name("nodim").set_stride({1});
     REQUIRE(t.validate().is_failure());
   }
 
   SECTION("Empty stride fails validation") {
     TensorAttr t;
-    t.set_dim({1});
+    t.set_name("nostride").set_dim({1});
     REQUIRE(t.validate().is_failure());
   }
 
@@ -77,7 +77,7 @@ TEST_CASE("TensorAttr validation edge cases", "[TensorAttr]") {
 
   SECTION("Dim and stride of different ranks is invalid") {
     TensorAttr t;
-    t.set_dim({2}).set_stride({1, 1});
+    t.set_name("diffrank").set_dim({2}).set_stride({1, 1});
     REQUIRE(t.validate().is_failure());
   }
 


### PR DESCRIPTION
TensorAttr improvements:
- Check for contiguity (support for strided tensors is planned for post MVP)
- Check for uniqueness in preassigned tensor UIDs
- Use good defaults for TensorAttr names from consumer node names

Other minor diff:
- Move non-builder method definitions inline in Graph class to keep this tractable (as we add more op builders)