### PR TITLE
[Fusili][NFC] Split test targets for better debuggability/logging

### DIFF
--- a/sharkfuser/CMakeLists.txt
+++ b/sharkfuser/CMakeLists.txt
@@ -36,6 +36,7 @@ set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 # Add include directory for header-only library
 add_library(sharkfuser INTERFACE)
 target_include_directories(sharkfuser INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+set(SHARKFUSER_LINK_LIBRARY_NAME "sharkfuser")
 
 # Version pins for dependencies
 set(SHARKFUSER_IREE_GIT_TAG "iree-3.6.0rc20250612")
@@ -44,6 +45,12 @@ set(SHARKFUSER_CATCH2_GIT_TAG "v3.8.1")
 # Includes
 include(FetchContent)
 include(CTest)
+
+# Local Includes
+list(APPEND CMAKE_MODULE_PATH
+  ${CMAKE_CURRENT_LIST_DIR}/build_tools/cmake/
+)
+include(CTestMacros)
 
 # Build options
 option(SHARKFUSER_BUILD_TESTS "Builds C++ tests" ON)
@@ -117,8 +124,9 @@ if(SHARKFUSER_BUILD_TESTS)
   enable_testing()
 endif()
 
+# Code coverage exclusions
 configure_file(
-  ${CMAKE_SOURCE_DIR}/CTestCustom.cmake.in
+  ${CMAKE_SOURCE_DIR}/build_tools/cmake/CTestCustom.cmake.in
   ${CMAKE_BINARY_DIR}/CTestCustom.cmake
   COPYONLY
 )

--- a/sharkfuser/CMakeLists.txt
+++ b/sharkfuser/CMakeLists.txt
@@ -34,9 +34,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
 # Add include directory for header-only library
-add_library(sharkfuser INTERFACE)
-target_include_directories(sharkfuser INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-set(SHARKFUSER_LINK_LIBRARY_NAME "sharkfuser")
+add_library(libfusili INTERFACE)
+target_include_directories(libfusili INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # Version pins for dependencies
 set(SHARKFUSER_IREE_GIT_TAG "iree-3.6.0rc20250612")

--- a/sharkfuser/README.md
+++ b/sharkfuser/README.md
@@ -26,6 +26,8 @@ To re-run failed tests verbosely:
 ctest --test-dir build --rerun-failed --output-on-failure --verbose
 ```
 
+Tests and samples are also built as standalone binary targets in the `build/bin` directory to help with debugging isolated failures.
+
 ### Code coverage (using gcov + lcov):
 
 This works with gcc builds (code coverage with clang instrumentation is future work).
@@ -73,12 +75,12 @@ To configure logging behavior using environment variables:
 | `FUSILI_LOG_FILE` set to `stdout` or `stderr`  | no logging            | logging to cout / cerr
 | `FUSILI_LOG_FILE` set to `/path/to/file.txt`   | no logging            | logging to file.txt
 
-Alternatively, one may call the logging API directly as needed:
+Tests and samples that are built with the cmake flag `-DSHARKFUSER_DEBUG_BUILD=ON` have their env variables automatically configured for logging to cout.
 
+Alternatively, one may call the logging API directly as needed:
 - Calling `fusili::isLoggingEnabled() = <true|false>` has the same effect as setting `FUSILI_LOG_INFO = 1|0`.
 - Calling `fusili::getStream() = <stream_name>` has the same effect as setting the output stream using `FUSILI_LOG_FILE`.
 
-Tests and samples that are built with the cmake flag `-DSHARKFUSER_DEBUG_BUILD=ON` have their env variables automatically configured for logging to cout.
 
 ## Project Roadmap
 - [x] Build/test infra, logging, code coverage reporting

--- a/sharkfuser/build_tools/cmake/CTestCustom.cmake.in
+++ b/sharkfuser/build_tools/cmake/CTestCustom.cmake.in
@@ -4,6 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# Excludes specific directories from code coverage reporting
 set(CTEST_CUSTOM_COVERAGE_EXCLUDE
   ${CTEST_CUSTOM_COVERAGE_EXCLUDE}
   "build/*"

--- a/sharkfuser/build_tools/cmake/CTestMacros.cmake
+++ b/sharkfuser/build_tools/cmake/CTestMacros.cmake
@@ -46,7 +46,7 @@ function(add_sharkfuser_test)
   # Place executable in the bin directory
   set_target_properties(
       ${_RULE_NAME} PROPERTIES
-      RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
+      RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
   )
 endfunction()
 
@@ -92,6 +92,6 @@ function(add_sharkfuser_sample)
   # Place executable in the bin directory
   set_target_properties(
       ${_RULE_NAME} PROPERTIES
-      RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
+      RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
   )
 endfunction()

--- a/sharkfuser/build_tools/cmake/CTestMacros.cmake
+++ b/sharkfuser/build_tools/cmake/CTestMacros.cmake
@@ -19,7 +19,7 @@ function(_add_sharkfuser_target)
   # Link libraries/dependencies
   target_link_libraries(${_RULE_NAME} PRIVATE
     ${_RULE_DEPS}
-    ${SHARKFUSER_LINK_LIBRARY_NAME}
+    libfusili
     Catch2::Catch2WithMain
   )
 

--- a/sharkfuser/build_tools/cmake/CTestMacros.cmake
+++ b/sharkfuser/build_tools/cmake/CTestMacros.cmake
@@ -1,0 +1,97 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+function(add_sharkfuser_test)
+  cmake_parse_arguments(
+    _RULE           # prefix
+    ""              # options
+    "NAME"          # one value keywords
+    "SRCS;DEPS"     # multi-value keywords
+    ${ARGN}         # other arguments
+  )
+
+  if(NOT SHARKFUSER_BUILD_TESTS)
+    return()
+  endif()
+
+  add_executable(${_RULE_NAME} ${_RULE_SRCS})
+
+  # Link libraries/dependencies
+  target_link_libraries(${_RULE_NAME} PRIVATE
+    ${_RULE_DEPS}
+    ${SHARKFUSER_LINK_LIBRARY_NAME}
+    Catch2::Catch2WithMain
+  )
+
+  # Set compiler options for code coverage
+  if(SHARKFUSER_CODE_COVERAGE)
+    target_compile_options(${_RULE_NAME} PRIVATE -coverage -O0 -g)
+    target_link_options(${_RULE_NAME} PRIVATE -coverage)
+  endif()
+
+  add_test(NAME ${_RULE_NAME} COMMAND ${_RULE_NAME})
+
+  # Set logging environment variables
+  if(SHARKFUSER_DEBUG_BUILD)
+    set_tests_properties(
+      ${_RULE_NAME} PROPERTIES
+      ENVIRONMENT "FUSILI_LOG_INFO=1;FUSILI_LOG_FILE=stdout"
+    )
+  endif()
+
+  # Place executable in the bin directory
+  set_target_properties(
+      ${_RULE_NAME} PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
+  )
+endfunction()
+
+
+function(add_sharkfuser_sample)
+  cmake_parse_arguments(
+    _RULE           # prefix
+    ""              # options
+    "NAME"          # one value keywords
+    "SRCS;DEPS"     # multi-value keywords
+    ${ARGN}         # other arguments
+  )
+
+  if(NOT SHARKFUSER_BUILD_SAMPLES)
+    return()
+  endif()
+
+  add_executable(${_RULE_NAME} ${_RULE_SRCS})
+
+  # Link libraries/dependencies
+  target_link_libraries(${_RULE_NAME} PRIVATE
+    ${_RULE_DEPS}
+    ${SHARKFUSER_LINK_LIBRARY_NAME}
+    Catch2::Catch2WithMain
+  )
+
+  # Set compiler options for code coverage
+  if(SHARKFUSER_CODE_COVERAGE)
+    target_compile_options(${_RULE_NAME} PRIVATE -coverage -O0 -g)
+    target_link_options(${_RULE_NAME} PRIVATE -coverage)
+  endif()
+
+  add_test(NAME ${_RULE_NAME} COMMAND ${_RULE_NAME})
+
+  # Set logging environment variables
+  if(SHARKFUSER_DEBUG_BUILD)
+    set_tests_properties(
+      ${_RULE_NAME} PROPERTIES
+      ENVIRONMENT "FUSILI_LOG_INFO=1;FUSILI_LOG_FILE=stdout"
+    )
+  endif()
+
+  # Place executable in the bin directory
+  set_target_properties(
+      ${_RULE_NAME} PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
+  )
+endfunction()

--- a/sharkfuser/build_tools/cmake/CTestMacros.cmake
+++ b/sharkfuser/build_tools/cmake/CTestMacros.cmake
@@ -5,93 +5,87 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 
+function(_add_sharkfuser_target)
+  cmake_parse_arguments(
+    _RULE               # prefix
+    ""                  # options
+    "NAME;BIN_SUBDIR"   # one value keywords
+    "SRCS;DEPS"         # multi-value keywords
+    ${ARGN}             # extra arguments
+  )
+
+  add_executable(${_RULE_NAME} ${_RULE_SRCS})
+
+  # Link libraries/dependencies
+  target_link_libraries(${_RULE_NAME} PRIVATE
+    ${_RULE_DEPS}
+    ${SHARKFUSER_LINK_LIBRARY_NAME}
+    Catch2::Catch2WithMain
+  )
+
+  # Set compiler options for code coverage
+  if(SHARKFUSER_CODE_COVERAGE)
+    target_compile_options(${_RULE_NAME} PRIVATE -coverage -O0 -g)
+    target_link_options(${_RULE_NAME} PRIVATE -coverage)
+  endif()
+
+  add_test(NAME ${_RULE_NAME} COMMAND ${_RULE_NAME})
+
+  # Set logging environment variables
+  if(SHARKFUSER_DEBUG_BUILD)
+    set_tests_properties(
+      ${_RULE_NAME} PROPERTIES
+      ENVIRONMENT "FUSILI_LOG_INFO=1;FUSILI_LOG_FILE=stdout"
+    )
+  endif()
+
+  # Place executable in the build/bin sub-directory
+  set_target_properties(
+      ${_RULE_NAME} PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${_RULE_BIN_SUBDIR}
+  )
+endfunction()
+
+
 function(add_sharkfuser_test)
   cmake_parse_arguments(
-    _RULE           # prefix
-    ""              # options
-    "NAME"          # one value keywords
-    "SRCS;DEPS"     # multi-value keywords
-    ${ARGN}         # other arguments
+    _RULE
+    ""
+    "NAME"
+    "SRCS;DEPS"
+    ${ARGN}
   )
 
   if(NOT SHARKFUSER_BUILD_TESTS)
     return()
   endif()
 
-  add_executable(${_RULE_NAME} ${_RULE_SRCS})
-
-  # Link libraries/dependencies
-  target_link_libraries(${_RULE_NAME} PRIVATE
-    ${_RULE_DEPS}
-    ${SHARKFUSER_LINK_LIBRARY_NAME}
-    Catch2::Catch2WithMain
-  )
-
-  # Set compiler options for code coverage
-  if(SHARKFUSER_CODE_COVERAGE)
-    target_compile_options(${_RULE_NAME} PRIVATE -coverage -O0 -g)
-    target_link_options(${_RULE_NAME} PRIVATE -coverage)
-  endif()
-
-  add_test(NAME ${_RULE_NAME} COMMAND ${_RULE_NAME})
-
-  # Set logging environment variables
-  if(SHARKFUSER_DEBUG_BUILD)
-    set_tests_properties(
-      ${_RULE_NAME} PROPERTIES
-      ENVIRONMENT "FUSILI_LOG_INFO=1;FUSILI_LOG_FILE=stdout"
-    )
-  endif()
-
-  # Place executable in the bin directory
-  set_target_properties(
-      ${_RULE_NAME} PROPERTIES
-      RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  _add_sharkfuser_target(
+    NAME ${_RULE_NAME}
+    SRCS ${_RULE_SRCS}
+    DEPS ${_RULE_DEPS}
+    BIN_SUBDIR tests
   )
 endfunction()
 
 
 function(add_sharkfuser_sample)
   cmake_parse_arguments(
-    _RULE           # prefix
-    ""              # options
-    "NAME"          # one value keywords
-    "SRCS;DEPS"     # multi-value keywords
-    ${ARGN}         # other arguments
+    _RULE
+    ""
+    "NAME"
+    "SRCS;DEPS"
+    ${ARGN}
   )
 
   if(NOT SHARKFUSER_BUILD_SAMPLES)
     return()
   endif()
 
-  add_executable(${_RULE_NAME} ${_RULE_SRCS})
-
-  # Link libraries/dependencies
-  target_link_libraries(${_RULE_NAME} PRIVATE
-    ${_RULE_DEPS}
-    ${SHARKFUSER_LINK_LIBRARY_NAME}
-    Catch2::Catch2WithMain
-  )
-
-  # Set compiler options for code coverage
-  if(SHARKFUSER_CODE_COVERAGE)
-    target_compile_options(${_RULE_NAME} PRIVATE -coverage -O0 -g)
-    target_link_options(${_RULE_NAME} PRIVATE -coverage)
-  endif()
-
-  add_test(NAME ${_RULE_NAME} COMMAND ${_RULE_NAME})
-
-  # Set logging environment variables
-  if(SHARKFUSER_DEBUG_BUILD)
-    set_tests_properties(
-      ${_RULE_NAME} PROPERTIES
-      ENVIRONMENT "FUSILI_LOG_INFO=1;FUSILI_LOG_FILE=stdout"
-    )
-  endif()
-
-  # Place executable in the bin directory
-  set_target_properties(
-      ${_RULE_NAME} PROPERTIES
-      RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  _add_sharkfuser_target(
+    NAME ${_RULE_NAME}
+    SRCS ${_RULE_SRCS}
+    DEPS ${_RULE_DEPS}
+    BIN_SUBDIR samples
   )
 endfunction()

--- a/sharkfuser/samples/CMakeLists.txt
+++ b/sharkfuser/samples/CMakeLists.txt
@@ -15,25 +15,8 @@ if(NOT catch2_FOUND)
   FetchContent_MakeAvailable(catch2)
 endif()
 
-# Add sample executable
-add_executable(sharkfuser_samples
-  convolution/conv_fprop.cpp
-)
-target_link_libraries(sharkfuser_samples PRIVATE sharkfuser Catch2::Catch2WithMain)
-if(SHARKFUSER_CODE_COVERAGE)
-  target_compile_options(sharkfuser_samples PRIVATE -coverage -O0 -g)
-  target_link_options(sharkfuser_samples PRIVATE -coverage)
-endif()
-add_test(NAME sharkfuser_samples COMMAND sharkfuser_samples)
-if(SHARKFUSER_DEBUG_BUILD)
-  set_tests_properties(
-    sharkfuser_samples PROPERTIES
-    ENVIRONMENT "FUSILI_LOG_INFO=1;FUSILI_LOG_FILE=stdout"
-  )
-endif()
-
-# Place executable in the bin directory
-set_target_properties(
-    sharkfuser_samples PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
+add_sharkfuser_sample(
+  NAME sharkfuser_convolution_samples
+  SRCS
+    convolution/conv_fprop.cpp
 )

--- a/sharkfuser/tests/CMakeLists.txt
+++ b/sharkfuser/tests/CMakeLists.txt
@@ -15,32 +15,35 @@ if(NOT catch2_FOUND)
   FetchContent_MakeAvailable(catch2)
 endif()
 
-# Add test executable
-add_executable(sharkfuser_tests
-  test_tensor.cpp
-  test_logging.cpp
-  test_attributes.cpp
-  test_tensor_attributes.cpp
-  test_conv_attributes.cpp
-  test_context.cpp
-  test_conv_node.cpp
-  test_graph.cpp
+add_sharkfuser_test(
+  NAME sharkfuser_attribute_tests
+  SRCS
+    test_attributes.cpp
+    test_tensor_attributes.cpp
+    test_conv_attributes.cpp
 )
-target_link_libraries(sharkfuser_tests PRIVATE sharkfuser Catch2::Catch2WithMain)
-if(SHARKFUSER_CODE_COVERAGE)
-  target_compile_options(sharkfuser_tests PRIVATE -coverage -O0 -g)
-  target_link_options(sharkfuser_tests PRIVATE -coverage)
-endif()
-add_test(NAME sharkfuser_tests COMMAND sharkfuser_tests)
-if(SHARKFUSER_DEBUG_BUILD)
-  set_tests_properties(
-    sharkfuser_tests PROPERTIES
-    ENVIRONMENT "FUSILI_LOG_INFO=1;FUSILI_LOG_FILE=stdout"
-  )
-endif()
 
-# Place executable in the bin directory
-set_target_properties(
-    sharkfuser_tests PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
+add_sharkfuser_test(
+  NAME sharkfuser_tensor_tests
+  SRCS
+    test_tensor.cpp
+)
+
+add_sharkfuser_test(
+  NAME sharkfuser_node_tests
+  SRCS
+    test_conv_node.cpp
+)
+
+add_sharkfuser_test(
+  NAME sharkfuser_graph_tests
+  SRCS
+    test_graph.cpp
+    test_context.cpp
+)
+
+add_sharkfuser_test(
+  NAME sharkfuser_logging_tests
+  SRCS
+    test_logging.cpp
 )


### PR DESCRIPTION
This is a non-functional change.

Noticed a weird behavior where logs were being suppressed for all tests, but working fine for samples. After some digging into, it turns out they were clubbed into a single `sharkfuser_tests` target and among them there was the `test_logging.cpp` which had manual overrides on logging behavior, affecting other tests as well. 

In general I'd been meaning to split the tests into logical targets to help with debugging, so here it is. 

We now have:
```cmake
add_sharkfuser_test(
  NAME sharkfuser_attribute_tests
  SRCS
    test_attributes.cpp
    test_tensor_attributes.cpp
    test_conv_attributes.cpp
)

add_sharkfuser_test(
  NAME sharkfuser_tensor_tests
  SRCS
    test_tensor.cpp
)

add_sharkfuser_test(
  NAME sharkfuser_node_tests
  SRCS
    test_conv_node.cpp
)

add_sharkfuser_test(
  NAME sharkfuser_graph_tests
  SRCS
    test_graph.cpp
    test_context.cpp
)

add_sharkfuser_test(
  NAME sharkfuser_logging_tests
  SRCS
    test_logging.cpp
)
```