### PR TITLE
[sharktank][mlir_kernel] Check for cache before generating kernel IR

### DIFF
--- a/sharktank/sharktank/kernels/mlir_kernel.py
+++ b/sharktank/sharktank/kernels/mlir_kernel.py
@@ -332,12 +332,6 @@ def mlir_kernel(
                     else:
                         dtypes[sym_ty.dtype.name] = ty.element_type
 
-                # Get the MLIR spec.
-                mlir_spec = func(*input_values, *([None] * len(result_args)))
-
-                # Insert type aliases to the mlir_spec.
-                mlir = self._get_type_aliases(dims, dtypes) + mlir_spec.mlir
-
                 # Generate kernel name.
                 kernel_name = self._get_kernel_name(func.__name__, dims, dtypes)
 
@@ -352,6 +346,12 @@ def mlir_kernel(
                 # If this kernel is not already generated, generate it using
                 # the mlir spec.
                 if symbol_name is None:
+                    # Get the MLIR spec.
+                    mlir_spec = func(*input_values, *([None] * len(result_args)))
+
+                    # Insert type aliases to the mlir_spec.
+                    mlir = self._get_type_aliases(dims, dtypes) + mlir_spec.mlir
+
                     # Generate the MLIR spec using jinja.
                     asm = (
                         _get_jinja2_env()


### PR DESCRIPTION
Before this PR, every time we used a wave kernel in a loop, the kernel would get generated every time by `wave_compile` but the actual kernel used would always be cached. After this patch, we first check for the cache, and then generate it.