### PR TITLE
[Fusili] Test harness for MLIR asm emitter

### DIFF
--- a/.github/workflows/ci-sharkfuser.yml
+++ b/.github/workflows/ci-sharkfuser.yml
@@ -112,6 +112,10 @@ jobs:
       working-directory: ${{ env.SHARKFUSER_DIR }}
       run: |
         ctest --test-dir build -T test -T coverage --timeout 30
+        # LLVM includes some broken .gcda files to test llvm-cov. There doesn't
+        # seem to be a way to convince lcov to not scan the broken files, only
+        # to ignore them after the scan, hence the `--ignore-errors` flag as
+        # well as the `--exclude`.
         lcov --capture --directory build --ignore-errors gcov,version --exclude "*/_deps/*" --output-file build/coverage.info
         lcov --remove build/coverage.info 'build/*' '/usr/*' --ignore-errors unused --output-file build/coverage.info
         genhtml build/coverage.info --output-directory coverage_report

--- a/.github/workflows/ci-sharkfuser.yml
+++ b/.github/workflows/ci-sharkfuser.yml
@@ -35,7 +35,8 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     defaults:
       run:
-        shell: bash
+        # github actions swaps the {0} at the end for your script
+        shell: bash --noprofile --norc -exo pipefail {0}
     strategy:
       fail-fast: false
       matrix:
@@ -110,10 +111,9 @@ jobs:
       if: ${{ matrix.name == 'Ubuntu (GCC 13, Code Coverage)' }}
       working-directory: ${{ env.SHARKFUSER_DIR }}
       run: |
-        set -x
         ctest --test-dir build -T test -T coverage --timeout 30
-        lcov --capture --directory build --ignore-errors gcov,version --output-file build/coverage.info
-        lcov --remove build/coverage.info 'build/*' '/usr/*' '/tmp/*' --output-file build/coverage.info
+        lcov --capture --directory build --ignore-errors gcov,version --exclude "*/_deps/*" --output-file build/coverage.info
+        lcov --remove build/coverage.info 'build/*' '/usr/*' --output-file build/coverage.info
         genhtml build/coverage.info --output-directory coverage_report
 
     - name: Upload code coverage report

--- a/.github/workflows/ci-sharkfuser.yml
+++ b/.github/workflows/ci-sharkfuser.yml
@@ -113,7 +113,7 @@ jobs:
       run: |
         ctest --test-dir build -T test -T coverage --timeout 30
         lcov --capture --directory build --ignore-errors gcov,version --exclude "*/_deps/*" --output-file build/coverage.info
-        lcov --remove build/coverage.info 'build/*' '/usr/*' --output-file build/coverage.info
+        lcov --remove build/coverage.info 'build/*' '/usr/*' --ignore-errors unused --output-file build/coverage.info
         genhtml build/coverage.info --output-directory coverage_report
 
     - name: Upload code coverage report

--- a/.github/workflows/ci-sharkfuser.yml
+++ b/.github/workflows/ci-sharkfuser.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     defaults:
       run:
-        shell: bash -x
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
@@ -110,6 +110,7 @@ jobs:
       if: ${{ matrix.name == 'Ubuntu (GCC 13, Code Coverage)' }}
       working-directory: ${{ env.SHARKFUSER_DIR }}
       run: |
+        set -x
         ctest --test-dir build -T test -T coverage --timeout 30
         lcov --capture --directory build --ignore-errors gcov,version --output-file build/coverage.info
         lcov --remove build/coverage.info 'build/*' '/usr/*' '/tmp/*' --output-file build/coverage.info

--- a/.github/workflows/ci-sharkfuser.yml
+++ b/.github/workflows/ci-sharkfuser.yml
@@ -112,12 +112,8 @@ jobs:
       working-directory: ${{ env.SHARKFUSER_DIR }}
       run: |
         ctest --test-dir build -T test -T coverage --timeout 30
-        # LLVM includes some broken .gcda files to test llvm-cov. There doesn't
-        # seem to be a way to convince lcov to not scan the broken files, only
-        # to ignore them after the scan, hence the `--ignore-errors` flag as
-        # well as the `--exclude`.
-        lcov --capture --directory build --ignore-errors gcov,version --exclude "*/_deps/*" --output-file build/coverage.info
-        lcov --remove build/coverage.info 'build/*' '/usr/*' --ignore-errors unused --output-file build/coverage.info
+        lcov --capture --directory build --output-file build/coverage.info
+        lcov --remove build/coverage.info 'build/*' '/usr/*' --output-file build/coverage.info
         genhtml build/coverage.info --output-directory coverage_report
 
     - name: Upload code coverage report

--- a/.github/workflows/ci-sharkfuser.yml
+++ b/.github/workflows/ci-sharkfuser.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     defaults:
       run:
-        shell: bash
+        shell: bash -x
     strategy:
       fail-fast: false
       matrix:
@@ -111,7 +111,7 @@ jobs:
       working-directory: ${{ env.SHARKFUSER_DIR }}
       run: |
         ctest --test-dir build -T test -T coverage --timeout 30
-        lcov --capture --directory build --ignore-errors gcov --output-file build/coverage.info
+        lcov --capture --directory build --ignore-errors gcov,version --output-file build/coverage.info
         lcov --remove build/coverage.info 'build/*' '/usr/*' '/tmp/*' --output-file build/coverage.info
         genhtml build/coverage.info --output-directory coverage_report
 

--- a/.github/workflows/ci-sharkfuser.yml
+++ b/.github/workflows/ci-sharkfuser.yml
@@ -47,6 +47,7 @@ jobs:
               -DCMAKE_C_COMPILER=clang-18
               -DCMAKE_CXX_COMPILER=clang++-18
               -DCMAKE_LINKER_TYPE=LLD
+              -DPython3_EXECUTABLE=$(which python3)
               -DSHARKFUSER_DEBUG_BUILD=OFF
               -DSHARKFUSER_CODE_COVERAGE=OFF
             additional-packages: clang lld
@@ -59,6 +60,7 @@ jobs:
               -DCMAKE_C_COMPILER=clang-18
               -DCMAKE_CXX_COMPILER=clang++-18
               -DCMAKE_LINKER_TYPE=LLD
+              -DPython3_EXECUTABLE=$(which python3)
               -DSHARKFUSER_DEBUG_BUILD=ON
               -DSHARKFUSER_CODE_COVERAGE=OFF
             additional-packages: clang lld
@@ -70,6 +72,7 @@ jobs:
             cmake-options:
               -DCMAKE_C_COMPILER=gcc-13
               -DCMAKE_CXX_COMPILER=g++-13
+              -DPython3_EXECUTABLE=$(which python3)
               -DSHARKFUSER_DEBUG_BUILD=OFF
               -DSHARKFUSER_CODE_COVERAGE=ON
             additional-packages: lcov
@@ -108,8 +111,8 @@ jobs:
       working-directory: ${{ env.SHARKFUSER_DIR }}
       run: |
         ctest --test-dir build -T test -T coverage --timeout 30
-        lcov --capture --directory build --output-file build/coverage.info
-        lcov --remove build/coverage.info 'build/*' '/usr/*' --output-file build/coverage.info
+        lcov --capture --directory build --ignore-errors gcov --output-file build/coverage.info
+        lcov --remove build/coverage.info 'build/*' '/usr/*' '/tmp/*' --output-file build/coverage.info
         genhtml build/coverage.info --output-directory coverage_report
 
     - name: Upload code coverage report

--- a/sharkfuser/CMakeLists.txt
+++ b/sharkfuser/CMakeLists.txt
@@ -82,6 +82,9 @@ set(IREE_BUILD_TESTS OFF)
 set(IREE_BUILD_SAMPLES OFF)
 set(IREE_ERROR_ON_MISSING_SUBMODULES OFF)
 set(IREE_HAL_DRIVER_DEFAULTS OFF)
+set(IREE_TARGET_BACKEND_DEFAULTS OFF)
+set(IREE_INPUT_STABLEHLO OFF)
+set(IREE_INPUT_TOSA OFF)
 set(IREE_HAL_DRIVER_LOCAL_SYNC OFF)
 set(IREE_HAL_DRIVER_LOCAL_TASK OFF)
 set(IREE_HAL_DRIVER_VULKAN OFF)
@@ -101,8 +104,6 @@ else()
   list(APPEND IREE_SUBMODULES "third_party/hip-build-deps")
   if(IREE_BUILD_COMPILER)
     list(APPEND IREE_SUBMODULES "third_party/llvm-project")
-    list(APPEND IREE_SUBMODULES "third_party/stablehlo")
-    list(APPEND IREE_SUBMODULES "third_party/spirv_cross")
     list(APPEND IREE_SUBMODULES "third_party/torch-mlir")
   endif()
   FetchContent_Declare(
@@ -117,6 +118,18 @@ else()
   FetchContent_GetProperties(sharkfuser_iree)
   if(NOT sharkfuser_iree_POPULATED)
     FetchContent_MakeAvailable(sharkfuser_iree)
+
+    # LLVM repo has several .gcda and .gcno files as test fixtures for llvm-cov.
+    # Those .g* files will have version issues + errors when importing with our
+    # code coverage. It's remarkably difficult to convince lcov to ignore files,
+    # so the easiest thing to do is just strip them out.
+    message(STATUS "Removing codecov files from LLVM")
+    execute_process(
+      COMMAND ${CMAKE_COMMAND}
+              -DSHARKFUSER_IREE_SOURCE_DIR=${sharkfuser_iree_SOURCE_DIR}
+              -P ${CMAKE_CURRENT_SOURCE_DIR}/build_tools/cmake/strip_codecov_files.cmake
+      WORKING_DIRECTORY ${sharkfuser_iree_SOURCE_DIR}
+    )
   endif()
 endif()
 
@@ -136,7 +149,7 @@ if(SHARKFUSER_BUILD_TESTS)
   # Grab lit from IREE LLVM. We could also look into using a python pip
   # dependency.
   set(LLVM_EXTERNAL_LIT "${LLVM_SOURCE_DIR}/utils/lit/lit.py")
-  message(STATUS "LLVM_EXTERNAL_LIT ${LLVM_EXTERNAL_LIT}")
+  message(STATUS "Using LIT from IREE LLVM: ${LLVM_EXTERNAL_LIT}")
 
   add_subdirectory(tests)
   enable_testing()

--- a/sharkfuser/CMakeLists.txt
+++ b/sharkfuser/CMakeLists.txt
@@ -77,7 +77,7 @@ message(STATUS "  - Host")
 ################################################################################
 
 set(IREE_VISIBILITY_HIDDEN OFF)
-set(IREE_BUILD_COMPILER OFF)
+set(IREE_BUILD_COMPILER ON)
 set(IREE_BUILD_TESTS OFF)
 set(IREE_BUILD_SAMPLES OFF)
 set(IREE_ERROR_ON_MISSING_SUBMODULES OFF)
@@ -94,7 +94,17 @@ if(SHARKFUSER_IREE_SOURCE_DIR)
   add_subdirectory(${SHARKFUSER_IREE_SOURCE_DIR} sharkfuser_iree SYSTEM EXCLUDE_FROM_ALL)
 else()
   message(STATUS "Fetching IREE sources from tag ${SHARKFUSER_IREE_GIT_TAG}")
-  set(IREE_SUBMODULES "third_party/benchmark third_party/cpuinfo third_party/flatcc third_party/hip-build-deps")
+  set(IREE_SUBMODULES "")
+  list(APPEND IREE_SUBMODULES "third_party/benchmark")
+  list(APPEND IREE_SUBMODULES "third_party/cpuinfo")
+  list(APPEND IREE_SUBMODULES "third_party/flatcc")
+  list(APPEND IREE_SUBMODULES "third_party/hip-build-deps")
+  if(IREE_BUILD_COMPILER)
+    list(APPEND IREE_SUBMODULES "third_party/llvm-project")
+    list(APPEND IREE_SUBMODULES "third_party/stablehlo")
+    list(APPEND IREE_SUBMODULES "third_party/spirv_cross")
+    list(APPEND IREE_SUBMODULES "third_party/torch-mlir")
+  endif()
   FetchContent_Declare(
     sharkfuser_iree
     GIT_REPOSITORY  https://github.com/iree-org/iree.git
@@ -119,6 +129,15 @@ endif()
 # Build tests
 if(SHARKFUSER_BUILD_TESTS)
   message(STATUS "Building SharkFuser tests")
+
+  # Require Python 3.8+ for lit tests
+  find_package(Python3 3.8 REQUIRED COMPONENTS Interpreter)
+
+  # Grab lit from IREE LLVM. We could also look into using a python pip
+  # dependency.
+  set(LLVM_EXTERNAL_LIT "${LLVM_SOURCE_DIR}/utils/lit/lit.py")
+  message(STATUS "LLVM_EXTERNAL_LIT ${LLVM_EXTERNAL_LIT}")
+
   add_subdirectory(tests)
   enable_testing()
 endif()

--- a/sharkfuser/README.md
+++ b/sharkfuser/README.md
@@ -43,6 +43,7 @@ To generate code coverage metrics:
 cmake -GNinja -S. -Bbuild \
     -DCMAKE_C_COMPILER=gcc \
     -DCMAKE_CXX_COMPILER=g++ \
+    -DPython3_EXECUTABLE=$(which python3) \
     -DSHARKFUSER_CODE_COVERAGE=ON
 cmake --build build --target all
 ctest --test-dir build -T test -T coverage

--- a/sharkfuser/README.md
+++ b/sharkfuser/README.md
@@ -11,11 +11,17 @@ A side note on naming: 'SharkFuser' is the name of the project (may change as th
 ## Developer Guide:
 
 ### Build and test (debug build):
+
+**Python Requirements:** [`lit`](https://llvm.org/docs/CommandGuide/lit.html)
+tests require Python. No external Python dependencies are needed - you can use
+your system Python or create a virtual environment.
+
 ```shell
 cmake -GNinja -S. -Bbuild \
     -DCMAKE_C_COMPILER=clang \
     -DCMAKE_CXX_COMPILER=clang++ \
     -DCMAKE_LINKER_TYPE=LLD \
+    -DPython3_EXECUTABLE=$(which python3) \
     -DSHARKFUSER_DEBUG_BUILD=ON
 cmake --build build --target all
 ctest --test-dir build

--- a/sharkfuser/build_tools/cmake/CTestCustom.cmake.in
+++ b/sharkfuser/build_tools/cmake/CTestCustom.cmake.in
@@ -10,3 +10,7 @@ set(CTEST_CUSTOM_COVERAGE_EXCLUDE
   "build/*"
   "/usr/*"
 )
+
+set(CTEST_COVERAGE_EXTRA_FLAGS
+  ${CTEST_COVERAGE_EXTRA_FLAGS}
+  "--exclude */_deps/*")

--- a/sharkfuser/build_tools/cmake/CTestCustom.cmake.in
+++ b/sharkfuser/build_tools/cmake/CTestCustom.cmake.in
@@ -10,7 +10,3 @@ set(CTEST_CUSTOM_COVERAGE_EXCLUDE
   "build/*"
   "/usr/*"
 )
-
-set(CTEST_COVERAGE_EXTRA_FLAGS
-  ${CTEST_COVERAGE_EXTRA_FLAGS}
-  "--exclude */_deps/*")

--- a/sharkfuser/build_tools/cmake/CTestMacros.cmake
+++ b/sharkfuser/build_tools/cmake/CTestMacros.cmake
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 
-# Creates and executable target for use in a test.
+# Creates an executable target for use in a test.
 #
 # NAME
 #  The name of the executable target to create (required)
@@ -188,7 +188,7 @@ function(add_sharkfuser_lit_test)
     NAME ${_TEST_NAME}
     SRCS ${_RULE_SRC}
     DEPS ${_RULE_DEPS}
-    BIN_SUBDIR samples
+    BIN_SUBDIR lit
   )
 
   # Pass lit locations of tools in build directory through `--path` arguments.

--- a/sharkfuser/build_tools/cmake/CTestMacros.cmake
+++ b/sharkfuser/build_tools/cmake/CTestMacros.cmake
@@ -5,7 +5,21 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 
-function(_add_sharkfuser_target)
+# Creates and executable target for use in a test.
+#
+# NAME
+#  The name of the executable target to create (required)
+#
+# SRCS
+#  Source files to compile into the executable (required)
+#
+# DEPS
+#  Additional library dependencies beyond the standard ones
+#  (libfusili and Catch2::Catch2WithMain are always linked)
+#
+# BIN_SUBDIR
+#  Subdirectory under build/bin/ where the executable will be placed
+function(_add_sharkfuser_test_target)
   cmake_parse_arguments(
     _RULE               # prefix
     ""                  # options
@@ -29,6 +43,33 @@ function(_add_sharkfuser_target)
     target_link_options(${_RULE_NAME} PRIVATE -coverage)
   endif()
 
+  # Place executable in the build/bin sub-directory
+  set_target_properties(
+      ${_RULE_NAME} PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${_RULE_BIN_SUBDIR}
+  )
+endfunction()
+
+
+# Creates and executable target + test.
+function(_add_sharkfuser_test)
+  cmake_parse_arguments(
+    _RULE               # prefix
+    ""                  # options
+    "NAME;BIN_SUBDIR"   # one value keywords
+    "SRCS;DEPS"         # multi-value keywords
+    ${ARGN}             # extra arguments
+  )
+
+  # Create the target first
+  _add_sharkfuser_test_target(
+    NAME ${_RULE_NAME}
+    SRCS ${_RULE_SRCS}
+    DEPS ${_RULE_DEPS}
+    BIN_SUBDIR ${_RULE_BIN_SUBDIR}
+  )
+
+  # Add the test
   add_test(NAME ${_RULE_NAME} COMMAND ${_RULE_NAME})
 
   # Set logging environment variables
@@ -38,15 +79,20 @@ function(_add_sharkfuser_target)
       ENVIRONMENT "FUSILI_LOG_INFO=1;FUSILI_LOG_FILE=stdout"
     )
   endif()
-
-  # Place executable in the build/bin sub-directory
-  set_target_properties(
-      ${_RULE_NAME} PROPERTIES
-      RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${_RULE_BIN_SUBDIR}
-  )
 endfunction()
 
 
+# Creates a sharkfuser test.
+#
+# NAME
+#  The name of the executable target to create (required)
+#
+# SRCS
+#  Source files to compile into the executable (required)
+#
+# DEPS
+#  Additional library dependencies beyond the standard ones
+#  (libfusili and Catch2::Catch2WithMain are always linked)
 function(add_sharkfuser_test)
   cmake_parse_arguments(
     _RULE
@@ -60,7 +106,7 @@ function(add_sharkfuser_test)
     return()
   endif()
 
-  _add_sharkfuser_target(
+  _add_sharkfuser_test(
     NAME ${_RULE_NAME}
     SRCS ${_RULE_SRCS}
     DEPS ${_RULE_DEPS}
@@ -69,6 +115,17 @@ function(add_sharkfuser_test)
 endfunction()
 
 
+# Creates a sharkfuser sample.
+#
+# NAME
+#  The name of the executable target to create (required)
+#
+# SRCS
+#  Source files to compile into the executable (required)
+#
+# DEPS
+#  Additional library dependencies beyond the standard ones
+#  (libfusili and Catch2::Catch2WithMain are always linked)
 function(add_sharkfuser_sample)
   cmake_parse_arguments(
     _RULE
@@ -82,10 +139,84 @@ function(add_sharkfuser_sample)
     return()
   endif()
 
-  _add_sharkfuser_target(
+  _add_sharkfuser_test(
     NAME ${_RULE_NAME}
     SRCS ${_RULE_SRCS}
     DEPS ${_RULE_DEPS}
     BIN_SUBDIR samples
   )
+endfunction()
+
+
+# Creates a lit test that compiles a source file and runs lit on it.
+#
+#  add_sharkfuser_lit_test(
+#    SRC <source-file>
+#    [TOOLS <tool1> <tool2> ...]
+#    [DEPS <dep1> <dep2> ...]
+#  )
+#
+# SRC
+#  The source file to compile and test (required)
+#
+# TOOLS
+#  External tools needed for the test (e.g., FileCheck)
+#
+# DEPS
+#  Library dependencies for the compiled executable
+function(add_sharkfuser_lit_test)
+  if(NOT SHARKFUSER_BUILD_TESTS)
+    return()
+  endif()
+
+  cmake_parse_arguments(
+    _RULE               # prefix
+    ""                  # options
+    "SRC"               # one value keywords
+    "TOOLS;DEPS"        # multi-value keywords
+    ${ARGN}
+  )
+  if(NOT _RULE_SRC)
+    message(FATAL_ERROR "add_sharkfuser_lit_test: SRC parameter is required")
+  endif()
+
+  get_filename_component(_ABSOLUTE_RULE_SRC ${_RULE_SRC} ABSOLUTE)
+  get_filename_component(_TEST_NAME ${_RULE_SRC} NAME_WE)
+
+  # The executable who's output is being lit tested.
+  _add_sharkfuser_test_target(
+    NAME ${_TEST_NAME}
+    SRCS ${_RULE_SRC}
+    DEPS ${_RULE_DEPS}
+    BIN_SUBDIR samples
+  )
+
+  # Pass lit locations of tools in build directory through `--path` arguments.
+  set(_LIT_PATH_ARGS "--path" "$<TARGET_FILE_DIR:${_TEST_NAME}>")
+  foreach(_TOOL IN LISTS _RULE_TOOLS)
+    list(APPEND _LIT_PATH_ARGS "--path" "$<TARGET_FILE_DIR:${_TOOL}>")
+  endforeach()
+
+  add_test(
+    NAME
+      ${_TEST_NAME}
+    COMMAND
+      "${Python3_EXECUTABLE}"
+      "${LLVM_EXTERNAL_LIT}"
+      "${_ABSOLUTE_RULE_SRC}"
+      ${_LIT_PATH_ARGS}
+      # lit config sets the "%test_exe" substitution based on this param.
+      "--param" "TEST_EXE=$<TARGET_FILE:${_TEST_NAME}>"
+      # Ensures lit prints a (more) useful error message on failure.
+      "--verbose"
+  )
+
+  # Apparently this flag helps FileCheck spit out nicer error messages.
+  set_tests_properties(${_TEST_NAME} PROPERTIES ENVIRONMENT
+    "FILECHECK_OPTS=--enable-var-scope")
+
+  # Dependencies for the test.
+  if(_RULE_TOOLS)
+    set_tests_properties(${_TEST_NAME} PROPERTIES DEPENDS "${_RULE_TOOLS}")
+  endif()
 endfunction()

--- a/sharkfuser/build_tools/cmake/strip_codecov_files.cmake
+++ b/sharkfuser/build_tools/cmake/strip_codecov_files.cmake
@@ -1,0 +1,23 @@
+if(NOT DEFINED SHARKFUSER_IREE_SOURCE_DIR)
+  message(FATAL_ERROR "SHARKFUSER_IREE_SOURCE_DIR must be defined")
+endif()
+
+set(THIRD_PARTY_DIR "${SHARKFUSER_IREE_SOURCE_DIR}/third_party")
+
+# Find all .gcda files
+file(GLOB_RECURSE GCDA_FILES "${THIRD_PARTY_DIR}/*.gcda")
+
+# Find all .gcno files
+file(GLOB_RECURSE GCNO_FILES "${THIRD_PARTY_DIR}/*.gcno")
+
+# Combine the lists
+set(CODECOV_FILES ${GCDA_FILES} ${GCNO_FILES})
+
+message(STATUS "CODECOV_FILES: ${CODECOV_FILES}")
+
+# Remove files
+if(CODECOV_FILES)
+  file(REMOVE ${CODECOV_FILES})
+else()
+  message(STATUS "No .gcda/.gcno files found.")
+endif()

--- a/sharkfuser/tests/CMakeLists.txt
+++ b/sharkfuser/tests/CMakeLists.txt
@@ -50,5 +50,4 @@ add_sharkfuser_test(
 
 add_sharkfuser_lit_test(
 	SRC example_lit_test.cpp
-	TOOLS FileCheck
 )

--- a/sharkfuser/tests/CMakeLists.txt
+++ b/sharkfuser/tests/CMakeLists.txt
@@ -47,3 +47,8 @@ add_sharkfuser_test(
   SRCS
     test_logging.cpp
 )
+
+add_sharkfuser_lit_test(
+	SRC example_lit_test.cpp
+	TOOLS FileCheck
+)

--- a/sharkfuser/tests/example_lit_test.cpp
+++ b/sharkfuser/tests/example_lit_test.cpp
@@ -1,0 +1,9 @@
+// RUN: %test_exe | FileCheck %s
+
+#include <iostream>
+
+int main() {
+  // CHECK: Hello sharkfuser!
+  std::cout << "Hello sharkfuser!" << std::endl;
+  return 0;
+}

--- a/sharkfuser/tests/lit.cfg.py
+++ b/sharkfuser/tests/lit.cfg.py
@@ -1,0 +1,24 @@
+import os
+import tempfile
+
+import lit.formats
+from lit.llvm import llvm_config
+
+config.name = "sharkfuser"
+
+config.test_format = lit.formats.ShTest()
+
+config.suffixes = [".cpp"]
+
+# test_source_root: The root path where tests are located.
+config.test_source_root = os.path.dirname(__file__)
+
+# Without temfile lit writes `.lit_test_times.txt` and an `Output` folder into
+# the source tree.
+config.test_exec_root = os.path.join(tempfile.gettempdir(), "lit")
+
+# CMake provides the path of the executable who's output is being lit tested
+# through a generator expression.
+test_exe = lit_config.params.get("TEST_EXE")
+if test_exe:
+    config.substitutions.append(("%test_exe", test_exe))

--- a/sharkfuser/tests/lit.cfg.py
+++ b/sharkfuser/tests/lit.cfg.py
@@ -13,7 +13,7 @@ config.suffixes = [".cpp"]
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
 
-# Without temfile lit writes `.lit_test_times.txt` and an `Output` folder into
+# Without tempfile lit writes `.lit_test_times.txt` and an `Output` folder into
 # the source tree.
 config.test_exec_root = os.path.join(tempfile.gettempdir(), "lit")
 


### PR DESCRIPTION
This PR sets up `lit` + `FileCheck` tests for MLIR asm emitter. `lit` + `FileCheck`  are a well known and battle tested formula for testing MLIR asm, this approach should minimize fiddling with exact string matches.