### PR TITLE
[sharktank][llm] Restrict page dimension to device_block_count

### DIFF
--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -140,7 +140,13 @@ def main():
             "paged_kv_cache": {
                 "attention_head_count_kv": hp.attention_head_count_kv,
                 "block_seq_stride": llama_config.block_seq_stride,
-                "device_block_count": args.device_block_count,  # so that this makes its way into the config file & can be edited.
+                # The compiler assumes that the page_dim cannot be greater
+                # than the device block count. Be careful while modifying
+                # this. Ideally, we want to allocate the number of pages such
+                # that (head_dim * block_seq_stride * num_pages) <= int32_max,
+                # to allow doing int32 indexing for kv cache gather/scatter,
+                # which is good for buffer loads on gfx94x+.
+                "device_block_count": args.device_block_count,
                 "kv_cache_dtype": kv_cache_dtype,
                 "paged_kv_block_size_elements_per_device": paged_kv_block_size_elements_per_device,
             },
@@ -160,7 +166,7 @@ def main():
             cache_state = model.cache.allocate(
                 page_count=hp.context_length // llama_config.block_seq_stride
             )
-            page_dim = torch.export.Dim("page")
+            page_dim = torch.export.Dim("page", max=args.device_block_count)
 
             pipeline_parallelism_size = len(cache_state)
             tensor_parallelism_size = 1


### PR DESCRIPTION
This allows us to use buffer load instructions for kv cache load/stores better.