### PR TITLE
Use int8 for handling float8_e4m3fn compatiblity

### DIFF
--- a/sharktank/sharktank/utils/iree.py
+++ b/sharktank/sharktank/utils/iree.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
 
 torch_dtype_to_hal_element_type_map = {
     torch.float8_e4m3fnuz: iree.runtime.HalElementType.FLOAT_8_E4M3_FNUZ,
+    torch.float8_e4m3fn: iree.runtime.HalElementType.FLOAT_8_E4M3_FN,
     torch.bfloat16: iree.runtime.HalElementType.BFLOAT_16,
 }
 

--- a/sharktank/sharktank/utils/iree.py
+++ b/sharktank/sharktank/utils/iree.py
@@ -48,6 +48,7 @@ hal_element_type_to_torch_dtype_map = {
 
 dtype_to_dtype_reinterpret_map = {
     torch.float8_e4m3fnuz: torch.int8,
+    torch.float8_e4m3fn: torch.int8,
     torch.bfloat16: torch.int16,
 }
 """We want to map dtypes unsupported by iree.runtime.DeviceArray.


### PR DESCRIPTION
I should have included this in https://github.com/nod-ai/shark-ai/pull/1852