### PR TITLE
[Fusili] Bring in `iree-opt` in preparation for vmfb generation

### DIFF
--- a/sharkfuser/README.md
+++ b/sharkfuser/README.md
@@ -24,8 +24,13 @@ To build and test Fusili, the following dependencies are needed:
 - catch2
 - lit
 - filecheck
+- iree-opt
 
-Easiest way to get [`lit`](https://llvm.org/docs/CommandGuide/lit.html) and [`filecheck`](https://github.com/AntonLydike/filecheck) without depending on LLVM is through Python (pip install). One may either use system Python or create a virtual environment (preferred) like so:
+Easiest way to get [`lit`](https://llvm.org/docs/CommandGuide/lit.html),
+[`filecheck`](https://github.com/AntonLydike/filecheck), and `iree-opt` without
+depending on LLVM or building IREE from source is through Python (pip install).
+One may either use system Python or create a virtual environment (preferred)
+like so:
 ```shell
 python -m venv --prompt fusili .venv
 source .venv/bin/activate

--- a/sharkfuser/build_tools/cmake/CTestMacros.cmake
+++ b/sharkfuser/build_tools/cmake/CTestMacros.cmake
@@ -129,7 +129,7 @@ function(add_sharkfuser_lit_test)
   )
 
   # Pass locations of tools in build directory to lit through `--path` arguments.
-  set(_LIT_PATH_ARGS)
+  set(_LIT_PATH_ARGS "--path" "$<TARGET_FILE_DIR:FileCheck>")
   foreach(_TOOL IN LISTS _RULE_TOOLS)
     list(APPEND _LIT_PATH_ARGS "--path" "$<TARGET_FILE_DIR:${_TOOL}>")
   endforeach()

--- a/sharkfuser/test_requirements.txt
+++ b/sharkfuser/test_requirements.txt
@@ -1,2 +1,3 @@
 lit
 filecheck
+iree-base-compiler

--- a/sharkfuser/tests/CMakeLists.txt
+++ b/sharkfuser/tests/CMakeLists.txt
@@ -25,6 +25,21 @@ if(NOT SHARKFUSER_EXTERNAL_FILECHECK)
   endif()
 endif()
 message(STATUS "Using filecheck: ${SHARKFUSER_EXTERNAL_FILECHECK}")
+# wrap FileCheck in a CMake target interface
+add_executable(FileCheck IMPORTED GLOBAL)
+set_target_properties(FileCheck PROPERTIES IMPORTED_LOCATION "${SHARKFUSER_EXTERNAL_FILECHECK}")
+
+# Find iree-opt program (pip or system installed)
+if(NOT SHARKFUSER_EXTERNAL_IREE_OPT)
+  find_program(SHARKFUSER_EXTERNAL_IREE_OPT NAMES iree-opt)
+  if(NOT SHARKFUSER_EXTERNAL_IREE_OPT)
+    message(FATAL_ERROR "Could not find 'iree-opt' in PATH. Please install iree-opt (e.g., pip install iree-base-compiler).")
+  endif()
+endif()
+message(STATUS "Using iree-opt: ${SHARKFUSER_EXTERNAL_IREE_OPT}")
+# wrap iree-opt in a CMake target interface
+add_executable(IREEOpt IMPORTED GLOBAL)
+set_target_properties(IREEOpt PROPERTIES IMPORTED_LOCATION "${SHARKFUSER_EXTERNAL_IREE_OPT}")
 
 
 add_sharkfuser_test(
@@ -62,4 +77,5 @@ add_sharkfuser_test(
 
 add_sharkfuser_lit_test(
   SRC test_example_lit.cpp
+  TOOLS IREEOpt
 )

--- a/sharkfuser/tests/test_example_lit.cpp
+++ b/sharkfuser/tests/test_example_lit.cpp
@@ -1,9 +1,15 @@
+// RUN: %test_exe | iree-opt --verify-roundtrip
 // RUN: %test_exe | filecheck %s
 
 #include <iostream>
 
 int main() {
-  // CHECK: Hello sharkfuser!
-  std::cout << "Hello sharkfuser!" << std::endl;
+  // CHECK: func.func @main()
+  std::cout << "module {" << std::endl;
+  std::cout << "  func.func @main() -> i32 {" << std::endl;
+  std::cout << "    %c0 = arith.constant 0 : i32" << std::endl;
+  std::cout << "    return %c0 : i32" << std::endl;
+  std::cout << "  }" << std::endl;
+  std::cout << "}" << std::endl;
   return 0;
 }


### PR DESCRIPTION
This PR brings in iree-opt and adds a simple test to verify generated MLIR. The pattern should work for IR verification tests once the MLIR asm emitter is in place. Similarly, we can create vmfb from generated asm with `iree-compile` with a similar `find_program` approach.