### PR TITLE
[sharktank] In eager do not use kernel for fp4 matmul

### DIFF
--- a/sharktank/sharktank/ops/custom_impls.py
+++ b/sharktank/sharktank/ops/custom_impls.py
@@ -114,11 +114,17 @@ def matmul_generic_tensor_block_scaled_fp4(
     lhs, rhs: QuantizedTensor, *, transpose_rhs: bool
 ):
     """Generic kernel for FP4 E2M1 block scaled layouts."""
+
+    if rhs.layout_type is not BlockScaledFp4Layout:
+        return NotImplemented
+
+    if not torch.compiler.is_compiling():
+        lhs = unbox_tensor(lhs)
+        rhs = unbox_tensor(rhs)
+        return matmul(lhs, rhs, transpose_rhs=transpose_rhs)
+
     lhs = unbox_tensor(lhs)
     if not transpose_rhs:
-        return NotImplemented
-    layout = rhs.layout_type
-    if layout is not BlockScaledFp4Layout:
         return NotImplemented
     rhs_unpacked = rhs.unpack()
     quantizer = DynamicFp4BlockQuantizer(

--- a/sharktank/sharktank/types/quantizers.py
+++ b/sharktank/sharktank/types/quantizers.py
@@ -53,6 +53,8 @@ from .tensors import (
     dtype_to_serialized_name,
 )
 
+from sharktank.utils import iterables_equal
+
 __all__ = [
     "DynamicFp4BlockQuantizer",
     "DynamicScaledQuantizer",
@@ -89,7 +91,11 @@ class QuantizerTensor(InferenceTensor):
         else:
             assert isinstance(t, torch.Tensor)
             raw_tensor = t
-        return self._quantize_raw_tensor(raw_tensor, name=name)
+        res = self._quantize_raw_tensor(raw_tensor, name=name)
+        assert iterables_equal(
+            res.shape, t.shape
+        ), f"Quantization error, input and output shapes differ {t.shape} != {res.shape}"
+        return res
 
     @abstractmethod
     def _quantize_raw_tensor(self, t: torch.Tensor, *, name: str) -> QuantizedTensor:

--- a/sharktank/sharktank/utils/misc.py
+++ b/sharktank/sharktank/utils/misc.py
@@ -44,23 +44,27 @@ def longest_equal_range(l1: List[Any], l2: List[Any]) -> int:
     return min(len(list(l1)), len(list(l2)))
 
 
+_non_existent_value = object()
+"""This needs to be defined in the global scope because during torch tracing we can't
+do object()."""
+
+
 def iterables_equal(
     iterable1: Iterable,
     iterable2: Iterable,
     *,
     elements_equal: Callable[[Any, Any], bool] | None = None,
 ) -> bool:
-    non_existent_value = object()
     elements_equal = elements_equal or eq
 
     def elements_equal_fn(x: Any, y: Any) -> bool:
-        if x is non_existent_value or y is non_existent_value:
+        if x is _non_existent_value or y is _non_existent_value:
             return False
         return elements_equal(x, y)
 
     return all(
         elements_equal_fn(v1, v2)
-        for v1, v2 in zip_longest(iterable1, iterable2, fillvalue=non_existent_value)
+        for v1, v2 in zip_longest(iterable1, iterable2, fillvalue=_non_existent_value)
     )
 
 

--- a/sharktank/sharktank/utils/testing.py
+++ b/sharktank/sharktank/utils/testing.py
@@ -836,7 +836,7 @@ def create_sample_tensor_from_class(
         return new_t
 
     if base_tensor is None:
-        base_tensor = torch.tensor([[1, 0, 1], [0, 1, 0]])
+        base_tensor = torch.tensor([[1, 0, 1, 0], [0, 1, 0, 1]])
 
     if tensor_clazz is torch.Tensor:
         return clone(unbox_tensor(base_tensor), None)


### PR DESCRIPTION
The wave_mxfp4_bmm kernel works only for some AMD GPU architectures.
```
error: 'amdgpu.scaled_mfma' op scaled MFMA only supported on gfx908+
```

It is also desirable to have eager execution path that does not depend on IREE. This would allow us to have a simple reference implementation that we can test against.

In eager we dequantize the arguments and run a "normal" matmul.