### PR TITLE
[sharktank] make fp4 block-quantized have scales with trailing singleton dimension

### DIFF
--- a/sharktank/sharktank/models/llama/tools/import_quark_dataset.py
+++ b/sharktank/sharktank/models/llama/tools/import_quark_dataset.py
@@ -134,7 +134,7 @@ def create_fp4_block_tensor(
 
     layout = BlockScaledFp4Layout(
         shape=original_shape,
-        d=scale_tensor,
+        d=scale_tensor.unsqueeze(-1),
         qs=weight_tensor,
         block_size=block_size,
         use_fe8m0_scale=use_fe8m0,

--- a/sharktank/sharktank/ops/custom_impls.py
+++ b/sharktank/sharktank/ops/custom_impls.py
@@ -133,9 +133,9 @@ def matmul_generic_tensor_block_scaled_fp4(
     # TODO: fix quantization so the flatten is not necessary
     return wave_mxfp4_bmm(
         lhs_unpacked.qs_bit_packed.flatten(start_dim=-2),
-        lhs_unpacked.d,
+        lhs_unpacked.d.squeeze(-1),
         rhs_unpacked.qs_bit_packed.flatten(start_dim=-2),
-        rhs_unpacked.d,
+        rhs_unpacked.d.squeeze(-1),
         output,
     )
 

--- a/sharktank/sharktank/ops/quantized_impls.py
+++ b/sharktank/sharktank/ops/quantized_impls.py
@@ -193,9 +193,7 @@ def extract_slice_BlockScaledFp4Layout(tensor: PlanarQuantizedTensor, key: Slice
     # One more dimension for indexing in the block.
     slice_.append(slice(None))
 
-    # TODO: Remove assert and enable this when BlockScaledFp4Layout aligns with BlockScaledLayout.
-    assert len(layout.d.shape) + 1 == len(layout.qs_bit_packed.shape)
-    # block_scale_slice.append(slice(None))
+    block_scale_slice.append(slice(None))
 
     # Reintroduce singleton dimension inserts.
     slice_ = unsqueeze_slice_like(tuple(slice_), like=key)

--- a/sharktank/sharktank/types/layouts.py
+++ b/sharktank/sharktank/types/layouts.py
@@ -598,6 +598,10 @@ class BlockScaledFp4Layout(BlockScaledPackedLayout):
         block_size: int = 32,
         use_fe8m0_scale: bool = True,
     ):
+        if len(qs.shape) == len(d.shape) + 1:
+            # Legacy scale format with no trailing singleton dimension to match qs.
+            # This is here to avoid breaking existing IRPA files.
+            d = d.unsqueeze(-1)
         assert iterables_equal(qs.shape[:-1], d.shape[:-1])
         assert math.prod(shape) == math.prod(qs.shape) * 2
         assert qs.shape[-1] * 2 == block_size

--- a/sharktank/sharktank/types/layouts.py
+++ b/sharktank/sharktank/types/layouts.py
@@ -14,11 +14,12 @@ packed realizations as a QuantizedTensor subtype, each also has a generic
 planar QuantizedTensor which carries its tensors unpacked.
 """
 
-from abc import abstractmethod
 import math
-from typing import Optional
-
 import torch
+import warnings
+
+from abc import abstractmethod
+from typing import Optional
 
 from .tensors import (
     register_quantized_layout,
@@ -601,6 +602,14 @@ class BlockScaledFp4Layout(BlockScaledPackedLayout):
         if len(qs.shape) == len(d.shape) + 1:
             # Legacy scale format with no trailing singleton dimension to match qs.
             # This is here to avoid breaking existing IRPA files.
+            warnings.warn(
+                (
+                    "Constructing BlockScaledFp4Layout with scales tensor of shape "
+                    f"{d.shape} without a trailing singleton dimension is deprecated. "
+                    "Maybe you are using an old model file (IRPA)."
+                ),
+                DeprecationWarning,
+            )
             d = d.unsqueeze(-1)
         assert iterables_equal(qs.shape[:-1], d.shape[:-1])
         assert math.prod(shape) == math.prod(qs.shape) * 2

--- a/sharktank/sharktank/types/layouts.py
+++ b/sharktank/sharktank/types/layouts.py
@@ -585,7 +585,7 @@ class BlockScaledFp4Layout(BlockScaledPackedLayout):
     block size is 32 and the original shape was NxK, then the component
     shapes would be:
 
-    * `d`: `[N, K // 32]` (per-block scales)
+    * `d`: `[N, K // 32, 1]` (per-block scales)
     * `qs`: `[N, K // 32, 16]` (packed FP4 indices, 32 values packed into 16 bytes)
     """
 
@@ -598,14 +598,10 @@ class BlockScaledFp4Layout(BlockScaledPackedLayout):
         block_size: int = 32,
         use_fe8m0_scale: bool = True,
     ):
-        assert iterables_equal(
-            qs.shape[:-1], d.shape
-        ), "TODO: remove when this class is refactored to comply with BlockScaledLayout"
+        assert iterables_equal(qs.shape[:-1], d.shape[:-1])
         assert math.prod(shape) == math.prod(qs.shape) * 2
         assert qs.shape[-1] * 2 == block_size
-        self._shape = shape
-        self._d = d
-        self._qs = qs
+        super().__init__(shape=shape, d=d, qs_packed=qs)
         self._block_size = block_size
         self._use_fe8m0_scale = use_fe8m0_scale
 
@@ -661,9 +657,8 @@ class BlockScaledFp4Layout(BlockScaledPackedLayout):
 
         # Scale each block
         scales_float = convert_fp4_scales_to_float(self.d, self.use_fe8m0_scale)
-        scales_expanded = scales_float.unsqueeze(-1)
         dequantized_blocked = (
-            fp4_as_float * scales_expanded
+            fp4_as_float * scales_float
         )  # Shape: [num_blocks, block_size]
 
         if dequantized_blocked.dtype != dtype:

--- a/sharktank/sharktank/types/ocp_floats.py
+++ b/sharktank/sharktank/types/ocp_floats.py
@@ -247,7 +247,7 @@ def compute_fp4_block_scales(
         scales_float = torch.pow(2.0, exponent)
         scales = scales_float
 
-    return scales, scales_float
+    return scales.unsqueeze(-1), scales_float.unsqueeze(-1)
 
 
 def fp4_e2m1_to_float32(fp4_indices: torch.Tensor) -> torch.Tensor:

--- a/sharktank/sharktank/types/quantizers.py
+++ b/sharktank/sharktank/types/quantizers.py
@@ -505,7 +505,8 @@ def _fp4_block_quantize_tensor(
 
     Args:
         t: Input tensor of shape [..., N] to quantize (must have N % block_size == 0)
-        scales: Per-block scales (either float or integer exponents, shape matches blocked tensor)
+        scales: Per-block scales (either float or integer exponents, shape matches
+                blocked tensor with a trailing singleton dimension)
         block_size: Size of each block
         use_fe8m0_scale: Whether scales are FE8M0
         name: Name for the resulting tensor
@@ -529,12 +530,12 @@ def _fp4_block_quantize_tensor(
 
     # Prepare scales for broadcasting - add dimension for block_size
     if use_fe8m0_scale:
-        scales_broadcast = e8m0_to_float32(scales).unsqueeze(-1)
+        scales_f32 = e8m0_to_float32(scales)
     else:
-        scales_broadcast = scales.unsqueeze(-1)
+        scales_f32 = scales
 
     # Scale the blocked values via broadcasting
-    scaled_values = values_blocked / scales_broadcast
+    scaled_values = values_blocked / scales_f32
 
     # Convert to FP4 indices (preserves shape)
     quantized_indices = float32_to_fp4_e2m1(scaled_values)
@@ -573,6 +574,10 @@ class StaticFp4BlockQuantizer(QuantizerTensor):
         dtype: torch.dtype = torch.float32,
         name: str = UnnamedTensorName,
     ):
+        """
+        Args:
+        scales: with shape `blocked_shape + [1]`.
+        """
         super().__init__(shape=scales.shape, name=name)
         if block_size <= 0:
             raise ValueError(f"Block size must be positive, got {block_size}")

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -962,8 +962,8 @@ class TransposeTest(unittest.TestCase):
             dtype=torch.float32,
         )
         block_size = 2
-        scales_shape = list(expected.shape)
-        scales_shape[-1] //= block_size
+        scales_shape = list(expected.shape) + [1]
+        scales_shape[-2] //= block_size
         quantizer = StaticFp4BlockQuantizer(
             scales=torch.ones(size=scales_shape, dtype=torch.float32),
             dtype=torch.float32,
@@ -977,8 +977,8 @@ class TransposeTest(unittest.TestCase):
             [[-6, -4, -2, 0], [-5, -3, -2, -1]], dtype=torch.float32
         )
         block_size = 2
-        scales_shape = list(expected.shape)
-        scales_shape[-1] //= block_size
+        scales_shape = list(expected.shape) + [1]
+        scales_shape[-2] //= block_size
         quantizer = StaticFp4BlockQuantizer(
             scales=torch.full(size=scales_shape, fill_value=0.5, dtype=torch.float32),
             dtype=torch.float32,

--- a/sharktank/tests/types/layouts_test.py
+++ b/sharktank/tests/types/layouts_test.py
@@ -125,5 +125,24 @@ class TensorScaledLayoutTest(unittest.TestCase):
         )
 
 
+class TestBlockScaledFp4Layout:
+    def test_legacy_construction_with_no_trailing_singleton_dim_in_scale_tensor(slef):
+        """Make sure we can construct with scale of shape [3, 4, 12] instead of [3, 4, 12, 1]."""
+        block_size = 4
+        shape = [3, 4, 12]
+        d_shape = list(shape)
+        d_shape[-1] = d_shape[-1] // block_size
+        qs_shape = list(d_shape) + [block_size // 2]
+        d = torch.empty(d_shape, dtype=torch.float)
+        qs = torch.empty(qs_shape, dtype=torch.uint8)
+        layout = BlockScaledFp4Layout(
+            shape=shape, d=d, qs=qs, block_size=block_size, use_fe8m0_scale=False
+        )
+        assert (
+            len(layout.qs_bit_packed.shape) == len(layout.d.shape)
+            and layout.d.shape[-1] == 1
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/sharktank/tests/types/quantizers_test.py
+++ b/sharktank/tests/types/quantizers_test.py
@@ -326,7 +326,7 @@ class DynamicFP4BlockQuantizerTest(Fp4BlockQuantizerTestBase):
         layout_16 = quantized_tensor_16.unpack()
         self.assertEqual(len(layout_16.d), 8)
 
-    def testFp4BlockQuantization(self):
+    def testFp4BlockQuantization2(self):
         """Test FP4 block quantization with configurable block size and FE8M0 scales."""
         original_data = torch.randn(64, dtype=torch.float32) * 4.0
 

--- a/sharktank/tests/types/quantizers_test.py
+++ b/sharktank/tests/types/quantizers_test.py
@@ -384,7 +384,7 @@ class DynamicFP4BlockQuantizerTest(Fp4BlockQuantizerTestBase):
 class StaticFp4BlockQuantizerTest(Fp4BlockQuantizerTestBase):
     def testStaticFp4QuantDequant(self):
         orig_value = self.get_fp4_exact_values()
-        scales = torch.tensor([1.0], dtype=torch.float32)
+        scales = torch.tensor([1.0], dtype=torch.float32).unsqueeze(-1)
         static_quantizer = StaticFp4BlockQuantizer(
             scales=scales,
             block_size=8,
@@ -409,7 +409,7 @@ class StaticFp4BlockQuantizerTest(Fp4BlockQuantizerTestBase):
 
         # Create static quantizer with manually set FE8M0 scales
         # For 64 elements with block_size=32, we need 2 blocks
-        scales = torch.tensor([130, 131], dtype=torch.uint8)
+        scales = torch.tensor([130, 131], dtype=torch.uint8).unsqueeze(-1)
 
         static_quantizer = StaticFp4BlockQuantizer(
             scales=scales,
@@ -431,8 +431,9 @@ class StaticFp4BlockQuantizerTest(Fp4BlockQuantizerTestBase):
 
     def testStaticFp4TwoDimensionalScales(self):
         orig_value = self.get_fp4_exact_values().reshape(2, 4)
-        scales = torch.tensor([[1.0, 1.0], [1.0, 1.0]], dtype=torch.float32)
-        # scales = torch.tensor([1.0], dtype=torch.float32)
+        scales = torch.tensor([[1.0, 1.0], [1.0, 1.0]], dtype=torch.float32).unsqueeze(
+            -1
+        )
         static_quantizer = StaticFp4BlockQuantizer(
             scales=scales,
             block_size=2,
@@ -458,7 +459,9 @@ class StaticFp4BlockQuantizerTest(Fp4BlockQuantizerTestBase):
             # Create appropriate scales for this block size
             expected_num_blocks = (60 + block_size - 1) // block_size
             # Use simple fe8m0
-            scales = torch.randint(125, 130, (expected_num_blocks,), dtype=torch.uint8)
+            scales = torch.randint(
+                125, 130, (expected_num_blocks,), dtype=torch.uint8
+            ).unsqueeze(-1)
 
             static_quantizer = StaticFp4BlockQuantizer(
                 scales=scales,
@@ -491,7 +494,7 @@ class StaticFp4BlockQuantizerTest(Fp4BlockQuantizerTestBase):
     def testReplicatedStaticFp4Quantizer(self):
         """Test that replicated static FP4 quantizer works correctly."""
         orig_value = self.get_fp4_exact_values()
-        scales = torch.tensor([1.0], dtype=torch.float32)
+        scales = torch.tensor([1.0], dtype=torch.float32).unsqueeze(-1)
 
         # Create a static quantizer with replicated scales
         static_quantizer = StaticFp4BlockQuantizer(


### PR DESCRIPTION
To align BlockScaledFp4Layout with the base class BlockScaledLayout make the per-block scale tensor have a shape blocked_shape + [1]. Fixes https://github.com/nod-ai/shark-ai/issues/1833.

This change breaks existing IRPA files that hold FP4 quantized tensors. They will need to be regenerated.