### PR TITLE
[Fusili] Boilerplate to bring in `iree-compile` for subprocess call

### DIFF
--- a/sharkfuser/CMakeLists.txt
+++ b/sharkfuser/CMakeLists.txt
@@ -45,6 +45,21 @@ list(APPEND CMAKE_MODULE_PATH
   ${CMAKE_CURRENT_LIST_DIR}/build_tools/cmake/
 )
 include(CTestMacros)
+include(SharkfuserUtils)
+
+# Find iree-compile
+sharkfuser_find_external_tool(iree-compile "Please install iree-compile (e.g., pip install iree-base-compiler).")
+
+# Create external_tools.h.inc
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/templates/external_tools.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/include/fusili/external_tools.h.inc
+  @ONLY
+)
+
+# Include directories
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_BINARY_DIR}/include)
 
 # Build options
 option(SHARKFUSER_BUILD_TESTS "Builds C++ tests" ON)

--- a/sharkfuser/CMakeLists.txt
+++ b/sharkfuser/CMakeLists.txt
@@ -36,6 +36,7 @@ set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 # Add include directory for header-only library
 add_library(libfusili INTERFACE)
 target_include_directories(libfusili INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_include_directories(libfusili INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/include)
 
 # Includes
 include(CTest)
@@ -56,10 +57,6 @@ configure_file(
   ${CMAKE_CURRENT_BINARY_DIR}/include/fusili/external_tools.h.inc
   @ONLY
 )
-
-# Include directories
-include_directories(${PROJECT_SOURCE_DIR}/include)
-include_directories(${PROJECT_BINARY_DIR}/include)
 
 # Build options
 option(SHARKFUSER_BUILD_TESTS "Builds C++ tests" ON)

--- a/sharkfuser/build_tools/cmake/SharkfuserUtils.cmake
+++ b/sharkfuser/build_tools/cmake/SharkfuserUtils.cmake
@@ -1,0 +1,22 @@
+# Usage: sharkfuser_find_external_tool(TOOL_NAME [EXTRA_ERROR_MESSAGE])
+macro(sharkfuser_find_external_tool TOOL_NAME)
+  # Parse optional extra error message
+  set(_EXTRA_ERROR_MSG "")
+  if(${ARGC} GREATER 1)
+    set(_EXTRA_ERROR_MSG "${ARGV1}")
+  endif()
+
+  # Convert tool name to uppercase with underscores for variable name
+  string(REPLACE "-" "_" _TOOL_VAR_NAME "${TOOL_NAME}")
+  string(TOUPPER "${_TOOL_VAR_NAME}" _TOOL_VAR_NAME)
+  set(_FULL_VAR_NAME "SHARKFUSER_EXTERNAL_${_TOOL_VAR_NAME}")
+
+  # Find the tool if not already set
+  if(NOT ${_FULL_VAR_NAME})
+    find_program(${_FULL_VAR_NAME} NAMES ${TOOL_NAME})
+    if(NOT ${_FULL_VAR_NAME})
+      message(FATAL_ERROR "Could not find '${TOOL_NAME}' in PATH.${_EXTRA_ERROR_MSG}")
+    endif()
+  endif()
+  message(STATUS "Using ${TOOL_NAME}: ${${_FULL_VAR_NAME}}")
+endmacro()

--- a/sharkfuser/build_tools/cmake/SharkfuserUtils.cmake
+++ b/sharkfuser/build_tools/cmake/SharkfuserUtils.cmake
@@ -1,3 +1,9 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 # Usage: sharkfuser_find_external_tool(TOOL_NAME [EXTRA_ERROR_MESSAGE])
 macro(sharkfuser_find_external_tool TOOL_NAME)
   # Parse optional extra error message
@@ -15,7 +21,7 @@ macro(sharkfuser_find_external_tool TOOL_NAME)
   if(NOT ${_FULL_VAR_NAME})
     find_program(${_FULL_VAR_NAME} NAMES ${TOOL_NAME})
     if(NOT ${_FULL_VAR_NAME})
-      message(FATAL_ERROR "Could not find '${TOOL_NAME}' in PATH.${_EXTRA_ERROR_MSG}")
+      message(FATAL_ERROR "Could not find '${TOOL_NAME}' in PATH. ${_EXTRA_ERROR_MSG}")
     endif()
   endif()
   message(STATUS "Using ${TOOL_NAME}: ${${_FULL_VAR_NAME}}")

--- a/sharkfuser/include/fusili.h
+++ b/sharkfuser/include/fusili.h
@@ -8,6 +8,7 @@
 #define FUSILI_H
 
 #include "fusili/context.h"
+#include "fusili/external_tools.h"
 #include "fusili/graph.h"
 #include "fusili/logging.h"
 #include "fusili/types.h"

--- a/sharkfuser/include/fusili/external_tools.h
+++ b/sharkfuser/include/fusili/external_tools.h
@@ -1,0 +1,6 @@
+#ifndef FUSILI_TOOLS_H
+#define FUSILI_TOOLS_H
+
+#include "fusili/external_tools.h.inc"
+
+#endif // FUSILI_TOOLS_H

--- a/sharkfuser/include/fusili/external_tools.h
+++ b/sharkfuser/include/fusili/external_tools.h
@@ -1,6 +1,12 @@
-#ifndef FUSILI_TOOLS_H
-#define FUSILI_TOOLS_H
+// Copyright 2025 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef FUSILI_EXTERNAL_TOOLS_H
+#define FUSILI_EXTERNAL_TOOLS_H
 
 #include "fusili/external_tools.h.inc"
 
-#endif // FUSILI_TOOLS_H
+#endif // FUSILI_EXTERNAL_TOOLS_H

--- a/sharkfuser/templates/external_tools.h.in
+++ b/sharkfuser/templates/external_tools.h.in
@@ -1,0 +1,2 @@
+// Auto-generated from external_tools.h.in - do not edit
+#define IREE_COMPILE_PATH "@SHARKFUSER_EXTERNAL_IREE_COMPILE@"

--- a/sharkfuser/templates/external_tools.h.in
+++ b/sharkfuser/templates/external_tools.h.in
@@ -1,2 +1,9 @@
+// Copyright 2025 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 // Auto-generated from external_tools.h.in - do not edit
+
 #define IREE_COMPILE_PATH "@SHARKFUSER_EXTERNAL_IREE_COMPILE@"

--- a/sharkfuser/tests/CMakeLists.txt
+++ b/sharkfuser/tests/CMakeLists.txt
@@ -9,35 +9,15 @@
 find_package(Catch2 3 REQUIRED)
 
 # Find lit program (pip or system installed)
-if(NOT SHARKFUSER_EXTERNAL_LIT)
-  find_program(SHARKFUSER_EXTERNAL_LIT NAMES lit)
-  if(NOT SHARKFUSER_EXTERNAL_LIT)
-    message(FATAL_ERROR "Could not find 'lit' in PATH. Please install lit (e.g., pip install lit).")
-  endif()
-endif()
-message(STATUS "Using lit: ${SHARKFUSER_EXTERNAL_LIT}")
+sharkfuser_find_external_tool(lit "Please install lit (e.g., pip install lit).")
 
-# Find filecheck program (pip or system installed)
-if(NOT SHARKFUSER_EXTERNAL_FILECHECK)
-  find_program(SHARKFUSER_EXTERNAL_FILECHECK NAMES filecheck)
-  if(NOT SHARKFUSER_EXTERNAL_FILECHECK)
-    message(FATAL_ERROR "Could not find 'filecheck' in PATH. Please install filecheck (e.g., pip install filecheck).")
-  endif()
-endif()
-message(STATUS "Using filecheck: ${SHARKFUSER_EXTERNAL_FILECHECK}")
-# wrap filecheck in a CMake target interface
+# Find filecheck program (pip or system installed) + wrap in a CMake target interface
+sharkfuser_find_external_tool(filecheck "Please install filecheck (e.g., pip install filecheck).")
 add_executable(filecheck IMPORTED GLOBAL)
 set_target_properties(filecheck PROPERTIES IMPORTED_LOCATION "${SHARKFUSER_EXTERNAL_FILECHECK}")
 
-# Find iree-opt program (pip or system installed)
-if(NOT SHARKFUSER_EXTERNAL_IREE_OPT)
-  find_program(SHARKFUSER_EXTERNAL_IREE_OPT NAMES iree-opt)
-  if(NOT SHARKFUSER_EXTERNAL_IREE_OPT)
-    message(FATAL_ERROR "Could not find 'iree-opt' in PATH. Please install iree-opt (e.g., pip install iree-base-compiler).")
-  endif()
-endif()
-message(STATUS "Using iree-opt: ${SHARKFUSER_EXTERNAL_IREE_OPT}")
-# wrap iree-opt in a CMake target interface
+# Find iree-opt program (pip or system installed) + wrap CMake target interface
+sharkfuser_find_external_tool(iree-opt "Please install filecheck (e.g., pip install iree-base-compiler).")
 add_executable(iree-opt IMPORTED GLOBAL)
 set_target_properties(iree-opt PROPERTIES IMPORTED_LOCATION "${SHARKFUSER_EXTERNAL_IREE_OPT}")
 


### PR DESCRIPTION
This is NFC, but (assuming it merges) establishes the pattern we'll use to bring in `iree-compile` for a subprocess call in C++.