### PR TITLE
[sharktank] Improve non-default torch device placement

### DIFF
--- a/sharktank/conftest.py
+++ b/sharktank/conftest.py
@@ -70,6 +70,7 @@ def pytest_addoption(parser):
         "--device",
         type=str,
         action="store",
+        default="cpu",
         help="List a torch device, (e.g., 'cuda:0')",
     )
     parser.addoption(
@@ -348,7 +349,7 @@ def caching(request: FixtureRequest) -> Optional[bool]:
 
 
 @pytest.fixture(scope="class")
-def device(request: FixtureRequest) -> Optional[bool]:
+def device(request: FixtureRequest) -> str:
     return set_fixture_from_cli_option(request, "device")
 
 

--- a/sharktank/sharktank/layers/causal_llm.py
+++ b/sharktank/sharktank/layers/causal_llm.py
@@ -12,6 +12,7 @@ from sharktank.types import (
     ReplicatedTensor,
     Theta,
 )
+from sharktank.utils import torch_device_equal
 from .base import (
     ThetaLayer,
 )
@@ -55,8 +56,8 @@ class BaseCausalLMModel(ThetaLayer):
     def _assert_device(self, *ts: torch.Tensor, dtype: Optional[torch.dtype] = None):
         if self.device is not None:
             for t in ts:
-                assert (
-                    t.device == self.device
+                assert torch_device_equal(
+                    t.device, self.device
                 ), f"Expected tensor to be on device {self.device} but it is on {t.device}"
                 if dtype is not None:
                     assert (

--- a/sharktank/sharktank/types/ocp_floats.py
+++ b/sharktank/sharktank/types/ocp_floats.py
@@ -288,7 +288,9 @@ def float32_to_fp4_e2m1(values: torch.Tensor) -> torch.Tensor:
     if values.numel() == 0:
         return torch.empty_like(values, dtype=torch.uint8)
 
-    lookup_table = get_fp4_lookup_table(FloatingPointFormat.E2M1)
+    lookup_table = get_fp4_lookup_table(FloatingPointFormat.E2M1).to(
+        device=values.device
+    )
 
     # Find closest FP4 value for each input
     values_expanded = values.unsqueeze(-1)  # [..., 1]


### PR DESCRIPTION
Use custom device comparison to circumvent the fact that `cuda` and `cuda:0` are considered different devices.

Make cpu the default test torch device.