### PR TITLE
[sharktank] Fix ShardedRotaryLayer to not produce nested replicated tensors

### DIFF
--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -990,6 +990,10 @@ class ShardedTensor(InferenceTensor):
                 f".shard.{i}" in shard.name
             ), f"Shard {i} of {name} has name {shard.name}, expected {name}.shard.{i}"
 
+        assert all(
+            not isinstance(s, ShardedTensor) for s in self._shards
+        ), "ShardedTensor within a shard of a sharded tensor is not supported."
+
     def __invert__(self):
         return self.clone(ts=[~t for t in self._shards])
 


### PR DESCRIPTION
This fixes the calculation of the batch mask to not produce a replicated tensor within a replicated tensor as a shard.