### PR TITLE
[Shortfin] Fix bugs in workloadbuilder

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/scheduler.py
+++ b/shortfin/python/shortfin_apps/llm/components/scheduler.py
@@ -92,14 +92,14 @@ class WorkloadBuilder:
             job = job[self._ideal_batch_size :]
 
         # Place into existing jobs if here is available space:
-        worksize = len(job)
-        if worksize <= self.available():
+        if len(job) <= self.available():
             for queue in self._queues:
                 available = self._ideal_batch_size - len(queue)
                 if available > 0:
-                    self._occupancy += available
-                    queue.extend(job[available:])
-                    job = job[available:]
+                    needed = min(available, len(job))
+                    self._occupancy += needed
+                    queue.extend(job[:needed])
+                    job = job[needed:]
 
                 if len(job) == 0:
                     break
@@ -107,7 +107,7 @@ class WorkloadBuilder:
 
         # Create a new job for the workload
         self._occupancy += len(job)
-        self._queues.append(job)
+        self._queues.append(job.copy())
 
     def get_scheduled(self):
         return set(itertools.chain(*self._queues))

--- a/shortfin/tests/apps/llm/components/scheduler_test.py
+++ b/shortfin/tests/apps/llm/components/scheduler_test.py
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from shortfin_apps.llm.components.scheduler import Scheduler
+from shortfin_apps.llm.components.scheduler import Scheduler, WorkloadBuilder
 
 
 class FakeBatcher:
@@ -201,3 +201,91 @@ def test_scheduler_reserved_two_separate():
     to_schedule = scheduler.should_execute(pending=workload, strobe=2)
     assert sorted(to_schedule[0]) == workload[0]
     assert sorted(to_schedule[1]) == workload[1]
+
+
+class TestWorkloadBuilder:
+    def setup_method(self):
+        self.workload_builder = WorkloadBuilder(ideal_batch_size=4)
+
+    def test_workload_builder_less_than_ideal(self):
+        job = ["Task1", "Task2"]
+        self.workload_builder.add_work(job)
+        assert self.workload_builder.get_jobs() == [job]
+        assert self.workload_builder.available() == 2
+
+    def test_workload_builder_more_than_ideal(self):
+        job = ["Task1", "Task2", "Task3", "Task4", "Task5"]
+        self.workload_builder.add_work(job)
+
+        assert self.workload_builder.get_jobs() == [
+            job[: self.ideal_batch_size],
+            job[self.ideal_batch_size :],
+        ]
+        assert self.workload_builder.available() == 3
+
+    def test_workload_builder_exactly_ideal(self):
+        job = ["Task1", "Task2", "Task3", "Task4"]
+        self.workload_builder.add_work(job)
+        assert self.workload_builder.get_jobs() == [job]
+        assert self.workload_builder.available() == 0
+
+    def test_workload_builder_two_small_jobs(self):
+        job1 = ["Task1"]
+        job2 = ["Task2"]
+        self.workload_builder.add_work(job1)
+        assert self.workload_builder.available() == 3
+        assert self.workload_builder.get_jobs() == [job1]
+        print(job1)
+        self.workload_builder.add_work(job2)
+        assert self.workload_builder.available() == 2
+        print(job1)
+        assert self.workload_builder.get_jobs() == [job1 + job2]
+
+    def test_workload_builder_multiple_jobs_exact_size(self):
+        job = [f"Task{i+1}" for i in range(12)]
+        self.workload_builder.add_work(job)
+
+        assert self.workload_builder.get_jobs() == [job[0:4], job[4:8], job[8:12]]
+        assert self.workload_builder.available() == 0
+
+    def test_workload_builder_multiple_jobs_smaller_size(self):
+        """
+        Jobs are added unbroken until there is enough room to fully break up an
+        incoming job. This happens with the 4th job (Task10) in the test."""
+        jobs = [
+            ["Task1", "Task2", "Task3"],
+            ["Task4", "Task5", "Task6"],
+            ["Task7", "Task8", "Task9"],
+            ["Task10", "Task11", "Task12"],
+            ["Task13", "Task14", "Task15"],
+            ["Task16", "Task17", "Task18"],
+        ]
+        expected = [
+            ["Task1", "Task2", "Task3", "Task10"],
+            ["Task4", "Task5", "Task6", "Task11"],
+            ["Task7", "Task8", "Task9", "Task12"],
+            ["Task13", "Task14", "Task15"],
+            ["Task16", "Task17", "Task18"],
+        ]
+        for job in jobs:
+            self.workload_builder.add_work(job)
+        assert self.workload_builder.get_jobs() == expected
+        assert self.workload_builder.available() == 2
+
+    def test_workload_builder_multiple_jobs(self):
+        jobs = [
+            ["Task1", "Task2"],
+            ["Task3", "Task4", "Task5", "Task6"],
+            ["Task7"],
+            ["Task8", "Task9", "Task10", "Task11", "Task12"],
+        ]
+        expected = [
+            ["Task1", "Task2", "Task7", "Task12"],
+            ["Task3", "Task4", "Task5", "Task6"],
+            ["Task8", "Task9", "Task10", "Task11"],
+        ]
+        for job in jobs:
+            self.workload_builder.add_work(job)
+
+        assert self.workload_builder.get_jobs() == expected
+        assert self.workload_builder.available() == 0


### PR DESCRIPTION
**Fixes**
- Slicing of job to extend queue
- Copying of input jobs when added them in their entirety to the queue
- Correct occupancy and slicing calculation when splitting incoming job over multiple existing existing jobs

**Additions**
- Tests