### PR TITLE
Ensure error message is properly logged when `kvcache OOM` occurs

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/kvcache/base_attention_cache.py
+++ b/shortfin/python/shortfin_apps/llm/components/kvcache/base_attention_cache.py
@@ -91,11 +91,13 @@ class BasePagedAttentionCacheAllocation(PageAllocation):
                 pages_needed - len(self._pages)
             )
             if new_pages is None:
-                raise CacheAllocationFailure(
-                    f"FATAL: Failed to allocate {pages_needed - len(self._pages)} from `PagePool`.\n"
+                msg = (
+                    f"FATAL: Failed to allocate {pages_needed - len(self._pages)} pages from `PagePool`.\n"
                     f"Required pages: {pages_needed}, Available pages: {len(self._cache.page_pool.available_pages)}, Total pages: {self._cache.page_pool.config.alloc_page_count}\n"
-                    f"Consider raising the `paged_kv_cache.device_block_count value in the model configuration file."
+                    f"Consider re-exporting the model with a higher `--device-block-count` value."
                 )
+                logger.error(msg)
+                raise CacheAllocationFailure(msg)
             if self._cache.use_ref_counts:
                 self._cache.increment_pages(new_pages)
 
@@ -172,11 +174,13 @@ class BasePagedAttentionCache:
         pages = self.page_pool.acquire_free_pages(pages_needed)
 
         if pages is None:
-            raise CacheAllocationFailure(
-                f"FATAL: Failed to allocate {pages_needed} from `PagePool`.\n"
+            msg = (
+                f"FATAL: Failed to allocate {pages_needed} pages from `PagePool`.\n"
                 f"Required pages: {pages_needed}, Available pages: {len(self.page_pool.available_pages)}, Total pages: {self.page_pool.config.alloc_page_count}\n"
-                f"Consider raising the `paged_kv_cache.device_block_count` value in the model configuration file."
+                f"Consider re-exporting the model with a higher `--device-block-count` value."
             )
+            logger.error(msg)
+            raise CacheAllocationFailure(msg)
 
         if self.use_ref_counts:
             self.increment_pages(pages)

--- a/shortfin/python/shortfin_apps/llm/components/kvcache/base_attention_cache.py
+++ b/shortfin/python/shortfin_apps/llm/components/kvcache/base_attention_cache.py
@@ -92,7 +92,7 @@ class BasePagedAttentionCacheAllocation(PageAllocation):
             )
             if new_pages is None:
                 msg = (
-                    f"FATAL: Failed to allocate {pages_needed - len(self._pages)} pages from `PagePool`.\n"
+                    f"FATAL CacheAllocationFailure: Failed to allocate {pages_needed - len(self._pages)} pages from `PagePool`.\n"
                     f"Required pages: {pages_needed}, Available pages: {len(self._cache.page_pool.available_pages)}, Total pages: {self._cache.page_pool.config.alloc_page_count}\n"
                     f"Consider re-exporting the model with a higher `--device-block-count` value."
                 )
@@ -175,7 +175,7 @@ class BasePagedAttentionCache:
 
         if pages is None:
             msg = (
-                f"FATAL: Failed to allocate {pages_needed} pages from `PagePool`.\n"
+                f"FATAL CacheAllocationFailure: Failed to allocate {pages_needed} pages from `PagePool`.\n"
                 f"Required pages: {pages_needed}, Available pages: {len(self.page_pool.available_pages)}, Total pages: {self.page_pool.config.alloc_page_count}\n"
                 f"Consider re-exporting the model with a higher `--device-block-count` value."
             )


### PR DESCRIPTION
Ensure KVCache OOM (page exhaustion) failure is properly logged when it occurs server-side.

Will do a follow up to close the client connection, instead of just leaving it hanging.

For now, this will at least make the error obvious server-side.

Output example:

```bash
[2025-07-28 15:21:47.187] [error] [base_attention_cache.py:182] FATAL CacheAllocationFailure: Failed to allocate 6 pages from `PagePool`.
Required pages: 6, Available pages: 2, Total pages: 2
Consider re-exporting the model with a higher `--device-block-count` value.
```