### PR TITLE
Fix for the repeatable response due to truncation of prompt

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/tokenizer.py
+++ b/shortfin/python/shortfin_apps/llm/components/tokenizer.py
@@ -26,6 +26,7 @@ class Tokenizer:
         )
         self._raw = raw_tk
         self._raw.enable_padding(pad_id=pad_id)
+        self._raw.no_truncation()
 
     @staticmethod
     def from_pretrained(name: str) -> "Tokenizer":


### PR DESCRIPTION
Fix of the shortfin repeatable issue in case of longer prompts:
- It was due to truncation of the prompt at tokenizer side. 
- Added no_truncation call for now, if require, we can add higher number truncation or directly pass user given seq_length as truncation number - Need to discuss before finalizing the code.