### PR TITLE
Update Wave dependency to `wave-lang` from `iree-turbine`

### DIFF
--- a/requirements-iree-pinned.txt
+++ b/requirements-iree-pinned.txt
@@ -1,4 +1,5 @@
 # Pinned versions of IREE dependencies.
+wave-lang==1.0.2
 
 # Keep these versions synced with SHORTFIN_IREE_GIT_TAG in shortfin/CMakeLists.txt
 --find-links https://iree.dev/pip-release-links.html

--- a/requirements-iree-unpinned.txt
+++ b/requirements-iree-unpinned.txt
@@ -1,4 +1,5 @@
 # Unpinned versions of IREE dependencies.
+wave-lang
 
 --pre
 --find-links https://iree.dev/pip-release-links.html

--- a/sharktank/sharktank/kernels/wave/attention.py
+++ b/sharktank/sharktank/kernels/wave/attention.py
@@ -7,17 +7,17 @@
 from sharktank.kernels.base import *
 from sharktank.kernels.mlir_kernel import *
 from sharktank.kernels.wave.utils import get_wave_module_body_asm
-from iree.turbine.kernel.wave.templates.vanilla_attention import (
+from wave_lang.kernel.wave.templates.vanilla_attention import (
     get_bhsd_attention_kernel,
 )
-from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
-from iree.turbine.kernel.wave.compile import wave_compile, WaveCompileOptions
-from iree.turbine.kernel.wave.templates.attention_common import AttentionShape
-from iree.turbine.kernel.wave.constraints import MMAType
-from iree.turbine.kernel.wave.utils.general_utils import (
+from wave_lang.kernel.wave.scheduling.schedule import SchedulingType
+from wave_lang.kernel.wave.compile import wave_compile, WaveCompileOptions
+from wave_lang.kernel.wave.templates.attention_common import AttentionShape
+from wave_lang.kernel.wave.constraints import MMAType
+from wave_lang.kernel.wave.utils.general_utils import (
     get_default_scheduling_params,
 )
-from iree.turbine.kernel.wave.utils.run_utils import (
+from wave_lang.kernel.wave.utils.run_utils import (
     set_default_run_config,
 )
 from iree.compiler.ir import (
@@ -56,6 +56,7 @@ def get_wave_flash_attention_asm(
         denorm_fp_math_f32="preserve-sign",
         func_name=target_function_name,
         compile_to_mlir=True,
+        iree_launch_async=False,
     )
     options = set_default_run_config(options)
     with Context() as ctx:

--- a/sharktank/sharktank/kernels/wave/mxfp4_gemm.py
+++ b/sharktank/sharktank/kernels/wave/mxfp4_gemm.py
@@ -7,17 +7,17 @@
 from sharktank.kernels.base import *
 from sharktank.kernels.mlir_kernel import *
 from sharktank.kernels.wave.utils import get_wave_module_body_asm
-import iree.turbine.kernel.lang as tkl
-import iree.turbine.kernel.wave as tkw
-from iree.turbine.kernel.lang.global_symbols import *
-from iree.turbine.kernel.wave.scheduling.schedule import SchedulingType
-from iree.turbine.kernel.wave.compile import wave_compile, WaveCompileOptions
-from iree.turbine.kernel.wave.templates.attention_common import AttentionShape
-from iree.turbine.kernel.wave.constraints import ScaledMMAType
-from iree.turbine.kernel.wave.utils.general_utils import (
+import wave_lang.kernel.lang as tkl
+import wave_lang.kernel.wave as tkw
+from wave_lang.kernel.lang.global_symbols import *
+from wave_lang.kernel.wave.scheduling.schedule import SchedulingType
+from wave_lang.kernel.wave.compile import wave_compile, WaveCompileOptions
+from wave_lang.kernel.wave.templates.attention_common import AttentionShape
+from wave_lang.kernel.wave.constraints import ScaledMMAType
+from wave_lang.kernel.wave.utils.general_utils import (
     get_default_scheduling_params,
 )
-from iree.turbine.kernel.wave.utils.run_utils import (
+from wave_lang.kernel.wave.utils.run_utils import (
     set_default_run_config,
 )
 from iree.compiler.ir import (
@@ -125,6 +125,7 @@ def get_wave_mxfp4_bmm_asm(
         dynamic_symbols=dynamic_symbols,
         func_name=target_function_name,
         compile_to_mlir=True,
+        iree_launch_async=False,
     )
     options = set_default_run_config(options)
 


### PR DESCRIPTION
Wave was migrated from the `iree-turbine` package to `wave-lang`.

See https://github.com/iree-org/wave