### PR TITLE
Update GitHub Actions workflows to use MI325 runners instead of MI300

### DIFF
--- a/.github/workflows/ci-llama-large-tests.yaml
+++ b/.github/workflows/ci-llama-large-tests.yaml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci-llama-quick-tests.yaml
+++ b/.github/workflows/ci-llama-quick-tests.yaml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci-sdxl.yaml
+++ b/.github/workflows/ci-sdxl.yaml
@@ -37,7 +37,7 @@ env:
 jobs:
   install-and-test:
     name: Install and test
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux25-1gpu-ossci-nod-ai
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ci-sglang-benchmark.yml
+++ b/.github/workflows/ci-sglang-benchmark.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         include:
           - name: amdgpu_rocm_mi300_gfx942
-            runs-on: linux-mi300-1gpu-ossci-nod-ai
+            runs-on: linux-mi325-1gpu-ossci-nod-ai
             test_device: gfx942
             python-version: 3.11
       fail-fast: false
@@ -111,7 +111,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
     defaults:
       run:
         shell: bash
@@ -197,7 +197,7 @@ jobs:
     needs: benchmark_sglang
     name: "Docker Cleanup"
     if: always()
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
     steps:
       - name: Stop sglang-server
         run: docker stop sglang-server || true # Stop container if it's running

--- a/.github/workflows/ci-sglang-integration-tests.yml
+++ b/.github/workflows/ci-sglang-integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci-sharktank-nightly.yml
+++ b/.github/workflows/ci-sharktank-nightly.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.11]
-        runs-on: [linux-mi300-1gpu-ossci-nod-ai]
+        runs-on: [linux-mi325-1gpu-ossci-nod-ai]
       fail-fast: false
     runs-on: ${{matrix.runs-on}}
     defaults:
@@ -92,7 +92,7 @@ jobs:
     strategy:
       matrix:
         version: [3.11]
-        runs-on: [linux-mi300-1gpu-ossci-nod-ai]
+        runs-on: [linux-mi325-1gpu-ossci-nod-ai]
       fail-fast: false
     runs-on: ${{matrix.runs-on}}
     defaults:

--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -143,7 +143,7 @@ jobs:
         python-version: ["3.12"]
         torch-version: ["2.5.1"]
         iree-target-args: ["--iree-hip-target=gfx942 --iree-hal-target-device=hip"]
-        runs-on: [linux-mi300-8gpu-ossci-nod-ai]
+        runs-on: [linux-mi325-8gpu-ossci-nod-ai]
       fail-fast: false
     runs-on: ${{matrix.runs-on}}
     defaults:
@@ -200,7 +200,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.11]
-        runs-on: [linux-mi300-1gpu-ossci-nod-ai]
+        runs-on: [linux-mi325-1gpu-ossci-nod-ai]
       fail-fast: false
     runs-on: ${{matrix.runs-on}}
     defaults:

--- a/.github/workflows/ci-shortfin-nightly.yml
+++ b/.github/workflows/ci-shortfin-nightly.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   install-and-test:
     name: Install and test
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ci_eval_short.yaml
+++ b/.github/workflows/ci_eval_short.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         version: [3.11]
-        runs-on: [linux-mi300-1gpu-ossci-nod-ai]
+        runs-on: [linux-mi325-1gpu-ossci-nod-ai]
       fail-fast: false
     runs-on: ${{matrix.runs-on}}
     defaults:

--- a/.github/workflows/ci_llama_3.1_405b_fp16_tp8.yml
+++ b/.github/workflows/ci_llama_3.1_405b_fp16_tp8.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: linux-mi300-8gpu-ossci-nod-ai
+    runs-on: linux-mi325-8gpu-ossci-nod-ai
     defaults:
       run:
         shell: bash
@@ -173,7 +173,7 @@ jobs:
   push_logs:
     name: "Push log llama 405B FP16 TP8"
     needs: [ test_llama_large ]
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
     steps:
     - name: Download log artifacts
       uses: actions/download-artifact@v4

--- a/.github/workflows/ci_llama_3.1_405b_fp8_tp8.yml
+++ b/.github/workflows/ci_llama_3.1_405b_fp8_tp8.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: linux-mi300-8gpu-ossci-nod-ai
+    runs-on: linux-mi325-8gpu-ossci-nod-ai
     defaults:
       run:
         shell: bash
@@ -173,7 +173,7 @@ jobs:
   push_logs:
     name: "Push log llama 405B FP8 TP8"
     needs: [ test_llama_large ]
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
     steps:
     - name: Download log artifacts
       uses: actions/download-artifact@v4

--- a/.github/workflows/ci_llama_3.1_70b_fp16.yml
+++ b/.github/workflows/ci_llama_3.1_70b_fp16.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
     defaults:
       run:
         shell: bash
@@ -174,7 +174,7 @@ jobs:
   push_logs:
     name: "Push log llama 70B FP16"
     needs: [ test_llama_large ]
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
     steps:
     - name: Download log artifacts
       uses: actions/download-artifact@v4

--- a/.github/workflows/ci_llama_3.1_70b_fp16_tp8.yml
+++ b/.github/workflows/ci_llama_3.1_70b_fp16_tp8.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: linux-mi300-8gpu-ossci-nod-ai
+    runs-on: linux-mi325-8gpu-ossci-nod-ai
     defaults:
       run:
         shell: bash
@@ -173,7 +173,7 @@ jobs:
   push_logs:
     name: "Push log llama 70B FP16 TP8"
     needs: [ test_llama_large ]
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
     steps:
     - name: Download log artifacts
       uses: actions/download-artifact@v4

--- a/.github/workflows/ci_llama_3.1_70b_fp8.yml
+++ b/.github/workflows/ci_llama_3.1_70b_fp8.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
     defaults:
       run:
         shell: bash
@@ -175,7 +175,7 @@ jobs:
   push_logs:
     name: "Push log llama 70B FP8"
     needs: [ test_llama_large ]
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
     steps:
     - name: Download log artifacts
       uses: actions/download-artifact@v4

--- a/.github/workflows/ci_llama_3.1_8b_fp16.yml
+++ b/.github/workflows/ci_llama_3.1_8b_fp16.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
     defaults:
       run:
         shell: bash
@@ -175,7 +175,7 @@ jobs:
   push_logs:
     name: "Push log llama 8B FP16"
     needs: [ test_llama_large ]
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
     steps:
     - name: Download log artifacts
       uses: actions/download-artifact@v4

--- a/.github/workflows/ci_llama_3.1_8b_fp8.yml
+++ b/.github/workflows/ci_llama_3.1_8b_fp8.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         version: [ 3.11 ]
       fail-fast: false
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
     defaults:
       run:
         shell: bash
@@ -175,7 +175,7 @@ jobs:
   push_logs:
     name: "Push log llama 8B FP8"
     needs: [ test_llama_large ]
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux25-1gpu-ossci-nod-ai
     steps:
     - name: Download log artifacts
       uses: actions/download-artifact@v4

--- a/.github/workflows/ci_mistral_nemo_instruct_2407.yml
+++ b/.github/workflows/ci_mistral_nemo_instruct_2407.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
     defaults:
       run:
         shell: bash
@@ -175,7 +175,7 @@ jobs:
   push_logs:
     name: "Push log Mistral nemo Instruct 2407"
     needs: [ test_llama_large ]
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
     steps:
     - name: Download log artifacts
       uses: actions/download-artifact@v4

--- a/.github/workflows/ci_sdxl_flux_serving.yml
+++ b/.github/workflows/ci_sdxl_flux_serving.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         version: [3.11]
       fail-fast: false
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
     defaults:
       run:
         shell: bash
@@ -108,7 +108,7 @@ jobs:
   push_images:
     name: "Push sdxl/flux generated images"
     needs: [test_sdxl_flux_serving]
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
     steps:
       - name: Download log artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/pkgci_shark_ai.yml
+++ b/.github/workflows/pkgci_shark_ai.yml
@@ -32,7 +32,7 @@ jobs:
             test_device: cpu
             python-version: 3.11
           - name: amdgpu_rocm_mi300_gfx942
-            runs-on: linux-mi300-2gpu-ossci-nod-ai
+            runs-on: linux-mi325-2gpu-ossci-nod-ai
             test_device: gfx942
             python-version: 3.11
     defaults:
@@ -79,7 +79,7 @@ jobs:
             test_device: cpu
             python-version: 3.11
           - name: amdgpu_rocm_mi300_gfx942
-            runs-on: linux-mi300-1gpu-ossci-nod-ai
+            runs-on: linux25-1gpu-ossci-nod-ai
             test_device: gfx942
             python-version: 3.11
     defaults:
@@ -126,7 +126,7 @@ jobs:
             test_device: cpu
             python-version: 3.11
           - name: amdgpu_rocm_mi300_gfx942
-            runs-on: linux-mi300-1gpu-ossci-nod-ai
+            runs-on: linux-mi325-1gpu-ossci-nod-ai
             test_device: gfx942
             python-version: 3.11
     defaults:


### PR DESCRIPTION
Replaced all runs-on values referencing MI300 GPU runners with MI325 equivalents across multiple CI workflows, including LLaMA, SDXL, SHARKTank, SGlang, Mistral, and pkgci. This ensures tests and builds are aligned with the new MI325 hardware in the ossci-nod-ai cluster.

