### PR TITLE
[sharktank] make quantize a proper op with multiple dispatch

### DIFF
--- a/sharktank/sharktank/layers/conv.py
+++ b/sharktank/sharktank/layers/conv.py
@@ -58,9 +58,9 @@ class Conv2DLayer(ThetaLayer):
             x = ops.elementwise(torch.mul, x, self.premul_input)
 
         if q_input is not None:
-            x = q_input.quantize(x)
+            x = ops.quantize(x, q_input)
         elif qdq_input is not None:
-            x = qdq_input.quantize(x).unpack().dequant()
+            x = ops.quantize(x, qdq_input).unpack().dequant()
 
         # Primary computation.
         y = ops.conv2d(
@@ -120,9 +120,9 @@ class Conv3DLayer(ThetaLayer):
             x = ops.elementwise(torch.mul, x, self.premul_input)
 
         if q_input is not None:
-            x = q_input.quantize(x)
+            x = ops.quantize(x, q_input)
         elif qdq_input is not None:
-            x = qdq_input.quantize(x).unpack().dequant()
+            x = ops.quantize(x, qdq_input).unpack().dequant()
 
         # Primary computation.
         y = ops.conv3d(
@@ -182,9 +182,9 @@ class Conv1DLayer(ThetaLayer):
             x = ops.elementwise(torch.mul, x, self.premul_input)
 
         if q_input is not None:
-            x = q_input.quantize(x)
+            x = ops.quantize(x, q_input)
         elif qdq_input is not None:
-            x = qdq_input.quantize(x).unpack().dequant()
+            x = ops.quantize(x, qdq_input).unpack().dequant()
 
         # Primary computation.
         y = ops.conv1d(

--- a/sharktank/sharktank/layers/linear.py
+++ b/sharktank/sharktank/layers/linear.py
@@ -67,12 +67,12 @@ class LinearLayer(ThetaLayer):
             x = ops.elementwise(torch.mul, x, self.premul_input)
 
         if q_input is not None:
-            x = q_input.quantize(x)
+            x = ops.quantize(x, q_input)
             if self.fake_quant:
                 x = x.unpack().dequant()
 
         elif qdq_input is not None:
-            x = qdq_input.quantize(x).unpack().dequant()
+            x = ops.quantize(x, qdq_input).unpack().dequant()
 
         y = ops.linear(x, weight, bias)
 
@@ -80,5 +80,5 @@ class LinearLayer(ThetaLayer):
             y = y.unpack().dequant()
 
         if qdq_output is not None:
-            y = qdq_output.quantize(y).unpack().dequant()
+            y = ops.quantize(y, qdq_output).unpack().dequant()
         return y

--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -1050,10 +1050,12 @@ class PagedAttention:
             if probs_quantizer is not None:
                 if fake_quant:
                     attn_weights = (
-                        probs_quantizer.quantize(attn_weights).unpack().dequant()
+                        ops.quantize(attn_weights, probs_quantizer).unpack().dequant()
                     )
                 else:
-                    attn_weights = probs_quantizer.quantize(attn_weights).unpack().qs
+                    attn_weights = (
+                        ops.quantize(attn_weights, probs_quantizer).unpack().qs
+                    )
             attn_weights = ops.to(attn_weights, dtype=q.dtype)
             return ops.matmul(attn_weights, v)  # (bs, heads, slen, head_dim)
 

--- a/sharktank/sharktank/layers/paged_llama_attention_block.py
+++ b/sharktank/sharktank/layers/paged_llama_attention_block.py
@@ -168,11 +168,11 @@ class PagedLlamaAttentionBlock(ThetaLayer):
                 xk = embedding.apply_batched_mask(xt=xk, mask=embedding_batch_mask)
 
         if self.attn_q.q_output is not None:
-            xq = self.attn_q.q_output.quantize(xq)
+            xq = ops.quantize(xq, self.attn_q.q_output)
         if self.attn_k.q_output is not None:
-            xk = self.attn_k.q_output.quantize(xk)
+            xk = ops.quantize(xk, self.attn_k.q_output)
         if self.attn_v.q_output is not None:
-            xv = self.attn_v.q_output.quantize(xv)
+            xv = ops.quantize(xv, self.attn_v.q_output)
         return xq, xk, xv
 
     def pre_process_attention(
@@ -259,8 +259,8 @@ class PagedLlamaAttentionBlock(ThetaLayer):
             if not self.fake_quant:
                 # TODO: this seems like a bastardization of our quantized tensor api
                 # Probably want to add support for using quantized tensors more directly
-                xk = self.cache_quantizer.quantize(xk).unpack().qs
-                xv = self.cache_quantizer.quantize(xv).unpack().qs
+                xk = ops.quantize(xk, self.cache_quantizer).unpack().qs
+                xv = ops.quantize(xv, self.cache_quantizer).unpack().qs
 
         # Pad final dim of v to match with kv cache
         if self.attn_type == "mla" and self.head_dim != self.v_head_dim:

--- a/sharktank/sharktank/models/punet/layers.py
+++ b/sharktank/sharktank/models/punet/layers.py
@@ -422,9 +422,9 @@ class AttentionLayer(ThetaLayer):
         out_k = self.theta.optional_tensor("out_k")
         out_v = self.theta.optional_tensor("out_v")
 
-        query = query if out_q is None else out_q.quantize(query)
-        key = key if out_k is None else out_k.quantize(key)
-        value = value if out_v is None else out_v.quantize(value)
+        query = query if out_q is None else ops.quantize(query, out_q)
+        key = key if out_k is None else ops.quantize(key, out_k)
+        value = value if out_v is None else ops.quantize(value, out_v)
 
         inner_dim = key.shape[-1]
 
@@ -515,7 +515,7 @@ class AttentionLayer(ThetaLayer):
         if premul_input is not None:
             x = ops.elementwise(torch.mul, x, premul_input)
         if q_input is not None:
-            x = q_input.quantize(x)
+            x = ops.quantize(x, q_input)
         return x
 
     def _apply_linear(self, weight_theta: Theta, x):

--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -1052,6 +1052,17 @@ def permute_split(tensor: SplitPrimitiveTensor, dims: List[int]):
     return SplitPrimitiveTensor(ts=permuted_shards, shard_dim=permuted_shard_dim)
 
 
+@quantize.override(SplitPrimitiveTensor, ShardedTensor)
+def quantize_split(
+    tensor: SplitPrimitiveTensor, quantizer: ShardedTensor, name: str
+) -> SplitPrimitiveTensor:
+    shards = [
+        quantize(tensor_shard, quantizer_shard)
+        for tensor_shard, quantizer_shard in zip(tensor.shards, quantizer.shards)
+    ]
+    return tensor.clone(ts=shards, name=name)
+
+
 @reduce_scatter.override(UnreducedTensor)
 def reduce_scatter(tensor: UnreducedTensor, scatter_dim: int) -> SplitPrimitiveTensor:
     # The performance here is contingent on the ability to have multiple transfers in

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -15,6 +15,7 @@ from torch import Tensor, dtype
 
 from sharktank.types import (
     AnyTensor,
+    QuantizerTensor,
     Slice,
     ShardedTensor,
     SplitPrimitiveTensor,
@@ -22,6 +23,7 @@ from sharktank.types import (
     sharding,
     InferenceTensor,
     PrimitiveTensor,
+    UnnamedTensorName,
 )
 
 
@@ -60,6 +62,7 @@ __all__ = [
     "module_register_buffer",
     "pad",
     "permute",
+    "quantize",
     "rms_norm",
     "reduce_scatter",
     "repeat",
@@ -1006,6 +1009,30 @@ def _module_register_buffer_trampoline(
             return override, result
     else:
         d.fail(args)
+
+
+@overridable
+def quantize(
+    tensor: AnyTensor, quantizer: AnyTensor, name: str = UnnamedTensorName
+) -> AnyTensor:
+    """Quantize a tensor using the provided quantizer."""
+    ...
+
+
+@quantize.trampoline
+def _quantize_trampoline(
+    d: SignatureDispatcher,
+    tensor: AnyTensor,
+    quantizer: AnyTensor,
+    name: str = UnnamedTensorName,
+) -> AnyTensor:
+    tensors = (tensor, quantizer)
+    for override in d.find_overrides(tensors):
+        result = override(tensor, quantizer, name)
+        if result is not NotImplemented:
+            return override, result
+    else:
+        d.fail(tensors)
 
 
 @overridable(is_trivially_replicable=False)

--- a/sharktank/sharktank/types/pipelining.py
+++ b/sharktank/sharktank/types/pipelining.py
@@ -12,7 +12,6 @@ from iree.turbine.aot import DeviceTensorTrait, ExternalTensorTrait
 from sharktank.types import (
     AnyTensor,
     ReplicatedTensor,
-    ReplicatedQuantizerTensor,
     QuantizerTensor,
     ShardedTensor,
     Theta,
@@ -45,10 +44,6 @@ def pipeline_parallelize_theta(
 
             if isinstance(tensor, ShardedTensor):
                 new_tensor = tensor.clone(ts=shards, devices=new_devices)
-            elif isinstance(tensor, QuantizerTensor):
-                new_tensor = ReplicatedQuantizerTensor(
-                    ts=shards, name=tensor.name, devices=new_devices
-                )
             else:
                 new_tensor = ReplicatedTensor(
                     ts=shards, name=tensor.name, devices=new_devices

--- a/sharktank/sharktank/types/quantizers.py
+++ b/sharktank/sharktank/types/quantizers.py
@@ -60,7 +60,6 @@ __all__ = [
     "DynamicFp4BlockQuantizer",
     "DynamicScaledQuantizer",
     "QuantizerTensor",
-    "ReplicatedQuantizerTensor",
     "StaticFp4BlockQuantizer",
     "StaticScaledQuantizer",
 ]
@@ -72,55 +71,9 @@ class QuantizerTensor(InferenceTensor):
     def quantize(
         self, t: AnyTensor, *, name: str = UnnamedTensorName
     ) -> QuantizedTensor | ReplicatedTensor:
-        """Quantize from an arbitrary source tensor (framework or inference).
+        from sharktank import ops
 
-        This has some additional heuristics for unpacking and rescaling
-        of InferenceTensors.
-        """
-        if isinstance(t, InferenceTensor):
-            if isinstance(t, PrimitiveTensor):
-                raw_tensor = t.as_torch()
-            elif isinstance(t, QuantizedTensor):
-                import warnings
-
-                warnings.warn(f"Requantizing already quantized tensor {t} to {self}")
-                raw_tensor = t.unpack().dequant()
-            else:
-                raise TypeError(
-                    f"Unsupported tensor type in QuantizerTensor.quantize: {type(t)}"
-                )
-        else:
-            assert isinstance(t, torch.Tensor)
-            raw_tensor = t
-        res = self._quantize_raw_tensor(raw_tensor, name=name)
-        assert iterables_equal(
-            res.shape, t.shape
-        ), f"Quantization error, input and output shapes differ {t.shape} != {res.shape}"
-        return res
-
-    @abstractmethod
-    def _quantize_raw_tensor(self, t: torch.Tensor, *, name: str) -> QuantizedTensor:
-        """Performs a quantizing transformation on t, returning a QuantizeTensor."""
-        ...
-
-
-class ReplicatedQuantizerTensor(ReplicatedTensor, QuantizerTensor):
-    def quantize(
-        self, t: ReplicatedTensor, *, name=UnnamedTensorName
-    ) -> ReplicatedTensor:
-        assert isinstance(t, ReplicatedTensor)
-
-        quantized_shards = [
-            quantizer.quantize(shard, name=f"{name}.rank{i}")
-            for i, (quantizer, shard) in enumerate(zip(self.shards, t.shards))
-        ]
-        return ReplicatedTensor(ts=quantized_shards, devices=t.devices, name=name)
-
-    def _quantize_raw_tensor(
-        self, t: AnyTensor, *, name: str = UnnamedTensorName
-    ) -> QuantizedTensor:
-        """Performs a quantizing transformation on t, returning a QuantizeTensor."""
-        raise NotImplementedError("Should be using the version in the shards.")
+        return ops.quantize(t, self, name)
 
 
 @register_inference_tensor
@@ -189,75 +142,6 @@ class StaticScaledQuantizer(QuantizerTensor):
             .unpack()
             .dequant()
         )
-
-    def _quantize_raw_tensor(self, t: torch.Tensor, *, name: str) -> QuantizedTensor:
-        """Performs a quantizing transformation on t, returning a QuantizeTensor."""
-        shape = list(t.shape)
-        axis = self._axis
-        offset = self._offset
-        if axis is None:
-            # Per tensor.
-            if offset is None:
-                # Changed to t/reciprocal because narrow float types are garbage
-                qs = saturate_cast(
-                    t / self._reciprocal_scale,
-                    dtype=self.dtype,
-                    disable_saturate=self._disable_saturate,
-                )
-            else:
-                qs = saturate_cast(
-                    t / self._reciprocal_scale + offset,
-                    dtype=self.dtype,
-                    disable_saturate=self._disable_saturate,
-                )
-            return PlanarQuantizedTensor(
-                shape=shape,
-                name=name,
-                layout=TensorScaledLayout(
-                    shape=shape,
-                    d=self._reciprocal_scale,
-                    qs=qs,
-                    m=self._offset,
-                    dtype=t.dtype,  # Original dtype.
-                ),
-            )
-        else:
-            # Expand the scale/reciprocal to correspond to the broadcast axis.
-            scale = self._scale
-            reciprocal_scale = self._reciprocal_scale
-            offset = self._offset
-            assert axis >= 0 and axis < len(
-                shape
-            ), f"Per-axis scale {axis} out of bounds of shape {shape}"
-            scale_shape = [1] * len(shape)
-            scale_shape[axis] = scale.shape[0]
-            broadcast_scale = scale.reshape(scale_shape)
-            broadcast_reciprocal_scale = reciprocal_scale.reshape(scale_shape)
-            if offset is None:
-                broadcast_offset = None
-                qs = saturate_cast(
-                    t * broadcast_scale,
-                    dtype=self.dtype,
-                    disable_saturate=self._disable_saturate,
-                )
-            else:
-                broadcast_offset = offset.reshape(scale_shape)
-                qs = saturate_cast(
-                    t * broadcast_scale + broadcast_offset,
-                    dtype=self.dtype,
-                    disable_saturate=self._disable_saturate,
-                )
-            return PlanarQuantizedTensor(
-                shape=shape,
-                name=name,
-                layout=TensorScaledLayout(
-                    shape=shape,
-                    d=broadcast_reciprocal_scale,
-                    qs=qs,
-                    m=broadcast_offset,
-                    dtype=t.dtype,  # Original dtype.
-                ),
-            )
 
     @property
     def axis(self) -> Optional[int]:
@@ -404,29 +288,6 @@ class DynamicScaledQuantizer(QuantizerTensor):
         assert (
             dtype.is_floating_point or dtype.is_signed
         ), f"DynamicScaledQuantizer dtype must be fp or signed but got {dtype}"
-
-    def _quantize_raw_tensor(self, t: torch.Tensor, *, name: str) -> QuantizedTensor:
-        dtype = self._dtype
-        amax = torch.max(torch.abs(t))
-        if dtype.is_floating_point:
-            finfo = torch.finfo(dtype)
-            scale = finfo.max / amax.clamp(finfo.eps)
-            reciprocal_scale = 1 / scale
-            qs = saturate_cast(t * scale, self.dtype, round_int=True)
-        else:
-            eps = 1e-6
-            iinfo = torch.iinfo(dtype)
-            scale = iinfo.max / amax.clamp(eps)
-            reciprocal_scale = 1.0 / scale
-            qs = saturate_cast(t * scale, self.dtype, round_int=True)
-        shape = list(t.shape)
-        return PlanarQuantizedTensor(
-            shape=shape,
-            name=name,
-            layout=TensorScaledLayout(
-                shape=shape, d=reciprocal_scale, qs=qs, dtype=t.dtype  # Original dtype.
-            ),
-        )
 
     @property
     def dtype(self) -> torch.dtype:
@@ -598,17 +459,6 @@ class StaticFp4BlockQuantizer(QuantizerTensor):
         self._use_fe8m0_scale = use_fe8m0_scale
         self._dtype = dtype
 
-    def _quantize_raw_tensor(self, t: torch.Tensor, *, name: str) -> QuantizedTensor:
-        """Performs FP4 block quantization on tensor t using pre-computed scales."""
-
-        return _fp4_block_quantize_tensor(
-            t=t,
-            scales=self.scales,
-            block_size=self._block_size,
-            use_fe8m0_scale=self._use_fe8m0_scale,
-            name=name,
-        )
-
     @property
     def scales(self) -> torch.Tensor:
         return self._scales
@@ -733,50 +583,6 @@ class DynamicFp4BlockQuantizer(QuantizerTensor):
         self._use_fe8m0_scale = use_fe8m0_scale
         self._dtype = dtype
         self._use_sharktank_kernel = use_sharktank_kernel
-
-    def _quantize_raw_tensor(self, t: torch.Tensor, *, name: str) -> QuantizedTensor:
-        """Performs FP4 block quantization on tensor t."""
-        t_padded = pad_tensor_for_block_quantization(t, self._block_size)
-
-        # Compute scales per block
-        orig_shape = list(t_padded.shape)
-        num_blocks = orig_shape[-1] // self._block_size
-        blocked_shape = orig_shape[:-1] + [num_blocks, self._block_size]
-        packed_shape = orig_shape[:-1] + [num_blocks, self._block_size // 2]
-        values_blocked = t_padded.reshape(blocked_shape)
-
-        if self._use_sharktank_kernel:
-            flattened = values_blocked.view(-1, 32).to(torch.float32)
-            scales, packed_fp4_flat = dynamic_quantize_to_fp4(flattened)
-            packed_fp4 = packed_fp4_flat.view(packed_shape)
-            # Reshape scales to match the expected blocked dimensions
-            scales_shape = orig_shape[:-1] + [num_blocks]
-            scales = scales.view(scales_shape)
-
-            layout = BlockScaledFp4Layout(
-                shape=list(t.shape),
-                d=scales,
-                qs=packed_fp4,
-                block_size=self._block_size,
-                use_fe8m0_scale=self._use_fe8m0_scale,
-            )
-            return PlanarQuantizedTensor(
-                shape=list(t.shape),
-                name=name,
-                layout=layout,
-            )
-        block_max = torch.max(torch.abs(values_blocked), dim=-1, keepdim=False)[0]
-        scales, _ = compute_fp4_block_scales(
-            block_max, self._use_fe8m0_scale, self._dtype
-        )
-
-        return _fp4_block_quantize_tensor(
-            t=t_padded,
-            scales=scales,
-            block_size=self._block_size,
-            use_fe8m0_scale=self._use_fe8m0_scale,
-            name=name,
-        )
 
     @property
     def block_size(self) -> int:

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -61,6 +61,7 @@ __all__ = [
     "SplitPrimitiveTensor",
     "torch_tree_flatten",
     "unbox_tensor",
+    "UnnamedTensorName",
     "UnreducedTensor",
 ]
 

--- a/sharktank/tests/types/quantizers_test.py
+++ b/sharktank/tests/types/quantizers_test.py
@@ -8,6 +8,7 @@ import unittest
 
 import torch
 
+from sharktank import ops
 from sharktank.types import *
 from sharktank.types.ocp_floats import fp4_e2m1_to_float32
 from sharktank.types.quantizers import DynamicFp4BlockQuantizer, StaticFp4BlockQuantizer
@@ -612,12 +613,12 @@ class StaticFp4BlockQuantizerTest(Fp4BlockQuantizerTestBase):
         # Should match original values exactly for representable FP4 values
         torch.testing.assert_close(orig_value, dequant_value, atol=0.0, rtol=0.0)
 
-        replicated_quantizer = ReplicatedQuantizerTensor(
-            ts=static_quantizer, shard_count=4
-        )
+        replicated_quantizer = ReplicatedTensor(ts=static_quantizer, shard_count=4)
         orig_values_replicated = ReplicatedTensor(ts=orig_value, shard_count=4)
-        qt_value_replicated = replicated_quantizer.quantize(
-            orig_values_replicated, name="test_replicated_static_fp4"
+        qt_value_replicated = ops.quantize(
+            orig_values_replicated,
+            replicated_quantizer,
+            name="test_replicated_static_fp4",
         )
         # TODO: Enable after generalizating add_to_archive
         # qt_value_replicated = self._roundtrip(qt_value_replicated, "_replicated_static_fp4_qt_value")


### PR DESCRIPTION
In order to avoid proliferating quantizer types like for split and replicated sharded tensors, QuantizerTensor.quantize and descendants are implemented as an op utilizing the dispatch mechanism.