### PR TITLE
Fix error: zero-dimensional arrays cannot be concatenated

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/decoder/decoder.py
+++ b/shortfin/python/shortfin_apps/llm/components/decoder/decoder.py
@@ -215,7 +215,7 @@ class LlmDecoder:
 
         indices = [np.asarray(req.result_indices) for req in reqs]
 
-        if indices[0] is not None:
+        if isinstance(indices[0], np.ndarray) and indices[0].ndim >= 1:
             indices = np.concatenate(indices, axis=1)[0]
             beams = tokens // token_options
             tokens = np.take(indices, tokens)


### PR DESCRIPTION
Why:
When indices[0] is 0-dimensional NumPy array that wraps the Python object None, the if check below will pass
    _if indices[0] is not None:_

But 
np.concatenate(indices, axis=1)[0] will fail since indices[0] is 0-dimensional

How:
Check whether indices[0].ndim >= 1