### PR TITLE
[sharktank] make cat work with f8 eager CPU

### DIFF
--- a/sharktank/sharktank/ops/__init__.py
+++ b/sharktank/sharktank/ops/__init__.py
@@ -35,3 +35,5 @@ from . import sharded_impls
 # Comment this out to completely disable optimized quantized implementations.
 from . import qconv_impls
 from . import qlinear_impls
+
+from . import cpu_impls

--- a/sharktank/sharktank/ops/cpu_impls.py
+++ b/sharktank/sharktank/ops/cpu_impls.py
@@ -1,0 +1,44 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import torch
+
+from ._registry import AllOfType
+from .signatures import *
+from sharktank.types import (
+    DefaultPrimitiveTensor,
+    PrimitiveTensor,
+    DefaultPrimitiveTensor,
+    unbox_tensor,
+)
+from torch import Tensor
+from typing import Sequence
+
+
+@cat.override(AllOfType(Tensor, PrimitiveTensor))
+def cat_cpu_eager_f8(
+    tensors: Sequence[Tensor | PrimitiveTensor], dim: int
+) -> Tensor | PrimitiveTensor:
+    """A workaround for torch not having CPU implementation for f8.
+    During export we don't want to bitcast to int8 as the IREE compiler can't optimize
+    out the bitcast in some cases."""
+    is_inference_tensor = isinstance(tensors[0], PrimitiveTensor)
+    tensors = [unbox_tensor(t) for t in tensors]
+
+    int8_like_dtypes = [torch.float8_e4m3fn, torch.float8_e4m3fnuz]
+    if torch.compiler.is_compiling() or not all(
+        t.dtype in int8_like_dtypes and t.is_cpu for t in tensors
+    ):
+        return NotImplemented
+
+    orig_dtype = tensors[0].dtype
+    tensors = [t.view(dtype=torch.int8) for t in tensors]
+    result = cat(tensors, dim)
+    result = result.view(dtype=orig_dtype)
+
+    if is_inference_tensor:
+        result = DefaultPrimitiveTensor(data=result)
+    return result

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -92,26 +92,9 @@ def _split_argmax(input_tensor, dim, keepdim: bool = False, chunk_size: int = 12
 
 
 @cat.override(AllOfType(Tensor, PrimitiveTensor))
-def cat_default(
-    tensors: Sequence[Tensor | PrimitiveTensor], dim: int
-) -> Tensor | PrimitiveTensor:
-    is_inference_tensor = isinstance(tensors[0], PrimitiveTensor)
-    tensors = [unbox_tensor(t) for t in tensors]
-
-    int8_like_dtypes = [torch.float8_e4m3fn, torch.float8_e4m3fnuz]
-    should_reinterpret = not torch.compiler.is_compiling() and any(
-        t.dtype in int8_like_dtypes and t.is_cpu for t in tensors
-    )
-    if should_reinterpret:
-        orig_dtype = tensors[0].dtype
-        tensors = [t.view(dtype=torch.int8) for t in tensors]
-
+def cat_default(tensors: Sequence[Tensor | PrimitiveTensor], dim: int):
     result = torch.cat([unbox_tensor(t) for t in tensors], dim)
-
-    if should_reinterpret:
-        result = result.view(dtype=orig_dtype)
-
-    if is_inference_tensor:
+    if isinstance(tensors[0], PrimitiveTensor):
         result = DefaultPrimitiveTensor(data=result)
     return result
 

--- a/sharktank/tests/ops/ops_test.py
+++ b/sharktank/tests/ops/ops_test.py
@@ -145,6 +145,20 @@ class BroadcastDimsTest(unittest.TestCase):
         assert res[1] == 2
 
 
+class TestCat:
+    @pytest.mark.parametrize(
+        "dtype, dim", [(torch.float8_e4m3fnuz, 0), (torch.float8_e4m3fn, 1)]
+    )
+    def testCatEagerF8(self, deterministic_random_seed, dtype: torch.dtype, dim: int):
+        tensors = [torch.rand([2, 3, 4], dtype=torch.float32) for _ in range(2)]
+        tensors = [t.to(dtype=dtype) for t in tensors]
+        actual = ops.cat(tensors, dim=dim)
+
+        tensors_as_int8 = [t.view(dtype=torch.int8) for t in tensors]
+        expected = torch.cat(tensors_as_int8, dim=dim).view(dtype=dtype)
+        assert_tensor_close(actual, expected, rtol=0, atol=0)
+
+
 class EqualTest(unittest.TestCase):
     def testEqualTorchTensors(self):
         a = torch.rand(2, 3, dtype=torch.float32)


### PR DESCRIPTION
In eager mode on the CPU device we need to reinterpret to int8 as torch.cat has no implementation for float8_e4m3fn and float8_e4m3fnuz.