### PR TITLE
Move CI job form MI300 to MI325

### DIFF
--- a/.github/workflows/ci-sharktank-nightly.yml
+++ b/.github/workflows/ci-sharktank-nightly.yml
@@ -166,7 +166,7 @@ jobs:
     strategy:
       matrix:
         version: [3.11]
-        runs-on: [linux-mi300-8gpu-ossci-nod-ai]
+        runs-on: [linux-mi325-8gpu-ossci-nod-ai]
       fail-fast: false
     runs-on: ${{matrix.runs-on}}
     defaults:


### PR DESCRIPTION
This was missed during the migration.
We don't have MI300 CI machines anymore.