### PR TITLE
[FUSILLI] Use lowercase tool names in CMake cache variabls

### DIFF
--- a/sharkfuser/build_tools/cmake/CTestMacros.cmake
+++ b/sharkfuser/build_tools/cmake/CTestMacros.cmake
@@ -134,7 +134,7 @@ function(add_sharkfuser_lit_test)
   add_test(
     NAME ${_TEST_NAME}
     COMMAND
-      ${SHARKFUSER_EXTERNAL_LIT}
+      ${SHARKFUSER_EXTERNAL_lit}
       ${_LIT_PATH_ARGS}
       "--param" "TEST_EXE=$<TARGET_FILE:${_TEST_NAME}>"
       "--verbose"

--- a/sharkfuser/build_tools/cmake/SharkfuserUtils.cmake
+++ b/sharkfuser/build_tools/cmake/SharkfuserUtils.cmake
@@ -14,7 +14,6 @@ macro(sharkfuser_find_program TOOL_NAME)
 
   # Convert tool name to uppercase with underscores for variable name
   string(REPLACE "-" "_" _TOOL_VAR_NAME "${TOOL_NAME}")
-  string(TOUPPER "${_TOOL_VAR_NAME}" _TOOL_VAR_NAME)
   set(_FULL_VAR_NAME "SHARKFUSER_EXTERNAL_${_TOOL_VAR_NAME}")
 
   # Find the tool if not already set

--- a/sharkfuser/templates/external_tools.h.in
+++ b/sharkfuser/templates/external_tools.h.in
@@ -6,4 +6,4 @@
 
 // Auto-generated from external_tools.h.in - do not edit
 
-#define IREE_COMPILE_PATH "@SHARKFUSER_EXTERNAL_IREE_COMPILE@"
+#define IREE_COMPILE_PATH "@SHARKFUSER_EXTERNAL_iree_compile@"

--- a/sharkfuser/tests/CMakeLists.txt
+++ b/sharkfuser/tests/CMakeLists.txt
@@ -17,7 +17,6 @@ sharkfuser_find_program(filecheck "Please install filecheck (e.g., pip install f
 # Find iree-opt program
 sharkfuser_find_program(iree-opt "Please install iree-opt (e.g., pip install iree-base-compiler).")
 
-
 add_sharkfuser_test(
   NAME sharkfuser_attribute_tests
   SRCS


### PR DESCRIPTION
CMake’s built-in cache variables (e.g., `Python3_EXECUTABLE`) use lowercase tool names. Following that convention avoids confusion between `filecheck` and `FileCheck` both exist. Hyphens in tool names are replaced with underscores because cache variables can be set through the shell, where hyphens are invalid in variable names.