### PR TITLE
Fix issues in smoke test

### DIFF
--- a/app_tests/integration_tests/llm/model_management.py
+++ b/app_tests/integration_tests/llm/model_management.py
@@ -190,7 +190,7 @@ _PREDEFINED_MODELS = {
         tokenizer_id="Mxode/TinyStories-LLaMA2-25M-256h-4l-GQA",
         batch_sizes=(4,),
         device_settings=None,
-        top_k=2,
+        top_k=1,
     ),
     "tinystories_llama2_25m_gpu_topk_k4": ModelConfig(
         source=ModelSource.HUGGINGFACE_FROM_SAFETENSORS,


### PR DESCRIPTION
**Why:**
This smoke test is used to test deterministic sampling methods, when num_beams =2, we must use beam search. otherwise it is a waste of computing resource.

**How:**
Remove test_multi_hypothesis_switch
