### PR TITLE
Strip Tests and Support for multigreedy

### DIFF
--- a/shortfin/python/shortfin_apps/llm/server.py
+++ b/shortfin/python/shortfin_apps/llm/server.py
@@ -114,7 +114,6 @@ def add_service_args(parser: argparse.ArgumentParser):
         action="store_true",
         default=False,
         help="Use beam search for decoding.",
-        deprecated=True,
     )
     parser.add_argument(
         "--use_new_decoder",


### PR DESCRIPTION
Multi greedy was intended as a stepping stone to beam search. Removing testing support as its just technical debt now.