### PR TITLE
[sharktank] refactor pipeline-parallel FFN example

### DIFF
--- a/sharktank/sharktank/evaluate/perplexity_torch.py
+++ b/sharktank/sharktank/evaluate/perplexity_torch.py
@@ -20,7 +20,7 @@ from sharktank.layers import *
 from sharktank.types import *
 
 from sharktank.models.llm import *
-from sharktank.types.pipelining import pipeline_parallelize_theta
+from sharktank.types.pipelining import pipeline_parallelize_llm_theta
 
 from sharktank.utils import cli
 from sharktank.utils.load_llm import *
@@ -110,7 +110,7 @@ class PerplexityTorch:
         tokenizer: Optional[InferenceTokenizer] = None,
     ):
 
-        block_to_pipeline, pipeline_to_devices = pipeline_parallelize_theta(
+        block_to_pipeline, pipeline_to_devices = pipeline_parallelize_llm_theta(
             dataset.root_theta, pipeline_parallelism_size
         )
 

--- a/sharktank/sharktank/examples/pipeline/export_ppffn_net.py
+++ b/sharktank/sharktank/examples/pipeline/export_ppffn_net.py
@@ -18,17 +18,23 @@ import math
 
 import torch
 
+from typing import Any
 from sharktank.utils import cli
 from sharktank.layers import *
 from sharktank import ops
 from sharktank.types import *
-from sharktank.types.pipelining import pipeline_parallelize_theta
+from sharktank.types.pipelining import (
+    default_distribute_blocks_for_pipeline_parallelism,
+    parallelize_in_place,
+)
 
 from iree.turbine.aot import DeviceAffinity, export
 
 
-def create_theta(dim: int, shard_count: int, num_layers: int, save_path):
-    split_size = dim // shard_count
+def create_theta(
+    dim: int, tensor_parallelism_size: int, num_layers: int, save_path
+) -> Theta:
+    split_size = dim // tensor_parallelism_size
     weights = []
     for layer in range(num_layers):
         _shard = torch.rand(dim, dim, dtype=torch.float16) / math.sqrt(dim)
@@ -38,96 +44,129 @@ def create_theta(dim: int, shard_count: int, num_layers: int, save_path):
                 shard_dim=1,
                 ts=_shard.split(split_size, dim=1),
             )
-            if shard_count > 1
-            else DefaultPrimitiveTensor(name=f"block.{layer}.ffn.weight", data=_shard)
+            if tensor_parallelism_size > 1
+            else DefaultPrimitiveTensor(name=f"blk.{layer}.ffn.weight", data=_shard)
         )
 
-    ones = torch.ones(dim, dim, dtype=torch.float16)
-    weights.append(
-        SplitPrimitiveTensor(
-            name="token_embd.weight",
-            shard_dim=1,
-            ts=ones.split(split_size, dim=1),
-        )
-        if shard_count > 1
-        else DefaultPrimitiveTensor(name="token_embd.weight", data=ones)
-    )
-    weights.append(
-        SplitPrimitiveTensor(
-            name="output.weight",
-            shard_dim=1,
-            ts=ones.split(split_size, dim=1),
-        )
-        if shard_count > 1
-        else DefaultPrimitiveTensor(name="output.weight", data=ones)
-    )
-    ones = torch.ones(1, dim, dtype=torch.float16)
-    weights.append(
-        SplitPrimitiveTensor(
-            name="output_norm.weight",
-            shard_dim=1,
-            ts=ones.split(split_size, dim=1),
-        )
-        if shard_count > 1
-        else DefaultPrimitiveTensor(name="output_norm.weight", data=ones)
+    return Theta(weights)
+
+
+def pipeline_parallelize_theta(
+    theta: Theta, pipeline_parallelism_size: int
+) -> tuple[list[int] | None, list[list[int]] | None]:
+    """
+    Pipeline parallelize theta for LLM.
+    Both DeepSeek and Llama.
+    """
+    if pipeline_parallelism_size == 1:
+        return None, None
+
+    sample_weight = theta("blk.0.ffn.weight")
+    tensor_parallelism_size = (
+        sample_weight.shard_count if isinstance(sample_weight, ShardedTensor) else 1
     )
 
-    ds = Dataset({}, Theta(weights))
-    ds.save(save_path)
+    block_indices = theta.tensor("blk").keys()
+    block_count = len(block_indices)
+
+    (
+        block_to_pipeline_stage,
+        pipeline_stage_to_devices,
+    ) = default_distribute_blocks_for_pipeline_parallelism(
+        block_count=block_count,
+        pipeline_parallelism_size=pipeline_parallelism_size,
+        tensor_parallelism_size=tensor_parallelism_size,
+    )
+
+    assert (
+        bi == i for i, bi in enumerate(block_indices)
+    ), "Blocks assumed to be numbered contiguously from [0, N-1]"
+    for blk_idx in block_indices:
+        blk_idx = int(blk_idx)
+        stage = block_to_pipeline_stage[blk_idx]
+        devices = pipeline_stage_to_devices[stage]
+
+        block_data = theta.tensor("blk", blk_idx)
+        for t_name in block_data.keys():
+            parallelize_in_place(block_data[t_name], devices)
+
+    return block_to_pipeline_stage, pipeline_stage_to_devices
 
 
 class PPFFN(ThetaLayer):
-    block_to_pipeline: tuple[int, ...]
-    pipeline_to_devices: tuple[list[int], ...]
+    block_to_pipeline_stage: tuple[int, ...]
+    pipeline_stage_to_devices: tuple[list[int], ...]
 
     def __init__(
         self,
         theta,
-        block_to_pipeline: tuple[int, ...],
-        pipeline_to_devices: tuple[list[int], ...],
+        block_to_pipeline_stage: tuple[int, ...],
+        pipeline_stage_to_devices: tuple[list[int], ...],
     ):
         super().__init__(theta)
-        self.block_to_pipeline = block_to_pipeline
-        self.pipeline_to_devices = pipeline_to_devices
-
-    def _inter_layer_callback(self, x: ShardedTensor, curr_block: int):
-        if self.block_to_pipeline is None:
-            return x
-
-        if curr_block >= len(self.block_to_pipeline) - 1:
-            return x
-
-        curr_pipeline = self.block_to_pipeline[curr_block]
-        next_pipeline = self.block_to_pipeline[curr_block + 1]
-
-        curr_devices = self.pipeline_to_devices[curr_pipeline]
-        next_devices = self.pipeline_to_devices[next_pipeline]
-
-        if all(d_curr == d_next for d_curr, d_next in zip(curr_devices, next_devices)):
-            return x
-
-        shards = ShardedTensor.move_shards_to_new_devices(
-            x.shards, old_devices=curr_devices, new_devices=next_devices
+        self.block_to_pipeline_stage = block_to_pipeline_stage
+        self.pipeline_stage_to_devices = pipeline_stage_to_devices
+        self.blocks = torch.nn.ModuleList(
+            LinearLayer(theta(f"blk.{block_idx}.ffn"))
+            for block_idx in range(len(block_to_pipeline_stage))
         )
-        return x.clone(ts=shards, devices=next_devices)
+
+    def _prepare_pipeline_parallel_block_args(
+        self, x: torch.Tensor | ReplicatedTensor, block_index: int
+    ) -> dict[str, Any]:
+        """
+        Args:
+        -----
+        x: pipeline input or previous layer output.
+        """
+
+        res = {}
+        if block_index == 0:
+            res["x"] = ReplicatedTensor(
+                ts=x,
+                shard_count=len(self.pipeline_stage_to_devices[0]),
+                devices=self.pipeline_stage_to_devices[0],
+            )
+        else:
+            stage = self.block_to_pipeline_stage[block_index]
+            prev_stage = self.block_to_pipeline_stage[block_index - 1]
+
+            stage_devices = self.pipeline_stage_to_devices[stage]
+            prev_stage_devices = self.pipeline_stage_to_devices[prev_stage]
+
+            x = ops.replicate(x, count=x.shard_count)
+
+            if all(
+                prev_stage_device == stage_device
+                for prev_stage_device, stage_device in zip(
+                    prev_stage_devices, stage_devices
+                )
+            ):
+                res["x"] = x
+            else:
+                shards = ShardedTensor.move_shards_to_new_devices(
+                    x.shards, old_devices=prev_stage_devices, new_devices=stage_devices
+                )
+                res["x"] = x.clone(ts=shards, devices=stage_devices)
+
+        return res
 
     def forward(self, x: torch.Tensor):
-        num_blocks = len(self.block_to_pipeline)
-        shard_count = self.theta.tensor("blk.0.ffn.weight").shard_count
-
-        x = ReplicatedTensor(
-            ts=x, shard_count=shard_count, devices=self.pipeline_to_devices[0]
-        )
-        for block in range(num_blocks):
-            weight = self.theta.tensor(f"blk.{block}.ffn.weight")
-            x = ops.replicate(ops.linear(x, weight), shard_count)
-            x = self._inter_layer_callback(x, block)
+        for block_index, block in enumerate(self.blocks):
+            block_kwargs = self._prepare_pipeline_parallel_block_args(x, block_index)
+            x = block(**block_kwargs)
 
         return ops.unshard(x)
 
 
 def main(raw_args=None):
     parser = cli.create_parser()
+    parser.add_argument(
+        "--tensor-parallelism-size",
+        type=int,
+        default=1,
+        help="Number of tensor shards for tensor parallelism.",
+    )
     parser.add_argument(
         "output_file",
         type=str,
@@ -151,24 +190,29 @@ def main(raw_args=None):
                 f"Parent directory for output file does not exist: {output_dir}"
             )
 
-    bs = 16
-    sl = 128
-    primary_dim = 128 * 2**5
-    shard_count = 2
-    num_layers = 40
-    create_theta(primary_dim, shard_count, num_layers, save_path=args.output_irpa_file)
-
-    pp_count = 4
-    ds = Dataset.load(args.output_irpa_file)
-    block_to_pipeline, pipeline_to_devices = pipeline_parallelize_theta(
-        ds.root_theta, pp_count
+    bs = 11
+    input_dim = 13
+    ffn_hidden_dim = 5 * args.tensor_parallelism_size
+    pp_count = 3
+    num_layers = pp_count * 2
+    theta = create_theta(
+        ffn_hidden_dim,
+        args.tensor_parallelism_size,
+        num_layers,
+        save_path=args.output_irpa_file,
     )
 
-    mdl = PPFFN(ds.root_theta, block_to_pipeline, pipeline_to_devices)
+    block_to_pipeline_stage, pipeline_stage_to_devices = pipeline_parallelize_theta(
+        theta, pp_count
+    )
+    Dataset({}, theta).save(args.output_irpa_file)
+    ds = Dataset.load(args.output_irpa_file)
 
-    example_arg = torch.empty(bs, sl, primary_dim, dtype=torch.float16)
+    mdl = PPFFN(ds.root_theta, block_to_pipeline_stage, pipeline_stage_to_devices)
+
+    example_arg = torch.empty(bs, input_dim, ffn_hidden_dim, dtype=torch.float16)
     ep = torch.export.export(mdl, (example_arg,), strict=False)
-    cm = export(ep, arg_device={0: DeviceAffinity(str(pipeline_to_devices[0][0]))})
+    cm = export(ep, arg_device={0: DeviceAffinity(pipeline_stage_to_devices[0][0])})
 
     if args.output_file == "-":
         print(cm.mlir_module)

--- a/sharktank/sharktank/types/pipelining.py
+++ b/sharktank/sharktank/types/pipelining.py
@@ -8,20 +8,61 @@
 Specifications describing how
 """
 
-from iree.turbine.aot import DeviceTensorTrait, ExternalTensorTrait
+from iree.turbine.aot import DeviceTensorTrait
 from sharktank.types import (
     AnyTensor,
     ReplicatedTensor,
-    QuantizerTensor,
     ShardedTensor,
     Theta,
 )
 
-
 from typing import Tuple
 
 
-def pipeline_parallelize_theta(
+def default_distribute_blocks_for_pipeline_parallelism(
+    block_count: int,
+    pipeline_parallelism_size: int,
+    tensor_parallelism_size: int,
+) -> tuple[list[int] | None, list[list[int]] | None]:
+    """Assign blocks/layers to pipeline stages and devices(ordinals) to stages."""
+    if pipeline_parallelism_size == 1:
+        return None, None
+
+    block_to_pipeline_stage = [
+        i * pipeline_parallelism_size // block_count for i in range(block_count)
+    ]
+    pipeline_stage_to_devices = [
+        [p * tensor_parallelism_size + d for d in range(tensor_parallelism_size)]
+        for p in range(pipeline_parallelism_size)
+    ]
+    return block_to_pipeline_stage, pipeline_stage_to_devices
+
+
+def parallelize_in_place(
+    block_data: dict[str, AnyTensor],
+    new_devices: Tuple[int, ...],
+) -> None:
+    """
+    Parallelize the theta data in place.
+    """
+    for block_key in list(block_data.keys()):
+        tensor = block_data[block_key]
+        shards = tensor.shards if isinstance(tensor, ShardedTensor) else [tensor]
+
+        if isinstance(tensor, ShardedTensor):
+            new_tensor = tensor.clone(ts=shards, devices=new_devices)
+        else:
+            new_tensor = ReplicatedTensor(
+                ts=shards, name=tensor.name, devices=new_devices
+            )
+
+        for shard, device in zip(new_tensor.shards, new_tensor.devices, strict=True):
+            DeviceTensorTrait(device).set(shard.as_torch())
+
+        block_data[block_key] = new_tensor
+
+
+def pipeline_parallelize_llm_theta(
     theta: Theta, pipeline_parallelism_size: int
 ) -> tuple[list[int] | None, list[list[int]] | None]:
     """
@@ -31,54 +72,35 @@ def pipeline_parallelize_theta(
     if pipeline_parallelism_size == 1:
         return None, None
 
-    def parallelize_in_place(
-        block_data: dict[str, AnyTensor],
-        new_devices: Tuple[int, ...],
-    ) -> None:
-        """
-        Parallelize the block data in place.
-        """
-        for block_key in list(block_data.keys()):
-            tensor = block_data[block_key]
-            shards = tensor.shards if isinstance(tensor, ShardedTensor) else [tensor]
-
-            if isinstance(tensor, ShardedTensor):
-                new_tensor = tensor.clone(ts=shards, devices=new_devices)
-            else:
-                new_tensor = ReplicatedTensor(
-                    ts=shards, name=tensor.name, devices=new_devices
-                )
-
-            block_data[block_key] = new_tensor
-
     _t = theta.tensor("token_embd")["weight"]
     shard_count = _t.shard_count if isinstance(_t, ShardedTensor) else 1
 
     block_indices = theta.tensor("blk").keys()
     block_count = len(block_indices)
 
-    block_to_pipeline = [
-        i * pipeline_parallelism_size // block_count for i in range(block_count)
-    ]
-    pipeline_to_devices = [
-        [p * shard_count + d for d in range(shard_count)]
-        for p in range(pipeline_parallelism_size)
-    ]
+    (
+        block_to_pipeline_stage,
+        pipeline_stage_to_devices,
+    ) = default_distribute_blocks_for_pipeline_parallelism(
+        block_count=block_count,
+        pipeline_parallelism_size=pipeline_parallelism_size,
+        tensor_parallelism_size=shard_count,
+    )
 
     assert (
         bi == i for i, bi in enumerate(block_indices)
     ), "Blocks assumed to be numbered contiguously from [0, N-1]"
     for blk_idx in block_indices:
         blk_idx = int(blk_idx)
-        pipeline = block_to_pipeline[blk_idx]
-        devices = pipeline_to_devices[pipeline]
+        stage = block_to_pipeline_stage[blk_idx]
+        devices = pipeline_stage_to_devices[stage]
 
         block_data = theta.tensor("blk", blk_idx)
         for t_name in block_data.keys():
             parallelize_in_place(block_data[t_name], devices)
 
-    parallelize_in_place(theta.tensor("token_embd"), pipeline_to_devices[0])
-    parallelize_in_place(theta.tensor("output_norm"), pipeline_to_devices[-1])
-    parallelize_in_place(theta.tensor("output"), pipeline_to_devices[-1])
+    parallelize_in_place(theta.tensor("token_embd"), pipeline_stage_to_devices[0])
+    parallelize_in_place(theta.tensor("output_norm"), pipeline_stage_to_devices[-1])
+    parallelize_in_place(theta.tensor("output"), pipeline_stage_to_devices[-1])
 
-    return block_to_pipeline, pipeline_to_devices
+    return block_to_pipeline_stage, pipeline_stage_to_devices

--- a/sharktank/sharktank/types/tensors.py
+++ b/sharktank/sharktank/types/tensors.py
@@ -1111,6 +1111,7 @@ class ShardedTensorBase(ShardedTensor):
         extra_properties = {
             "shard_count": len(self._shards),
             "shape": list(self.shape),
+            "devices": self.devices,
         }
         if self.shard_dim is not None:
             extra_properties.update({"shard_dim": self.shard_dim})
@@ -1165,22 +1166,24 @@ class ShardedTensorBase(ShardedTensor):
             if "shard_dim" in extra_properties
             else None
         )
+        devices = extra_properties.get("devices", tuple(range(shard_count)))
         ts = []
         for i in range(shard_count):
             t_name = str(i)
             try:
                 t = raw_tensors[t_name]
                 ts.append(t)
-                # TODO: this should be changed to tracked device affinity
-                DeviceTensorTrait(i).set(t)
+                DeviceTensorTrait(devices[i]).set(t)
             except KeyError as e:
                 raise IOError(
                     f"Missing component tensor '{t_name}' in {raw_tensors.keys()}"
                 ) from e
         if shard_dim is None:
-            return cls(name=name, shape=shape, ts=ts)
+            return cls(name=name, shape=shape, ts=ts, devices=devices)
         else:
-            return cls(name=name, shape=shape, ts=ts, shard_dim=shard_dim)
+            return cls(
+                name=name, shape=shape, ts=ts, devices=devices, shard_dim=shard_dim
+            )
 
     def __repr__(self):
         return (
@@ -1499,6 +1502,7 @@ class ReplicatedTensor(ShardedTensor):
             {"": self.name},
             extra_properties={
                 "shard_count": len(self._shards),
+                "devices": self.devices,
             },
         )
 
@@ -1531,6 +1535,7 @@ class ReplicatedTensor(ShardedTensor):
         extra_properties: dict[str, Any],
     ) -> "InferenceTensor":
         shard_count = int(extra_properties["shard_count"])
+        devices = extra_properties.get("devices", tuple(range(shard_count)))
         try:
             # We have to do this to avoid exporting as part of the `mlir` blob:
             t = raw_tensors[""]
@@ -1539,13 +1544,12 @@ class ReplicatedTensor(ShardedTensor):
                 nt = deepcopy(t)
                 ts.append(nt)
 
-            # TODO This should be changed to assigned affinities
             for i in range(shard_count):
-                DeviceTensorTrait(i).set(ts[i])
+                DeviceTensorTrait(devices[i]).set(ts[i])
 
         except KeyError as e:
             raise IOError(f"Missing component tensor '' in {raw_tensors.keys()}") from e
-        return cls(name=name, ts=ts)
+        return cls(name=name, ts=ts, devices=devices)
 
     def __getitem__(self, key):
         keys = [key]

--- a/sharktank/sharktank/utils/testing.py
+++ b/sharktank/sharktank/utils/testing.py
@@ -27,7 +27,7 @@ from sys import platform
 from datasets import load_dataset
 
 from sharktank.types import *
-from sharktank.types.pipelining import pipeline_parallelize_theta
+from sharktank.types.pipelining import pipeline_parallelize_llm_theta
 from sharktank.utils.io import ShardedArchiveBuilder
 from .math import cosine_similarity
 
@@ -232,7 +232,7 @@ class IreeVsEagerLLMTester:
         )
 
         # Note: Must be after saving the dataset and creating the exporter but before moving theta to the provided device.
-        block_to_pipeline, pipeline_to_devices = pipeline_parallelize_theta(
+        block_to_pipeline, pipeline_to_devices = pipeline_parallelize_llm_theta(
             theta, self.config.pipeline_parallelism_size
         )
         self.config.block_to_pipeline_map = block_to_pipeline

--- a/sharktank/tests/examples/main_test.py
+++ b/sharktank/tests/examples/main_test.py
@@ -8,6 +8,7 @@ import pytest
 import sys
 import unittest
 
+from parameterized import parameterized
 from sharktank.utils.testing import MainRunnerTestBase
 
 
@@ -30,13 +31,25 @@ class ShardingTests(MainRunnerTestBase):
     sys.platform == "win32", reason="https://github.com/nod-ai/shark-ai/issues/698"
 )
 class PipelineTests(MainRunnerTestBase):
-    def testExportPFfnNet(self):
+    @parameterized.expand(
+        [
+            (1,),
+            (2,),
+        ]
+    )
+    def testExportPFfnNet(self, tensor_parallelism_size: int):
         from sharktank.examples.pipeline.export_ppffn_net import main
 
         irpa_path = self.get_irpa_path("ppffn")
         output_path = self.get_file_path("output_ppffn.mlir")
 
-        self.run_main(main, "--output-irpa-file", irpa_path, output_path)
+        self.run_main(
+            main,
+            f"--tensor-parallelism-size={tensor_parallelism_size}",
+            "--output-irpa-file",
+            irpa_path,
+            output_path,
+        )
         self.assertFileWritten(irpa_path)
         self.assertFileWritten(output_path)
 


### PR DESCRIPTION
The main modeling structure is maintained where layers/blocks are mapped to pipeline stages and pipeline stages are mapped to device sets. This looks like the most natural way to represent this.

Utilize method _prepare_pipeline_parallel_block_args to prepare the arguments of a layer/block.

Write actually the pipeline parallelized theta and not the original before pipelining. This required adding device writing/reading when saving/loading sharded tensors.

Refactor pipeline-parallelisation of the theta to not use the function for LLMs directly to avoid having to include unused parameters like token_embd, etc.

Make 2 tests. One where pipeline-parallelism is combined with tensor-parallelism and one where it is without tensor-parallelism.