### PR TITLE
[sharktank] fix test for wave fp4 gemm kernel

### DIFF
--- a/sharktank/conftest.py
+++ b/sharktank/conftest.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from pytest import FixtureRequest
 from typing import Any, Generator, Optional
 
+from sharktank.utils.testing import IreeFlags
 
 # Tests under each top-level directory will get a mark.
 TLD_MARKS = {
@@ -430,14 +431,6 @@ def model_artifacts(request: FixtureRequest) -> dict[str, str]:
         request, "--deepseek-v3-tp8-model-path", "deepseek_v3_tp8_model"
     )
     return model_path
-
-
-@dataclass
-class IreeFlags:
-    iree_device: str
-    iree_hip_target: str
-    iree_hal_target_device: str
-    iree_hal_local_target_device_backends: str
 
 
 @pytest.fixture(scope="class")

--- a/sharktank/sharktank/ops/quantized_impls.py
+++ b/sharktank/sharktank/ops/quantized_impls.py
@@ -167,11 +167,11 @@ def quantize_dynamic_fp4_block_quantizer(
     values_blocked = t_padded.reshape(blocked_shape)
 
     if quantizer._use_sharktank_kernel:
-        flattened = values_blocked.view(-1, quantizer.block_size).to(torch.float32)
+        flattened = values_blocked.reshape(-1, quantizer.block_size).to(torch.float32)
         scales, packed_fp4_flat = dynamic_quantize_to_fp4(flattened)
         packed_fp4 = packed_fp4_flat.view(packed_shape)
         # Reshape scales to match the expected blocked dimensions
-        scales_shape = orig_shape[:-1] + [num_blocks]
+        scales_shape = orig_shape[:-1] + [num_blocks, 1]
         scales = scales.view(scales_shape)
 
         layout = BlockScaledFp4Layout(

--- a/sharktank/sharktank/utils/testing.py
+++ b/sharktank/sharktank/utils/testing.py
@@ -4,6 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from dataclasses import dataclass
 from typing import Optional
 import contextlib
 from pathlib import Path
@@ -66,6 +67,14 @@ is_not_cpu_condition = (
 is_hip_condition = "config.getoption('iree_hal_target_device') == 'hip'"
 is_cpu = pytest.mark.skipif(is_not_cpu_condition)
 is_cpu_win = pytest.mark.skipif(is_cpu_condition and platform == "win32")
+
+
+@dataclass
+class IreeFlags:
+    iree_device: str
+    iree_hip_target: str
+    iree_hal_target_device: str
+    iree_hal_local_target_device_backends: str
 
 
 def is_iree_hal_target_device_cpu(v: str, /) -> bool:


### PR DESCRIPTION
Fix the RHS transpose as the kernel does `A x B^T` rather than `A x B`.

During quantization don't take a view, but rashape as the tensor may have layout that can't be reshaped without copying.

Refactor the test to include different matrix sizes and make sure m != n != k.