### PR TITLE
Argmax export should not drop the options dimension

### DIFF
--- a/sharktank/sharktank/models/llm/export.py
+++ b/sharktank/sharktank/models/llm/export.py
@@ -23,9 +23,8 @@ def argmax_output(
     indices_expanded = indices.unsqueeze(-1)
 
     max_logits = ops.gather(logits, dim=-1, index=indices_expanded)
-    max_logits = max_logits.squeeze(-1)
 
-    return max_logits, indices
+    return max_logits, indices_expanded
 
 
 def topk_output(


### PR DESCRIPTION
Dropping the options dimensions treats top-k and argmax in a different way at the service side. This is unnecessary as there is no special casing required between the two.