### PR TITLE
Enable new decoder - remove multigreedy case

### DIFF
--- a/app_tests/integration_tests/llm/shortfin/tinystories_llama2_25m_test.py
+++ b/app_tests/integration_tests/llm/shortfin/tinystories_llama2_25m_test.py
@@ -222,45 +222,6 @@ class TestLLMServer:
                         message=f"Greedy generation did not match expected pattern.\nExpected to be one of: {GOLDEN_RESPONSE}\nActual response: {response_text}",
                     )
 
-    def test_multi_hypothesis_switch(
-        self,
-        server: tuple[Any, int, ServerConfig],
-    ):
-        """Tests switching to multi-beam generation.
-
-        Args:
-            server: Tuple of (process, port, config) from server fixture
-        """
-        process, port, _ = server
-        assert process.poll() is None, "Server process terminated unexpectedly"
-
-        # Test multi-beam generation
-        num_beams = 2
-        sampling_params = {
-            "max_completion_tokens": 15,
-            "temperature": 0.7,
-            "num_beams": num_beams,
-            "use_beam_search": False,
-        }
-        prompt = GOLDEN_PROMPT
-        response = self._generate(prompt, port, sampling_params=sampling_params)
-
-        response = json.loads(response)
-        req_output = GenerateReqOutput(**response)
-
-        for prompt_response in req_output.responses:
-            prompt_response = PromptResponse(**prompt_response)
-            assert len(prompt_response.responses) == num_beams
-            for generated_response in prompt_response.responses:
-                generated_response = GeneratedResponse(**generated_response)
-                response_text = generated_response.text
-                if response_text not in GOLDEN_RESPONSE:
-                    raise AccuracyValidationException(
-                        expected=f"{GOLDEN_RESPONSE}...",
-                        actual=response_text,
-                        message=f"Multi-beam generation did not match expected pattern.\nExpected to be one of: {GOLDEN_BEAM_SEARCH_RESPONSE}\nActual response: '{response_text}'",
-                    )
-
     def test_beam_search_switch(
         self,
         request: pytest.FixtureRequest,

--- a/shortfin/python/shortfin_apps/llm/components/config_struct.py
+++ b/shortfin/python/shortfin_apps/llm/components/config_struct.py
@@ -241,7 +241,7 @@ class ServerParams:
 
     decode_config: DecodeConfig | None = None
 
-    use_new_decoder: bool = False
+    use_new_decoder: bool = True
 
     use_native_impls: bool = False
 

--- a/shortfin/python/shortfin_apps/llm/components/decoder/decoder.py
+++ b/shortfin/python/shortfin_apps/llm/components/decoder/decoder.py
@@ -154,10 +154,11 @@ class PageManager:
         else:
             used = set()
             for beam in new_beam_page_ids:
-                if len(beam) > 1 and beam[-1] in used:
-                    new_page = self.allocate(1)[0]
-                    self._page_pool.copy_page_index(beam[-1], new_page)
-                    beam[-1] = new_page
+                if len(beam) > 0:
+                    if beam[-1] in used:
+                        new_page = self.allocate(1)[0]
+                        self._page_pool.copy_page_index(beam[-1], new_page)
+                        beam[-1] = new_page
                     used.add(beam[-1])
 
         # Check if the pages a shared between all queries:

--- a/shortfin/python/shortfin_apps/llm/components/decoder/decoder.py
+++ b/shortfin/python/shortfin_apps/llm/components/decoder/decoder.py
@@ -154,17 +154,18 @@ class PageManager:
         else:
             used = set()
             for beam in new_beam_page_ids:
-                if beam[-1] in used:
+                if len(beam) > 1 and beam[-1] in used:
                     new_page = self.allocate(1)[0]
                     self._page_pool.copy_page_index(beam[-1], new_page)
                     beam[-1] = new_page
+                    used.add(beam[-1])
 
-                used.add(beam[-1])
-
-        first_page = new_beam_page_ids[0][0]
-        if all(first_page == b[0] for b in new_beam_page_ids):
-            self._shared_pages.append(first_page)
-            new_beam_page_ids = [b[1:] for b in new_beam_page_ids]
+        # Check if the pages a shared between all queries:
+        if len(new_beam_page_ids[0]) > 0:
+            first_page = new_beam_page_ids[0][0]
+            if all(first_page == b[0] for b in new_beam_page_ids):
+                self._shared_pages.append(first_page)
+                new_beam_page_ids = [b[1:] for b in new_beam_page_ids]
 
         self._beam_page_ids = new_beam_page_ids
         self._position += 1

--- a/shortfin/python/shortfin_apps/llm/server.py
+++ b/shortfin/python/shortfin_apps/llm/server.py
@@ -118,7 +118,7 @@ def add_service_args(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--use_new_decoder",
         action="store_true",
-        default=False,
+        default=True,
         help="Use the new decoder infrastructure.",
     )
     parser.add_argument(


### PR DESCRIPTION
We should only be performing beam search with multiple hypothesis cases. Removed the corresponding tests and enabled the new decoder. Some fixes to the page manager work better for non topk.
