### PR TITLE
Add kvcache dtype option to run_llm_vmfb

### DIFF
--- a/sharktank/sharktank/tools/run_llm_vmfb.py
+++ b/sharktank/sharktank/tools/run_llm_vmfb.py
@@ -79,7 +79,11 @@ if __name__ == "__main__":
         "--steps", help="steps to perform decode", type=int, required=True
     )
     parser.add_argument(
-        "--kv-cache-dtype", help="Specify the kv-cache dtype", required=False
+        "--kv-cache-dtype",
+        help="Specify the kv-cache dtype",
+        type=str,
+        required=False,
+        default="float16",
     )
     args = parser.parse_args()
     main(

--- a/sharktank/sharktank/tools/run_llm_vmfb.py
+++ b/sharktank/sharktank/tools/run_llm_vmfb.py
@@ -25,7 +25,7 @@ class Tokenizer:
 
 
 class Decoder:
-    def __init__(self, *, vmfb_fp, config_fp, irpa_fp):
+    def __init__(self, *, vmfb_fp, config_fp, irpa_fp, kv_cache_dtype):
 
         with open(vmfb_fp, "rb") as f:
             vmfb_bytes = f.read()
@@ -47,6 +47,7 @@ class Decoder:
             block_count=self._block_count,
             block_seq_stride=self._block_seq_stride,
             page_size=self._page_size,
+            kv_cache_dtype=kv_cache_dtype,
         )
         self._decoder = self._llm.make_decoder()
 
@@ -55,10 +56,12 @@ class Decoder:
         return tokens
 
 
-def main(prompt, steps, vmfb, config, irpa, tokenizer):
+def main(prompt, steps, vmfb, config, irpa, tokenizer, kv_cache_dtype):
     tokenizer = Tokenizer(tokenizer)
     ids = tokenizer.encode([prompt])
-    decoder = Decoder(vmfb_fp=vmfb, config_fp=config, irpa_fp=irpa)
+    decoder = Decoder(
+        vmfb_fp=vmfb, config_fp=config, irpa_fp=irpa, kv_cache_dtype=kv_cache_dtype
+    )
     tokens = ids[0]
 
     selected = decoder.decode(tokens=tokens, steps=steps)
@@ -75,6 +78,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--steps", help="steps to perform decode", type=int, required=True
     )
+    parser.add_argument(
+        "--kv-cache-dtype", help="Specify the kv-cache dtype", required=False
+    )
     args = parser.parse_args()
     main(
         prompt=args.prompt,
@@ -83,4 +89,5 @@ if __name__ == "__main__":
         vmfb=args.vmfb,
         config=args.config,
         tokenizer=args.tokenizer,
+        kv_cache_dtype=args.kv_cache_dtype,
     )

--- a/sharktank/sharktank/utils/llm_utils.py
+++ b/sharktank/sharktank/utils/llm_utils.py
@@ -17,13 +17,15 @@ np_dtype_to_torch_dtype = {
 np_dtype_to_hal_dtype = {
     numpy.float16: iree.runtime.HalElementType.FLOAT_16,
     numpy.float32: iree.runtime.HalElementType.FLOAT_32,
-    torch.float8_e4m3fnuz: iree.runtime.HalElementType.FLOAT_8_E4M3_FN,
+    torch.float8_e4m3fn: iree.runtime.HalElementType.FLOAT_8_E4M3_FN,
+    torch.float8_e4m3fnuz: iree.runtime.HalElementType.FLOAT_8_E4M3_FNUZ,
 }
 
 dtype_string_to_type = {
     "float16": numpy.float16,
     "float32": numpy.float32,
-    "float8_e4m3fn": torch.float8_e4m3fnuz,
+    "float8_e4m3fn": torch.float8_e4m3fn,
+    "float8_e4m3fnuz": torch.float8_e4m3fnuz,
 }
 
 
@@ -193,7 +195,7 @@ class LlmBatch:
         page_count: int,
         page_size: int,
         block_stride: int,
-        kv_cache_dtype: None,
+        kv_cache_dtype: str,
     ):
         self._instance = instance
         self._page_count = page_count
@@ -202,10 +204,9 @@ class LlmBatch:
         self._prefill_bs = instance._prefill_bs
         self._decode_bs = instance._decode_bs
 
-        self.cache_dtype = (
-            dtype_string_to_type[kv_cache_dtype] if kv_cache_dtype else numpy.float16
+        self._cache = instance.allocate(
+            page_count, page_size, dtype=dtype_string_to_type[kv_cache_dtype]
         )
-        self._cache = instance.allocate(page_count, page_size, dtype=self.cache_dtype)
         self._page_id = 1
 
     def reset(self, bs):
@@ -371,7 +372,12 @@ class LlmPerplexityEval:
 
 class LlmInstance:
     def __init__(
-        self, model_instance, block_seq_stride, page_size, block_count, kv_cache_dtype
+        self,
+        model_instance,
+        block_seq_stride,
+        page_size,
+        block_count,
+        kv_cache_dtype="float16",
     ):
         self._instance = model_instance
         self._block_seq_stride = block_seq_stride


### PR DESCRIPTION
Specifying kv-cache-dtype helps in running fp8 based models using run_llm_vmfb