### PR TITLE
Handle prefill EOT and remove tokenizer padding

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/decoder/decoder.py
+++ b/shortfin/python/shortfin_apps/llm/components/decoder/decoder.py
@@ -144,6 +144,9 @@ class PageManager:
         return allocation
 
     def step_pages(self, select):
+        if len(select) == 0:
+            return
+
         new_page = (self._position % self._tokens_per_page) == 0
         new_beam_page_ids = [[p for p in self._beam_page_ids[b]] for b in select]
 
@@ -407,15 +410,18 @@ class LlmDecoder:
             [prefill_req.result_logits], [prefill_req.result_indices]
         )
 
-        # Decode requests:
+        # Setup decode requests:
         decode_reqs = self.create_decode_reqs(prefill_req)
 
-        # Update the reqs:
-        page_ids = page_manager.step_pages(beams)
-        to_run = self.setup_req(decode_reqs, tokens, input_length, page_ids)
-
         # Run Decoder:
-        for i in range(self._decode_config.max_completion_tokens - 1):
+        for _ in range(self._decode_config.max_completion_tokens - 1):
+            if token_selector.done() or self._cancelled or len(beams) == 0:
+                break
+
+            # Update the reqs:
+            page_ids = page_manager.step_pages(beams)
+            to_run = self.setup_req(decode_reqs, tokens, input_length, page_ids)
+
             input_length = input_length + 1
 
             self._decode_batcher.reserve_workload(
@@ -433,12 +439,6 @@ class LlmDecoder:
                 [req.result_logits for req in to_run],
                 [req.result_indices for req in to_run],
             )
-
-            if token_selector.done() or self._cancelled or len(beams) == 0:
-                break
-
-            page_ids = page_manager.step_pages(beams)
-            to_run = self.setup_req(decode_reqs, tokens, input_length, page_ids)
 
         # Remove the reservation:
         self._decode_batcher.reserve_workload(rid=prefill_req.orig_instance_id, count=0)

--- a/shortfin/python/shortfin_apps/llm/components/scheduler.py
+++ b/shortfin/python/shortfin_apps/llm/components/scheduler.py
@@ -230,7 +230,8 @@ class Scheduler:
         self._workgroup_placement[rid] = workgroup_sel.wid
 
     def _remove(self, *, rid):
-        assert rid in self._workgroup_placement
+        if rid not in self._workgroup_placement:
+            return
 
         wid = self._workgroup_placement[rid]
         workgroup = self._workgroups[wid]

--- a/shortfin/python/shortfin_apps/llm/components/tokenizer.py
+++ b/shortfin/python/shortfin_apps/llm/components/tokenizer.py
@@ -25,7 +25,6 @@ class Tokenizer:
             raw_tk.token_to_id(eos_token) if eos_token is not None else None
         )
         self._raw = raw_tk
-        self._raw.enable_padding(pad_id=pad_id)
         self._raw.no_truncation()
 
     @staticmethod

--- a/shortfin/tests/apps/llm/components/tokenizer_test.py
+++ b/shortfin/tests/apps/llm/components/tokenizer_test.py
@@ -17,7 +17,7 @@ def bert_tokenizer():
 def test_tokenizers_lib(bert_tokenizer):
     enc0, enc1 = bert_tokenizer.encode(["This is sequence 1", "Sequence 2"])
     assert enc0.ids == [101, 1188, 1110, 4954, 122, 102]
-    assert enc1.ids == [101, 22087, 25113, 123, 102, 0]
+    assert enc1.ids == [101, 22087, 25113, 123, 102]
     texts = bert_tokenizer.decode([enc0.ids, enc1.ids])
     assert texts == ["This is sequence 1", "Sequence 2"]
 


### PR DESCRIPTION
Needed to remove padding for batch encode. Encoding does not include the sequence length for batch encoding so this would result in end paddings of the sequence.

Also - if the first token encountered was a EOS token then stepping would fail. Reworked initialization / errors to better handle this and have a uniform stepping location of page ids.