### PR TITLE
Move allocate_cache from btacher.py to decoder.py

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/invocation.py
+++ b/shortfin/python/shortfin_apps/llm/components/invocation.py
@@ -90,13 +90,6 @@ class LlmTask:
         if len(result) > 1:
             indices = result[1]
 
-        # TODO (stbaione): Move this to the `decoder`
-        # publish cache pages
-        for r in self.exec_requests:
-            total_tokens = r.start_position + len(r.input_token_ids)
-            number_of_complete_pages = total_tokens // self._seq_stride
-            r.publish_allocated_pages(number_of_complete_pages)
-
         exec_requests = self.exec_requests
         buffers = (logits, indices)
         transfer = any([req.return_host_array for req in exec_requests])


### PR DESCRIPTION
1. Rewire batcher.py so that the page_cache no longer allocates in the batcher and instead perform the allocation in decoder.py. 
2. Removing the publish pages function so it occurs post prefill and post all decode steps