### PR TITLE
Remove unused cruft from exec request

### DIFF
--- a/shortfin/tests/apps/llm/components/batcher_test.py
+++ b/shortfin/tests/apps/llm/components/batcher_test.py
@@ -76,7 +76,6 @@ def exec_req_list():
                 phase=InferencePhase.PREFILL,
                 input_token_ids=input_tokens,
                 rid=str(uuid4()),
-                status_tracker=None,
             )
             exec_reqs.append(exec_req)
             input_tokens = [val + 1 for val in input_tokens]

--- a/shortfin/tests/apps/llm/components/invocation_test.py
+++ b/shortfin/tests/apps/llm/components/invocation_test.py
@@ -85,7 +85,6 @@ def staggered_exec_req_list(cache_ref_count, page_pool):
                 phase=InferencePhase.PREFILL,
                 input_token_ids=input_tokens,
                 rid=str(uuid4()),
-                status_tracker=None,
             )
             exec_reqs.append(exec_req)
             input_tokens = [val + 1 for val in input_tokens]

--- a/shortfin/tests/apps/llm/components/messages_test.py
+++ b/shortfin/tests/apps/llm/components/messages_test.py
@@ -53,26 +53,6 @@ def test_inference_exec_request_repr(mock_void_future):
 
 
 @patch("shortfin.VoidFuture")
-def test_copy_exec_request(mock_void_future, mock_base_cache, dummy_pages):
-    req = LlmInferenceExecRequest(InferencePhase.PREFILL, [1, 2, 3, 4], rid="test123")
-    req._cache = mock_base_cache
-    allocation = BasePagedAttentionCacheAllocation(dummy_pages, cache=mock_base_cache)
-    req.allocation = allocation
-    with patch.object(mock_base_cache, "fork_pages", return_value=allocation):
-        new_req = LlmInferenceExecRequest.copy_exec_request(req)
-        for attribute in {"start_position", "prompt_length", "_cache"}:
-            original_attr = getattr(req, attribute)
-            new_attr = getattr(new_req, attribute)
-            assert (
-                new_attr == original_attr
-            ), f"Error copying exec request, expected `{attribute}` to be {original_attr} but got {new_attr}"
-
-        assert (
-            new_req.allocation == allocation
-        ), f"Error copying exec request, expected `allocation` to be {allocation} but got {new_req.allocation}"
-
-
-@patch("shortfin.VoidFuture")
 def test_inference_exec_request_reset(mock_void_future):
     """
     Test the string representation of InferenceExecRequest in different states.


### PR DESCRIPTION
LLM Exec request contained unused cruft including copying and status tracker types.