### PR TITLE
Kvcache Replumbing

### DIFF
--- a/sharktank/sharktank/evaluate/perplexity_iree.py
+++ b/sharktank/sharktank/evaluate/perplexity_iree.py
@@ -217,7 +217,7 @@ class PerplexityIree:
 
         token_batch, seq_lens_batch = pad_tokens(
             token_ids=token_batch.tolist(),
-            pad_to_multiple_of=self.generator.model.cache.pad_sequence_stride,
+            pad_to_multiple_of=self.generator.model.paged_attention.pad_sequence_stride,
         )
 
         logger.debug(f"{token_batch}")
@@ -237,7 +237,7 @@ class PerplexityIree:
         for i in range(self.pipeline_parallelism_size):
             self.cache_state.extend(
                 prepare_iree_module_function_args(
-                    args=[self.batch.cache_state[i]],
+                    args=[self.batch.cache_state.state[i]],
                     devices=devices[i : (i + 1) * self.tensor_parallelism_size],
                 )
             )
@@ -423,7 +423,7 @@ class PerplexityIree:
         else:
             self.token_ids, self.seq_lens = self.generator.tokenizer.encode(
                 test_prompts,
-                pad_to_multiple_of=self.generator.model.cache.pad_sequence_stride,
+                pad_to_multiple_of=self.generator.model.paged_attention.pad_sequence_stride,
             )
 
             logger.debug(f" Prompts for Evaluation:")

--- a/sharktank/sharktank/evaluate/perplexity_torch.py
+++ b/sharktank/sharktank/evaluate/perplexity_torch.py
@@ -142,7 +142,7 @@ class PerplexityTorch:
 
         token_batch, seq_lens_batch = pad_tokens(
             token_ids=token_batch.tolist(),
-            pad_to_multiple_of=self.generator.model.cache.pad_sequence_stride,
+            pad_to_multiple_of=self.generator.model.paged_attention.pad_sequence_stride,
         )
 
         logger.debug(f"{token_batch}")
@@ -253,7 +253,7 @@ class PerplexityTorch:
         else:
             self.token_ids, self.seq_lens = self.generator.tokenizer.encode(
                 test_prompts,
-                pad_to_multiple_of=self.generator.model.cache.pad_sequence_stride,
+                pad_to_multiple_of=self.generator.model.paged_attention.pad_sequence_stride,
             )
 
             logger.debug(f" Prompts for Evaluation:")

--- a/sharktank/sharktank/export_layer/export_kv_cache.py
+++ b/sharktank/sharktank/export_layer/export_kv_cache.py
@@ -10,7 +10,7 @@ from iree.turbine.aot import *
 
 from sharktank.types import SplitPrimitiveTensor
 from sharktank.ops import reshard_split, replicate
-from sharktank.layers.paged_attention import PagedAttention
+from sharktank.layers.paged_attention import build_cache
 from sharktank.utils import cli
 
 
@@ -59,14 +59,13 @@ def main():
     page_count = bs * seq_length // block_seq_stride
     write_seq_length = seq_length - 4
 
-    cache = PagedAttention(
-        block_seq_stride=block_seq_stride,
+    cache = build_cache(
         transformer_block_count=transformer_block_count,
         attn_head_count=attn_head_count,
         attn_head_dim=attn_head_dim,
-        shard_count=args.sharding,
+        cache_partition_count=2,
+        block_seq_stride=block_seq_stride,
         cache_dtype=torch.float32,
-        attn_dtype=torch.float32,
         device=None,
     )
 

--- a/sharktank/sharktank/layers/__init__.py
+++ b/sharktank/sharktank/layers/__init__.py
@@ -6,7 +6,7 @@
 
 from .base import *
 from .conv import Conv2DLayer, Conv3DLayer, Conv1DLayer
-from .paged_attention import PagedAttention, attn_type_map
+from .paged_attention import PagedAttention, attn_type_map, KVCache, build_cache
 from .causal_llm import BaseCausalLMModel
 from .linear import LinearLayer
 from .norm import RMSNormLayer, LayerNorm

--- a/sharktank/sharktank/layers/paged_llama_attention_block.py
+++ b/sharktank/sharktank/layers/paged_llama_attention_block.py
@@ -13,7 +13,7 @@ from .base import Theta, ThetaLayer
 from .linear import LinearLayer
 from .norm import RMSNormLayer, L2Norm
 from .latent_attention_block import LatentAttentionBlock
-from .paged_attention import PagedAttention, attn_type_map
+from .paged_attention import KVCache, PagedAttention, attn_type_map
 from sharktank import ops
 
 __all__ = [
@@ -30,7 +30,7 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         theta: Theta,
         *,
         block_index: int,
-        cache: PagedAttention,
+        paged_attention: PagedAttention,
         head_count: int,
         head_dim: int,
         head_count_kv: int,
@@ -48,7 +48,7 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         floor_scale: Optional[float] = None,
     ):
         super().__init__(theta)
-        self.paged_attention = cache
+        self.paged_attention = paged_attention
         self.block_index = block_index
         self.head_count = head_count
         self.head_dim = head_dim
@@ -201,7 +201,7 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         start_positions: Optional[torch.Tensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
         embedding_batch_mask: None | tuple[InferenceTensor, InferenceTensor] = None,
-        cache_state: list[torch.Tensor] = None,
+        cache_state: KVCache,
     ):
         x = self.attn_norm(h)
 

--- a/sharktank/sharktank/utils/create_cache.py
+++ b/sharktank/sharktank/utils/create_cache.py
@@ -7,7 +7,7 @@
 from sharktank.layers import *
 
 
-def create_paged_kv_cache(config: LlamaModelConfig) -> PagedAttention:
+def create_paged_attention(config: LlamaModelConfig) -> PagedAttention:
     if config.kv_cache_type != "paged":
         raise ValueError("Model does not use paged kv cache, cannot create kv cache")
 
@@ -18,9 +18,25 @@ def create_paged_kv_cache(config: LlamaModelConfig) -> PagedAttention:
         attn_head_count=hp.attention_head_count_kv,
         attn_head_dim=hp.attn_head_dim,
         attn_type=attn_type_map[hp.model_arch],
-        cache_partition_count=2,  # One for each of K/V.
         block_seq_stride=config.block_seq_stride,
         device=config.device,
         cache_dtype=dtype,
         attn_dtype=config.attention_dtype,
+    )
+
+
+def create_kv_cache(config: LlamaModelConfig) -> KVCache:
+    if config.kv_cache_type != "paged":
+        raise ValueError("Model does not use paged kv cache, cannot create kv cache")
+
+    hp = config.hp
+    dtype = config.kv_cache_dtype or config.attention_dtype
+
+    return KVCache(
+        transformer_block_count=hp.block_count,
+        attn_head_count=hp.attention_head_count_kv,
+        attn_head_dim=hp.attn_head_dim,
+        block_seq_stride=config.block_seq_stride,
+        cache_dtype=dtype,
+        device=config.device,
     )

--- a/sharktank/tests/layers/paged_llama_attention_block_test.py
+++ b/sharktank/tests/layers/paged_llama_attention_block_test.py
@@ -8,6 +8,8 @@ import pytest
 
 import logging
 
+from sharktank.layers.paged_attention import KVCache
+
 logging.basicConfig(level=logging.DEBUG)
 
 import unittest
@@ -56,17 +58,24 @@ class PagedLlamaAttentionBlockTest(unittest.TestCase):
     def testExportNondecomposed(self):
         dtype = torch.float32
 
-        cache = PagedAttention(
+        paged_attention = PagedAttention(
+            transformer_block_count=self.transformer_block_count,
+            attn_head_count=self.head_count_kv,
+            attn_head_dim=self.attention_head_dim,
+            block_seq_stride=self.block_seq_stride,
+            cache_dtype=dtype,
+            attn_dtype=dtype,
+        )
+
+        kv_cache = KVCache(
             transformer_block_count=self.transformer_block_count,
             attn_head_count=self.head_count_kv,
             attn_head_dim=self.attention_head_dim,
             cache_partition_count=self.cache_partition_count,
             block_seq_stride=self.block_seq_stride,
             cache_dtype=dtype,
-            attn_dtype=dtype,
         )
-
-        cache_state = cache.allocate(self.page_count)
+        cache_state = kv_cache.allocate(self.page_count)
         cache_state[0] = torch.rand(cache_state[0].shape, dtype=dtype)
 
         theta = make_llama_attention_block_theta(
@@ -79,7 +88,7 @@ class PagedLlamaAttentionBlockTest(unittest.TestCase):
         attn = PagedLlamaAttentionBlock(
             theta=theta,
             block_index=self.block_index,
-            cache=cache,
+            paged_attention=paged_attention,
             head_count=self.attention_head_count,
             head_dim=self.attention_head_dim,
             head_count_kv=self.head_count_kv,
@@ -99,12 +108,13 @@ class PagedLlamaAttentionBlockTest(unittest.TestCase):
 
         class MyModule(torch.nn.Module):
             def forward(self, h, seq_block_ids, cache_state):
+                kv_cache.state = cache_state
                 return attn.forward(
                     h,
                     seq_block_ids=seq_block_ids,
                     embedding=embedding_module,
                     start_index=0,
-                    cache_state=cache_state,
+                    cache_state=kv_cache,
                 )
 
         mod = MyModule()

--- a/sharktank/tests/models/grok/test_grok.py
+++ b/sharktank/tests/models/grok/test_grok.py
@@ -10,6 +10,8 @@ from sharktank.models.grok.toy_grok import generate
 import torch
 import pytest
 
+from sharktank.utils.create_cache import create_kv_cache
+
 
 @pytest.mark.xfail(
     raises=AssertionError,
@@ -32,14 +34,15 @@ def test_grok():
     ids = torch.asarray([ids], dtype=torch.int64)
     block_ids = torch.asarray([[i for i in range(blocks)]]).to(torch.int64)
 
-    cache_state = model.cache.allocate(
+    kv_cache = create_kv_cache(config)
+    kv_cache.state = kv_cache.allocate(
         page_count=config.hp.context_length // config.block_seq_stride
     )
 
     logits = model.prefill(
         tokens=ids,
         attention_mask=None,
-        cache_state=cache_state,
+        cache_state=kv_cache,
         seq_block_ids=block_ids,
     )
 

--- a/sharktank/tests/models/llama/test_llama.py
+++ b/sharktank/tests/models/llama/test_llama.py
@@ -13,6 +13,7 @@ import torch
 
 from sharktank.models.llm import *
 from sharktank.models.llama.toy_llama import generate
+from sharktank.utils.create_cache import create_kv_cache
 from sharktank.utils.export_artifacts import IreeCompileException
 from sharktank.utils.testing import (
     is_mi300x,
@@ -39,7 +40,8 @@ class CrossEntropyTest(unittest.TestCase):
         ids = torch.asarray([ids], dtype=torch.int64)
         block_ids = torch.asarray([[i for i in range(blocks)]]).to(torch.int64)
 
-        cache_state = model.cache.allocate(
+        cache_state = create_kv_cache(config)
+        cache_state.state = cache_state.allocate(
             page_count=config.hp.context_length // config.block_seq_stride
         )
 

--- a/sharktank/tests/models/llama4/llama4_test.py
+++ b/sharktank/tests/models/llama4/llama4_test.py
@@ -1,5 +1,6 @@
 import re
 import transformers.models
+from sharktank.utils.create_cache import create_kv_cache
 from sharktank.utils.testing import TempDirTestBase
 from sharktank.models.llama4.testing import (
     make_toy_model_config,
@@ -88,7 +89,8 @@ class Llama4Test(TempDirTestBase):
         hf_output = run_hf_model()
 
         page_count = (len(input_ids[0]) // config.block_seq_stride) * batch_size
-        kv_cache_state = model.cache.allocate(page_count)
+        kv_cache_state = create_kv_cache(config)
+        kv_cache_state.state = kv_cache_state.allocate(page_count)
         seq_block_ids = torch.arange(
             start=0, end=input_ids.numel() // config.block_seq_stride, dtype=torch.long
         ).view(batch_size, batch_seq_len // config.block_seq_stride)


### PR DESCRIPTION
- Instead of passing around a list of tensors for the cache state, we now pass around a KVCache object.
- Remove KVCache from PagedAttention and disentangle the two.
- Renamed model.cache to model.paged_attention, which is what it is.