### PR TITLE
Softmax should occur in f32

### DIFF
--- a/sharktank/sharktank/models/llm/export.py
+++ b/sharktank/sharktank/models/llm/export.py
@@ -76,10 +76,14 @@ class ServicePagedLlmModelV1(torch.nn.Module):
         logits = ops.unshard(logits)
 
         if self.config.logits_normalization == "softmax":
+            logits = logits.to(dtype=torch.float32)
             logits = ops.softmax(logits, dim=-1)
+            logits = logits.to(dtype=torch.float16)
 
         if self.config.logits_normalization == "log_softmax":
+            logits = logits.to(dtype=torch.float32)
             logits = ops.elementwise(torch.log, ops.softmax(logits, dim=-1))
+            logits = logits.to(dtype=torch.float16)
 
         if self.config.prefill_final_logits:
             last_seq_lens = seq_lens


### PR DESCRIPTION
If softmax is in f16 there is a risk of under/overflow during softmax. Changing to f32 makes this numerically stable.