### PR TITLE
Add a vmfb perplexity generating tool

### DIFF
--- a/sharktank/sharktank/models/llm/config.py
+++ b/sharktank/sharktank/models/llm/config.py
@@ -4,7 +4,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import json
+
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Optional
 
 
@@ -28,6 +31,13 @@ class ServiceConfig:
     logits_normalization: Optional[str]
     top_k: Optional[int]
     paged_kv_cache: KVCacheConfig
+
+    @staticmethod
+    def load(fp: Path):
+        with open(fp, "rt") as f:
+            server_config = ServiceConfig(**json.loads(f.read()))
+            server_config.paged_kv_cache = KVCacheConfig(**server_config.paged_kv_cache)
+        return server_config
 
 
 @dataclass

--- a/sharktank/sharktank/tools/perplexity_llm_vmfb.py
+++ b/sharktank/sharktank/tools/perplexity_llm_vmfb.py
@@ -1,0 +1,78 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import argparse
+import dataclasses
+import json
+import tokenizers
+
+from datasets import load_dataset
+
+from sharktank.models.llm.config import ServiceConfig
+from sharktank.utils.llm_utils import IreeInstance, LlmInstance
+
+
+class Tokenizer:
+    def __init__(self, fp):
+        self.t = tokenizers.Tokenizer.from_file(fp)
+
+    def encode(self, texts: list[str]) -> list[list[int]]:
+        """Encodes a batch of texts, applying no padding."""
+        return [s.ids for s in self.t.encode_batch(texts)]
+
+    def decode(self, sequences) -> list[str]:
+        """Decodes a batch of sequences to text."""
+        return self.t.decode_batch(sequences)
+
+
+def main(dataset, vmfb, config, irpa, tokenizer):
+    tokenizer = Tokenizer(tokenizer)
+
+    with open(dataset, "r") as dataset:
+        dataset = json.load(dataset)
+
+    name = dataset["dataset"]
+    revision = dataset["revision"]
+    split = dataset["split"]
+    ids = dataset["ids"]
+
+    test_prompts = load_dataset(name, revision, split=split)["text"]
+    test_prompts = [test_prompts[id] for id in ids]
+    encoded = tokenizer.encode(test_prompts)
+
+    iree = IreeInstance(devices=["hip://0"], vmfb=vmfb, parameters=irpa)
+    server_config = ServiceConfig.load(config)
+    llm = LlmInstance.load(iree, server_config)
+
+    runner = llm.make_perplexity_eval()
+    results = runner.batch_prefill_perplexity(requests=encoded)
+
+    scores = {id : result.score for id, result in zip(ids, results)}
+    results = {
+        "dataset" : name,
+        "revision" : revision,
+        "split" : split,
+        "scores" : scores,
+    }
+
+    print(json.dumps(results, indent=1))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset", help="Path to dataset", required=True)
+    parser.add_argument("--irpa", help="IRPA parameters file", required=True)
+    parser.add_argument("--vmfb", help="vmfb file path", required=True)
+    parser.add_argument("--config", help="json config file for server", required=True)
+    parser.add_argument("--tokenizer", help="json tokenizer config file", required=True)
+    args = parser.parse_args()
+    main(
+        dataset=args.dataset,
+        irpa=args.irpa,
+        vmfb=args.vmfb,
+        config=args.config,
+        tokenizer=args.tokenizer,
+    )

--- a/sharktank/tests/models/llama/toy_llama_test.py
+++ b/sharktank/tests/models/llama/toy_llama_test.py
@@ -62,9 +62,9 @@ class ToyLlamaTest(unittest.TestCase):
         # fmt: off
         seq = [0, 208, 214, 29, 19, 86, 176, 120, 120, 80, 120, 208, 37, 157, 191, 137, ]
         # fmt: on
-        all_match, score = decoder.prefill_cross_entropy([seq])[0]
-        assert all_match == True
-        torch.testing.assert_close(score, 0.583, atol=1e-2, rtol=1e-2)
+        result = decoder.prefill_cross_entropy([seq])[0]
+        assert result.valid
+        torch.testing.assert_close(result.score, 0.583, atol=1e-2, rtol=1e-2)
 
     def testDecodePerplexity(self):
         decoder = self._instance.make_perplexity_eval()
@@ -72,9 +72,9 @@ class ToyLlamaTest(unittest.TestCase):
         # fmt: off
         seq = [0, 208, 214, 29, 19, 86, 176, 120, 120, 80, 120, 208, 37, 157, 191, 137, ]
         # fmt: on
-        all_match, score = decoder.decode_cross_entropy([seq])[0]
-        assert all_match == True
-        torch.testing.assert_close(score, 0.583, atol=1e-2, rtol=1e-2)
+        result = decoder.decode_cross_entropy([seq])[0]
+        assert result.valid
+        torch.testing.assert_close(result.score, 0.583, atol=1e-2, rtol=1e-2)
 
 
 @pytest.mark.usefixtures("iree_flags")
@@ -109,6 +109,6 @@ class ToyLlamaIreeTest(unittest.TestCase):
         # fmt: off
         seq = [0, 208, 214, 29, 19, 86, 176, 120, 120, 80, 120, 208, 37, 157, 191, 137, ]
         # fmt: on
-        all_match, score = decoder.prefill_cross_entropy([seq])[0]
-        assert all_match == True
-        torch.testing.assert_close(score, 0.583, atol=1e-2, rtol=1e-2)
+        result = decoder.prefill_cross_entropy([seq])[0]
+        assert result.valid
+        torch.testing.assert_close(result.score, 0.583, atol=1e-2, rtol=1e-2)


### PR DESCRIPTION
Per dataset spec this computes the perplexity score per sequence. This can be used for checking numerics but also used to generate baselines for perplexity test suites.