### PR TITLE
Replace KVCache list of tensors with simple CacheAllocation wrapper object

### DIFF
--- a/sharktank/sharktank/export_layer/export_paged_attention.py
+++ b/sharktank/sharktank/export_layer/export_paged_attention.py
@@ -16,6 +16,7 @@ import torch.nn.functional as F
 from iree.turbine.aot import *
 
 from sharktank.layers import *
+from sharktank.layers.paged_attention import CacheAllocation
 from sharktank.types import *
 from sharktank.models.llama.testing import *
 from sharktank.utils import cli
@@ -33,7 +34,7 @@ def paged_attention(
     seq_block_ids: torch.Tensor,
     start_positions: Optional[torch.Tensor] = None,
     attention_mask: Optional[torch.Tensor] = None,
-    cache_state: list[torch.Tensor] = None,
+    cache_state: CacheAllocation = None,
 ):
 
     block_index = attention_block.block_index
@@ -81,7 +82,7 @@ def run_llama(
     attention_mask: torch.Tensor,
     # [bs, batch_seq_len // block_seq_stride]
     seq_block_ids: torch.Tensor,
-    cache_state: list[torch.Tensor],
+    cache_state: CacheAllocation,
     # [bs] of starting positions
     start_positions: Optional[torch.Tensor] = None,
 ):

--- a/sharktank/sharktank/layers/__init__.py
+++ b/sharktank/sharktank/layers/__init__.py
@@ -6,7 +6,7 @@
 
 from .base import *
 from .conv import Conv2DLayer, Conv3DLayer, Conv1DLayer
-from .paged_attention import PagedAttention, attn_type_map
+from .paged_attention import PagedAttention, attn_type_map, CacheAllocation
 from .causal_llm import BaseCausalLMModel
 from .linear import LinearLayer
 from .norm import RMSNormLayer, LayerNorm

--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -29,7 +29,7 @@ from sharktank import ops, kernels
 from sharktank.kernels.mlir_kernel import *
 from sharktank.types.tensors import AnyTensor
 
-__all__ = ["PagedAttention", "attn_type_map"]
+__all__ = ["PagedAttention", "attn_type_map", "CacheAllocation"]
 
 
 attn_type_map = {
@@ -153,6 +153,17 @@ def pack_raw_tensor(tensor, quantizer):
     return PlanarQuantizedTensor(shape=tensor.shape, layout=layout)
 
 
+class CacheAllocation:
+    def __init__(self, allocation: list[torch.Tensor]):
+        self.allocation = allocation
+
+    def __len__(self):
+        return len(self.allocation)
+
+    def __getitem__(self, idx):
+        return self.allocation[idx]
+
+
 class KVCache:
     def __init__(
         self,
@@ -189,7 +200,7 @@ class KVCache:
 
         self.page_slab_flat_dims = math.prod(self.sub_page_dims)
 
-    def allocate(self, page_count: int) -> List[torch.Tensor]:
+    def allocate(self, page_count: int) -> CacheAllocation:
         tensors = [
             torch.empty(
                 [page_count, self.page_slab_flat_dims],
@@ -198,20 +209,20 @@ class KVCache:
             )
         ]
 
-        return tensors
+        return CacheAllocation(tensors)
 
     @property
     def state_count(self):
         return 1
 
-    def unflatten_page_table(self, state: List[torch.Tensor]) -> List[torch.Tensor]:
+    def unflatten_page_table(self, state: CacheAllocation) -> List[torch.Tensor]:
         assert len(state) == 1
         """Unflattens the 2D page tables to 6D tensors."""
         return [state[0].unflatten(1, self.sub_page_dims)]
 
     def read(
         self,
-        state: List[torch.Tensor],
+        state: CacheAllocation,
         *,
         transformer_block_index: int,
         page_ids: torch.Tensor,
@@ -243,7 +254,7 @@ class KVCache:
     def write(
         self,
         *,
-        state: List[torch.Tensor],
+        state: CacheAllocation,
         cache_partitions: List[torch.Tensor],
         transformer_block_index: int,
         page_ids: torch.Tensor,
@@ -287,7 +298,7 @@ class KVCache:
     def write_timestep(
         self,
         *,
-        state: List[torch.Tensor],
+        state: CacheAllocation,
         cache_partitions: List[torch.Tensor],
         transformer_block_index: int,
         seq_positions: torch.Tensor,
@@ -413,12 +424,12 @@ class PagedAttention:
     def pad_sequence_stride(self) -> int:
         return self.block_seq_stride
 
-    def allocate(self, page_count: int) -> List[torch.Tensor]:
+    def allocate(self, page_count: int) -> CacheAllocation:
         return self.kv_cache.allocate(page_count=page_count)
 
     def read(
         self,
-        state: List[Union[torch.Tensor]],
+        state: CacheAllocation,
         *,
         transformer_block_index: int,
         page_ids: Optional[torch.Tensor] = None,
@@ -431,7 +442,7 @@ class PagedAttention:
 
     def write_timestep(
         self,
-        state: List[torch.Tensor],
+        state: CacheAllocation,
         cache_partitions: List[torch.Tensor],
         transformer_block_index: int,
         seq_positions: torch.Tensor,
@@ -447,7 +458,7 @@ class PagedAttention:
 
     def write(
         self,
-        state: List[torch.Tensor],
+        state: CacheAllocation,
         cache_partitions: List[torch.Tensor],
         *,
         transformer_block_index: int,
@@ -531,7 +542,7 @@ class PagedAttention:
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
-        cache_state: List[torch.Tensor],
+        cache_state: CacheAllocation,
         seq_block_ids: torch.Tensor,
         block_index: int,
         start_positions: torch.Tensor,
@@ -586,7 +597,7 @@ class PagedAttention:
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
-        cache_state: List[torch.Tensor],
+        cache_state: CacheAllocation,
         seq_block_ids: torch.Tensor,
         block_index: int,
         start_positions: Optional[torch.Tensor],

--- a/sharktank/sharktank/layers/paged_llama_attention_block.py
+++ b/sharktank/sharktank/layers/paged_llama_attention_block.py
@@ -13,7 +13,7 @@ from .base import Theta, ThetaLayer
 from .linear import LinearLayer
 from .norm import RMSNormLayer, L2Norm
 from .latent_attention_block import LatentAttentionBlock
-from .paged_attention import PagedAttention, attn_type_map
+from .paged_attention import CacheAllocation, PagedAttention, attn_type_map
 from sharktank import ops
 
 __all__ = [
@@ -201,7 +201,7 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         start_positions: Optional[torch.Tensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
         embedding_batch_mask: None | tuple[InferenceTensor, InferenceTensor] = None,
-        cache_state: list[torch.Tensor] = None,
+        cache_state: CacheAllocation | None = None,
     ):
         x = self.attn_norm(h)
 

--- a/sharktank/sharktank/models/llm/llm.py
+++ b/sharktank/sharktank/models/llm/llm.py
@@ -123,7 +123,7 @@ class PagedLlmModelV1(BaseCausalLMModel):
         attention_mask: Union[torch.Tensor, None],
         # [bs, batch_seq_len // block_seq_stride]
         seq_block_ids: torch.Tensor,
-        cache_state: torch.Tensor,
+        cache_state: CacheAllocation,
         start_positions: Optional[torch.Tensor] = None,
     ):
 
@@ -182,7 +182,7 @@ class PagedLlmModelV1(BaseCausalLMModel):
         start_positions: torch.Tensor,
         # [bs, batch_seq_len // block_seq_stride]
         seq_block_ids: torch.Tensor,
-        cache_state: torch.Tensor,
+        cache_state: CacheAllocation,
     ):
         # Precompute a position based mask for computing rope embeddings
         # as it is the same for all blocks.
@@ -376,7 +376,7 @@ class AttentionFFNBlock(ThetaLayer):
         embedding_batch_mask: tuple[InferenceTensor, InferenceTensor]
         | InferenceTensor
         | None = None,
-        cache_state: list[torch.Tensor] = None,
+        cache_state: CacheAllocation | None = None,
     ):
         h = self.attn(
             h,

--- a/sharktank/sharktank/utils/load_llm.py
+++ b/sharktank/sharktank/utils/load_llm.py
@@ -267,7 +267,7 @@ class Batch:
             self.dump_args(phase="prefill", arg_name="seq_lens", arg=self.seq_lens)
             self.dump_args(phase="prefill", arg_name="seq_block_ids", arg=seq_block_ids)
             self.dump_args(
-                phase="prefill", arg_name="cache_state", arg=self.cache_state
+                phase="prefill", arg_name="cache_state", arg=self.cache_state.allocation
             )
 
         self.prefill_logits = model.prefill(

--- a/sharktank/sharktank/utils/load_llm.py
+++ b/sharktank/sharktank/utils/load_llm.py
@@ -343,7 +343,7 @@ class Batch:
             self.dump_args(
                 phase="decode",
                 arg_name="cache_state",
-                arg=self.cache_state,
+                arg=self.cache_state.allocation,
                 decode_step=self.decode_step,
             )
 

--- a/sharktank/sharktank/utils/load_llm.py
+++ b/sharktank/sharktank/utils/load_llm.py
@@ -13,6 +13,7 @@ import numpy as np
 
 import torch
 
+from sharktank.layers.paged_attention import CacheAllocation
 from sharktank.types import *
 from sharktank.models.llm import PagedLlmModelV1
 
@@ -129,7 +130,7 @@ class Batch:
         parent: TorchGenerator,
         token_ids: torch.Tensor,
         seq_lens: torch.Tensor,
-        cache_state: list[torch.Tensor | SplitPrimitiveTensor | ReplicatedTensor],
+        cache_state: CacheAllocation,
         bs: int,
         dump_path: Path,
         dump_decode_steps: int,


### PR DESCRIPTION
Instead of plumbing through a list of tensors everywhere, use a small object. No functionality changes for now, just initial signature changes.