### PR TITLE
Bump iree to `3.7.0rc20250822` and kernels for matmul_transpose change

### DIFF
--- a/requirements-iree-pinned.txt
+++ b/requirements-iree-pinned.txt
@@ -3,6 +3,6 @@ wave-lang==1.0.2
 
 # Keep these versions synced with SHORTFIN_IREE_GIT_TAG in shortfin/CMakeLists.txt
 --find-links https://iree.dev/pip-release-links.html
-iree-base-compiler==3.7.0rc20250811
-iree-base-runtime==3.7.0rc20250811
-iree-turbine==3.7.0rc20250811
+iree-base-compiler==3.7.0rc20250822
+iree-base-runtime==3.7.0rc20250822
+iree-turbine==3.7.0rc20250822

--- a/sharktank/sharktank/kernels/templates/batch_matmul_transpose_b.mlir
+++ b/sharktank/sharktank/kernels/templates/batch_matmul_transpose_b.mlir
@@ -24,7 +24,13 @@ util.func private @sharktank_batch_matmul_transpose_b_{{spec_sig}}(
   %result_empty_dynamic = tensor.empty(%batch_dim, %m_dim, %n_dim) : !c_dynamic_tensor_type
   %result_empty = tensor.cast %result_empty_dynamic : !c_dynamic_tensor_type to !c_tensor_type
   %result_fill = linalg.fill ins(%zero: !dtype) outs(%result_empty: !c_tensor_type) -> !c_tensor_type
-  %result = linalg.batch_matmul_transpose_b ins(%a, %b: !a_tensor_type, !b_tensor_type) outs(%result_fill: !c_tensor_type) -> !c_tensor_type
+  %result = linalg.batch_matmul
+    indexing_maps = [
+      affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>,
+      affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>,
+      affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+    ]
+    ins(%a, %b: !a_tensor_type, !b_tensor_type) outs(%result_fill: !c_tensor_type) -> !c_tensor_type
   util.return %result : !c_tensor_type
 }
 

--- a/sharktank/sharktank/kernels/templates/mmtfp_2d.mlir
+++ b/sharktank/sharktank/kernels/templates/mmtfp_2d.mlir
@@ -25,7 +25,12 @@ util.func private @sharktank_mmtfp_2d_{{n}}_{{k}}_{{a_type}}{{bT_type}}{{accum_t
   %result_init = linalg.fill
     ins(%zero : !accum_type)
     outs(%result_empty: !accum_tensor_type) -> !accum_tensor_type
-  %result_accum = linalg.matmul_transpose_b
+  %result_accum = linalg.matmul
+    indexing_maps = [
+      affine_map<(d0, d1, d2) -> (d0, d2)>,
+      affine_map<(d0, d1, d2) -> (d1, d2)>,
+      affine_map<(d0, d1, d2) -> (d0, d1)>
+    ]
     ins (%a, %bT: !a_tensor_type, !bT_tensor_type)
     outs (%result_init: !accum_tensor_type) -> !accum_tensor_type
   %result_cast_empty = tensor.empty(%m) : !c_tensor_type

--- a/sharktank/sharktank/kernels/templates/mmtfp_3d.mlir
+++ b/sharktank/sharktank/kernels/templates/mmtfp_3d.mlir
@@ -39,7 +39,12 @@ util.func private @sharktank_mmtfp_3d_{{n}}_{{k}}_{{a_type}}{{bT_type}}{{accum_t
   %result_init = linalg.fill
     ins(%zero : !accum_type)
     outs(%result_empty: !accum_tensor_type) -> !accum_tensor_type
-  %result_accum = linalg.batch_matmul_transpose_b
+  %result_accum = linalg.batch_matmul
+    indexing_maps = [
+      affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>,
+      affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>,
+      affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+    ]
     ins (%a, %bT_broadcast: !a_tensor_type, !bT_broadcast_tensor_type)
     outs (%result_init: !accum_tensor_type) -> !accum_tensor_type
   %result_cast_empty = tensor.empty(%b0, %m) : !c_tensor_type

--- a/sharktank/tests/kernels/batch_matmul_transpose_b_test.py
+++ b/sharktank/tests/kernels/batch_matmul_transpose_b_test.py
@@ -97,7 +97,7 @@ class batch_matmul_transpose_b_test(unittest.TestCase):
         reason="""No uint32 dtype conversions in IREE Turbine.
         Does not work with unsigned types. The kernel needs to be adapted.
         The problem is that we reinterpret cast to signless integer types.
-        Maybe linalg.batch_matmul_transpose_b when promoting from i8 to i32 assumes a
+        Maybe linalg.batch_matmul when promoting from i8 to i32 assumes a
         signed type even though i8 is signless."""
     )
     def testArgUi8AccumUi32(self):

--- a/sharktuner/model_tuner/double_mmt.mlir
+++ b/sharktuner/model_tuner/double_mmt.mlir
@@ -8,9 +8,21 @@ func.func @main(%arg0: !matA_0, %arg1: !matB_0) -> !matC_1 {
   %cst = arith.constant 0.000000e+00 : f32
   %5 = tensor.empty() : !matC_0
   %6 = linalg.fill ins(%cst : f32) outs(%5 : !matC_0) -> !matC_0
-  %7 = linalg.matmul_transpose_b ins(%arg0, %arg1 : !matA_0, !matB_0) outs(%6 : !matC_0) -> !matC_0
+  %7 = linalg.matmul
+    indexing_maps = [
+      affine_map<(d0, d1, d2) -> (d0, d2)>,
+      affine_map<(d0, d1, d2) -> (d1, d2)>,
+      affine_map<(d0, d1, d2) -> (d0, d1)>
+    ]
+    ins(%arg0, %arg1 : !matA_0, !matB_0) outs(%6 : !matC_0) -> !matC_0
   %8 = tensor.empty() : !matC_1
   %9 = linalg.fill ins(%cst : f32) outs(%8 : !matC_1) -> !matC_1
-  %10 = linalg.matmul_transpose_b ins(%7, %7 : !matC_0, !matC_0) outs(%9 : !matC_1) -> !matC_1
+  %10 = linalg.matmul
+    indexing_maps = [
+      affine_map<(d0, d1, d2) -> (d0, d2)>,
+      affine_map<(d0, d1, d2) -> (d1, d2)>,
+      affine_map<(d0, d1, d2) -> (d0, d1)>
+    ]
+    ins(%7, %7 : !matC_0, !matC_0) outs(%9 : !matC_1) -> !matC_1
   return %10 : !matC_1
 }

--- a/shortfin/CMakeLists.txt
+++ b/shortfin/CMakeLists.txt
@@ -47,7 +47,7 @@ add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 # Prefer to keep the IREE git tag synced with the Python package version in the
 # requirements-iree-pinned.txt file. At a minimum, the compiler from those
 # packages must be compatible with the runtime at this source ref.
-set(SHORTFIN_IREE_GIT_TAG "iree-3.7.0rc20250811")
+set(SHORTFIN_IREE_GIT_TAG "iree-3.7.0rc20250822")
 
 
 # build options

--- a/shortfin/src/shortfin/local/scheduler.cc
+++ b/shortfin/src/shortfin/local/scheduler.cc
@@ -43,7 +43,8 @@ Account::Account(Scheduler &scheduler, Device *device)
 
 void Account::Initialize() {
   SHORTFIN_THROW_IF_ERROR(iree_hal_semaphore_create(
-      hal_device(), /*initial_value=*/idle_timepoint_,
+      hal_device(), IREE_HAL_QUEUE_AFFINITY_ANY,
+      /*initial_value=*/idle_timepoint_,
       /*flags=*/IREE_HAL_SEMAPHORE_FLAG_NONE, sem_.for_output()));
   Reset();
 }
@@ -76,7 +77,8 @@ VoidFuture Account::OnSync() {
   scheduler_.system().blocking_executor().Schedule([sem = std::move(sem),
                                                     idle_timepoint, future]() {
     iree_status_t status =
-        iree_hal_semaphore_wait(sem, idle_timepoint, iree_infinite_timeout());
+        iree_hal_semaphore_wait(sem, idle_timepoint, iree_infinite_timeout(),
+                                IREE_HAL_WAIT_FLAG_DEFAULT);
     if (!iree_status_is_ok(status)) {
       const_cast<VoidFuture &>(future).set_failure(status);
     } else {


### PR DESCRIPTION
Interface changes in [IREE-21619](https://github.com/iree-org/iree/pull/21619), which require a small update in the shortfin code.

In that PR, @benvanik states that "Behavior is defaulted to what it is today before these additions...", so I followed what seemed to be the default flags throughout that PR to maintain current behavior (i.e. [here](https://github.com/iree-org/iree/pull/21619/files#diff-289c6144e8b6d353bc4e1dba6a206d8b2da145ffa66f5e659cf1b6c2345103cfR386)).

Could use a double-check to make sure that this is in fact maintaining current behavior on the `shortfin` side.

Also includes @vivekkhandelwal1's changes to fix the `matmul_transpose` op, merged from #2055 