### PR TITLE
Finish plumbing matmul-kernel arg through perplexity_iree.py

### DIFF
--- a/sharktank/sharktank/evaluate/perplexity_iree.py
+++ b/sharktank/sharktank/evaluate/perplexity_iree.py
@@ -56,6 +56,7 @@ class PerplexityIree:
         tensor_parallelism_size,
         pipeline_parallelims_size,
         attention_kernel,
+        matmul_kernel,
         block_seq_stride,
         activation_dtype,
         attention_dtype,
@@ -74,12 +75,12 @@ class PerplexityIree:
         self.bs = bs
         self.tensor_parallelism_size = tensor_parallelism_size
         self.attention_kernel = attention_kernel
+        self.matmul_kernel = matmul_kernel
         self.block_seq_stride = block_seq_stride
         self.activation_dtype = activation_dtype
         self.attention_dtype = attention_dtype
         self.kv_cache_dtype = kv_cache_dtype
         self.pipeline_parallelism_size = pipeline_parallelims_size
-        self.attention_kernel = attention_kernel
         self.use_attention_mask = use_attention_mask
         self.use_hf = use_hf
         self.weight_path_str = weight_path_str
@@ -147,6 +148,7 @@ class PerplexityIree:
             iree_hal_target_device=self.iree_hal_target_device,
             hip_device_id=self.iree_devices[0],
             attention_kernel=self.attention_kernel,
+            matmul_kernel=self.matmul_kernel,
             tensor_parallelism_size=self.tensor_parallelism_size,
             pipeline_parallelism_size=self.pipeline_parallelism_size,
             block_seq_stride=self.block_seq_stride,
@@ -186,6 +188,7 @@ class PerplexityIree:
             pipeline_parallelism_size=self.pipeline_parallelism_size,
             block_seq_stride=self.block_seq_stride,
             attention_kernel=self.attention_kernel,
+            matmul_kernel=self.matmul_kernel,
             use_hf=self.use_hf,
             block_to_pipeline_map=block_to_pipeline,
             pipeline_to_device_map=pipeline_to_devices,
@@ -492,6 +495,7 @@ def run_perplexity_iree(
         tensor_parallelism_size=tensor_parallelism_size,
         pipeline_parallelims_size=pipeline_parallelism_size,
         attention_kernel=args.attention_kernel,
+        matmul_kernel=args.matmul_kernel,
         block_seq_stride=args.block_seq_stride,
         use_attention_mask=args.use_attention_mask,
         activation_dtype=args.activation_dtype,

--- a/sharktank/sharktank/utils/export_artifacts.py
+++ b/sharktank/sharktank/utils/export_artifacts.py
@@ -349,7 +349,7 @@ class ExportArtifacts:
         if self.attention_kernel is not None:
             export_args.append(f"--attention-kernel={self.attention_kernel}")
         if self.matmul_kernel is not None:
-            export_args.append(f"--matmul-kernel={self.matmul_kernel}")
+            export_args.append(f"--matmul-kernel='{self.matmul_kernel}'")
 
         if self.kv_cache_dtype is not None:
             export_args.append(f"--kv-cache-dtype={self.kv_cache_dtype}")


### PR DESCRIPTION
This PR finishes plumbing through `--matmul-kernel` argument, so that we can run PPL using either assembly or sharktank fp4 matmul kernels. The argument needs to be in quotes, which is why I added them to the CLI argument.

Ex:
```
python -m sharktank.evaluate.perplexity_iree \
--irpa-file=/shark-dev/llama3.1/405b/instruct/weights/fp4/fp4_2025_07_10_fn.irpa \
--tokenizer-config-json=/shark-dev/llama3.1/405b/instruct/weights/fp4/tokenizer_config.json    \
--iree-device='hip://4'     \
--iree-hal-target-device=hip     \
--iree-hip-target=gfx950     \
--num-prompts=4     \
--verbose     \
--attention-dtype=float16     \
--activation-dtype=float16     \
--attention-kernel=torch     \
--kv-cache-dtype=float16     \
--use-hf \
--matmul-kernel="sharktank.asm;*"
```