### PR TITLE
[tuner] update the example mmt file

### DIFF
--- a/sharktuner/model_tuner/double_mmt.mlir
+++ b/sharktuner/model_tuner/double_mmt.mlir
@@ -1,7 +1,6 @@
 !matA_0 = tensor<2048x2048xf16>
 !matB_0 = tensor<2048x2048xf16>
 !matC_0 = tensor<2048x2048xf32>
-
 !matC_1 = tensor<2048x2048xf32>
 
 func.func @main(%arg0: !matA_0, %arg1: !matB_0) -> !matC_1 {


### PR DESCRIPTION
Due to `*_matmul_transpose_*` operations having been dropped from IREE, the example mmt file in the tuner should be updated as well.
