### PR TITLE
[Sharktank] Change pipeline_parallism_size to be a calculated property

### DIFF
--- a/sharktank/sharktank/evaluate/perplexity_iree.py
+++ b/sharktank/sharktank/evaluate/perplexity_iree.py
@@ -185,7 +185,6 @@ class PerplexityIree:
             attention_dtype=self.attention_dtype,
             kv_cache_dtype=self.kv_cache_dtype,
             tensor_parallelism_size=self.tensor_parallelism_size,
-            pipeline_parallelism_size=self.pipeline_parallelism_size,
             block_seq_stride=self.block_seq_stride,
             attention_kernel=self.attention_kernel,
             matmul_kernel=self.matmul_kernel,

--- a/sharktank/sharktank/evaluate/perplexity_torch.py
+++ b/sharktank/sharktank/evaluate/perplexity_torch.py
@@ -121,7 +121,6 @@ class PerplexityTorch:
             attention_dtype=attention_dtype,
             kv_cache_dtype=kv_cache_dtype,
             tensor_parallelism_size=tensor_parallelism_size,
-            pipeline_parallelism_size=pipeline_parallelism_size,
             block_to_pipeline_map=block_to_pipeline,
             pipeline_to_device_map=pipeline_to_devices,
             block_seq_stride=block_seq_stride,

--- a/sharktank/sharktank/examples/export_paged_llm_v1.py
+++ b/sharktank/sharktank/examples/export_paged_llm_v1.py
@@ -236,7 +236,6 @@ def main():
     llama_config = LlamaModelConfig(
         hp,
         tensor_parallelism_size=args.tensor_parallelism_size,
-        pipeline_parallelism_size=args.pipeline_parallelism_size,
         use_hf=args.use_hf,
         static_tables=False,  # Rely on the compiler for hoisting tables.
         attention_kernel=args.attention_kernel,

--- a/sharktank/sharktank/examples/paged_llm_v1.py
+++ b/sharktank/sharktank/examples/paged_llm_v1.py
@@ -54,7 +54,6 @@ def main(cli_args: list[str] | None = None):
     config.matmul_kernel = args.matmul_kernel
     config.kv_cache_dtype = args.kv_cache_dtype
     config.use_hf = args.use_hf
-    config.pipeline_parallelism_size = args.pipeline_parallelism_size
     config.fake_quant = args.fake_quant
 
     if args.tensor_parallelism_size != config.tensor_parallelism_size:

--- a/sharktank/sharktank/layers/configs/llm_configs.py
+++ b/sharktank/sharktank/layers/configs/llm_configs.py
@@ -386,10 +386,6 @@ class LlamaModelConfig:
     # arguments.
     tensor_parallelism_size: int = 1
 
-    # How many groups of (roughly) uniform size to
-    # If greater than 1, the model will re-wrap all non-sharded tensors as sharded over 1 device.
-    pipeline_parallelism_size: int = 1
-
     # Mapping between a transformer block and the corresponding pipeline
     block_to_pipeline_map: tuple[int, ...] = None
 
@@ -433,6 +429,14 @@ class LlamaModelConfig:
     # The default data type to use for model parameters and computations.
     dtype: Optional[torch.dtype] = None
 
+    @property
+    def pipeline_parallelism_size(self) -> int:
+        return (
+            1
+            if self.pipeline_to_device_map is None
+            else len(self.pipeline_to_device_map)
+        )
+
     def __post_init__(self):
         if self.moe_layers is None:
             if self.hp.interleave_moe_layer_step is None:
@@ -471,7 +475,6 @@ class LlamaModelConfig:
         res["attention_dtype"] = dtype_to_serialized_name(self.attention_dtype)
         res["fake_quant"] = self.fake_quant
         res["tensor_parallelism_size"] = self.tensor_parallelism_size
-        res["pipeline_parallelism_size"] = self.pipeline_parallelism_size
         res["block_to_pipeline_map"] = self.block_to_pipeline_map
         res["pipeline_to_device_map"] = self.pipeline_to_device_map
         res["attention_kernel"] = self.attention_kernel

--- a/sharktank/tests/layers/configs_test.py
+++ b/sharktank/tests/layers/configs_test.py
@@ -56,7 +56,6 @@ def test_llama_model_config_to_from_properties_roundtrip():
         attention_dtype=torch.float32,
         fake_quant=False,
         tensor_parallelism_size=13,
-        pipeline_parallelism_size=14,
         block_to_pipeline_map=(
             15,
             16,


### PR DESCRIPTION
Instead of storing a redundant value in `LlamaModelConfig`, `pipeline_parallism_size ` is now calculated based on the provided `pipeline_to_device_map`.