### PR TITLE
[tuner] add acc layout match to constraint generation for attention

### DIFF
--- a/sharktuner/sharktuner/dispatch_constraints.py
+++ b/sharktuner/sharktuner/dispatch_constraints.py
@@ -440,6 +440,7 @@ def generate_attention_vector_distribute_constraints(
     qk_mma_acc_layout = create_mma_layout("qk_acc")
     pv_mma_lhs_layout = create_mma_layout("pv_lhs")
     pv_mma_rhs_layout = create_mma_layout("pv_rhs")
+    pv_mma_acc_layout = create_mma_layout("pv_acc")
 
     constraints = []
     constraints += [
@@ -468,8 +469,12 @@ def generate_attention_vector_distribute_constraints(
             mma_intrinsics=mma_intrinsics,
             lhs_layout=pv_mma_lhs_layout,
             rhs_layout=pv_mma_rhs_layout,
-            acc_layout=None,
+            acc_layout=pv_mma_acc_layout,
         )
+    ]
+
+    constraints += [
+        match_layout(qk_mma_acc_layout, pv_mma_acc_layout),
     ]
 
     constraints += [

--- a/sharktuner/sharktuner/dispatch_constraints.py
+++ b/sharktuner/sharktuner/dispatch_constraints.py
@@ -473,9 +473,7 @@ def generate_attention_vector_distribute_constraints(
         )
     ]
 
-    constraints += [
-        match_layout(qk_mma_acc_layout, pv_mma_acc_layout),
-    ]
+    constraints += [match_layout(qk_mma_acc_layout, pv_mma_acc_layout)]
 
     constraints += [
         qk_matmul.m % qk_intrinsic_mn == 0,


### PR DESCRIPTION
This PR is mainly sync with the change from https://github.com/iree-org/iree/pull/21729, adding acc layout matching constraint to tuner.

Here is the link to the tuner log based on this PR: https://gist.github.com/bangtianliu/2450e15526f4d4d1b7b5815af918c856