### PR TITLE
[Sharktank] Replumb PagedAttention to have their own KVCache object

### DIFF
--- a/sharktank/sharktank/evaluate/perplexity_iree.py
+++ b/sharktank/sharktank/evaluate/perplexity_iree.py
@@ -219,7 +219,7 @@ class PerplexityIree:
 
         token_batch, seq_lens_batch = pad_tokens(
             token_ids=token_batch.tolist(),
-            pad_to_multiple_of=self.generator.model.cache.pad_sequence_stride,
+            pad_to_multiple_of=self.generator.model.paged_attention.pad_sequence_stride,
         )
 
         logger.debug(f"{token_batch}")
@@ -425,7 +425,7 @@ class PerplexityIree:
         else:
             self.token_ids, self.seq_lens = self.generator.tokenizer.encode(
                 test_prompts,
-                pad_to_multiple_of=self.generator.model.cache.pad_sequence_stride,
+                pad_to_multiple_of=self.generator.model.paged_attention.pad_sequence_stride,
             )
 
             logger.debug(f" Prompts for Evaluation:")

--- a/sharktank/sharktank/evaluate/perplexity_torch.py
+++ b/sharktank/sharktank/evaluate/perplexity_torch.py
@@ -141,7 +141,7 @@ class PerplexityTorch:
 
         token_batch, seq_lens_batch = pad_tokens(
             token_ids=token_batch.tolist(),
-            pad_to_multiple_of=self.generator.model.cache.pad_sequence_stride,
+            pad_to_multiple_of=self.generator.model.paged_attention.pad_sequence_stride,
         )
 
         logger.debug(f"{token_batch}")
@@ -252,7 +252,7 @@ class PerplexityTorch:
         else:
             self.token_ids, self.seq_lens = self.generator.tokenizer.encode(
                 test_prompts,
-                pad_to_multiple_of=self.generator.model.cache.pad_sequence_stride,
+                pad_to_multiple_of=self.generator.model.paged_attention.pad_sequence_stride,
             )
 
             logger.debug(f" Prompts for Evaluation:")

--- a/sharktank/sharktank/examples/validate_paged_llama_model.py
+++ b/sharktank/sharktank/examples/validate_paged_llama_model.py
@@ -30,7 +30,7 @@ def main(args: list[str]):
     llama_config.activation_dtype = torch.float16
     model = PagedLlmModelV1(dataset.root_theta, llama_config)
 
-    cache_state = model.cache.allocate(page_count=128)
+    cache_state = model.paged_attention.allocate(page_count=128)
 
     start_index = 0
     next_batch = torch.tensor(
@@ -77,7 +77,7 @@ def main(args: list[str]):
             64 * [0],
         ]
     )
-    assert next_batch.shape[1] % model.cache.block_seq_stride == 0
+    assert next_batch.shape[1] % model.paged_attention.block_seq_stride == 0
     seq_block_ids = torch.tensor(
         [
             [127, 0, 0, 0],
@@ -119,7 +119,7 @@ def main(args: list[str]):
     seq_lens = seq_lens + 1
 
     input_mask = create_input_mask(
-        seq_lens, seq_block_ids.shape[1] * model.cache.block_seq_stride
+        seq_lens, seq_block_ids.shape[1] * model.paged_attention.block_seq_stride
     )
     decode_attention_mask = create_attention_mask_for_decode(
         input_mask, llama_config.activation_dtype

--- a/sharktank/sharktank/export_layer/export_paged_attention.py
+++ b/sharktank/sharktank/export_layer/export_paged_attention.py
@@ -176,7 +176,7 @@ def main():
     model = PagedLlamaAttentionBlock(
         theta=attention_block_theta,
         block_index=0,
-        cache=create_paged_kv_cache(llama_config),
+        paged_attention=create_paged_attention(llama_config),
         head_count=llama_config.hp.attention_head_count,
         head_dim=llama_config.hp.attn_head_dim,
         head_count_kv=llama_config.hp.attention_head_count_kv,

--- a/sharktank/sharktank/layers/paged_llama_attention_block.py
+++ b/sharktank/sharktank/layers/paged_llama_attention_block.py
@@ -31,7 +31,7 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         theta: Theta,
         *,
         block_index: int,
-        cache: PagedAttention,
+        paged_attention: PagedAttention,
         head_count: int,
         head_dim: int,
         head_count_kv: int,
@@ -50,7 +50,7 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         floor_scale: Optional[float] = None,
     ):
         super().__init__(theta)
-        self.paged_attention = cache
+        self.paged_attention = paged_attention
         self.block_index = block_index
         self.head_count = head_count
         self.head_dim = head_dim

--- a/sharktank/sharktank/models/llm/export.py
+++ b/sharktank/sharktank/models/llm/export.py
@@ -53,7 +53,7 @@ class ServicePagedLlmModelV1(torch.nn.Module):
         return self.model.config.kv_cache_type == "paged"
 
     def allocate_cache(self, page_count: int) -> CacheAllocation:
-        return self.model.cache.allocate(page_count=page_count)
+        return self.model.paged_attention.allocate(page_count=page_count)
 
     def prefill(
         self, tokens, start_pos, seq_lens, seq_block_ids, cache_state: CacheAllocation
@@ -114,7 +114,8 @@ class ServicePagedLlmModelV1(torch.nn.Module):
         cache_state: CacheAllocation,
     ):
         input_mask = create_input_mask(
-            seq_lens, seq_block_ids.shape[1] * self.model.cache.block_seq_stride
+            seq_lens,
+            seq_block_ids.shape[1] * self.model.paged_attention.block_seq_stride,
         )
         attention_mask = create_attention_mask_for_decode(
             input_mask, self.model.activation_dtype

--- a/sharktank/sharktank/models/llm/testing.py
+++ b/sharktank/sharktank/models/llm/testing.py
@@ -24,7 +24,7 @@ def make_random_decode_args(
     start_positions = [prefill_seq_lens]
     seq_lens = prefill_seq_lens + 1
     batch_seq_len = round_up_to_multiple_of(
-        int(torch.max(seq_lens)), model.cache.pad_sequence_stride
+        int(torch.max(seq_lens)), model.paged_attention.pad_sequence_stride
     )
     decode_token_ids = torch.randint(
         low=0,
@@ -39,7 +39,9 @@ def make_random_decode_args(
             batch_size, -1
         )
     ]
-    cache_state = model.cache.allocate(page_count=seq_block_ids[0].numel() + batch_size)
+    cache_state = model.paged_attention.allocate(
+        page_count=seq_block_ids[0].numel() + batch_size
+    )
     cache_state = [torch.rand_like(cache_state[0])]
     return OrderedDict(
         [
@@ -67,7 +69,7 @@ def make_random_prefill_args(
         device=model.device,
     )
     batch_seq_len = round_up_to_multiple_of(
-        int(torch.max(seq_lens)), model.cache.pad_sequence_stride
+        int(torch.max(seq_lens)), model.paged_attention.pad_sequence_stride
     )
     token_ids = torch.randint(
         low=0,
@@ -88,7 +90,9 @@ def make_random_prefill_args(
             device=model.device,
         ).view(batch_size, -1)
     ]
-    cache_state = model.cache.allocate(page_count=seq_block_ids[0].numel() + batch_size)
+    cache_state = model.paged_attention.allocate(
+        page_count=seq_block_ids[0].numel() + batch_size
+    )
     cache_state = [torch.rand_like(cache_state[0])]
     return OrderedDict(
         [

--- a/sharktank/sharktank/utils/create_cache.py
+++ b/sharktank/sharktank/utils/create_cache.py
@@ -7,7 +7,7 @@
 from sharktank.layers import *
 
 
-def create_paged_kv_cache(config: LlamaModelConfig) -> PagedAttention:
+def create_paged_attention(config: LlamaModelConfig) -> PagedAttention:
     if config.kv_cache_type != "paged":
         raise ValueError("Model does not use paged kv cache, cannot create kv cache")
 

--- a/sharktank/sharktank/utils/llm_utils.py
+++ b/sharktank/sharktank/utils/llm_utils.py
@@ -192,7 +192,8 @@ class TorchInstance:
         cache_state = [torch.asarray(cache_state)]
 
         input_mask = create_input_mask(
-            seq_lens, tokens.shape[1] * self._model.cache.block_seq_stride
+            seq_lens,
+            tokens.shape[1] * self._model.paged_attention.block_seq_stride,
         )
         attention_mask = create_attention_mask_for_decode(
             input_mask, self._model.activation_dtype

--- a/sharktank/sharktank/utils/load_llm.py
+++ b/sharktank/sharktank/utils/load_llm.py
@@ -42,7 +42,7 @@ class TorchGenerator:
 
     @property
     def block_seq_stride(self) -> int:
-        return self.model.cache.block_seq_stride
+        return self.model.paged_attention.block_seq_stride
 
     def preprocess_prompts(
         self,
@@ -58,7 +58,7 @@ class TorchGenerator:
 
         token_ids, seq_lens = pad_tokens(
             token_ids,
-            pad_to_multiple_of=self.model.cache.pad_sequence_stride,
+            pad_to_multiple_of=self.model.paged_attention.pad_sequence_stride,
             device=self.model.device,
         )
 
@@ -75,7 +75,7 @@ class TorchGenerator:
         # TODO: refactor to not use list[list[int]] as this is not efficient.
         token_ids = [[int(t) for t in s] for s in token_ids]
         token_ids, seq_lens = pad_tokens(
-            token_ids, pad_to_multiple_of=self.model.cache.pad_sequence_stride
+            token_ids, pad_to_multiple_of=self.model.paged_attention.pad_sequence_stride
         )
         token_ids = torch.tensor(token_ids, device=self.model.device)
         seq_lens = torch.tensor(seq_lens, device=self.model.device)
@@ -99,7 +99,7 @@ class TorchGenerator:
             * 2
         )
 
-        cache_state = self.model.cache.allocate(self.page_cache_size)
+        cache_state = self.model.paged_attention.allocate(self.page_cache_size)
         self.free_pages = list(range(1, self.page_cache_size))
 
         assert (

--- a/sharktank/tests/models/grok/test_grok.py
+++ b/sharktank/tests/models/grok/test_grok.py
@@ -32,7 +32,7 @@ def test_grok():
     ids = torch.asarray([ids], dtype=torch.int64)
     block_ids = torch.asarray([[i for i in range(blocks)]]).to(torch.int64)
 
-    cache_state = model.cache.allocate(
+    cache_state = model.paged_attention.allocate(
         page_count=config.hp.context_length // config.block_seq_stride
     )
 

--- a/sharktank/tests/models/llama/attention_test.py
+++ b/sharktank/tests/models/llama/attention_test.py
@@ -74,22 +74,13 @@ class TestAttentionBlock:
             hp,
             attention_kernel="torch",
             block_seq_stride=block_seq_stride,
+            attention_dtype=torch.float32,
+            kv_cache_dtype=torch.float32,
         )
 
-        paged_kv_cache = PagedAttention(
-            transformer_block_count=head_count,
-            attn_head_count=head_count,
-            attn_head_dim=head_dim,
-            cache_partition_count=2,  # One for each of K/V.
-            block_seq_stride=block_seq_stride,
-            device="cpu",
-            cache_dtype=torch.float32,
-            attn_dtype=torch.float32,
-        )
         attention_block = AttentionFFNBlock(
             theta=attention_block_theta,
             block_index=block_index,
-            cache=paged_kv_cache,
             config=llama_config,
         )
         attention_embedding = build_rotary_layer(
@@ -111,7 +102,7 @@ class TestAttentionBlock:
             start_positions=start_positions,
             embedding=attention_embedding,
             attention_mask=torch.zeros(1, seq_len, seq_len, dtype=torch.float32),
-            cache_state=paged_kv_cache.allocate(128),
+            cache_state=attention_block.attn.paged_attention.allocate(128),
             seq_block_ids=torch.arange(seq_len).view(1, -1),
         )
 

--- a/sharktank/tests/models/llama/test_llama.py
+++ b/sharktank/tests/models/llama/test_llama.py
@@ -39,7 +39,7 @@ class CrossEntropyTest(unittest.TestCase):
         ids = torch.asarray([ids], dtype=torch.int64)
         block_ids = torch.asarray([[i for i in range(blocks)]]).to(torch.int64)
 
-        cache_state = model.cache.allocate(
+        cache_state = model.paged_attention.allocate(
             page_count=config.hp.context_length // config.block_seq_stride
         )
 

--- a/sharktank/tests/models/llama4/llama4_test.py
+++ b/sharktank/tests/models/llama4/llama4_test.py
@@ -81,7 +81,7 @@ class Llama4Test(TempDirTestBase):
         hf_output = run_hf_model()
 
         page_count = (len(input_ids[0]) // config.block_seq_stride) * batch_size
-        kv_cache_state = model.cache.allocate(page_count)
+        kv_cache_state = model.paged_attention.allocate(page_count)
         seq_block_ids = torch.arange(
             start=0, end=input_ids.numel() // config.block_seq_stride, dtype=torch.long
         ).view(batch_size, batch_seq_len // config.block_seq_stride)


### PR DESCRIPTION
**Background:** The KVCache and PagedAttention objects do not hold onto the actual KVCache state.

Change how the PagedAttentionLayer is created so that each has their own distinct PagedAttention (and thus KVCache) object, so that we can add per-layer info (e.g. the kv quantizers) into the KVCache rather than pass them as args around.