### PR TITLE
Add model based VMFB tool and perplexity option

### DIFF
--- a/sharktank/sharktank/utils/llm_utils.py
+++ b/sharktank/sharktank/utils/llm_utils.py
@@ -10,7 +10,7 @@ from iree.runtime import ParameterIndex
 from sharktank.layers.configs.llm_configs import LlamaModelConfig
 from sharktank.models.llm.config import ServiceConfig
 from sharktank.models.llm import PagedLlmModelV1
-from sharktank.types import Theta
+from sharktank.types import Dataset, Theta
 
 np_dtype_to_torch_dtype = {
     numpy.float16: torch.float16,
@@ -131,10 +131,14 @@ class IreeInstance:
         return iree.runtime.DeviceArray(device=device, buffer_view=buffer_view)
 
     def prefill(self, *args):
-        return self._prefill(*args)
+        results = self._prefill(*args)
+        results = [numpy.asarray(r) for r in results]
+        return results
 
     def decode(self, *args):
-        return self._decode(*args)
+        results = self._decode(*args)
+        results = [numpy.asarray(r) for r in results]
+        return results
 
 
 class TorchInstance:
@@ -142,6 +146,19 @@ class TorchInstance:
         self._model = PagedLlmModelV1(theta=theta, config=config)
         self._prefill_bs = 1
         self._decode_bs = 1
+        self._config = config
+
+    @property
+    def config(self):
+        return self._config
+
+    @staticmethod
+    def load(filepath: pathlib.Path):
+        torch.set_default_device("cuda")
+        dataset = Dataset.load(path=filepath, device="cuda")
+        config = LlamaModelConfig.from_properties(dataset.properties)
+        return TorchInstance(theta=dataset.root_theta, config=config)
+
 
     def prefill(self, tokens, seq_lens, seq_block_ids, cache_state):
         tokens = torch.asarray(tokens)
@@ -161,12 +178,12 @@ class TorchInstance:
         )
 
         # TODO: This should be handled by the model
-        logits = torch.nn.functional.softmax(logits, dim=-1)
+        logits = torch.nn.functional.softmax(logits, dim=-1, dtype=torch.float32)
         logits = torch.log(logits)
-        k = 8
-        logits, indices = torch.topk(logits, k)
 
-        return logits, indices
+        logits = logits.cpu()
+
+        return logits
 
     def decode(self, tokens, seq_lens, start_positions, seq_block_ids, cache_state):
         tokens = torch.asarray(tokens)
@@ -189,12 +206,11 @@ class TorchInstance:
         )
 
         # TODO: This should be handled by the model
-        logits = torch.nn.functional.softmax(logits, dim=-1)
+        logits = torch.nn.functional.softmax(logits, dim=-1, dtype=torch.float32)
         logits = torch.log(logits)
-        k = 8
-        logits, indices = torch.topk(logits, k)
 
-        return logits, indices
+        logits = logits.cpu()
+        return logits
 
     def allocate(self, *shape, dtype):
         dtype = np_dtype_to_torch_dtype[dtype]
@@ -411,15 +427,15 @@ class LlmPerplexityEval:
         self._batch = batch
         self._logits_normalization = logits_normalization
 
-    def compute_cross_entropy(self, logits, indices, requests):
+    def compute_cross_entropy(self, logits, indices, requests, perplexity=False):
         results = []
         for i, req in enumerate(requests):
             req_len = len(req)
-            in_indices = torch.asarray(req[1:])
+            in_indices = numpy.asarray(req[1:])
             req_logits = logits[i, : req_len - 1]
 
             if indices is None:
-                req_indices = torch.arange(req_logits.shape[-1])[None, None, :]
+                req_indices = numpy.arange(req_logits.shape[-1])[None, None, :]
             else:
                 req_indices = indices[i, : req_len - 1]
 
@@ -438,9 +454,14 @@ class LlmPerplexityEval:
                     f"Unknown logits normalization: {self._logits_normalization}"
                 )
 
-            all_available = (torch.sum(matches) == req_len - 1).item()
+            numpy.save("/tmp/logits", req_logits)
+            all_available = (numpy.sum(matches) == req_len - 1).item()
             scores = numpy.sum(numpy.where(matches, req_logits, 0.0), axis=-1)
             cross_entropy = (-numpy.sum(scores) / (req_len - 1)).item()
+
+            if perplexity:
+                cross_entropy = numpy.exp(cross_entropy, dtype=float)
+
             results.append(LlmPerplexityEval.Result(all_available, cross_entropy))
 
         return results
@@ -453,9 +474,9 @@ class LlmPerplexityEval:
     def decode_bs(self):
         return self._batch._decode_bs
 
-    def prefill_cross_entropy(self, requests: list[list[int]]):
+    def prefill_cross_entropy(self, requests: list[list[int]], **kwargs):
         logits, indices = self._batch.prefill(requests)
-        return self.compute_cross_entropy(logits, indices, requests)
+        return self.compute_cross_entropy(logits, indices, requests, **kwargs)
 
     def decode_cross_entropy(self, requests: list[list[int]]):
         self._batch.reset(len(requests))
@@ -479,13 +500,13 @@ class LlmPerplexityEval:
         indices = numpy.concatenate(indices, axis=1)
         return self.compute_cross_entropy(logits, indices, requests)
 
-    def batch_prefill_perplexity(self, requests: list[list[int]]):
+    def batch_prefill_perplexity(self, requests: list[list[int]], **kwargs):
         bs = self.prefill_bs
         results = []
         while len(requests) > 0:
             batch = requests[:bs]
             requests = requests[bs:]
-            cross_entropy = self.prefill_cross_entropy(requests=batch)
+            cross_entropy = self.prefill_cross_entropy(requests=batch, **kwargs)
             results.extend(cross_entropy)
         return results
 


### PR DESCRIPTION
Reworked tooling to have a torch backed perplexity tool this allows us to test llama numerics without requiring iree execution.