### PR TITLE
[Sharktank] Move implementation of helper functions out of BaseCausalLMModel

### DIFF
--- a/sharktank/sharktank/layers/causal_llm.py
+++ b/sharktank/sharktank/layers/causal_llm.py
@@ -12,7 +12,6 @@ from sharktank.types import (
     ReplicatedTensor,
     Theta,
 )
-from sharktank.utils.llm_utils import logits_argmax
 from sharktank.utils.attention import *
 from .base import (
     ThetaLayer,
@@ -134,4 +133,10 @@ class BaseCausalLMModel(ThetaLayer):
         but it just creates a bunch of weirdly shaped little work on the
         accelerator. Statically looping like this is more efficient.
         """
-        return logits_argmax(logits, seq_lens)
+        bs, *_ = logits.shape
+        assert len(seq_lens) == bs
+        results = []
+        for batch, seq_len in enumerate(seq_lens):
+            step_logits = logits[batch, seq_len - 1]
+            results.append(torch.argmax(step_logits))
+        return results

--- a/sharktank/sharktank/layers/causal_llm.py
+++ b/sharktank/sharktank/layers/causal_llm.py
@@ -12,6 +12,7 @@ from sharktank.types import (
     ReplicatedTensor,
     Theta,
 )
+from sharktank.utils.llm_utils import logits_argmax
 from sharktank.utils.attention import *
 from .base import (
     ThetaLayer,
@@ -133,10 +134,4 @@ class BaseCausalLMModel(ThetaLayer):
         but it just creates a bunch of weirdly shaped little work on the
         accelerator. Statically looping like this is more efficient.
         """
-        bs, *_ = logits.shape
-        assert len(seq_lens) == bs
-        results = []
-        for batch, seq_len in enumerate(seq_lens):
-            step_logits = logits[batch, seq_len - 1]
-            results.append(torch.argmax(step_logits))
-        return results
+        return logits_argmax(logits, seq_lens)

--- a/sharktank/sharktank/layers/causal_llm.py
+++ b/sharktank/sharktank/layers/causal_llm.py
@@ -12,7 +12,7 @@ from sharktank.types import (
     ReplicatedTensor,
     Theta,
 )
-
+from sharktank.utils.attention import *
 from .base import (
     ThetaLayer,
 )
@@ -50,20 +50,14 @@ class BaseCausalLMModel(ThetaLayer):
 
         This can be overriden to decide on a different policy.
         """
-        return torch.tensor(float("-inf"), dtype=dtype, device=self.device)
+        return max_negative_value(dtype, self.device)
 
     def generate_causal_context_mask(
         self, src_len, target_len, start_positions
     ) -> torch.Tensor:
-        src = torch.arange(src_len)[None, None, None, :]
-        target = torch.arange(target_len)[None, None, :, None]
-
-        if start_positions is not None:
-            target = target + start_positions[:, None, None, None]
-
-        causal_context_mask = src > target
-
-        return causal_context_mask.to(self.device)
+        return create_causal_context_mask(
+            src_len, target_len, start_positions, self.device
+        )
 
     def input_mask(
         self,
@@ -76,21 +70,12 @@ class BaseCausalLMModel(ThetaLayer):
         The mask will be [bs, batch_seqlen] with True at any position that is
         masked.
         """
-        range_vector = torch.arange(0, batch_seqlen, 1, device=self.device)
-        matrix = seq_lens.unsqueeze(dim=-1)
-        mask = range_vector >= matrix
-        return mask
+        return create_input_mask(seq_lens, batch_seqlen, self.device)
 
     def decode_attention_mask(self, boolean_input_mask: torch.Tensor):
-        dtype = (
-            torch.float32
-            if self.attention_dtype == torch.float8_e4m3fnuz
-            else self.attention_dtype
+        return create_attention_mask_for_decode(
+            boolean_input_mask, self.attention_dtype, self.device
         )
-        numeric_mask = torch.where(
-            boolean_input_mask, self._maximally_negative_value(dtype), 0
-        ).to(dtype)
-        return numeric_mask.unsqueeze(1).unsqueeze(1).to(self.device)
 
     def attention_mask(
         self,
@@ -105,48 +90,16 @@ class BaseCausalLMModel(ThetaLayer):
         Since this is a bool tensor of context_length^2, different deployment
         scenarios can benefit from managing this in different ways.
         """
-
-        # Combine the causal context mask and input mask.
-        dtype = (
-            torch.float32
-            if self.attention_dtype == torch.float8_e4m3fnuz
-            else self.attention_dtype
+        return create_attention_mask(
+            input_mask, self.attention_dtype, start_positions, self.device
         )
-        _, batch_seq_len = input_mask.shape
-
-        causal_mask = self.generate_causal_context_mask(
-            src_len=batch_seq_len,
-            target_len=batch_seq_len,
-            start_positions=start_positions,
-        )
-        boolean_mask = torch.logical_or(causal_mask, input_mask[:, None, None, :])
-        numeric_mask = torch.where(
-            boolean_mask, self._maximally_negative_value(dtype), 0
-        ).to(dtype)
-        return numeric_mask.to(self.device)
 
     def chunked_attention_mask(
         self, attention_mask: torch.Tensor | ReplicatedTensor
     ) -> torch.Tensor:
         """Apply a chunked attention mask onto a mask."""
-        batch_seq_len = attention_mask.shape[2]
-        # TODO: handle decode step
-        start_index = 0
-        end_index = batch_seq_len
-        chunked_boolean_attention_mask = self.create_boolean_chunked_attention_mask(
-            attention_chunk_size=self.config.attention_chunk_size,
-            # TODO: handle decode step
-            start_index=start_index,
-            end_index=end_index,
-        ).to(attention_mask.device)
-
-        return torch.where(
-            chunked_boolean_attention_mask,
-            attention_mask,
-            torch.tensor(
-                self._maximally_negative_value(attention_mask.dtype),
-                dtype=attention_mask.dtype,
-            ),
+        return create_chunked_attention_mask(
+            attention_mask, self.config.attention_chunk_size
         )
 
     def create_boolean_chunked_attention_mask(
@@ -168,14 +121,9 @@ class BaseCausalLMModel(ThetaLayer):
         ⬚ - masked (False).
         ■ - unmasked (True).
         """
-        arange_vector = torch.arange(start_index, end_index)
-        block_pos = torch.abs(
-            arange_vector.unsqueeze(0) // attention_chunk_size
-            - arange_vector.unsqueeze(1) // attention_chunk_size
+        return create_boolean_chunked_attention_mask(
+            attention_chunk_size, start_index, end_index
         )
-        token_pos = arange_vector.unsqueeze(0) - arange_vector.unsqueeze(1)
-        mask = (block_pos == 0) & (token_pos <= 0)
-        return mask
 
     def extract_tokens_from_logits(
         self, logits: torch.Tensor, seq_lens: list[int]

--- a/sharktank/sharktank/layers/causal_llm.py
+++ b/sharktank/sharktank/layers/causal_llm.py
@@ -70,11 +70,11 @@ class BaseCausalLMModel(ThetaLayer):
         The mask will be [bs, batch_seqlen] with True at any position that is
         masked.
         """
-        return create_input_mask(seq_lens, batch_seqlen, self.device)
+        return create_input_mask(seq_lens, batch_seqlen)
 
     def decode_attention_mask(self, boolean_input_mask: torch.Tensor):
         return create_attention_mask_for_decode(
-            boolean_input_mask, self.attention_dtype, self.device
+            boolean_input_mask, self.attention_dtype
         )
 
     def attention_mask(
@@ -90,9 +90,7 @@ class BaseCausalLMModel(ThetaLayer):
         Since this is a bool tensor of context_length^2, different deployment
         scenarios can benefit from managing this in different ways.
         """
-        return create_attention_mask(
-            input_mask, self.attention_dtype, start_positions, self.device
-        )
+        return create_attention_mask(input_mask, self.attention_dtype, start_positions)
 
     def chunked_attention_mask(
         self, attention_mask: torch.Tensor | ReplicatedTensor

--- a/sharktank/sharktank/utils/attention.py
+++ b/sharktank/sharktank/utils/attention.py
@@ -1,0 +1,185 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import torch
+
+
+def max_negative_value(
+    dtype: torch.dtype, device: torch.device | None = None
+) -> torch.Tensor:
+    """Returns a maximally negative value for the given dtype."""
+    return torch.tensor(float("-inf"), dtype=dtype, device=device)
+
+
+def create_attention_mask(
+    boolean_input_mask: torch.Tensor,
+    attention_dtype: torch.dtype,
+    start_positions: torch.Tensor | None = None,
+    device: torch.device | None = None,
+) -> torch.Tensor:
+    """
+    Generates a causal attention mask of [bs, 1, sl, sl] of activation dtype.
+
+    All masked positions are -inf and unmasked are 0.0.
+
+    The causal context mask will either be generated or use the initialization time buffer.
+    Since this is a bool tensor of context_length^2, different deployment
+    scenarios can benefit from managing this in different ways.
+    """
+    # Combine the causal context mask and input mask.
+    dtype = (
+        torch.float32 if attention_dtype == torch.float8_e4m3fnuz else attention_dtype
+    )
+    _, batch_seq_len = boolean_input_mask.shape
+
+    causal_mask = create_causal_context_mask(
+        src_len=batch_seq_len,
+        target_len=batch_seq_len,
+        start_positions=start_positions,
+        device=device,
+    )
+    boolean_mask = torch.logical_or(causal_mask, boolean_input_mask[:, None, None, :])
+    numeric_mask = torch.where(boolean_mask, max_negative_value(dtype, device), 0).to(
+        dtype
+    )
+    return numeric_mask.to(device)
+
+
+def create_attention_mask_for_decode(
+    boolean_input_mask: torch.Tensor,
+    attention_dtype: torch.dtype,
+    device: torch.device | None = None,
+) -> torch.Tensor:
+    dtype = (
+        torch.float32 if attention_dtype == torch.float8_e4m3fnuz else attention_dtype
+    )
+    numeric_mask = torch.where(
+        boolean_input_mask, max_negative_value(dtype, device), 0
+    ).to(dtype)
+    return numeric_mask.unsqueeze(1).unsqueeze(1).to(device)
+
+
+def create_causal_context_mask(
+    src_len: int,
+    target_len: int,
+    start_positions: torch.Tensor | None = None,
+    device: torch.device | None = None,
+) -> torch.Tensor:
+    """
+    Generate a causal context mask of shape [1, 1, target_len, src_len].
+
+    If start_positions is provided, it should be a tensor of shape [bs] indicating
+    the starting position for each sequence in the batch. The mask will be adjusted
+    accordingly to ensure that each position can only attend to previous positions
+    in its own sequence.
+
+    Args:
+        src_len: Length of the source sequence.
+        target_len: Length of the target sequence.
+        start_positions: Optional tensor of shape [bs] indicating the starting position
+                         for each sequence in the batch.
+        device: The device to place the output mask on.
+    """
+    src = torch.arange(src_len, device=device)[None, None, None, :]
+    target = torch.arange(target_len, device=device)[None, None, :, None]
+
+    if start_positions is not None:
+        target = target + start_positions[:, None, None, None]
+
+    mask = src > target
+    return mask
+
+
+def create_boolean_chunked_attention_mask(
+    attention_chunk_size: int,
+    start_index: int,
+    end_index: int,
+    device: torch.device | None = None,
+) -> torch.Tensor:
+    """
+    Generate the following:
+
+    'What'      :  0 ■ ⬚ ⬚ ⬚ ⬚ ⬚    |
+    '▁is'       :  1 ■ ■ ⬚ ⬚ ⬚ ⬚     |
+    '▁ch'       :  2 ■ ■ ■ ⬚ ⬚ ⬚     |
+    'unked'     :  3 ⬚ ⬚ ⬚ ■ ⬚ ⬚    |
+    '▁attention':  4 ⬚ ⬚ ⬚ ■ ■ ⬚    |
+    '?'         :  5 ⬚ ⬚ ⬚ ■ ■ ■     |
+
+    If the chunk size is 3.
+    This can just be applied over the already created attention mask
+
+    ⬚ - masked (False).
+    ■ - unmasked (True).
+    """
+    arange_vector = torch.arange(start_index, end_index, device=device)
+    block_pos = torch.abs(
+        arange_vector.unsqueeze(0) // attention_chunk_size
+        - arange_vector.unsqueeze(1) // attention_chunk_size
+    )
+    token_pos = arange_vector.unsqueeze(0) - arange_vector.unsqueeze(1)
+    mask = (block_pos == 0) & (token_pos <= 0)
+    return mask
+
+
+def create_chunked_attention_mask(
+    attention_mask: torch.Tensor, attention_chunk_size: int
+) -> torch.Tensor:
+    """
+    Apply a chunked attention mask onto a mask.
+
+    This is a convenience function that combines the creation of the boolean
+    chunked attention mask and its application to the provided attention mask.
+
+    Args:
+        attention_mask: The original attention mask of shape [bs, 1, sl, sl].
+        attention_chunk_size: The size of each attention chunk.
+
+    Returns:
+        A new attention mask with chunked masking applied.
+    """
+    device = attention_mask.device
+    batch_seq_len = attention_mask.shape[2]
+    # TODO: handle decode step
+    start_index = 0
+    end_index = batch_seq_len
+    chunked_boolean_attention_mask = create_boolean_chunked_attention_mask(
+        attention_chunk_size=attention_chunk_size,
+        # TODO: handle decode step
+        start_index=start_index,
+        end_index=end_index,
+        device=device,
+    ).to(device)
+
+    return torch.where(
+        chunked_boolean_attention_mask,
+        attention_mask,
+        torch.tensor(
+            max_negative_value(attention_mask.dtype, device=device),
+            dtype=attention_mask.dtype,
+        ),
+    )
+
+
+def create_input_mask(
+    seq_lens: torch.Tensor,
+    batch_seqlen: int,
+    device: torch.device | None = None,
+) -> torch.Tensor:
+    """
+    Compute a boolean input mask for a batch of sequence lengths.
+
+    The mask will be [bs, batch_seqlen] with True at any position that is masked.
+
+    Args:
+        seq_lens: [bs] tensor of integers representing the sequence lengths.
+        batch_seqlen: The maximum sequence length in the batch.
+        device: The device to place the output mask on.
+    """
+    range_vector = torch.arange(0, batch_seqlen, 1, device=device)
+    matrix = seq_lens.unsqueeze(dim=-1)
+    mask = range_vector >= matrix
+    return mask

--- a/sharktank/sharktank/utils/llm_utils.py
+++ b/sharktank/sharktank/utils/llm_utils.py
@@ -59,23 +59,6 @@ def server_config_page_size(config: ServiceConfig):
     )
 
 
-def logits_argmax(logits: torch.Tensor, seq_lens: list[int]) -> list[int]:
-    """Extracts tokens from a batch of logits (B, S, D).
-
-    The length of seq_lens must be equal to the batch size.
-    Note that there are ways to code the indexing as tensor operations
-    but it just creates a bunch of weirdly shaped little work on the
-    accelerator. Statically looping like this is more efficient.
-    """
-    bs, *_ = logits.shape
-    assert len(seq_lens) == bs
-    results = []
-    for batch, seq_len in enumerate(seq_lens):
-        step_logits = logits[batch, seq_len - 1]
-        results.append(torch.argmax(step_logits))
-    return results
-
-
 class IreeInstance:
     def __init__(
         self,


### PR DESCRIPTION
The helper methods inside BaseCausalLMModel are being moved outside as proper helper functions. This particularly important for the attention mask related ones as the refactor is necessary in order to move the creation of the masks into the attention layer.