### PR TITLE
[sharktank] Make torch SDPA the default attention implementation

### DIFF
--- a/sharktank/sharktank/ops/attention_impls.py
+++ b/sharktank/sharktank/ops/attention_impls.py
@@ -62,23 +62,6 @@ def scaled_dot_product_attention_decomposed(
     return torch.matmul(attn_weights, v)
 
 
-@scaled_dot_product_attention.override(
-    AnyTensor, AnyTensor, AnyTensor, AnyType, impl_name="torch"
-)
-def scaled_dot_product_attention_torch(q, k, v, a, is_causal, scale, softcap, impl):
-    if softcap is not None:
-        return NotImplemented
-    q = unbox_tensor(q)
-    k = unbox_tensor(k)
-    v = unbox_tensor(v)
-    if a is not None:
-        a = unbox_tensor(a)
-
-    return torch.nn.functional.scaled_dot_product_attention(
-        q, k, v, attn_mask=a, dropout_p=0.0, is_causal=is_causal, scale=scale
-    )
-
-
 def _extract_linear_scale(t):
     if (
         isinstance(t, PlanarQuantizedTensor)
@@ -143,3 +126,20 @@ def scaled_dot_product_flash_attention_sharktank(
 
     atten = atten * vscale if vscale is not None else atten
     return atten
+
+
+@scaled_dot_product_attention.override(
+    AnyTensor, AnyTensor, AnyTensor, AnyType, impl_name="torch"
+)
+def scaled_dot_product_attention_torch(q, k, v, a, is_causal, scale, softcap, impl):
+    if softcap is not None:
+        return NotImplemented
+    q = unbox_tensor(q)
+    k = unbox_tensor(k)
+    v = unbox_tensor(v)
+    if a is not None:
+        a = unbox_tensor(a)
+
+    return torch.nn.functional.scaled_dot_product_attention(
+        q, k, v, attn_mask=a, dropout_p=0.0, is_causal=is_causal, scale=scale
+    )

--- a/sharktank/tests/kernels/attention_template_test.py
+++ b/sharktank/tests/kernels/attention_template_test.py
@@ -117,7 +117,7 @@ class custom_attention(unittest.TestCase):
                 scale = 1.0
                 return unbox_tensor(
                     ops.scaled_dot_product_attention(
-                        q, k, v, a=mask, is_causal=False, scale=scale
+                        q, k, v, a=mask, is_causal=False, scale=scale, impl="sharktank"
                     )
                 )
 


### PR DESCRIPTION
Currently "sharktank" is the default attention implementation, but this has the problem that it unconditionally always returns a f32 tensor. This diverges from the semantics of the torch operation, where the return dtype is dependent on the operands' dtypes.

It is strongly desirable for the default to do as torch does as it has a well documented behaviour. In general we should try hard for our defaults to not diverge from torch's semantics as this will cause confusion when porting models in the future. This actually already caused a problem with the Flux transformer, where downstream ops after attention would be in f32 instead of the desired bf32.

The change here relies on the resolution order of overrides, if no impl is specified then "torch" will be picked before "sharktank".