### PR TITLE
Bump iree pin on shortfin runtime build to iree-3.7.0rc20250828

### DIFF
--- a/requirements-iree-pinned.txt
+++ b/requirements-iree-pinned.txt
@@ -3,6 +3,6 @@ wave-lang==1.0.2
 
 # Keep these versions synced with SHORTFIN_IREE_GIT_TAG in shortfin/CMakeLists.txt
 --find-links https://iree.dev/pip-release-links.html
-iree-base-compiler==3.7.0rc20250822
-iree-base-runtime==3.7.0rc20250822
-iree-turbine==3.7.0rc20250822
+iree-base-compiler==3.7.0rc20250828
+iree-base-runtime==3.7.0rc20250828
+iree-turbine==3.7.0rc20250828

--- a/shortfin/CMakeLists.txt
+++ b/shortfin/CMakeLists.txt
@@ -47,7 +47,7 @@ add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 # Prefer to keep the IREE git tag synced with the Python package version in the
 # requirements-iree-pinned.txt file. At a minimum, the compiler from those
 # packages must be compatible with the runtime at this source ref.
-set(SHORTFIN_IREE_GIT_TAG "iree-3.7.0rc20250822")
+set(SHORTFIN_IREE_GIT_TAG "iree-3.7.0rc20250828")
 
 
 # build options


### PR DESCRIPTION
Runtime is pinned to a problematic iree pin with a nondeterministic loading issue. Bumping to the most recent pin should fix the nondeterminism issue.