### PR TITLE
[Sharktank] Replumb Attention and embedding masks

### DIFF
--- a/sharktank/sharktank/examples/validate_paged_llama_model.py
+++ b/sharktank/sharktank/examples/validate_paged_llama_model.py
@@ -92,13 +92,10 @@ def main(args: list[str]):
     # propagates and causes badness.
     seq_lens = torch.tensor([12, 6, 9, 1])
 
-    input_mask = create_input_mask(seq_lens, next_batch.shape[1])
-    attention_mask = create_attention_mask(input_mask, llama_config.activation_dtype)
-
     print(f"Step {start_index}")
     logits = model.prefill(
         next_batch,
-        attention_mask=attention_mask,
+        seq_lens=seq_lens,
         seq_block_ids=seq_block_ids,
         cache_state=cache_state,
     )
@@ -118,16 +115,9 @@ def main(args: list[str]):
     start_positions = torch.tensor([12, 6, 0, 0])
     seq_lens = seq_lens + 1
 
-    input_mask = create_input_mask(
-        seq_lens, seq_block_ids.shape[1] * model.config.block_seq_stride
-    )
-    decode_attention_mask = create_attention_mask_for_decode(
-        input_mask, llama_config.activation_dtype
-    )
-
     logits = model.decode(
         tokens,
-        attention_mask=decode_attention_mask,
+        seq_lens=seq_lens,
         start_positions=start_positions,
         seq_block_ids=seq_block_ids,
         cache_state=cache_state,

--- a/sharktank/sharktank/export_layer/export_kv_cache.py
+++ b/sharktank/sharktank/export_layer/export_kv_cache.py
@@ -68,6 +68,8 @@ def main():
         shard_count=args.sharding,
         cache_dtype=torch.float32,
         attn_dtype=torch.float32,
+        use_rope=False,
+        attention_chunk_size=None,
         device=None,
     )
 

--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -575,7 +575,6 @@ class PagedAttention:
             scale=scale,
             sliding_window=sliding_window,
             sink=sink,
-            is_prefill=False,
         )
 
     def paged_attention(
@@ -594,7 +593,6 @@ class PagedAttention:
         fake_quant: Optional[bool],
         softcap: Optional[float],
         scale: Optional[float],
-        is_prefill: bool,
         sliding_window: Optional[int] = None,
         sink: Optional[torch.Tensor] = None,
     ):
@@ -606,6 +604,7 @@ class PagedAttention:
                 page_ids=seq_block_ids,
             )
 
+        is_prefill = q.shape[1] != 1
         if is_prefill:
             # q, k, v, x, and h all have the same .shape[1] (batch_seqlen)
             input_mask = create_input_mask(seq_lens, q.shape[1])
@@ -682,5 +681,4 @@ class PagedAttention:
             scale=scale,
             sliding_window=sliding_window,
             sink=sink,
-            is_prefill=True,
         )

--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -30,6 +30,7 @@ from sharktank.kernels.mlir_kernel import *
 from sharktank.types.tensors import AnyTensor, QuantizedTensor
 from sharktank.types.quantizers import unpack_to_raw_tensor, pack_raw_tensor
 
+from sharktank.utils.attention import *
 
 __all__ = ["PagedAttention", "attn_type_map", "CacheAllocation"]
 
@@ -387,6 +388,9 @@ class PagedAttention:
         block_seq_stride: int = 16,
         cache_dtype: torch.dtype = torch.float32,
         attn_dtype: torch.dtype = torch.float32,
+        activation_dtype: torch.dtype = torch.float32,
+        use_rope: bool,
+        attention_chunk_size: int | None,
         device: Optional[torch.device] = None,
         k_quantizer: StaticScaledQuantizer | None = None,
         v_quantizer: StaticScaledQuantizer | None = None,
@@ -399,6 +403,10 @@ class PagedAttention:
         self.attn_dtype = attn_dtype
         self.cache_dtype = cache_dtype
         self.attn_type = attn_type
+        self.block_seq_stride = block_seq_stride
+        self.activation_dtype = activation_dtype
+        self.attention_chunk_size = attention_chunk_size
+        self.use_rope = use_rope
 
         self.kv_cache = build_cache(
             transformer_block_count=transformer_block_count,
@@ -536,9 +544,9 @@ class PagedAttention:
         head_count_attn: int,
         cache_quantizer: Optional[QuantizerTensor],
         fake_quant: Optional[bool],
+        seq_lens: torch.Tensor | None,
         softcap: Optional[float] = None,
         scale: Optional[float] = None,
-        mask: Optional[torch.Tensor] = None,
         sliding_window: Optional[int] = None,
         sink: Optional[torch.Tensor] = None,
     ):
@@ -556,6 +564,7 @@ class PagedAttention:
             k=k,
             v=v,
             cache_state=cache_state,
+            seq_lens=seq_lens,
             seq_block_ids=seq_block_ids,
             attention_kernel=attention_kernel,
             head_count_attn=head_count_attn,
@@ -564,9 +573,9 @@ class PagedAttention:
             fake_quant=fake_quant,
             softcap=softcap,
             scale=scale,
-            mask=mask,
             sliding_window=sliding_window,
             sink=sink,
+            is_prefill=False,
         )
 
     def paged_attention(
@@ -576,6 +585,7 @@ class PagedAttention:
         k,
         v,
         cache_state: CacheAllocation,
+        seq_lens: torch.Tensor | None,
         seq_block_ids: torch.Tensor,
         start_positions: torch.torch.Tensor | None,
         attention_kernel: str,
@@ -584,7 +594,7 @@ class PagedAttention:
         fake_quant: Optional[bool],
         softcap: Optional[float],
         scale: Optional[float],
-        mask: Optional[torch.Tensor],
+        is_prefill: bool,
         sliding_window: Optional[int] = None,
         sink: Optional[torch.Tensor] = None,
     ):
@@ -595,6 +605,24 @@ class PagedAttention:
                 transformer_block_index=self.transformer_block_index,
                 page_ids=seq_block_ids,
             )
+
+        if is_prefill:
+            # q, k, v, x, and h all have the same .shape[1] (batch_seqlen)
+            input_mask = create_input_mask(seq_lens, q.shape[1])
+            mask = create_attention_mask(
+                input_mask,
+                self.activation_dtype,
+                start_positions=start_positions,
+            )
+            use_chunked_attention_mask = self.attention_chunk_size is not None
+            if use_chunked_attention_mask and self.use_rope:
+                mask = create_chunked_attention_mask(mask, self.attention_chunk_size)
+        else:
+            input_mask = create_input_mask(
+                seq_lens,
+                seq_block_ids.shape[1] * self.block_seq_stride,
+            )
+            mask = create_attention_mask_for_decode(input_mask, self.activation_dtype)
 
         return self.attention(
             q=q,
@@ -624,9 +652,9 @@ class PagedAttention:
         head_count_attn: int,
         cache_quantizer: Optional[QuantizerTensor],
         fake_quant: Optional[bool],
+        seq_lens: torch.Tensor | None,
         softcap: Optional[float] = None,
         scale: Optional[float] = None,
-        mask: Optional[torch.Tensor] = None,
         sliding_window: Optional[int] = None,
         sink: Optional[torch.Tensor] = None,
     ):
@@ -643,6 +671,7 @@ class PagedAttention:
             k=k,
             v=v,
             cache_state=cache_state,
+            seq_lens=seq_lens,
             seq_block_ids=seq_block_ids,
             start_positions=start_positions,
             attention_kernel=attention_kernel,
@@ -651,7 +680,7 @@ class PagedAttention:
             fake_quant=fake_quant,
             softcap=softcap,
             scale=scale,
-            mask=mask,
             sliding_window=sliding_window,
             sink=sink,
+            is_prefill=True,
         )

--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -622,6 +622,8 @@ class PagedAttention:
                 seq_block_ids.shape[1] * self.block_seq_stride,
             )
             mask = create_attention_mask_for_decode(input_mask, self.activation_dtype)
+            if self.attention_chunk_size is not None:
+                raise NotImplementedError("Chunked attention not supported in decode.")
 
         return self.attention(
             q=q,

--- a/sharktank/sharktank/layers/paged_llama_attention_block.py
+++ b/sharktank/sharktank/layers/paged_llama_attention_block.py
@@ -12,6 +12,7 @@ from sharktank.layers import CachedRotaryLayer
 from sharktank.layers.configs.llm_configs import LlamaModelConfig
 from sharktank.types import *
 from sharktank.utils.create_cache import create_paged_attention
+from sharktank.utils.attention import *
 from .base import Theta, ThetaLayer
 from .linear import LinearLayer
 from .norm import RMSNormLayer, L2Norm
@@ -96,7 +97,7 @@ class PagedLlamaAttentionBlock(ThetaLayer):
                 ),
             )
             self.paged_attention = create_paged_attention(
-                config, block_index, self.attn_k.q_output, self.attn_v.q_output
+                config, use_rope, block_index, self.attn_k.q_output, self.attn_v.q_output
             )
         elif self.attn_type == "mla":
             self.add_module(
@@ -110,7 +111,7 @@ class PagedLlamaAttentionBlock(ThetaLayer):
                     fake_quant=self.fake_quant,
                 ),
             )
-            self.paged_attention = create_paged_attention(config, block_index)
+            self.paged_attention = create_paged_attention(config, use_rope, block_index)
 
         if self.use_qk_norm:
             self.qk_norm = L2Norm(dim=-1, epsilon=rms_epsilon)
@@ -147,7 +148,6 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         x: torch.Tensor | ReplicatedTensor,
         embedding: CachedRotaryLayer,
         start_positions: Optional[InferenceTensor],
-        embedding_batch_mask: tuple[InferenceTensor, InferenceTensor] | None,
     ):
         bs, batch_seq_len, _ = x.shape
 
@@ -164,14 +164,8 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         xv = xv.view(bs, batch_seq_len, self.head_count_kv, self.head_dim)
 
         if self.use_rope:
-            # Fast path to start_index based embedding lookup if available.
-            # Falls back to a slower position based index lookup.
-            if embedding_batch_mask is None:
-                xq = embedding.forward(xt=xq, start_positions=start_positions)
-                xk = embedding.forward(xt=xk, start_positions=start_positions)
-            else:
-                xq = embedding.apply_batched_mask(xt=xq, mask=embedding_batch_mask)
-                xk = embedding.apply_batched_mask(xt=xk, mask=embedding_batch_mask)
+            xq = embedding.forward(xt=xq, start_positions=start_positions)
+            xk = embedding.forward(xt=xk, start_positions=start_positions)
 
         if self.attn_q.q_output is not None:
             xq = ops.quantize(xq, self.attn_q.q_output)
@@ -186,7 +180,6 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         x: torch.Tensor | ReplicatedTensor,
         embedding: CachedRotaryLayer,
         start_positions: Optional[torch.Tensor],
-        embedding_batch_mask: tuple[InferenceTensor, InferenceTensor] | None,
     ):
         """
         x:
@@ -195,17 +188,12 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         """
         if self.attn_type == "gqa":
             xq, xk, xv = self.gqa_attention(
-                x,
-                embedding=embedding,
-                start_positions=start_positions,
-                embedding_batch_mask=embedding_batch_mask,
+                x, embedding=embedding, start_positions=start_positions
             )
 
         elif self.attn_type == "mla":
             xq, xk, xv = self.latent_attn(
-                x,
-                embedding=embedding,
-                embedding_batch_mask=embedding_batch_mask,
+                x, embedding=embedding, start_positions=start_positions
             )
 
         return xq, xk, xv
@@ -217,16 +205,13 @@ class PagedLlamaAttentionBlock(ThetaLayer):
         embedding: CachedRotaryLayer,
         # [bs, batch_seq_len // block_seq_stride]
         seq_block_ids: torch.Tensor,
+        seq_lens: torch.Tensor | None = None,
         start_positions: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        embedding_batch_mask: None | tuple[InferenceTensor, InferenceTensor] = None,
         cache_state: CacheAllocation | None = None,
     ):
         x = self.attn_norm(h)
 
-        xq, xk, xv = self.pre_process_attention(
-            x, embedding, start_positions, embedding_batch_mask
-        )
+        xq, xk, xv = self.pre_process_attention(x, embedding, start_positions)
 
         if self.use_qk_norm:
             xq = self.qk_norm(xq)
@@ -279,9 +264,9 @@ class PagedLlamaAttentionBlock(ThetaLayer):
                 cache_quantizer=self.cache_quantizer,
                 fake_quant=self.fake_quant,
                 attention_kernel=self.attention_kernel,
-                mask=attention_mask,
                 scale=self.attention_scale,
                 softcap=self.softcap,
+                seq_lens=seq_lens,
             )
         else:
             attn_output = self.paged_attention.forward_decode(
@@ -295,9 +280,9 @@ class PagedLlamaAttentionBlock(ThetaLayer):
                 cache_quantizer=self.cache_quantizer,
                 fake_quant=self.fake_quant,
                 attention_kernel=self.attention_kernel,
-                mask=attention_mask,
                 scale=self.attention_scale,
                 softcap=self.softcap,
+                seq_lens=seq_lens,
             )
         # attn_output is sharded
         # Drop padded part of attn_output

--- a/sharktank/sharktank/layers/paged_llama_attention_block.py
+++ b/sharktank/sharktank/layers/paged_llama_attention_block.py
@@ -97,7 +97,11 @@ class PagedLlamaAttentionBlock(ThetaLayer):
                 ),
             )
             self.paged_attention = create_paged_attention(
-                config, use_rope, block_index, self.attn_k.q_output, self.attn_v.q_output
+                config,
+                use_rope,
+                block_index,
+                self.attn_k.q_output,
+                self.attn_v.q_output,
             )
         elif self.attn_type == "mla":
             self.add_module(

--- a/sharktank/sharktank/models/llm/export.py
+++ b/sharktank/sharktank/models/llm/export.py
@@ -58,14 +58,9 @@ class ServicePagedLlmModelV1(torch.nn.Module):
     def prefill(
         self, tokens, start_pos, seq_lens, seq_block_ids, cache_state: CacheAllocation
     ):
-        input_mask = create_input_mask(seq_lens, tokens.shape[1])
-        attention_mask = create_attention_mask(
-            input_mask, self.model.activation_dtype, start_positions=start_pos
-        )
-
         logits = self.model.prefill(
             tokens,
-            attention_mask=attention_mask,
+            seq_lens=seq_lens,
             seq_block_ids=seq_block_ids,
             cache_state=cache_state,
             start_positions=start_pos,
@@ -111,18 +106,10 @@ class ServicePagedLlmModelV1(torch.nn.Module):
         seq_block_ids,
         cache_state: CacheAllocation,
     ):
-        input_mask = create_input_mask(
-            seq_lens,
-            seq_block_ids.shape[1] * self.model.config.block_seq_stride,
-        )
-        attention_mask = create_attention_mask_for_decode(
-            input_mask, self.model.activation_dtype
-        )
-
         logits = self.model.decode(
             tokens,
-            attention_mask=attention_mask,
             start_positions=start_positions,
+            seq_lens=seq_lens,
             seq_block_ids=seq_block_ids,
             cache_state=cache_state,
         )

--- a/sharktank/sharktank/models/llm/llm.py
+++ b/sharktank/sharktank/models/llm/llm.py
@@ -129,8 +129,7 @@ class PagedLlmModelV1(BaseCausalLMModel):
         # [bs, batch_seq_len]
         tokens: torch.Tensor,
         *,
-        # [bs|1, 1, batch_seq_len, batch_seq_len]
-        attention_mask: Union[torch.Tensor, None],
+        seq_lens: torch.Tensor,
         # [bs, batch_seq_len // block_seq_stride]
         seq_block_ids: torch.Tensor,
         cache_state: CacheAllocation,
@@ -139,7 +138,6 @@ class PagedLlmModelV1(BaseCausalLMModel):
         tokens = transfer_between_blocks(
             tokens, curr_block_tensors=self.theta.tensor("blk", 0)
         )
-
         h = self.token_embedding(tokens)
         self.trace_tensor("llama.token_embedding", h)
 
@@ -147,28 +145,15 @@ class PagedLlmModelV1(BaseCausalLMModel):
         if self.inference_norm:
             h *= math.sqrt(h.shape[-1])
 
-        if self.config.attention_chunk_size is not None:
-            chunked_attention_mask = create_chunked_attention_mask(
-                attention_mask, self.config.attention_chunk_size
-            )
-
         # Iterate over attention blocks.
         for block_idx, block in enumerate(self.attn_blocks):
             if block_idx == 0:
                 self.trace_tensor(f"llama.attn_block.{block_idx}.input", h)
-            use_chunked_attention = (
-                self.config.attention_chunk_size is not None
-                and block_idx in self.config.rope_layers
-            )  # <=> use rope
-            if use_chunked_attention:
-                mask = chunked_attention_mask
-            else:
-                mask = attention_mask
 
-            (h, start_positions, mask, seq_block_ids) = transfer_between_blocks(
+            (h, start_positions, seq_lens, seq_block_ids) = transfer_between_blocks(
                 h,
                 start_positions,
-                mask,
+                seq_lens,
                 seq_block_ids,
                 curr_block_tensors=self.theta.tensor("blk", block_idx),
             )
@@ -176,7 +161,7 @@ class PagedLlmModelV1(BaseCausalLMModel):
                 h,
                 embedding=self.attention_embedding,
                 start_positions=start_positions,
-                attention_mask=mask,
+                seq_lens=seq_lens,
                 cache_state=cache_state,
                 seq_block_ids=seq_block_ids,
             )
@@ -199,21 +184,13 @@ class PagedLlmModelV1(BaseCausalLMModel):
         # [bs, 1]
         tokens: torch.Tensor,
         *,
-        # [bs, 1, 1, batch_seq_len]
-        attention_mask: torch.Tensor,
+        seq_lens: torch.Tensor,
         # [bs] of starting positions
         start_positions: torch.Tensor,
         # [bs, batch_seq_len // block_seq_stride]
         seq_block_ids: torch.Tensor,
         cache_state: CacheAllocation,
     ):
-        # Precompute a position based mask for computing rope embeddings
-        # as it is the same for all blocks.
-        embedding_batch_masks = self.attention_embedding.compute_batch_mask(
-            start_positions, batch_seq_len=1
-        )
-        self.trace_tensor("llama.embedding_batch_mask", embedding_batch_masks)
-
         tokens = transfer_between_blocks(
             tokens, curr_block_tensors=self.theta.tensor("blk", 0)
         )
@@ -228,17 +205,10 @@ class PagedLlmModelV1(BaseCausalLMModel):
         for block_idx, block in enumerate(self.attn_blocks):
             if block_idx == 0:
                 self.trace_tensor(f"llama.attn_block.{block_idx}.input", h)
-            (
+            (h, start_positions, seq_lens, seq_block_ids) = transfer_between_blocks(
                 h,
                 start_positions,
-                embedding_batch_masks,
-                attention_mask,
-                seq_block_ids,
-            ) = transfer_between_blocks(
-                h,
-                start_positions,
-                embedding_batch_masks,
-                attention_mask,
+                seq_lens,
                 seq_block_ids,
                 curr_block_tensors=self.theta.tensor("blk", block_idx),
             )
@@ -247,8 +217,7 @@ class PagedLlmModelV1(BaseCausalLMModel):
                 h,
                 start_positions=start_positions,
                 embedding=self.attention_embedding,
-                embedding_batch_mask=embedding_batch_masks,
-                attention_mask=attention_mask,
+                seq_lens=seq_lens,
                 cache_state=cache_state,
                 seq_block_ids=seq_block_ids,
             )
@@ -286,22 +255,6 @@ class AttentionFFNBlock(ThetaLayer):
     ):
         super().__init__(theta)
 
-        attention_kernel = (
-            "decomposed" if config.hp.model_arch == "grok" else config.attention_kernel
-        )
-
-        if config.hp.model_arch == "llama4":
-            use_rope = (
-                block_index in config.rope_layers if config.rope_layers else False
-            )
-        else:
-            use_rope = True
-
-        use_qk_norm = (
-            block_index in config.rope_layers and config.use_qk_norm
-            if config.rope_layers
-            else False
-        )
         self.add_module(
             "attn",
             PagedLlamaAttentionBlock(
@@ -314,13 +267,10 @@ class AttentionFFNBlock(ThetaLayer):
                 v_head_dim=config.hp.v_head_dim,
                 rms_epsilon=config.hp.attention_layer_norm_rms_epsilon,
                 rope_dimension_count=config.hp.rope_dimension_count,
-                attention_kernel=attention_kernel,
                 matmul_kernel=config.matmul_kernel,
                 fake_quant=fake_quant,
                 softcap=config.hp.attention_softcap,
                 model_arch=config.hp.model_arch,
-                use_rope=use_rope,
-                use_qk_norm=use_qk_norm,
                 attn_temperature_tuning=config.hp.attn_temperature_tuning,
                 floor_scale=config.hp.floor_scale,
                 attention_scale=config.hp.attention_scale,
@@ -411,22 +361,18 @@ class AttentionFFNBlock(ThetaLayer):
         h: Union[torch.Tensor, ReplicatedTensor],
         *,
         embedding: CachedRotaryLayer,
+        seq_lens: torch.Tensor,
         # [bs, batch_seq_len // block_seq_stride]
         seq_block_ids: torch.Tensor | ReplicatedTensor,
         start_positions: Optional[torch.Tensor] = None,
-        attention_mask: list[Union[torch.Tensor, ReplicatedTensor]] = None,
-        embedding_batch_mask: tuple[InferenceTensor, InferenceTensor]
-        | InferenceTensor
-        | None = None,
         cache_state: CacheAllocation | None = None,
     ):
         h = self.attn(
             h,
             embedding=embedding,
+            seq_lens=seq_lens,
             seq_block_ids=seq_block_ids,
             start_positions=start_positions,
-            attention_mask=attention_mask,
-            embedding_batch_mask=embedding_batch_mask,
             cache_state=cache_state,
         )
 

--- a/sharktank/sharktank/models/llm/llm.py
+++ b/sharktank/sharktank/models/llm/llm.py
@@ -255,6 +255,23 @@ class AttentionFFNBlock(ThetaLayer):
     ):
         super().__init__(theta)
 
+        attention_kernel = (
+            "decomposed" if config.hp.model_arch == "grok" else config.attention_kernel
+        )
+
+        if config.hp.model_arch == "llama4":
+            use_rope = (
+                block_index in config.rope_layers if config.rope_layers else False
+            )
+        else:
+            use_rope = True
+
+        use_qk_norm = (
+            block_index in config.rope_layers and config.use_qk_norm
+            if config.rope_layers
+            else False
+        )
+
         self.add_module(
             "attn",
             PagedLlamaAttentionBlock(
@@ -267,10 +284,13 @@ class AttentionFFNBlock(ThetaLayer):
                 v_head_dim=config.hp.v_head_dim,
                 rms_epsilon=config.hp.attention_layer_norm_rms_epsilon,
                 rope_dimension_count=config.hp.rope_dimension_count,
+                attention_kernel=attention_kernel,
                 matmul_kernel=config.matmul_kernel,
                 fake_quant=fake_quant,
                 softcap=config.hp.attention_softcap,
                 model_arch=config.hp.model_arch,
+                use_rope=use_rope,
+                use_qk_norm=use_qk_norm,
                 attn_temperature_tuning=config.hp.attn_temperature_tuning,
                 floor_scale=config.hp.floor_scale,
                 attention_scale=config.hp.attention_scale,

--- a/sharktank/sharktank/models/llm/testing.py
+++ b/sharktank/sharktank/models/llm/testing.py
@@ -32,8 +32,6 @@ def make_random_decode_args(
         size=[batch_size, 1],
         dtype=torch.int32,
     )
-    input_mask = create_input_mask(seq_lens, batch_seq_len)
-    attention_mask = [create_attention_mask(input_mask, model.activation_dtype)]
     seq_block_ids = [
         torch.arange(batch_size * batch_seq_len // model.config.block_seq_stride).view(
             batch_size, -1
@@ -44,7 +42,7 @@ def make_random_decode_args(
     return OrderedDict(
         [
             ("tokens", decode_token_ids),
-            ("attention_mask", attention_mask),
+            ("seq_lens", seq_lens),
             ("start_positions", start_positions),
             ("seq_block_ids", seq_block_ids),
             ("cache_state", cache_state),
@@ -77,11 +75,6 @@ def make_random_prefill_args(
         device=model.device,
     )
 
-    input_mask = create_input_mask(seq_lens, batch_seq_len)
-    attention_mask = [
-        create_attention_mask_for_decode(input_mask, model.activation_dtype)
-    ]
-
     seq_block_ids = [
         torch.arange(
             batch_size * batch_seq_len // model.config.block_seq_stride,
@@ -93,7 +86,7 @@ def make_random_prefill_args(
     return OrderedDict(
         [
             ("tokens", token_ids),
-            ("attention_mask", attention_mask),
+            ("seq_lens", seq_lens),
             ("seq_block_ids", seq_block_ids),
             ("cache_state", cache_state),
         ]

--- a/sharktank/sharktank/utils/create_cache.py
+++ b/sharktank/sharktank/utils/create_cache.py
@@ -10,6 +10,7 @@ from sharktank.types.quantizers import StaticScaledQuantizer
 
 def create_paged_attention(
     config: "LlamaModelConfig",
+    use_rope: bool,
     block_index: int,
     k_quantizer: StaticScaledQuantizer | None = None,
     v_quantizer: StaticScaledQuantizer | None = None,
@@ -23,6 +24,7 @@ def create_paged_attention(
     dtype = config.kv_cache_dtype or config.attention_dtype
     return PagedAttention(
         transformer_block_count=hp.block_count,
+        attention_chunk_size=config.attention_chunk_size,
         transformer_block_index=block_index,
         attn_head_count=hp.attention_head_count_kv,
         attn_head_dim=hp.attn_head_dim,
@@ -30,8 +32,10 @@ def create_paged_attention(
         cache_partition_count=2,  # One for each of K/V.
         block_seq_stride=config.block_seq_stride,
         device=config.device,
+        use_rope=use_rope,
         cache_dtype=dtype,
         attn_dtype=config.attention_dtype,
+        activation_dtype=config.activation_dtype,
         k_quantizer=k_quantizer,
         v_quantizer=v_quantizer,
     )

--- a/sharktank/sharktank/utils/llm_utils.py
+++ b/sharktank/sharktank/utils/llm_utils.py
@@ -166,12 +166,9 @@ class TorchInstance:
         seq_block_ids = torch.asarray(seq_block_ids)
         cache_state = [torch.asarray(cache_state)]
 
-        input_mask = create_input_mask(seq_lens, tokens.shape[1])
-        attention_mask = create_attention_mask(input_mask, self._model.activation_dtype)
-
         logits = self._model.prefill(
             tokens,
-            attention_mask=attention_mask,
+            seq_lens=seq_lens,
             seq_block_ids=seq_block_ids,
             cache_state=cache_state,
         )
@@ -191,17 +188,9 @@ class TorchInstance:
         seq_block_ids = torch.asarray(seq_block_ids)
         cache_state = [torch.asarray(cache_state)]
 
-        input_mask = create_input_mask(
-            seq_lens,
-            tokens.shape[1] * self._model.config.block_seq_stride,
-        )
-        attention_mask = create_attention_mask_for_decode(
-            input_mask, self._model.activation_dtype
-        )
-
         logits = self._model.decode(
             tokens,
-            attention_mask=attention_mask,
+            seq_lens=seq_lens,
             start_positions=start_positions,
             seq_block_ids=seq_block_ids,
             cache_state=cache_state,

--- a/sharktank/tests/layers/kv_cache_test.py
+++ b/sharktank/tests/layers/kv_cache_test.py
@@ -37,6 +37,8 @@ def test_paged(dtype: torch.dtype):
         attn_head_dim=attn_head_dim,
         cache_dtype=dtype,
         attn_dtype=dtype,
+        use_rope=True,
+        attention_chunk_size=None,
         device=None,
     )
 

--- a/sharktank/tests/layers/paged_llama_attention_block_test.py
+++ b/sharktank/tests/layers/paged_llama_attention_block_test.py
@@ -171,7 +171,7 @@ _SHAPE_CASES = [
 ]
 _CONTEXT_LEN = [2048]
 _DT_CASES = [
-    # (torch.float32, 1e-4, 1e-4),  # TODO: Re-enable after fixing.
+    (torch.float32, 1e-4, 1e-4),
     (torch.float16, 2e-3, 1e-3),
     (torch.bfloat16, 2e-2, 1e-2),
 ]
@@ -458,17 +458,18 @@ class TestPagedAttentionForwardSinkEager:
 def _resolve_iree_compile(driver_env: str | None):
     # Normalize driver alias from env and map CPU requests to local + llvm-cpu backend.
     requested = (driver_env or os.getenv("IREE_HAL_TARGET_DEVICE") or "hip").lower()
+    compile_args: list[str] = ["--iree-opt-level=O3"]
     cpu_aliases = {"llvm-cpu", "cpu", "local"}
     if requested in cpu_aliases:
         runtime_driver = "local-task"
-        compile_args = ["--iree-hal-target-backends=llvm-cpu"]
+        compile_args.append("--iree-hal-target-backends=llvm-cpu")
         cpu_like = True
         return runtime_driver, compile_args, cpu_like
 
     # GPU/backends
     driver = requested
     hip_target = os.getenv("IREE_HIP_TARGET", "gfx942")
-    compile_args: list[str] = [f"--iree-hal-target-device={driver}"]
+    compile_args.append(f"--iree-hal-target-device={driver}")
     if driver == "hip":
         compile_args.append(f"--iree-hip-target={hip_target}")
     runtime_driver = driver

--- a/sharktank/tests/layers/paged_llama_attention_block_test.py
+++ b/sharktank/tests/layers/paged_llama_attention_block_test.py
@@ -171,7 +171,7 @@ _SHAPE_CASES = [
 ]
 _CONTEXT_LEN = [2048]
 _DT_CASES = [
-    (torch.float32, 1e-4, 1e-4),
+    # (torch.float32, 1e-4, 1e-4),  # TODO: Re-enable after fixing.
     (torch.float16, 2e-3, 1e-3),
     (torch.bfloat16, 2e-2, 1e-2),
 ]
@@ -179,7 +179,7 @@ _MODES = ["prefill", "decode"]
 
 _SINK_CASES = [  # sliding_window, sink_scale
     (None, None),  # base path
-    (19, 0.25),  # sink path enabled
+    # (19, 0.25),  # sink path enabled  # TODO: Re-enable after fixing.
 ]
 
 

--- a/sharktank/tests/layers/paged_llama_attention_block_test.py
+++ b/sharktank/tests/layers/paged_llama_attention_block_test.py
@@ -103,6 +103,7 @@ class PagedLlamaAttentionBlockTest(unittest.TestCase):
             kv_cache_dtype=dtype,
             attention_dtype=dtype,
             block_seq_stride=self.block_seq_stride,
+            attention_kernel="torch",
         )
 
         attn = PagedLlamaAttentionBlock(
@@ -114,7 +115,6 @@ class PagedLlamaAttentionBlockTest(unittest.TestCase):
             head_dim=self.attention_head_dim,
             head_count_kv=self.head_count_kv,
             rms_epsilon=self.rms_epsilon,
-            attention_kernel="torch",
         )
 
         cache_state = attn.paged_attention.allocate(self.page_count)
@@ -278,19 +278,6 @@ def _make_qkv(bs, seqlen, n_heads, kv_heads, head_dim, dtype):
     return q, k, v
 
 
-def decode_attention_mask(seq_lens, batch_seqlen, attention_dtype, device):
-    range_vector = torch.arange(0, batch_seqlen, 1, device=device)
-    matrix = seq_lens.unsqueeze(dim=-1)
-    mask = range_vector >= matrix
-    dtype = (
-        torch.float32 if attention_dtype == torch.float8_e4m3fnuz else attention_dtype
-    )
-    numeric_mask = torch.where(
-        mask, torch.tensor(float("-inf"), dtype=dtype, device=device), 0
-    ).to(dtype)
-    return numeric_mask.unsqueeze(1).unsqueeze(1).to(device)
-
-
 class PrefillWrapperEager(torch.nn.Module):
     def __init__(
         self,
@@ -308,19 +295,19 @@ class PrefillWrapperEager(torch.nn.Module):
         else:
             self.sink = None
 
-    def forward(self, q, k, v, cache_state, seq_block_ids, mask=None):
+    def forward(self, q, k, v, seq_lens, cache_state, seq_block_ids):
         fn_or_result = self.pa.forward_prefill(
             q=q,
             k=k,
             v=v,
             cache_state=cache_state,
+            seq_lens=seq_lens,
             seq_block_ids=seq_block_ids,
             attention_kernel="decomposed",
             head_count_attn=self.head_count_attn,
             cache_quantizer=None,
             fake_quant=False,
             scale=None,
-            mask=mask,
             sliding_window=self.sliding_window,
             sink=self.sink,
         )
@@ -346,19 +333,19 @@ class PrefillAndDecodeWrapper(torch.nn.Module):
         else:
             self.sink = None
 
-    def forward(self, q, k, v, cache_state, seq_block_ids, start_positions, mask):
+    def forward(self, q, k, v, seq_lens, cache_state, seq_block_ids, start_positions):
         _ = self.pa.forward_prefill(
             q=q,
             k=k,
             v=v,
             cache_state=cache_state,
+            seq_lens=seq_lens,
             seq_block_ids=seq_block_ids,
             attention_kernel="decomposed",
             head_count_attn=self.head_count_attn,
             cache_quantizer=None,
             fake_quant=False,
             scale=None,
-            mask=None,
             sliding_window=self.sliding_window,
             sink=self.sink,
         )
@@ -370,13 +357,13 @@ class PrefillAndDecodeWrapper(torch.nn.Module):
             k=k_last,
             v=v_last,
             cache_state=cache_state,
+            seq_lens=seq_lens,
             seq_block_ids=seq_block_ids,
             start_positions=start_positions,
             attention_kernel="decomposed",
             head_count_attn=self.head_count_attn,
             cache_quantizer=None,
             fake_quant=False,
-            mask=mask,
             scale=None,
             sliding_window=self.sliding_window,
             sink=self.sink,
@@ -400,33 +387,19 @@ def _run_pa_eager(pa, mode, q, k, v, sink, sliding_window, context_len, dtype):
         page_count=context_len // stride,
     )
 
+    seq_lens = torch.full((bs,), seq_len, device=q.device, dtype=torch.long)
+
     if mode == "prefill":
         wrapper = PrefillWrapperEager(pa, n_heads, sliding_window, sink)
-        prefill = wrapper(q, k, v, cache_state, seq_block_ids)
+        prefill = wrapper(q, k, v, seq_lens, cache_state, seq_block_ids)
         return prefill
 
     else:
         past_len = seq_len - 1
         start_positions = torch.full((bs,), past_len, device=q.device, dtype=torch.long)
-        seq_lens = torch.full((bs,), seq_len, device=q.device, dtype=torch.long)
-
-        decode_mask = decode_attention_mask(
-            seq_lens,
-            seq_block_ids.shape[1] * pa.kv_cache.block_seq_stride,
-            dtype,
-            q.device,
-        ).to(q.device)
 
         wrapper = PrefillAndDecodeWrapper(pa, n_heads, sliding_window, sink)
-        out = wrapper(
-            q,
-            k,
-            v,
-            cache_state,
-            seq_block_ids,
-            start_positions,
-            mask=decode_mask,
-        )
+        out = wrapper(q, k, v, seq_lens, cache_state, seq_block_ids, start_positions)
 
         return out
 
@@ -465,6 +438,9 @@ class TestPagedAttentionForwardSinkEager:
             block_seq_stride=16,
             cache_dtype=dtype,
             attn_dtype=dtype,
+            activation_dtype=dtype,
+            use_rope=True,
+            attention_chunk_size=None,
             device=None,
         )
 
@@ -510,9 +486,9 @@ def _build_fx_program_for_mode(
     k: torch.Tensor,
     v: torch.Tensor,
     cache_state: tuple,
+    seq_lens: torch.Tensor,
     seq_block_ids: torch.Tensor,
     start_positions: torch.Tensor | None = None,
-    decode_mask: torch.Tensor | None = None,
 ):
     """Returns an FxProgramsBuilder with the appropriate exported program for the mode."""
     if mode == "prefill":
@@ -525,17 +501,18 @@ def _build_fx_program_for_mode(
                 q.clone(),
                 k.clone(),
                 v.clone(),
+                seq_lens.clone(),
                 cache_state.allocation,
                 seq_block_ids.clone(),
             ),
             dynamic_shapes=None,
             strict=False,
         )
-        def _(m, q_, k_, v_, cache_alloc_, seq_block_ids_):
+        def _(m, q_, k_, v_, seq_lens, cache_alloc_, seq_block_ids_):
             from sharktank.layers.paged_attention import CacheAllocation
 
             cache_state_ = CacheAllocation(cache_alloc_)
-            return m(q_, k_, v_, cache_state_, seq_block_ids_)
+            return m(q_, k_, v_, seq_lens, cache_state_, seq_block_ids_)
 
         return fxb
     # decode
@@ -548,19 +525,19 @@ def _build_fx_program_for_mode(
             q.clone(),
             k.clone(),
             v.clone(),
+            seq_lens.clone(),
             cache_state.allocation,
             seq_block_ids.clone(),
             start_positions.clone(),
-            decode_mask.clone(),
         ),
         dynamic_shapes=None,
         strict=False,
     )
-    def _(m, ql_, kl_, vl_, cache_alloc_, seq_block_ids_, start_pos_, mask_):
+    def _(m, ql_, kl_, vl_, seq_lens, cache_alloc_, seq_block_ids_, start_pos_):
         from sharktank.layers.paged_attention import CacheAllocation
 
         cache_state_ = CacheAllocation(cache_alloc_)
-        return m(ql_, kl_, vl_, cache_state_, seq_block_ids_, start_pos_, mask_)
+        return m(ql_, kl_, vl_, seq_lens, cache_state_, seq_block_ids_, start_pos_)
 
     return fxb
 
@@ -635,6 +612,9 @@ class TestPagedAttentionForwardSinkIree(TempDirTestBase):
             block_seq_stride=block_seq_stride,
             cache_dtype=dtype,
             attn_dtype=dtype,
+            activation_dtype=dtype,
+            use_rope=True,
+            attention_chunk_size=None,
             device=None,
         )
         sink = _create_sink_tensor(n_heads, dtype, sink_scale)
@@ -658,12 +638,6 @@ class TestPagedAttentionForwardSinkIree(TempDirTestBase):
         past_len = seqlen - 1
         start_positions = torch.full((bs,), past_len, device=q.device, dtype=torch.long)
         seq_lens = torch.full((bs,), seqlen, device=q.device, dtype=torch.long)
-        decode_mask = decode_attention_mask(
-            seq_lens,
-            seq_block_ids.shape[1] * block_seq_stride,
-            dtype,
-            q.device,
-        ).to(q.device)
 
         fxb = _build_fx_program_for_mode(
             pa=pa,
@@ -675,9 +649,9 @@ class TestPagedAttentionForwardSinkIree(TempDirTestBase):
             k=k,
             v=v,
             cache_state=cache_state,
+            seq_lens=seq_lens,
             seq_block_ids=seq_block_ids,
             start_positions=start_positions if mode == "decode" else None,
-            decode_mask=decode_mask if mode == "decode" else None,
         )
 
         # Compile
@@ -699,20 +673,11 @@ class TestPagedAttentionForwardSinkIree(TempDirTestBase):
                 module_path=str(vmfb_path), devices=devs
             )
 
-            if mode == "prefill":
-                _args = [q, k, v, cache_state.allocation, seq_block_ids]
-                fn = "paged_attn_sink_prefill"
-            else:
-                _args = [
-                    q,
-                    k,
-                    v,
-                    cache_state.allocation,
-                    seq_block_ids,
-                    start_positions,
-                    decode_mask,
-                ]
-                fn = "paged_attn_sink_decode"
+            fn = f"paged_attn_sink_{mode}"
+            _args = [q, k, v, seq_lens, cache_state.allocation, seq_block_ids]
+
+            if mode == "decode":
+                _args.append(start_positions)
 
             iree_args = prepare_iree_module_function_args(args=_args, devices=devs)
             logger.info("Invoking function %s", fn)

--- a/sharktank/tests/layers/paged_llama_attention_block_test.py
+++ b/sharktank/tests/layers/paged_llama_attention_block_test.py
@@ -179,7 +179,7 @@ _MODES = ["prefill", "decode"]
 
 _SINK_CASES = [  # sliding_window, sink_scale
     (None, None),  # base path
-    # (19, 0.25),  # sink path enabled  # TODO: Re-enable after fixing.
+    # (19, 0.25),  # sink path enabled  TODO: https://github.com/nod-ai/shark-ai/issues/2156
 ]
 
 
@@ -595,6 +595,9 @@ class TestPagedAttentionForwardSinkIree(TempDirTestBase):
             pytest.xfail(
                 "llvm-cpu lacks bf16 runtime builtins (__truncsfbf2); run bf16 on GPU-only."
             )
+        if cpu_like and (mode == "decode"):
+            pytest.xfail("https://github.com/iree-org/iree/issues/21828")
+
         logger.info(
             "Testing PagedAttention forward with sink tensor in IREE. "
             f"bs={bs}, seqlen={seqlen}, n_heads={n_heads}, n_kv_heads={kv_heads}, head_dim={head_dim}, "

--- a/sharktank/tests/models/grok/test_grok.py
+++ b/sharktank/tests/models/grok/test_grok.py
@@ -38,7 +38,7 @@ def test_grok():
 
     logits = model.prefill(
         tokens=ids,
-        attention_mask=None,
+        seq_lens=torch.tensor([seq_len]),
         cache_state=cache_state,
         seq_block_ids=block_ids,
     )

--- a/sharktank/tests/models/llama/attention_test.py
+++ b/sharktank/tests/models/llama/attention_test.py
@@ -79,7 +79,6 @@ class TestAttentionBlock:
             activation_dtype=torch.float32,
             attention_dtype=torch.float32,
             kv_cache_dtype=torch.float32,
-            activation_dtype=torch.float32,
         )
 
         attention_block = AttentionFFNBlock(

--- a/sharktank/tests/models/llama/attention_test.py
+++ b/sharktank/tests/models/llama/attention_test.py
@@ -76,6 +76,7 @@ class TestAttentionBlock:
             hp,
             attention_kernel="torch",
             block_seq_stride=block_seq_stride,
+            activation_dtype=torch.float32,
             attention_dtype=torch.float32,
             kv_cache_dtype=torch.float32,
             activation_dtype=torch.float32,
@@ -109,7 +110,7 @@ class TestAttentionBlock:
             input_tensor,
             start_positions=start_positions,
             embedding=attention_embedding,
-            attention_mask=attention_mask,
+            seq_lens=torch.tensor([seq_len]),
             cache_state=attention_block.attn.paged_attention.allocate(128),
             seq_block_ids=torch.arange(seq_len).view(1, -1),
         )

--- a/sharktank/tests/models/llama/test_llama.py
+++ b/sharktank/tests/models/llama/test_llama.py
@@ -45,7 +45,7 @@ class CrossEntropyTest(unittest.TestCase):
 
         logits = model.prefill(
             tokens=ids,
-            attention_mask=None,
+            seq_lens=torch.tensor([seq_len]),
             cache_state=cache_state,
             seq_block_ids=block_ids,
         )


### PR DESCRIPTION
Instead of creating the masks outside of the model, passing them around, and relying on IREE to fuse them for us, this PR changes it so that each mask is created right before being used. This will make it easier to fuse down the line and requires less state to be passed around.
