### PR TITLE
Add void future awaitable onto array/storage transfers

### DIFF
--- a/shortfin/python/array_binding.cc
+++ b/shortfin/python/array_binding.cc
@@ -464,7 +464,12 @@ void BindArray(py::module_ &m) {
           },
           py::arg("pattern"), DOCSTRING_STORAGE_FILL)
       .def(
-          "copy_from", [](storage &self, storage &src) { self.copy_from(src); },
+          "copy_from",
+          [](storage &self, storage &src) {
+            auto res = self.copy_from(src);
+            py::object future = py::cast(res, py::rv_policy::move);
+            return future;
+          },
           py::arg("source_storage"), DOCSTRING_STORAGE_COPY_FROM)
       .def(
           "map",
@@ -621,10 +626,22 @@ void BindArray(py::module_ &m) {
             self.attr("storage").attr("fill")(buffer);
           },
           py::arg("pattern"), DOCSTRING_ARRAY_FILL)
-      .def("copy_from", &device_array::copy_from, py::arg("source_array"),
-           DOCSTRING_ARRAY_COPY_FROM)
-      .def("copy_to", &device_array::copy_to, py::arg("dest_array"),
-           DOCSTRING_ARRAY_COPY_TO)
+      .def(
+          "copy_from",
+          [](device_array &self, device_array &src) {
+            auto res = self.copy_from(src);
+            py::object future = py::cast(res, py::rv_policy::move);
+            return future;
+          },
+          py::arg("source_array"), DOCSTRING_ARRAY_COPY_FROM)
+      .def(
+          "copy_to",
+          [](device_array &self, device_array &src) {
+            auto res = self.copy_to(src);
+            py::object future = py::cast(res, py::rv_policy::move);
+            return future;
+          },
+          py::arg("dest_array"), DOCSTRING_ARRAY_COPY_TO)
       .def("view", PyDeviceArrayView, DOCSTRING_ARRAY_VIEW)
       .def(
           "map",

--- a/shortfin/src/shortfin/array/array.h
+++ b/shortfin/src/shortfin/array/array.h
@@ -16,6 +16,7 @@
 #include "shortfin/array/dtype.h"
 #include "shortfin/array/storage.h"
 #include "shortfin/array/xtensor_bridge.h"
+#include "shortfin/local/async.h"
 #include "shortfin/local/program_interfaces.h"
 #include "shortfin/support/api.h"
 
@@ -122,12 +123,12 @@ class SHORTFIN_API device_array
 
   // Performs either a d2h, h2d or d2d transfer from a source storage to this
   // storage. Equivalent to calling the same on the backing storage.
-  void copy_from(device_array &source_array) {
-    storage_.copy_from(source_array.storage_);
+  local::VoidFuture copy_from(device_array &source_array) {
+    return storage_.copy_from(source_array.storage_);
   }
   // Inverse of copy_from.
-  void copy_to(device_array &dest_array) {
-    dest_array.storage_.copy_from(storage_);
+  local::VoidFuture copy_to(device_array &dest_array) {
+    return dest_array.storage_.copy_from(storage_);
   }
 
   // Untyped access to the backing data. The array must be mappable. Specific

--- a/shortfin/src/shortfin/array/storage.h
+++ b/shortfin/src/shortfin/array/storage.h
@@ -9,6 +9,7 @@
 
 #include <string_view>
 
+#include "shortfin/local/async.h"
 #include "shortfin/local/fiber.h"
 #include "shortfin/local/program_interfaces.h"
 #include "shortfin/support/api.h"
@@ -106,7 +107,7 @@ class SHORTFIN_API storage : public local::ProgramInvocationMarshalable {
 
   // Performs either a d2h, h2d or d2d transfer from a source storage to this
   // storage.
-  void copy_from(storage &source_storage);
+  local::VoidFuture copy_from(storage &source_storage);
 
   iree_device_size_t byte_length() const {
     return iree_hal_buffer_byte_length(buffer_.get());

--- a/shortfin/tests/api/array_test.py
+++ b/shortfin/tests/api/array_test.py
@@ -66,8 +66,7 @@ def test_fill_copy_from_for_transfer(lsys, device):
         src = sfnp.device_array(device, [2, 4], sfnp.uint8)
         src.fill(b"\0\1\2\3")
         dst = src.for_transfer()
-        dst.copy_from(src)
-        await device
+        await dst.copy_from(src)
         assert list(dst.items) == [0, 1, 2, 3, 0, 1, 2, 3]
 
     lsys.run(main())
@@ -78,8 +77,7 @@ def test_fill_copy_to_for_transfer(lsys, device):
         src = sfnp.device_array(device, [2, 4], sfnp.uint8)
         src.fill(b"\0\1\2\3")
         dst = src.for_transfer()
-        src.copy_to(dst)
-        await device
+        await src.copy_to(dst)
         assert list(dst.items) == [0, 1, 2, 3, 0, 1, 2, 3]
 
     lsys.run(main())


### PR DESCRIPTION
Device level awaiting is problematic for multi requests. Instead we can await on the separate transfers.