### PR TITLE
[Sharktank] Remove block_index from PagedAttention.forward

### DIFF
--- a/sharktank/sharktank/export_layer/export_kv_cache.py
+++ b/sharktank/sharktank/export_layer/export_kv_cache.py
@@ -61,6 +61,7 @@ def main():
 
     cache = PagedAttention(
         block_seq_stride=block_seq_stride,
+        transformer_block_index=1,
         transformer_block_count=transformer_block_count,
         attn_head_count=attn_head_count,
         attn_head_dim=attn_head_dim,

--- a/sharktank/sharktank/export_layer/export_paged_attention.py
+++ b/sharktank/sharktank/export_layer/export_paged_attention.py
@@ -37,8 +37,6 @@ def paged_attention(
     attention_mask: Optional[torch.Tensor] = None,
     cache_state: CacheAllocation = None,
 ):
-
-    block_index = attention_block.block_index
     head_count = attention_block.head_count
     bs, batch_seq_len, _, _ = xq.shape
 
@@ -51,7 +49,6 @@ def paged_attention(
             v=xv,
             cache_state=cache_state,
             seq_block_ids=seq_block_ids,
-            block_index=block_index,
             head_count_attn=head_count,
             mask=attention_mask,
         )
@@ -62,7 +59,6 @@ def paged_attention(
             v=xv,
             cache_state=cache_state,
             seq_block_ids=seq_block_ids,
-            block_index=block_index,
             start_positions=start_positions,
             head_count_attn=head_count,
             mask=attention_mask,

--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -379,6 +379,7 @@ class PagedAttention:
         self,
         *,
         transformer_block_count: int,
+        transformer_block_index: int,
         attn_head_count: int,
         attn_head_dim: int,
         attn_type: str = "gqa",
@@ -391,6 +392,7 @@ class PagedAttention:
         v_quantizer: StaticScaledQuantizer | None = None,
     ):
         self.transformer_block_count = transformer_block_count
+        self.transformer_block_index = transformer_block_index
         self.head_count_kv = attn_head_count
         self.attn_head_dim = attn_head_dim
         self.device = device
@@ -529,7 +531,6 @@ class PagedAttention:
         v: torch.Tensor,
         cache_state: CacheAllocation,
         seq_block_ids: torch.Tensor,
-        block_index: int,
         start_positions: torch.Tensor,
         attention_kernel: str,
         head_count_attn: int,
@@ -545,7 +546,7 @@ class PagedAttention:
         self.write_timestep(
             cache_state,
             cache_partitions=[k, v],
-            transformer_block_index=block_index,
+            transformer_block_index=self.transformer_block_index,
             seq_positions=start_positions,
             page_ids=seq_block_ids,
         )
@@ -556,7 +557,6 @@ class PagedAttention:
             v=v,
             cache_state=cache_state,
             seq_block_ids=seq_block_ids,
-            block_index=block_index,
             attention_kernel=attention_kernel,
             head_count_attn=head_count_attn,
             cache_quantizer=cache_quantizer,
@@ -577,7 +577,6 @@ class PagedAttention:
         v,
         cache_state: CacheAllocation,
         seq_block_ids: torch.Tensor,
-        block_index: int,
         start_positions: torch.torch.Tensor | None,
         attention_kernel: str,
         head_count_attn: int,
@@ -593,7 +592,7 @@ class PagedAttention:
         if start_positions is not None:
             k, v = self.read(
                 cache_state,
-                transformer_block_index=block_index,
+                transformer_block_index=self.transformer_block_index,
                 page_ids=seq_block_ids,
             )
 
@@ -620,7 +619,6 @@ class PagedAttention:
         v: torch.Tensor,
         cache_state: CacheAllocation,
         seq_block_ids: torch.Tensor,
-        block_index: int,
         start_positions: Optional[torch.Tensor] = None,
         attention_kernel: str,
         head_count_attn: int,
@@ -635,7 +633,7 @@ class PagedAttention:
         self.write(
             cache_state,
             cache_partitions=[k, v],
-            transformer_block_index=block_index,
+            transformer_block_index=self.transformer_block_index,
             page_ids=seq_block_ids,
             start_positions=start_positions,
         )
@@ -646,7 +644,6 @@ class PagedAttention:
             v=v,
             cache_state=cache_state,
             seq_block_ids=seq_block_ids,
-            block_index=block_index,
             start_positions=start_positions,
             attention_kernel=attention_kernel,
             head_count_attn=head_count_attn,

--- a/sharktank/sharktank/layers/paged_llama_attention_block.py
+++ b/sharktank/sharktank/layers/paged_llama_attention_block.py
@@ -53,7 +53,6 @@ class PagedLlamaAttentionBlock(ThetaLayer):
     ):
         super().__init__(theta)
 
-        self.block_index = block_index
         self.head_count = head_count
         self.head_dim = head_dim
         self.head_count_kv = head_count_kv
@@ -97,7 +96,7 @@ class PagedLlamaAttentionBlock(ThetaLayer):
                 ),
             )
             self.paged_attention = create_paged_attention(
-                config, self.attn_k.q_output, self.attn_v.q_output
+                config, block_index, self.attn_k.q_output, self.attn_v.q_output
             )
         elif self.attn_type == "mla":
             self.add_module(
@@ -111,7 +110,7 @@ class PagedLlamaAttentionBlock(ThetaLayer):
                     fake_quant=self.fake_quant,
                 ),
             )
-            self.paged_attention = create_paged_attention(config)
+            self.paged_attention = create_paged_attention(config, block_index)
 
         if self.use_qk_norm:
             self.qk_norm = L2Norm(dim=-1, epsilon=rms_epsilon)
@@ -275,7 +274,6 @@ class PagedLlamaAttentionBlock(ThetaLayer):
                 v=xv,
                 cache_state=cache_state,
                 seq_block_ids=seq_block_ids,
-                block_index=self.block_index,
                 start_positions=start_positions,
                 head_count_attn=self.head_count,
                 cache_quantizer=self.cache_quantizer,
@@ -292,7 +290,6 @@ class PagedLlamaAttentionBlock(ThetaLayer):
                 v=xv,
                 cache_state=cache_state,
                 seq_block_ids=seq_block_ids,
-                block_index=self.block_index,
                 start_positions=start_positions,
                 head_count_attn=self.head_count,
                 cache_quantizer=self.cache_quantizer,

--- a/sharktank/sharktank/utils/create_cache.py
+++ b/sharktank/sharktank/utils/create_cache.py
@@ -10,6 +10,7 @@ from sharktank.types.quantizers import StaticScaledQuantizer
 
 def create_paged_attention(
     config: "LlamaModelConfig",
+    block_index: int,
     k_quantizer: StaticScaledQuantizer | None = None,
     v_quantizer: StaticScaledQuantizer | None = None,
 ) -> PagedAttention:
@@ -22,6 +23,7 @@ def create_paged_attention(
     dtype = config.kv_cache_dtype or config.attention_dtype
     return PagedAttention(
         transformer_block_count=hp.block_count,
+        transformer_block_index=block_index,
         attn_head_count=hp.attention_head_count_kv,
         attn_head_dim=hp.attn_head_dim,
         attn_type=attn_type_map[hp.model_arch],

--- a/sharktank/tests/layers/kv_cache_test.py
+++ b/sharktank/tests/layers/kv_cache_test.py
@@ -27,10 +27,12 @@ def test_paged(dtype: torch.dtype):
     attn_head_count = 4
     attn_head_dim = 16
     transformer_block_count = 4
+    transformer_block_index = 1
     block_seq_stride = 4
     cache = PagedAttention(
         block_seq_stride=block_seq_stride,
         transformer_block_count=transformer_block_count,
+        transformer_block_index=transformer_block_index,
         attn_head_count=attn_head_count,
         attn_head_dim=attn_head_dim,
         cache_dtype=dtype,
@@ -56,13 +58,13 @@ def test_paged(dtype: torch.dtype):
     cache.write(
         allocation,
         cache_partitions=[write_ones, write_twos],
-        transformer_block_index=1,
+        transformer_block_index=transformer_block_index,
         page_ids=write_page_ids,
     )
 
     read_back = cache.read(
         allocation,
-        transformer_block_index=1,
+        transformer_block_index=transformer_block_index,
         page_ids=write_page_ids,
     )
     assert_tensor_close(write_ones, read_back[0])
@@ -70,7 +72,7 @@ def test_paged(dtype: torch.dtype):
 
     # Check the others are still zero:
     for i in range(transformer_block_count):
-        if i == 1:
+        if i == transformer_block_index:
             continue
         read_ones = cache.read(
             allocation,
@@ -94,14 +96,14 @@ def test_paged(dtype: torch.dtype):
         cache.write_timestep(
             allocation,
             cache_partitions=[write_threes, write_fours],
-            transformer_block_index=1,
+            transformer_block_index=transformer_block_index,
             seq_positions=write_pos,
             page_ids=page_ids,
         )
 
     read_back = cache.read(
         allocation,
-        transformer_block_index=1,
+        transformer_block_index=transformer_block_index,
         page_ids=page_ids,
     )
 


### PR DESCRIPTION
Each PagedAttention object exists on a single block. The block_index is known when the object is instantiated.

Raw read, write, write_timestep functions were left unmodified to allow for easier testing.