### PR TITLE
[Sharktank] Add transfer to input tokens

### DIFF
--- a/sharktank/sharktank/models/llm/llm.py
+++ b/sharktank/sharktank/models/llm/llm.py
@@ -136,6 +136,9 @@ class PagedLlmModelV1(BaseCausalLMModel):
         cache_state: CacheAllocation,
         start_positions: Optional[torch.Tensor] = None,
     ):
+        tokens = transfer_between_blocks(
+            tokens, curr_block_tensors=self.theta.tensor("blk", 0)
+        )
 
         h = self.token_embedding(tokens)
         self.trace_tensor("llama.token_embedding", h)
@@ -211,6 +214,9 @@ class PagedLlmModelV1(BaseCausalLMModel):
         )
         self.trace_tensor("llama.embedding_batch_mask", embedding_batch_masks)
 
+        tokens = transfer_between_blocks(
+            tokens, curr_block_tensors=self.theta.tensor("blk", 0)
+        )
         h = self.token_embedding(tokens)
         self.trace_tensor("llama.token_embedding", h)
 

--- a/sharktank/sharktank/types/pipelining.py
+++ b/sharktank/sharktank/types/pipelining.py
@@ -92,10 +92,7 @@ def transfer_between_blocks(
             )
             new_x = x.clone(ts=shards, devices=new_devices)
         else:
-            shards = ShardedTensor.move_shards_to_new_devices(
-                (x,), new_devices=new_devices
-            )
-            new_x = ReplicatedTensor(ts=shards, devices=new_devices)
+            new_x = ReplicatedTensor(ts=x, devices=new_devices)
         new_xs.append(new_x)
 
     if len(new_xs) == 1:


### PR DESCRIPTION
Use `transfer_between_blocks` to replicate the input tokens for pipelined (or sharded) invocations of the model.