### PR TITLE
[Sharktank] Add DeviceAffinity state to CacheAllocation

### DIFF
--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -138,13 +138,14 @@ class CacheAllocation:
     def __init__(
         self, allocation: list[torch.Tensor], devices: list[int] | None = None
     ):
-        from iree.turbine.aot import DeviceAffinity
-
         devices = devices if devices is not None else list(range(len(allocation)))
         assert len(devices) == len(allocation)
-        self.device_affinities = [DeviceAffinity(device) for device in devices]
 
         self.allocation = allocation
+
+        from iree.turbine.aot import DeviceAffinity
+
+        self.device_affinities = [DeviceAffinity(device) for device in devices]
 
     def __len__(self):
         return len(self.allocation)


### PR DESCRIPTION
Cleans up the export_paged_llm script. Previous iteration of the script dedicated a lot of space to the device affinity calculations, and special-casing for different parallelism configurations.