### PR TITLE
[Sharktank] KV Quantizer replumb and KVCache revert

### DIFF
--- a/sharktank/sharktank/layers/__init__.py
+++ b/sharktank/sharktank/layers/__init__.py
@@ -6,7 +6,7 @@
 
 from .base import *
 from .conv import Conv2DLayer, Conv3DLayer, Conv1DLayer
-from .paged_attention import PagedAttention, attn_type_map, CacheAllocation
+from .paged_attention import PagedAttention, attn_type_map, CacheAllocation, KVCache
 from .causal_llm import BaseCausalLMModel
 from .linear import LinearLayer
 from .norm import RMSNormLayer, LayerNorm

--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -157,8 +157,6 @@ class KVCache:
         cache_dtype: torch.dtype = torch.float32,
         device: Optional[torch.device] = None,
         devices: List[int] | None = None,
-        k_quantizer: StaticScaledQuantizer | None = None,
-        v_quantizer: StaticScaledQuantizer | None = None,
     ):
         self.transformer_block_count = transformer_block_count
         self.attn_head_count = attn_head_count
@@ -168,8 +166,6 @@ class KVCache:
         self.cache_dtype = cache_dtype
         self.device = device
         self.devices = devices
-        self.k_quantizer = k_quantizer
-        self.v_quantizer = v_quantizer
 
         assert devices is None or len(devices) == 1
         assert cache_partition_count == 2
@@ -211,6 +207,8 @@ class KVCache:
         *,
         transformer_block_index: int,
         page_ids: torch.Tensor,
+        k_quantizer: StaticScaledQuantizer | None = None,
+        v_quantizer: StaticScaledQuantizer | None = None,
     ):
         page_table = self.unflatten_page_table(state)[0]
 
@@ -234,8 +232,8 @@ class KVCache:
         key = key.transpose(2, 3).flatten(1, 2)
         value = value.transpose(2, 3).flatten(1, 2)
 
-        key = pack_raw_tensor(key, self.k_quantizer)
-        value = pack_raw_tensor(value, self.v_quantizer)
+        key = pack_raw_tensor(key, k_quantizer)
+        value = pack_raw_tensor(value, v_quantizer)
 
         return key, value
 
@@ -335,8 +333,6 @@ def build_cache(
     block_seq_stride: int = 16,
     cache_dtype: torch.dtype = torch.float32,
     device: Optional[torch.device] = None,
-    k_quantizer: StaticScaledQuantizer | None = None,
-    v_quantizer: StaticScaledQuantizer | None = None,
 ):
     return KVCache(
         transformer_block_count=transformer_block_count,
@@ -347,8 +343,6 @@ def build_cache(
         cache_dtype=cache_dtype,
         device=device,
         devices=devices,
-        k_quantizer=k_quantizer,
-        v_quantizer=v_quantizer,
     )
 
 
@@ -403,6 +397,8 @@ class PagedAttention:
         self.attn_dtype = attn_dtype
         self.cache_dtype = cache_dtype
         self.attn_type = attn_type
+        self.k_quantizer = k_quantizer
+        self.v_quantizer = v_quantizer
         self.block_seq_stride = block_seq_stride
         self.activation_dtype = activation_dtype
         self.attention_chunk_size = attention_chunk_size
@@ -416,8 +412,6 @@ class PagedAttention:
             block_seq_stride=block_seq_stride,
             cache_dtype=cache_dtype,
             device=device,
-            k_quantizer=k_quantizer,
-            v_quantizer=v_quantizer,
         )
 
     def allocate(self, page_count: int) -> CacheAllocation:
@@ -435,6 +429,8 @@ class PagedAttention:
             state=state,
             transformer_block_index=transformer_block_index,
             page_ids=page_ids,
+            k_quantizer=self.k_quantizer,
+            v_quantizer=self.v_quantizer,
         )
 
     def write_timestep(

--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -32,7 +32,7 @@ from sharktank.types.quantizers import unpack_to_raw_tensor, pack_raw_tensor
 
 from sharktank.utils.attention import *
 
-__all__ = ["PagedAttention", "attn_type_map", "CacheAllocation"]
+__all__ = ["PagedAttention", "attn_type_map", "CacheAllocation", "KVCache"]
 
 attn_type_map = defaultdict(lambda: "gqa")
 attn_type_map.update(
@@ -373,46 +373,26 @@ class PagedAttention:
     def __init__(
         self,
         *,
-        transformer_block_count: int,
         transformer_block_index: int,
-        attn_head_count: int,
-        attn_head_dim: int,
         attn_type: str = "gqa",
-        cache_partition_count: int = 2,
-        block_seq_stride: int = 16,
-        cache_dtype: torch.dtype = torch.float32,
         attn_dtype: torch.dtype = torch.float32,
         activation_dtype: torch.dtype = torch.float32,
         use_rope: bool,
         attention_chunk_size: int | None,
-        device: Optional[torch.device] = None,
+        kv_cache: KVCache,
         k_quantizer: StaticScaledQuantizer | None = None,
         v_quantizer: StaticScaledQuantizer | None = None,
     ):
-        self.transformer_block_count = transformer_block_count
         self.transformer_block_index = transformer_block_index
-        self.head_count_kv = attn_head_count
-        self.attn_head_dim = attn_head_dim
-        self.device = device
+        self.block_seq_stride = kv_cache.block_seq_stride
         self.attn_dtype = attn_dtype
-        self.cache_dtype = cache_dtype
         self.attn_type = attn_type
+        self.kv_cache = kv_cache
         self.k_quantizer = k_quantizer
         self.v_quantizer = v_quantizer
-        self.block_seq_stride = block_seq_stride
         self.activation_dtype = activation_dtype
         self.attention_chunk_size = attention_chunk_size
         self.use_rope = use_rope
-
-        self.kv_cache = build_cache(
-            transformer_block_count=transformer_block_count,
-            attn_head_count=attn_head_count,
-            attn_head_dim=attn_head_dim,
-            cache_partition_count=cache_partition_count,
-            block_seq_stride=block_seq_stride,
-            cache_dtype=cache_dtype,
-            device=device,
-        )
 
     def allocate(self, page_count: int) -> CacheAllocation:
         return self.kv_cache.allocate(page_count=page_count)
@@ -473,7 +453,7 @@ class PagedAttention:
         return exp.flatten(2, 3)
 
     def gqa(self, head_count_attn, k, v):
-        gqa_n_rep = head_count_attn // self.head_count_kv
+        gqa_n_rep = head_count_attn // self.kv_cache.attn_head_count
         assert gqa_n_rep > 0
         if gqa_n_rep > 1:
             k = self.repeat_kv(x=k, n_rep=gqa_n_rep)

--- a/sharktank/sharktank/utils/create_cache.py
+++ b/sharktank/sharktank/utils/create_cache.py
@@ -10,6 +10,7 @@ from sharktank.types.quantizers import StaticScaledQuantizer
 
 def create_paged_attention(
     config: "LlamaModelConfig",
+    kv_cache: KVCache,
     use_rope: bool,
     block_index: int,
     k_quantizer: StaticScaledQuantizer | None = None,
@@ -21,19 +22,12 @@ def create_paged_attention(
         raise ValueError("Model does not use paged kv cache, cannot create kv cache")
 
     hp = config.hp
-    dtype = config.kv_cache_dtype or config.attention_dtype
     return PagedAttention(
-        transformer_block_count=hp.block_count,
         attention_chunk_size=config.attention_chunk_size,
         transformer_block_index=block_index,
-        attn_head_count=hp.attention_head_count_kv,
-        attn_head_dim=hp.attn_head_dim,
         attn_type=attn_type_map[hp.model_arch],
-        cache_partition_count=2,  # One for each of K/V.
-        block_seq_stride=config.block_seq_stride,
-        device=config.device,
+        kv_cache=kv_cache,
         use_rope=use_rope,
-        cache_dtype=dtype,
         attn_dtype=config.attention_dtype,
         activation_dtype=config.activation_dtype,
         k_quantizer=k_quantizer,

--- a/sharktank/tests/layers/kv_cache_test.py
+++ b/sharktank/tests/layers/kv_cache_test.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 
 from sharktank.layers import *
+from sharktank.layers.paged_attention import build_cache
 from sharktank.types import *
 from sharktank.utils.testing import assert_tensor_close
 
@@ -29,17 +30,21 @@ def test_paged(dtype: torch.dtype):
     transformer_block_count = 4
     transformer_block_index = 1
     block_seq_stride = 4
-    cache = PagedAttention(
-        block_seq_stride=block_seq_stride,
+
+    kv_cache = build_cache(
         transformer_block_count=transformer_block_count,
-        transformer_block_index=transformer_block_index,
         attn_head_count=attn_head_count,
         attn_head_dim=attn_head_dim,
+        block_seq_stride=block_seq_stride,
         cache_dtype=dtype,
+    )
+
+    cache = PagedAttention(
+        kv_cache=kv_cache,
+        transformer_block_index=transformer_block_index,
         attn_dtype=dtype,
         use_rope=True,
         attention_chunk_size=None,
-        device=None,
     )
 
     write_seq_length = seq_length - block_seq_stride

--- a/sharktank/tests/layers/paged_llama_attention_block_test.py
+++ b/sharktank/tests/layers/paged_llama_attention_block_test.py
@@ -6,7 +6,7 @@
 
 import pytest
 from sharktank.layers.configs.llm_configs import LlamaHParams, LlamaModelConfig
-from sharktank.layers.paged_attention import CacheAllocation
+from sharktank.layers.paged_attention import CacheAllocation, build_cache
 import unittest
 import torch
 from iree.turbine import aot
@@ -428,20 +428,22 @@ class TestPagedAttentionForwardSinkEager:
         context_len,
     ):
         torch.manual_seed(1234)
-        pa = PagedAttention(
+
+        kv_cache = build_cache(
             transformer_block_count=1,
-            transformer_block_index=0,
             attn_head_count=kv_heads,
             attn_head_dim=head_dim,
-            attn_type="gqa",
-            cache_partition_count=2,
             block_seq_stride=16,
             cache_dtype=dtype,
+        )
+        pa = PagedAttention(
+            kv_cache=kv_cache,
+            transformer_block_index=0,
+            attn_type="gqa",
             attn_dtype=dtype,
             activation_dtype=dtype,
             use_rope=True,
             attention_chunk_size=None,
-            device=None,
         )
 
         sink = _create_sink_tensor(n_heads, dtype, sink_scale)

--- a/sharktank/tests/models/llama/attention_test.py
+++ b/sharktank/tests/models/llama/attention_test.py
@@ -11,7 +11,7 @@ import torch
 
 from sharktank.layers import build_rotary_layer
 from sharktank.layers.configs.llm_configs import *
-from sharktank.layers.paged_attention import PagedAttention
+from sharktank.layers.paged_attention import PagedAttention, build_cache
 from sharktank.models.llm import AttentionFFNBlock
 from sharktank.models.llama.testing import *
 
@@ -81,10 +81,20 @@ class TestAttentionBlock:
             kv_cache_dtype=torch.float32,
         )
 
+        kv_cache = build_cache(
+            transformer_block_count=llama_config.hp.block_count,
+            attn_head_count=llama_config.hp.attention_head_count_kv,
+            attn_head_dim=llama_config.hp.attn_head_dim,
+            block_seq_stride=llama_config.block_seq_stride,
+            cache_dtype=llama_config.kv_cache_dtype,
+            device=llama_config.device,
+        )
+
         attention_block = AttentionFFNBlock(
             theta=attention_block_theta,
             block_index=block_index,
             config=llama_config,
+            kv_cache=kv_cache,
         )
         attention_embedding = build_rotary_layer(
             rope_dimension_count=rope_dimension_count,


### PR DESCRIPTION
- Move the K and Q quantizers out of the KVCache and into the per-layer PagedAttention instance.
- Change back to using a single KVCache instance for the whole model.