### PR TITLE
Fix initialize_program_modules

### DIFF
--- a/shortfin/python/shortfin_apps/utils.py
+++ b/shortfin/python/shortfin_apps/utils.py
@@ -484,12 +484,25 @@ class GenerateService:
         if component not in self.inference_modules:
             return []
 
-        return [
+        modules = []
+
+        # Add parameter provider
+        modules.append(
             sf.ProgramModule.parameter_provider(
                 self.sysman.ls, *self.inference_parameters.get(component, [])
-            ),
-            *self.inference_modules[component],
-        ]
+            )
+        )
+
+        # Add actual modules
+        component_modules = self.inference_modules.get(component, [])
+        if isinstance(component_modules, dict):
+            # Flatten all lists of modules from the batch_size keys
+            for mod_list in component_modules.values():
+                modules.extend(mod_list)
+        else:
+            modules.extend(component_modules)
+
+        return modules
 
     def create_program(
         self,


### PR DESCRIPTION
**Fix Issue below:**
_Run command:
export HIP_VISIBLE_DEVICES=0
export ROCR_VISIBLE_DEVICES=4
export PYTHONPATH=$(pwd)/shortfin/python

python3 -m shortfin_apps.llm.cli  --device hip  --tokenizer_json=/shark-dev/llama3.1/405b/instruct/weights/fp4/tokenizer.json  --model_config=/sharedfile/f4/2500/405b/pp1/out/f4_bs4_ds4.iree0905.shark0905_dfc.json  --vmfb=/sharedfile/f4/2500/405b/pp1/out/f4_bs4_ds4.iree0905.shark0905_dfc.vmfb  --parameters $IRPA_PATH  --benchmark  --benchmark_tasks=4  --device_ids 0  --input_token_length 128  --decode_steps=1  --workers_offline=4_

**Error:**
 File "/home/chiliu12/src/shark-ai/shortfin/python/shortfin_apps/utils.py", line 518, in create_program return sf.Program( ^^^^^^^^^^^ TypeError: __new__(): incompatible function arguments. The following argument types are supported: 1. __new__(cls: object, modules: collections.abc.Sequence[_shortfin_default.lib.local.ProgramModule], *, devices: collections.abc.Sequence[_shortfin_default.lib.local.Device], trace_execution: bool = False, isolation: _shortfin_default.lib.local.ProgramIsolation = ProgramIsolation.PER_FIBER) -> _shortfin_default.lib.local.Program Invoked with types: nanobind.nb_type_0, kwargs = { modules: list, devices: list, trace_execution: bool, isolation: _shortfin_default.lib.local.ProgramIsolation }
