### PR TITLE
Cast dtype before calling attention

### DIFF
--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -28,7 +28,12 @@ from sharktank.types import (
 )
 from sharktank import ops, kernels
 from sharktank.kernels.mlir_kernel import *
-from sharktank.types.tensors import AnyTensor, QuantizedTensor, ReplicatedTensor
+from sharktank.types.tensors import (
+    AnyTensor,
+    PrimitiveTensor,
+    QuantizedTensor,
+    ReplicatedTensor,
+)
 from sharktank.types.quantizers import unpack_to_raw_tensor, pack_raw_tensor
 
 

--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -611,9 +611,13 @@ class PagedAttention:
         k = k.transpose(1, 2)
         v = v.transpose(1, 2)
 
-        v_dtype = getattr(v, "dtype", None)
-        if v_dtype is None:
-            v_dtype = v.unpack().dtype
+        def get_dtype(tensor):
+            if isinstance(tensor, torch.Tensor) or isinstance(tensor, PrimitiveTensor):
+                return tensor.dtype
+            else:
+                return v.unpack().dtype
+
+        v_dtype = get_dtype(v)
         q = ops.to(q, v_dtype)
         k = ops.to(k, v_dtype)
 

--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -612,9 +612,10 @@ class PagedAttention:
         v = v.transpose(1, 2)
 
         v_dtype = getattr(v, "dtype", None)
-        if v_dtype is not None:
-            q = ops.to(q, v.dtype)
-            k = ops.to(k, v.dtype)
+        if v_dtype is None:
+            v_dtype = v.unpack().dtype
+        q = ops.to(q, v_dtype)
+        k = ops.to(k, v_dtype)
 
         return ops.scaled_dot_product_attention(
             q=q,  # [bs, ..., sl, dim]

--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -611,10 +611,8 @@ class PagedAttention:
         k = k.transpose(1, 2)
         v = v.transpose(1, 2)
 
-        if q.dtype != v.dtype:
-            q = q.to(v.dtype)
-        if k.dtype != v.dtype:
-            k = k.to(v.dtype)
+        q = ops.to(q, v.dtype)
+        k = ops.to(k, v.dtype)
 
         return ops.scaled_dot_product_attention(
             q=q,  # [bs, ..., sl, dim]

--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -611,8 +611,10 @@ class PagedAttention:
         k = k.transpose(1, 2)
         v = v.transpose(1, 2)
 
-        q = ops.to(q, v.dtype)
-        k = ops.to(k, v.dtype)
+        v_dtype = getattr(v, "dtype", None)
+        if v_dtype is not None:
+            q = ops.to(q, v.dtype)
+            k = ops.to(k, v.dtype)
 
         return ops.scaled_dot_product_attention(
             q=q,  # [bs, ..., sl, dim]

--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -611,6 +611,11 @@ class PagedAttention:
         k = k.transpose(1, 2)
         v = v.transpose(1, 2)
 
+        if q.dtype != v.dtype:
+            q = q.to(v.dtype)
+        if k.dtype != v.dtype:
+            k = k.to(v.dtype)
+
         return ops.scaled_dot_product_attention(
             q=q,  # [bs, ..., sl, dim]
             k=k,  # [bs, ..., sl, dim]


### PR DESCRIPTION
We could do the cast inside the attention op itself, but we should not, so that we can maintain parity with torch scaled_dot_product_attention, IMO