### PR TITLE
[Shortfin] Remove paged_kv_block_size_elements

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/kvcache/page_pool.py
+++ b/shortfin/python/shortfin_apps/llm/components/kvcache/page_pool.py
@@ -42,15 +42,18 @@ class PagePoolConfig:
     dtype: sf.dtype
     alloc_page_count: int
 
-    paged_kv_block_size_elements: int  # size of a single page as # of elements
-    # (e.g. one configuration for llama3.1 8b hax 32x2x16x8x128=1048576 elements where:
+    # Size of the page for each device that the model runs on.
+    # (e.g. one configuration for llama3.1 8b has 32x2x16x8x128=1048576 elements where:
     # 32: number of transformer blocks
     # 2: one for k + one for v
     # 16: tokens per page
     # 8: head count (32 heads, but every 4 heads share the same kv buffer)
     # 128: hidden dimension
-
-    paged_kv_block_size_elements_per_device: List[int] | None = None
+    #
+    # For single device execution, this will be [1048576]
+    # For multi-device execution, this will be split across devices
+    # (e.g. [524288, 524288] for 2 devices assuming an even split in number of transformer blocks)
+    paged_kv_block_size_elements_per_device: List[int]
 
 
 class PagePool(CacheStoreAbstract):
@@ -93,18 +96,9 @@ class PagePool(CacheStoreAbstract):
 
         self.available_pages = list(self.attn_page_entries)
 
-        paged_kv_block_size_elements_per_device = (
-            self.config.paged_kv_block_size_elements_per_device
-        )
-        if paged_kv_block_size_elements_per_device is None:
-            paged_kv_block_size_elements_per_device = [
-                self.config.paged_kv_block_size_elements // len(devices)
-            ] * len(devices)
-        assert len(devices) == len(paged_kv_block_size_elements_per_device)
-
         # Initialize a page table on each device.
         for device, paged_kv_block_size_elements in zip(
-            devices, paged_kv_block_size_elements_per_device
+            devices, self.config.paged_kv_block_size_elements_per_device
         ):
             page_table_shape = [
                 self.config.alloc_page_count,

--- a/shortfin/tests/apps/llm/components/kvcache/page_pool_test.py
+++ b/shortfin/tests/apps/llm/components/kvcache/page_pool_test.py
@@ -22,7 +22,7 @@ def setup_pool(generic_device):
         config=PagePoolConfig(
             alloc_page_count=256,
             dtype=sfnp.float16,
-            paged_kv_block_size_elements=393216,
+            paged_kv_block_size_elements_per_device=[393216],
         ),
     )
     return pool

--- a/shortfin/tests/apps/llm/components/kvcache/trie_attention_cache/mock_pool_test.py
+++ b/shortfin/tests/apps/llm/components/kvcache/trie_attention_cache/mock_pool_test.py
@@ -132,7 +132,7 @@ def page_pool(mock_device, mock_device_array):
         config = PagePoolConfig(
             dtype=sfnp.float16,
             alloc_page_count=TEST_POOL_CAPACITY,
-            paged_kv_block_size_elements=128,
+            paged_kv_block_size_elements_per_device=[128],
         )
 
         pool = PagePool(devices=[mock_device], config=config)

--- a/shortfin/tests/apps/llm/components/kvcache/trie_attention_cache/real_pool_test.py
+++ b/shortfin/tests/apps/llm/components/kvcache/trie_attention_cache/real_pool_test.py
@@ -53,7 +53,9 @@ def page_pool(real_device):
     config = PagePoolConfig(
         dtype=sfnp.float32,  # Using float32 as requested
         alloc_page_count=TEST_POOL_CAPACITY,  # Using 256 pages as requested
-        paged_kv_block_size_elements=TEST_BLOCK_SIZE,  # Using small block size (8) for testing
+        paged_kv_block_size_elements_per_device=[
+            TEST_BLOCK_SIZE
+        ],  # Using small block size (8) for testing
     )
 
     return PagePool(devices=[real_device], config=config)

--- a/shortfin/tests/apps/llm/conftest.py
+++ b/shortfin/tests/apps/llm/conftest.py
@@ -98,7 +98,7 @@ class MockPagePool(PagePool):
         self.config = PagePoolConfig(
             dtype=sfnp.float32,
             alloc_page_count=total_pages,
-            paged_kv_block_size_elements=TEST_PAGE_SIZE,
+            paged_kv_block_size_elements_per_device=[TEST_PAGE_SIZE],
         )
 
     def acquire_free_pages(self, count: int) -> List[PageInfo]:


### PR DESCRIPTION
Remove `paged_kv_block_size_elements` from pagePoolConfig and replace all usages with the more generic `paged_kv_block_size_elements_per_device`.

Keeps backwards compatability and provides a deprecation warning for any model that hits this fallback path.

