### PR TITLE
Update affinity solver max iterations for non sharded model compilation

### DIFF
--- a/scripts/export_and_compile.sh
+++ b/scripts/export_and_compile.sh
@@ -119,6 +119,7 @@ else
         --iree-hal-indirect-command-buffers=true \
         --iree-stream-resource-memory-model=discrete \
         --iree-hip-enable-tensor-ukernels \
+        --iree-stream-affinity-solver-max-iterations=1024 \
         --iree-hal-memoization=true --iree-codegen-enable-default-tuning-specs=true
 fi
 


### PR DESCRIPTION
- fixes failing llama70B-fp16 CI test
- increase affinity solver iterations to 1024 to handle single device llama70B compilation with device affinity attribute attached to inputs.