### PR TITLE
[sharktank] Add tool to print the keys/names and metadata of tensors in a safetensors file

### DIFF
--- a/sharktank/sharktank/tools/list_safetensors.py
+++ b/sharktank/sharktank/tools/list_safetensors.py
@@ -1,0 +1,38 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import argparse
+import safetensors
+
+
+def main(args: list[str] | None = None):
+    parser = argparse.ArgumentParser(
+        description="Print names/keys and optionally metadata of tensors in a safetensors file."
+    )
+    parser.add_argument(
+        "--show-metadata",
+        action="store_true",
+        help="Print also tensor metadata, shape and dtype.",
+    )
+    parser.add_argument(
+        "file_path",
+        type=str,
+        help="Path to safetensors file.",
+    )
+    args = parser.parse_args(args)
+
+    with safetensors.safe_open(args.file_path, framework="pt") as f:
+        keys = [key for key in f.keys()]
+        for key in keys:
+            if args.show_metadata:
+                tensor = f.get_tensor(key)
+                print(f"{key}: shape={list(tensor.shape)}, dtype={tensor.dtype}")
+            else:
+                print(key)
+
+
+if __name__ == "__main__":
+    main()

--- a/sharktank/tests/tools/list_sfaetensors_test.py
+++ b/sharktank/tests/tools/list_sfaetensors_test.py
@@ -1,0 +1,37 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from pathlib import Path
+from safetensors.torch import save_file
+from subprocess import check_output
+import sys
+import torch
+
+
+def test_list_safetensors(tmp_path: Path):
+    tensor1 = torch.ones([1, 2], dtype=torch.float32)
+    tensor2 = torch.ones([3, 4, 5], dtype=torch.int32)
+
+    file_name = tmp_path / "file.safetensors"
+    save_file(
+        filename=file_name,
+        tensors={
+            "tensor1": tensor1,
+            "tensor2": tensor2,
+        },
+    )
+
+    output = check_output(
+        [
+            sys.executable,
+            "-m",
+            "sharktank.tools.list_safetensors",
+            "--show-metadata",
+            str(file_name),
+        ]
+    ).decode()
+    assert "tensor1: shape=[1, 2], dtype=torch.float32" in output
+    assert "tensor2: shape=[3, 4, 5], dtype=torch.int32" in output


### PR DESCRIPTION
This tool helps explore tensors in a safetensors file. E.g.
```
python -m sharktank.tools.list_safetensors --show-metadata some.safetensors
```

```
tensor1: shape=[1, 2], dtype=torch.float32
tensor2: shape=[3, 4, 5], dtype=torch.int32
```