### PR TITLE
Output QType needs to be set as `torch.float16` for KV Cache

### DIFF
--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -232,8 +232,8 @@ class DefaultPagedKVCache(PagedKVCache):
         key = key.transpose(2, 3).flatten(1, 2)
         value = value.transpose(2, 3).flatten(1, 2)
 
-        key = pack_raw_tensor(key, k_quantizer)
-        value = pack_raw_tensor(value, v_quantizer)
+        key = pack_raw_tensor(key, k_quantizer, dtype=torch.float16)
+        value = pack_raw_tensor(value, v_quantizer, dtype=torch.float16)
 
         return key, value
 

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -455,7 +455,11 @@ def expand_quantized(tensor: QuantizedTensor, shape: List[int]) -> QuantizedTens
     if isinstance(unpacked, TensorScaledLayout):
         new_qs = unpacked._qs.expand(*shape)
         layout = TensorScaledLayout(
-            shape=new_qs.shape, d=unpacked._d, qs=new_qs, m=unpacked._m
+            shape=new_qs.shape,
+            d=unpacked._d,
+            qs=new_qs,
+            m=unpacked._m,
+            dtype=unpacked.dtype,
         )
         return PlanarQuantizedTensor(shape=new_qs.shape, layout=layout)
     return NotImplemented
@@ -476,7 +480,11 @@ def flatten_quantized(
     if isinstance(unpacked, TensorScaledLayout):
         new_qs = torch.flatten(unpacked._qs, start_dim, end_dim)
         layout = TensorScaledLayout(
-            shape=new_qs.shape, d=unpacked._d, qs=new_qs, m=unpacked._m
+            shape=new_qs.shape,
+            d=unpacked._d,
+            qs=new_qs,
+            m=unpacked._m,
+            dtype=unpacked.dtype,
         )
         return PlanarQuantizedTensor(shape=new_qs.shape, layout=layout)
     return NotImplemented
@@ -1013,7 +1021,11 @@ def unsqueeze_quantized(tensor: QuantizedTensor, dim: int) -> QuantizedTensor:
     if isinstance(unpacked, TensorScaledLayout):
         new_qs = unpacked._qs.unsqueeze(dim)
         layout = TensorScaledLayout(
-            shape=new_qs.shape, d=unpacked._d, qs=new_qs, m=unpacked._m
+            shape=new_qs.shape,
+            d=unpacked._d,
+            qs=new_qs,
+            m=unpacked._m,
+            dtype=unpacked.dtype,
         )
         return PlanarQuantizedTensor(shape=new_qs.shape, layout=layout)
     return NotImplemented

--- a/sharktank/sharktank/types/quantizers.py
+++ b/sharktank/sharktank/types/quantizers.py
@@ -738,7 +738,9 @@ def unpack_to_raw_tensor(tensor: AnyTensor) -> AnyTensor:
 
 
 def pack_raw_tensor(
-    tensor: AnyTensor, quantizer: StaticScaledQuantizer | None
+    tensor: AnyTensor,
+    quantizer: StaticScaledQuantizer | None,
+    dtype: torch.dtype | None = None,
 ) -> AnyTensor:
     if quantizer is None:
         return tensor
@@ -747,5 +749,6 @@ def pack_raw_tensor(
         d=quantizer._reciprocal_scale,
         qs=tensor,
         m=quantizer._offset,
+        dtype=dtype,
     )
     return PlanarQuantizedTensor(shape=tensor.shape, layout=layout)


### PR DESCRIPTION
The qscale type is being used to infer the q_output dtype which results in `torch.float32` while `torch.float16` is correct. Hardcoded for now but eventually `attn_dtype` should be plumbed.

This occurs when exporting with the torch operator and using an `fp8` cache but dequant to `fp16` for attention. Guarantee correct attention dtypes avoids running the `torch` operator with mixed types.