### PR TITLE
Fix export w/ `pipeline-parallelism` and `has-prefill-position`

### DIFF
--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -265,7 +265,7 @@ class DefaultPagedKVCache(PagedKVCache):
             page_index = (
                 start_positions.unsqueeze(1) // self.block_seq_stride
             ) + torch.arange(block_seq_len)
-            page_ids = torch.gather(page_ids, dim=1, index=page_index)
+            page_ids = ops.gather(page_ids, dim=1, index=page_index)
 
         _, block_seq_len, *_ = page_ids.shape
         for cache_partition_id, cache_partition in enumerate(cache_partitions):


### PR DESCRIPTION
## Description

Per [this suggestion](https://github.com/nod-ai/shark-ai/issues/2247#issuecomment-3293041131) from @Alex-Vasile:

Fixes #2247, `pipeline-parallelism + --has-prefill-position` export by changing `torch.gather` -> `ops.gather`