### PR TITLE
`TrieCache` w/ `start_positions` pt. 1

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/batching/modes/default.py
+++ b/shortfin/python/shortfin_apps/llm/components/batching/modes/default.py
@@ -369,14 +369,16 @@ class PrefillBatcherProcess(LlmBatcherProcess):
         ):
             return self._make_chunked_task_inputs(exec_request)
 
+        seq_len = len(exec_request.input_token_ids)
+        input_tokens = exec_request.input_token_ids[exec_request.start_position :]
         return [
             LlmTaskInput(
                 rid=exec_request.orig_instance_id,
                 instance_id=exec_request.instance_id,
                 block_count=exec_request.block_count,
                 seq_stride=self.page_seq_stride,
-                seq_len=len(exec_request.input_token_ids),
-                input_tokens=tuple(exec_request.input_token_ids),
+                seq_len=seq_len,
+                input_tokens=tuple(input_tokens),
                 page_ids=tuple(exec_request.page_ids),
                 start_position=exec_request.start_position,
             )
@@ -541,7 +543,10 @@ class DefaultBatchingEngine(BatchingTrait):
 
     @staticmethod
     def create(
-        batch_cfg: BatchConfig, page_cache: BasePagedAttentionCache, prefill_fiber: sf.Fiber, decode_fiber: sf.Fiber | None = None  # type: ignore
+        batch_cfg: BatchConfig,
+        page_cache: BasePagedAttentionCache,
+        prefill_fiber: sf.Fiber,
+        decode_fiber: sf.Fiber | None = None,  # type: ignore
     ):
         assert (
             decode_fiber is not None

--- a/shortfin/python/shortfin_apps/llm/components/decoder/decoder.py
+++ b/shortfin/python/shortfin_apps/llm/components/decoder/decoder.py
@@ -304,7 +304,6 @@ class TokenSelector:
             beams = tokens // token_options
             tokens = tokens % token_options
 
-        logger.info(f"SNB Scores: {scores}")
         beams, tokens = self._update_selector_state(beams, tokens, scores, step)
         return beams, tokens
 
@@ -464,13 +463,8 @@ class LlmDecoder:
         prefill_req: LlmInferenceExecRequest,
         token_selector: TokenSelector,
     ) -> Tuple[List[np.ndarray], List[Optional[np.ndarray]]]:
-        logger.info(
-            f"SNB running prefill for input length: {len(prefill_req.input_token_ids)}, with start_position: {prefill_req.start_position}"
-        )
         if prefill_req.start_position == len(prefill_req.input_token_ids):
-            logger.info("SNB skipping prefill submission...")
             beams, tokens = token_selector.step_next_cached_token(prefill_req)
-            logger.info(f"SNB produced tokens: {tokens} with beams: {beams}")
             return beams, tokens
 
         self._unified_batcher.submit(prefill_req)
@@ -479,7 +473,6 @@ class LlmDecoder:
         beams, tokens = token_selector.step(
             [prefill_req.result_logits], [prefill_req.result_indices]
         )
-        logger.info(f"SNB produced tokens: {tokens} with beams: {beams}")
         return beams, tokens
 
     async def run(self, input_ids):

--- a/shortfin/python/shortfin_apps/llm/components/generate.py
+++ b/shortfin/python/shortfin_apps/llm/components/generate.py
@@ -131,7 +131,6 @@ class ClientGenerateBatchProcess(sf.Process):
         return PrefillConfig(
             has_prefill_position=self.service.model_params.has_prefill_position,
             prefix_sharing_algorithm=self.service.server_params.prefix_sharing_algorithm,
-            chunk_block_size=self.service.server_params.chunk_block_size,
         )
 
     def get_decode_configs(self) -> List[DecodeConfig]:
@@ -180,7 +179,6 @@ class ClientGenerateBatchProcess(sf.Process):
         else:
             input_batch = self.tokenize()
 
-        logger.info(f"SNB encoded tokens: {input_batch[0]}")
         for config in decode_configs:
             if not self.validate_decode_config(self.responder, config):
                 return

--- a/shortfin/python/shortfin_apps/llm/components/generate.py
+++ b/shortfin/python/shortfin_apps/llm/components/generate.py
@@ -130,6 +130,8 @@ class ClientGenerateBatchProcess(sf.Process):
     def get_prefill_config(self) -> PrefillConfig:
         return PrefillConfig(
             has_prefill_position=self.service.model_params.has_prefill_position,
+            prefix_sharing_algorithm=self.service.server_params.prefix_sharing_algorithm,
+            chunk_block_size=self.service.server_params.chunk_block_size,
         )
 
     def get_decode_configs(self) -> List[DecodeConfig]:
@@ -178,6 +180,7 @@ class ClientGenerateBatchProcess(sf.Process):
         else:
             input_batch = self.tokenize()
 
+        logger.info(f"SNB encoded tokens: {input_batch[0]}")
         for config in decode_configs:
             if not self.validate_decode_config(self.responder, config):
                 return

--- a/shortfin/python/shortfin_apps/llm/components/invocation.py
+++ b/shortfin/python/shortfin_apps/llm/components/invocation.py
@@ -223,9 +223,6 @@ class PrefillTask(LlmTask):
 
         if self._has_prefill_position:
             start_positions = [task.start_position for task in task_inputs]
-            logger.info(
-                f"Using start_positions: {start_positions} for prefill invocation"
-            )
             start_positions_allocation = array_cache.allocate([batch_size], int_dtype)
             buffers.append(start_positions_allocation)
             data.append(start_positions)
@@ -234,8 +231,6 @@ class PrefillTask(LlmTask):
         buffers.extend([seq_lens_allocation, seq_block_ids_allocation])
         data.extend([seq_lens_data, seq_block_ids_data])
         defaults.extend([1, 0])
-
-        logger.info(f"SNB Prefill Data: {data}")
 
         args = create_argument_buffers(
             buffers=buffers,

--- a/shortfin/python/shortfin_apps/llm/components/kvcache/trie_attention_cache.py
+++ b/shortfin/python/shortfin_apps/llm/components/kvcache/trie_attention_cache.py
@@ -100,6 +100,7 @@ class TrieCacheInfo(CacheInfo):
     tokens: List[int]
     number_of_published_pages: int
     last_cached_node: TrieNode
+    total_matched_tokens: int
 
 
 class TriePagedAttentionCache(BasePagedAttentionCache):
@@ -168,6 +169,7 @@ class TriePagedAttentionCache(BasePagedAttentionCache):
                     pages=matched_pages + [],
                     number_of_published_pages=len(matched_pages),
                     pool=self.page_pool,
+                    total_matched_tokens=n_cached_tokens,
                 )
 
             new_page = self.page_pool.copy_page(pages[-1])
@@ -182,6 +184,7 @@ class TriePagedAttentionCache(BasePagedAttentionCache):
                 pages=matched_pages + [new_page],
                 number_of_published_pages=len(matched_pages),
                 pool=self.page_pool,
+                total_matched_tokens=n_cached_tokens,
             )
 
     def match(self, tokens: List[int]) -> Tuple[TrieNode, List[PageInfo]]:
@@ -339,6 +342,7 @@ class TriePagedAttentionCache(BasePagedAttentionCache):
                 last_cached_node=cur_node,
                 number_of_published_pages=len(cached_pages),
                 pool=self.page_pool,
+                total_matched_tokens=len(cached_pages) * self.tokens_per_page,
             )
 
     def extend_allocation(
@@ -397,6 +401,7 @@ class TriePagedAttentionCache(BasePagedAttentionCache):
             pool=cache_info.page_pool,
             last_cached_node=cache_info.last_cached_node,
             number_of_published_pages=cache_info.number_of_pages_to_publish,
+            total_matched_tokens=cache_info.total_matched_tokens,
         )
 
     def publish_pages_for_tokens(
@@ -477,6 +482,7 @@ class TriePagedAttentionCache(BasePagedAttentionCache):
                 last_cached_node=last_cached_node,
                 number_of_published_pages=number_of_published_pages,
                 pool=self.page_pool,
+                total_matched_tokens=cache_info.total_matched_tokens,
             )
 
     def free_cache_pages(self):
@@ -547,6 +553,7 @@ class TriePagedAttentionCache(BasePagedAttentionCache):
             last_cached_node=cache_info.last_cached_node,
             number_of_published_pages=cache_info.number_of_published_pages,
             pool=self.page_pool,
+            total_matched_tokens=cache_info.total_matched_tokens,
         )
 
     def shutdown(self):

--- a/shortfin/python/shortfin_apps/llm/components/prefill_config.py
+++ b/shortfin/python/shortfin_apps/llm/components/prefill_config.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Optional
 from dataclasses_json import dataclass_json, Undefined
 
 # TODO (stbaione): Extend for chunked prefill

--- a/shortfin/python/shortfin_apps/llm/components/prefill_config.py
+++ b/shortfin/python/shortfin_apps/llm/components/prefill_config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 from dataclasses_json import dataclass_json, Undefined
 
 # TODO (stbaione): Extend for chunked prefill
@@ -6,3 +7,5 @@ from dataclasses_json import dataclass_json, Undefined
 @dataclass(kw_only=True)
 class PrefillConfig:
     has_prefill_position: bool
+    prefix_sharing_algorithm: str
+    chunk_block_size: Optional[int]

--- a/shortfin/python/shortfin_apps/llm/components/prefill_config.py
+++ b/shortfin/python/shortfin_apps/llm/components/prefill_config.py
@@ -8,4 +8,3 @@ from dataclasses_json import dataclass_json, Undefined
 class PrefillConfig:
     has_prefill_position: bool
     prefix_sharing_algorithm: str
-    chunk_block_size: Optional[int]


### PR DESCRIPTION
Landing in progressive pieces. This enables properly setting the `start_positions` w/ `TrieCache` in the `single request, single beam` case. There will be a follow up PR to enable the `multi_beam` case.

I will need to find a good way to retain the `score history` of the tokens in the multi-beam case, so that I can return the proper scores in the scenario in which a request is a fully contained prefix of a previous request.

For cases where it is not a strict prefix, this should work.

I'm seeing the same issue here as #2235. 

Did some further analysis and it has to be something related to how we're writing/reading to the kvcache. Attached more details on that issue. 

Have a couple more changes to make, but publishing the draft PR, so that they can test potential fixes.