### PR TITLE
Fixes for `BaseAttentionCache`

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/kvcache/base_attention_cache.py
+++ b/shortfin/python/shortfin_apps/llm/components/kvcache/base_attention_cache.py
@@ -237,9 +237,8 @@ class BasePagedAttentionCache:
     def publish_pages_for_tokens(
         self, tokens, cache_info, *, publish_incomplete_page=False
     ) -> CacheInfo:
-        pass
+        return cache_info  # no-op for base class
 
     def release_pages(self, cache_info: CacheInfo):
         if cache_info is not None:
             self.free_pages(cache_info.pages)
-            self.free_pages(self._allocated_pages)


### PR DESCRIPTION
I was seeing some issues w/ batched requests using my local script. Seemed to be related to freeing pages still in use. Additionally, we were setting `allocated_cache_info` to None before freeing, which was causing some leakage.

- Don't free pages in use
- Make sure that `allocated_cache_info` isn't set to `None` before freeing