### PR TITLE
Llm fix unintended chunking

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/lifecycle.py
+++ b/shortfin/python/shortfin_apps/llm/components/lifecycle.py
@@ -95,13 +95,13 @@ class ShortfinLlmLifecycleManager:
     def __enter__(self):
         self.sysman.start()
         for service_name, service in self.services.items():
-            logger.info("Initializing service '%s': %r", service_name, service)
+            logging.info("Initializing service '%s': %r", service_name, service)
             service.start()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         for service_name, service in self.services.items():
-            logger.info("Shutting down service '%s'", service_name)
+            logging.info("Shutting down service '%s'", service_name)
             service.shutdown()
         self.sysman.shutdown()
         return False

--- a/shortfin/python/shortfin_apps/llm/components/lifecycle.py
+++ b/shortfin/python/shortfin_apps/llm/components/lifecycle.py
@@ -13,6 +13,9 @@ def lifecycle(app: FastApi):
         yield
 ```
 """
+import logging
+
+from contextlib import asynccontextmanager
 
 from .config_struct import ModelParams, ServerParams
 from .decode_config import DecodeConfig
@@ -23,8 +26,7 @@ from typing import TYPE_CHECKING
 from fastapi import FastAPI
 
 
-from contextlib import asynccontextmanager
-import logging
+logger = logging.getLogger(__name__)
 
 
 def get_eos_from_tokenizer_config(json_path):
@@ -93,13 +95,13 @@ class ShortfinLlmLifecycleManager:
     def __enter__(self):
         self.sysman.start()
         for service_name, service in self.services.items():
-            logging.info("Initializing service '%s': %r", service_name, service)
+            logger.info("Initializing service '%s': %r", service_name, service)
             service.start()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         for service_name, service in self.services.items():
-            logging.info("Shutting down service '%s'", service_name)
+            logger.info("Shutting down service '%s'", service_name)
             service.shutdown()
         self.sysman.shutdown()
         return False

--- a/shortfin/python/shortfin_apps/llm/components/lifecycle.py
+++ b/shortfin/python/shortfin_apps/llm/components/lifecycle.py
@@ -95,13 +95,13 @@ class ShortfinLlmLifecycleManager:
     def __enter__(self):
         self.sysman.start()
         for service_name, service in self.services.items():
-            logging.info("Initializing service '%s': %r", service_name, service)
+            logger.info("Initializing service '%s': %r", service_name, service)
             service.start()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         for service_name, service in self.services.items():
-            logging.info("Shutting down service '%s'", service_name)
+            logger.info("Shutting down service '%s'", service_name)
             service.shutdown()
         self.sysman.shutdown()
         return False

--- a/shortfin/python/shortfin_apps/llm/components/lifecycle.py
+++ b/shortfin/python/shortfin_apps/llm/components/lifecycle.py
@@ -13,6 +13,7 @@ def lifecycle(app: FastApi):
         yield
 ```
 """
+
 import logging
 
 from contextlib import asynccontextmanager

--- a/shortfin/python/shortfin_apps/llm/server.py
+++ b/shortfin/python/shortfin_apps/llm/server.py
@@ -116,7 +116,7 @@ def add_service_args(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--chunk_block_size",
         type=int,
-        default=8,
+        default=None,
         help="*Block-aligned* Chunk size to use for chunked prefill. Required if --use_chunked is set.",
     )
 


### PR DESCRIPTION
Since I was defaulting the server cli value to `8`, we were chunking when we weren't wanting to.

However, this and #2221 does not seem to be the cause of #2279. 

I was able to download the dataset being used in the mlperf harness, run a local shortfin 8b server, and checkout #2250 locally (one before), and am seeing the same reported bug:

```bash
:0:rocdevice.cpp            :2991: 123228313452 us:  Callback: Queue 0x7fa575000000 aborting with error : HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION: The agent attempted to access memory beyond the largest legal address. code: 0x29
```