### PR TITLE
[Fusilli] CI timeout fixes

### DIFF
--- a/.github/workflows/ci-sharkfuser.yml
+++ b/.github/workflows/ci-sharkfuser.yml
@@ -103,7 +103,7 @@ jobs:
       run: |
         build_tools/docker/exec_docker_ci.sh \
         bash -c "export FUSILLI_CACHE_DIR=/tmp && \
-                 ctest --test-dir build --output-on-failure --extra-verbose --timeout 30 && \
+                 ctest --test-dir build --output-on-failure --extra-verbose --timeout 60 && \
                  tests/test_cache_empty.sh"
 
     - name: Run code coverage
@@ -112,7 +112,7 @@ jobs:
       run: |
         build_tools/docker/exec_docker_ci.sh \
         bash -c "export FUSILLI_CACHE_DIR=/tmp && \
-                 ctest --test-dir build -T test -T coverage --timeout 30 && \
+                 ctest --test-dir build -T test -T coverage --timeout 60 && \
                  lcov --capture --directory build --output-file build/coverage.info && \
                  lcov --remove build/coverage.info '/usr/*' '*/iree/*' --output-file build/coverage.info && \
                  genhtml build/coverage.info --output-directory coverage_report"

--- a/sharkfuser/build_tools/cmake/FusilliTestUtils.cmake
+++ b/sharkfuser/build_tools/cmake/FusilliTestUtils.cmake
@@ -175,8 +175,6 @@ function(_add_fusilli_ctest_target)
 
   # Add the CTest test
   add_test(NAME ${_RULE_NAME} COMMAND ${_RULE_NAME})
-  # Set timeout to 60 seconds
-  set_tests_properties(${_RULE_NAME} PROPERTIES TIMEOUT 60)
 
   # Set logging environment variables
   if(FUSILLI_DEBUG_BUILD)


### PR DESCRIPTION
Remove the ctest timeout from the CMake target and update the ctest command in GHA workflow instead, since local runs shouldn't need a timeout. 

