### PR TITLE
[Fusilli] Refactor stride utilities to support ambiguous (unit dim) cases

### DIFF
--- a/sharkfuser/include/fusilli/attributes/tensor_attributes.h
+++ b/sharkfuser/include/fusilli/attributes/tensor_attributes.h
@@ -110,6 +110,89 @@
 
 namespace fusilli {
 
+// Generates stride order for a contiguous (channels-first) tensor. For a 4D
+// tensor, this would return {N: 3, C: 2, H: 1, W: 0} to represent an NCHW
+// in-memory layout. Here N is the slowest changing and W is the fastest
+// changing dimension.
+inline std::vector<size_t> getContiguousStrideOrder(size_t numDims) {
+  assert(numDims >= 3 &&
+         "Contiguous (channels-first) layout requires at least 3 dimensions");
+
+  std::vector<size_t> strideOrder(numDims);
+  size_t order = 0;
+  // Caution: Reverse iteration with size_t (unsigned) can lead to underflow
+  // when `i == 0` is decremented due to wrap-around to SIZE_MAX (which is
+  // positive and doesn't prevent control from entering the loop as intended).
+  // This can cause heap corruption when accessing strideOrder[SIZE_MAX].
+  // So we instead gate loop entry with `i > 0`.
+  for (size_t i = numDims; i > 0; --i)
+    strideOrder[i - 1] = order++;
+  return strideOrder;
+}
+
+// Generates stride order for a channels-last tensor. For a 4D tensor, this
+// would return {N: 3, C: 0, H: 2, W: 1} to represent an NHWC in-memory layout.
+// Here N is the slowest changing and C is the fastest changing dimension.
+inline std::vector<size_t> getChannelsLastStrideOrder(size_t numDims) {
+  assert(numDims >= 3 && "Channels-last layout requires at least 3 dimensions");
+
+  std::vector<size_t> strideOrder(numDims);
+  size_t order = 0;
+  strideOrder[1] = order++;
+  for (size_t i = numDims - 1; i > 1; --i)
+    strideOrder[i] = order++;
+  strideOrder[0] = order;
+  return strideOrder;
+}
+
+inline std::vector<size_t>
+getStrideOrderFromStride(const std::vector<int64_t> &stride) {
+  size_t numDims = stride.size();
+  std::vector<size_t> indices(numDims);
+  std::iota(indices.begin(), indices.end(), 0);
+
+  // Sort indices by stride value in ascending order to get the
+  // order of dims from fastest changing to slowest changing.
+  // For example, stride of (432, 1, 36, 3) yields sorted
+  // indices of (1, 3, 2, 0).
+  std::sort(indices.begin(), indices.end(),
+            [&stride](size_t i, size_t j) { return stride[i] < stride[j]; });
+
+  // Sorted indices of (1, 3, 2, 0) yields strideOrder of
+  // (3, 0, 2, 1) to represent NHWC layout.
+  std::vector<size_t> strideOrder(numDims);
+  for (size_t i = 0; i < numDims; ++i)
+    strideOrder[indices[i]] = i;
+
+  return strideOrder;
+}
+
+inline std::vector<int64_t>
+generateStrideFromDim(const std::vector<int64_t> &dim,
+                      const std::vector<size_t> &strideOrder) {
+  size_t numDims = dim.size();
+  std::vector<int64_t> stride(numDims);
+  std::vector<std::pair<size_t, int64_t>> idxToDimInStrideOrder(numDims);
+
+  // Example dim = (10, 3, 12, 12) and strideOrder = {3, 0, 2, 1}
+  // idxToDimInStrideOrder will be:
+  // { (1, 3), (3, 12), (2, 12), (0, 10) }
+  // ordered from fastest changing dim to slowest changing dim
+  for (size_t i = 0; i < numDims; ++i)
+    idxToDimInStrideOrder[strideOrder[i]] = std::make_pair(i, dim[i]);
+
+  // Stride is cumulative product of dimensions in the order specified by
+  // strideOrder. For the above example, this will yield:
+  // stride = (432, 1, 36, 3)
+  int64_t cumulativeProduct = 1;
+  for (size_t i = 0; i < numDims; ++i) {
+    stride[idxToDimInStrideOrder[i].first] = cumulativeProduct;
+    cumulativeProduct *= idxToDimInStrideOrder[i].second;
+  }
+
+  return stride;
+}
+
 class TensorAttr {
 public:
   using scalar_t = std::variant<int64_t, int32_t, float, double>;
@@ -146,17 +229,6 @@ public:
         !scalarValue_.has_value() && isScalar_, ErrorCode::InvalidAttribute,
         "Tensor '" + name_ +
             "' is marked as a scalar but does not have a scalar value set");
-
-    // Check for contiguity (inner dim stride is 1, monotonic).
-    FUSILLI_RETURN_ERROR_IF(
-        !(std::is_sorted(stride_.begin(), stride_.end(),
-                         std::greater<int64_t>()) &&
-          stride_.back() == 1),
-        ErrorCode::NotImplemented,
-        "Tensor '" + name_ +
-            "' is not contiguous as defined by its stride; please specify a "
-            "stride {A, B, ... Z} where A > B > ... Z and Z == 1. "
-            "This will be supported in a future release");
 
     return ok();
   }
@@ -288,89 +360,6 @@ struct TensorAttrSortByName {
     return a->getName() < b->getName();
   }
 };
-
-// Generates stride order for a contiguous (channels-first) tensor. For a 4D
-// tensor, this would return {N: 3, C: 2, H: 1, W: 0} to represent an NCHW
-// in-memory layout. Here N is the slowest changing and W is the fastest
-// changing dimension.
-inline std::vector<size_t> getContiguousStrideOrder(size_t numDims) {
-  assert(numDims >= 3 &&
-         "Contiguous (channels-first) layout requires at least 3 dimensions");
-
-  std::vector<size_t> strideOrder(numDims);
-  size_t order = 0;
-  // Caution: Reverse iteration with size_t (unsigned) can lead to underflow
-  // when `i == 0` is decremented due to wrap-around to SIZE_MAX (which is
-  // positive and doesn't prevent control from entering the loop as intended).
-  // This can cause heap corruption when accessing strideOrder[SIZE_MAX].
-  // So we instead gate loop entry with `i > 0`.
-  for (size_t i = numDims; i > 0; --i)
-    strideOrder[i - 1] = order++;
-  return strideOrder;
-}
-
-// Generates stride order for a channels-last tensor. For a 4D tensor, this
-// would return {N: 3, C: 0, H: 2, W: 1} to represent an NHWC in-memory layout.
-// Here N is the slowest changing and C is the fastest changing dimension.
-inline std::vector<size_t> getChannelsLastStrideOrder(size_t numDims) {
-  assert(numDims >= 3 && "Channels-last layout requires at least 3 dimensions");
-
-  std::vector<size_t> strideOrder(numDims);
-  size_t order = 0;
-  strideOrder[1] = order++;
-  for (size_t i = numDims - 1; i > 1; --i)
-    strideOrder[i] = order++;
-  strideOrder[0] = order;
-  return strideOrder;
-}
-
-inline std::vector<size_t>
-getStrideOrderFromStride(const std::vector<int64_t> &stride) {
-  size_t numDims = stride.size();
-  std::vector<size_t> indices(numDims);
-  std::iota(indices.begin(), indices.end(), 0);
-
-  // Sort indices by stride value in ascending order to get the
-  // order of dims from fastest changing to slowest changing.
-  // For example, stride of (432, 1, 36, 3) yields sorted
-  // indices of (1, 3, 2, 0).
-  std::sort(indices.begin(), indices.end(),
-            [&stride](size_t i, size_t j) { return stride[i] < stride[j]; });
-
-  // Sorted indices of (1, 3, 2, 0) yields strideOrder of
-  // (3, 0, 2, 1) to represent NHWC layout.
-  std::vector<size_t> strideOrder(numDims);
-  for (size_t i = 0; i < numDims; ++i)
-    strideOrder[indices[i]] = i;
-
-  return strideOrder;
-}
-
-inline std::vector<int64_t>
-generateStrideFromDim(const std::vector<int64_t> &dim,
-                      const std::vector<size_t> &strideOrder) {
-  size_t numDims = dim.size();
-  std::vector<int64_t> stride(numDims);
-  std::vector<std::pair<size_t, int64_t>> idxToDimInStrideOrder(numDims);
-
-  // Example dim = (10, 3, 12, 12) and strideOrder = {3, 0, 2, 1}
-  // idxToDimInStrideOrder will be:
-  // { (1, 3), (3, 12), (2, 12), (0, 10) }
-  // ordered from fastest changing dim to slowest changing dim
-  for (size_t i = 0; i < numDims; ++i)
-    idxToDimInStrideOrder[strideOrder[i]] = std::make_pair(i, dim[i]);
-
-  // Stride is cumulative product of dimensions in the order specified by
-  // strideOrder. For the above example, this will yield:
-  // stride = (432, 1, 36, 3)
-  int64_t cumulativeProduct = 1;
-  for (size_t i = 0; i < numDims; ++i) {
-    stride[idxToDimInStrideOrder[i].first] = cumulativeProduct;
-    cumulativeProduct *= idxToDimInStrideOrder[i].second;
-  }
-
-  return stride;
-}
 
 } // namespace fusilli
 

--- a/sharkfuser/include/fusilli/attributes/tensor_attributes.h
+++ b/sharkfuser/include/fusilli/attributes/tensor_attributes.h
@@ -293,12 +293,12 @@ struct TensorAttrSortByName {
 // tensor, this would return {N: 3, C: 2, H: 1, W: 0} to represent an NCHW
 // in-memory layout. Here N is the slowest changing and W is the fastest
 // changing dimension.
-inline std::vector<int64_t> getContiguousStrideOrder(size_t numDims) {
+inline std::vector<size_t> getContiguousStrideOrder(size_t numDims) {
   assert(numDims >= 3 &&
          "Contiguous (channels-first) layout requires at least 3 dimensions");
 
-  std::vector<int64_t> strideOrder(numDims);
-  int64_t order = 0;
+  std::vector<size_t> strideOrder(numDims);
+  size_t order = 0;
   // Caution: Reverse iteration with size_t (unsigned) can lead to underflow
   // when `i == 0` is decremented due to wrap-around to SIZE_MAX (which is
   // positive and doesn't prevent control from entering the loop as intended).
@@ -312,11 +312,11 @@ inline std::vector<int64_t> getContiguousStrideOrder(size_t numDims) {
 // Generates stride order for a channels-last tensor. For a 4D tensor, this
 // would return {N: 3, C: 0, H: 2, W: 1} to represent an NHWC in-memory layout.
 // Here N is the slowest changing and C is the fastest changing dimension.
-inline std::vector<int64_t> getChannelsLastStrideOrder(size_t numDims) {
+inline std::vector<size_t> getChannelsLastStrideOrder(size_t numDims) {
   assert(numDims >= 3 && "Channels-last layout requires at least 3 dimensions");
 
-  std::vector<int64_t> strideOrder(numDims);
-  int64_t order = 0;
+  std::vector<size_t> strideOrder(numDims);
+  size_t order = 0;
   strideOrder[1] = order++;
   for (size_t i = numDims - 1; i > 1; --i)
     strideOrder[i] = order++;
@@ -324,10 +324,10 @@ inline std::vector<int64_t> getChannelsLastStrideOrder(size_t numDims) {
   return strideOrder;
 }
 
-inline std::vector<int64_t>
+inline std::vector<size_t>
 getStrideOrderFromStride(const std::vector<int64_t> &stride) {
   size_t numDims = stride.size();
-  std::vector<int64_t> indices(numDims);
+  std::vector<size_t> indices(numDims);
   std::iota(indices.begin(), indices.end(), 0);
 
   // Sort indices by stride value in ascending order to get the
@@ -339,7 +339,7 @@ getStrideOrderFromStride(const std::vector<int64_t> &stride) {
 
   // Sorted indices of (1, 3, 2, 0) yields strideOrder of
   // (3, 0, 2, 1) to represent NHWC layout.
-  std::vector<int64_t> strideOrder(numDims);
+  std::vector<size_t> strideOrder(numDims);
   for (size_t i = 0; i < numDims; ++i)
     strideOrder[indices[i]] = i;
 
@@ -348,7 +348,7 @@ getStrideOrderFromStride(const std::vector<int64_t> &stride) {
 
 inline std::vector<int64_t>
 generateStrideFromDim(const std::vector<int64_t> &dim,
-                      const std::vector<int64_t> &strideOrder) {
+                      const std::vector<size_t> &strideOrder) {
   size_t numDims = dim.size();
   std::vector<int64_t> stride(numDims);
   std::vector<std::pair<size_t, int64_t>> idxToDimInStrideOrder(numDims);

--- a/sharkfuser/include/fusilli/node/conv_node.h
+++ b/sharkfuser/include/fusilli/node/conv_node.h
@@ -50,6 +50,7 @@ public:
   ErrorObject preValidateNode() const override final {
     FUSILLI_LOG_LABEL_ENDL("INFO: Pre-Validating ConvFPropNode '"
                            << convFPropAttr.getName() << "'");
+
     FUSILLI_RETURN_ERROR_IF(convFPropAttr.getPadding().empty(),
                             ErrorCode::AttributeNotSet, "Conv padding not set");
     FUSILLI_RETURN_ERROR_IF(convFPropAttr.getStride().empty(),
@@ -57,6 +58,24 @@ public:
     FUSILLI_RETURN_ERROR_IF(convFPropAttr.getDilation().empty(),
                             ErrorCode::AttributeNotSet,
                             "Conv dilation not set");
+
+    std::shared_ptr<TensorAttr> xT = convFPropAttr.getX();
+    std::shared_ptr<TensorAttr> wT = convFPropAttr.getW();
+
+    // Ensure input and weight tensors are set.
+    FUSILLI_RETURN_ERROR_IF(!xT, ErrorCode::AttributeNotSet,
+                            "Conv input tensor X not set");
+    FUSILLI_RETURN_ERROR_IF(!wT, ErrorCode::AttributeNotSet,
+                            "Conv weight tensor W not set");
+
+    // Contiguity checks on input and weight tensors.
+    FUSILLI_RETURN_ERROR_IF(!xT->isContiguous(), ErrorCode::NotImplemented,
+                            "Tensor '" + xT->getName() +
+                                "' is not contiguous as defined by its stride");
+    FUSILLI_RETURN_ERROR_IF(!wT->isContiguous(), ErrorCode::NotImplemented,
+                            "Tensor '" + wT->getName() +
+                                "' is not contiguous as defined by its stride");
+
     return ok();
   }
 
@@ -66,7 +85,7 @@ public:
 
     convFPropAttr.fillFromContext(context);
 
-    // Logical layout is always channels-first (NCHW if 4D)
+    // Logical layout is always channels-first (NCHW if 4D).
     std::shared_ptr<TensorAttr> xT = convFPropAttr.getX(); // NCHW if 4D
     std::shared_ptr<TensorAttr> wT = convFPropAttr.getW(); // KCRS if 4D
     std::shared_ptr<TensorAttr> yT = convFPropAttr.getY(); // NKPQ if 4D
@@ -85,7 +104,7 @@ public:
     // to start at index = 2 (after batch and channel dims).
     constexpr size_t kSpatialStartIdx = 2;
 
-    // Infer shape of output tensor
+    // Infer shape of output tensor/
     if (yDim.empty()) {
       yDim.resize(xDim.size());
       // N (batch dim)
@@ -121,18 +140,11 @@ public:
     FUSILLI_LOG_LABEL_ENDL("INFO: Post-Validating ConvFPropNode '"
                            << convFPropAttr.getName() << "'");
 
-    std::shared_ptr<TensorAttr> xT = convFPropAttr.getX();
-    std::shared_ptr<TensorAttr> wT = convFPropAttr.getW();
+    // Contiguity check for output tensor.
+    // When output strides are not specified, they are inferred and will be
+    // correct by construction. This check is for when output strides are
+    // specified by the user.
     std::shared_ptr<TensorAttr> yT = convFPropAttr.getY();
-
-    FUSILLI_RETURN_ERROR_IF(!xT->isContiguous(), ErrorCode::NotImplemented,
-                            "Tensor '" + xT->getName() +
-                                "' is not contiguous as defined by its stride");
-
-    FUSILLI_RETURN_ERROR_IF(!wT->isContiguous(), ErrorCode::NotImplemented,
-                            "Tensor '" + wT->getName() +
-                                "' is not contiguous as defined by its stride");
-
     FUSILLI_RETURN_ERROR_IF(!yT->isContiguous(), ErrorCode::NotImplemented,
                             "Tensor '" + yT->getName() +
                                 "' is not contiguous as defined by its stride");

--- a/sharkfuser/include/fusilli/node/conv_node.h
+++ b/sharkfuser/include/fusilli/node/conv_node.h
@@ -112,6 +112,51 @@ public:
 
     return ok();
   }
+
+  ErrorObject postValidateNode() const override final {
+    FUSILLI_LOG_LABEL_ENDL("INFO: Post-Validating ConvFPropNode '"
+                           << convFPropAttr.getName() << "'");
+
+    std::shared_ptr<TensorAttr> xT = convFPropAttr.getX(); // NCHW if 4D
+    std::shared_ptr<TensorAttr> wT = convFPropAttr.getW(); // KCRS if 4D
+    std::shared_ptr<TensorAttr> yT = convFPropAttr.getY(); // NKPQ if 4D
+
+    std::vector<int64_t> xStride = xT->getStride();
+    std::vector<int64_t> wStride = wT->getStride();
+    std::vector<int64_t> yStride = yT->getStride();
+
+    FUSILLI_RETURN_ERROR_IF(
+        !(std::is_sorted(xStride.begin(), xStride.end(),
+                         std::greater<int64_t>()) &&
+          xStride.back() == 1),
+        ErrorCode::NotImplemented,
+        "Tensor '" + xT->getName() +
+            "' is not contiguous as defined by its stride; please specify a "
+            "stride {A, B, ... Z} where A > B > ... Z and Z == 1. "
+            "This will be supported in a future release");
+
+    FUSILLI_RETURN_ERROR_IF(
+        !(std::is_sorted(wStride.begin(), wStride.end(),
+                         std::greater<int64_t>()) &&
+          wStride.back() == 1),
+        ErrorCode::NotImplemented,
+        "Tensor '" + wT->getName() +
+            "' is not contiguous as defined by its stride; please specify a "
+            "stride {A, B, ... Z} where A > B > ... Z and Z == 1. "
+            "This will be supported in a future release");
+
+    FUSILLI_RETURN_ERROR_IF(
+        !(std::is_sorted(yStride.begin(), yStride.end(),
+                         std::greater<int64_t>()) &&
+          yStride.back() == 1),
+        ErrorCode::NotImplemented,
+        "Tensor '" + yT->getName() +
+            "' is not contiguous as defined by its stride; please specify a "
+            "stride {A, B, ... Z} where A > B > ... Z and Z == 1. "
+            "This will be supported in a future release");
+
+    return ok();
+  }
 };
 
 } // namespace fusilli

--- a/sharkfuser/include/fusilli/node/conv_node.h
+++ b/sharkfuser/include/fusilli/node/conv_node.h
@@ -104,7 +104,7 @@ public:
     // to start at index = 2 (after batch and channel dims).
     constexpr size_t kSpatialStartIdx = 2;
 
-    // Infer shape of output tensor/
+    // Infer shape of output tensor.
     if (yDim.empty()) {
       yDim.resize(xDim.size());
       // N (batch dim)
@@ -121,9 +121,9 @@ public:
       yT->setDim(yDim);
     }
 
-    // Infer stride of output tensor
+    // Infer stride of output tensor.
     if (yStride.empty()) {
-      // When unspecified, preserve the stride order of xT (input tensor)
+      // When unspecified, preserve the stride order of xT (input tensor).
       yStride = xT->isContiguous()
                     ? generateStrideFromDim(
                           yDim, getContiguousStrideOrder(yDim.size()))

--- a/sharkfuser/tests/test_conv_node.cpp
+++ b/sharkfuser/tests/test_conv_node.cpp
@@ -27,20 +27,64 @@ TEST_CASE("ConvFPropNode preValidateNode detects missing attributes",
   Context ctx;
   ConvFPropAttr attr;
 
-  // Leave attributes empty to trigger errors.
-  ConvFPropNode node(std::move(attr), ctx);
-  REQUIRE(node.preValidateNode() == ErrorCode::AttributeNotSet);
-}
+  SECTION("Padding missing") {
+    ConvFPropNode node(std::move(attr), ctx);
 
-TEST_CASE("ConvFPropNode preValidateNode passes with all attributes set",
-          "[conv_node]") {
-  Context ctx;
-  ConvFPropAttr attr;
+    auto status = node.preValidateNode();
+    REQUIRE(isError(status));
+    REQUIRE(status.getCode() == ErrorCode::AttributeNotSet);
+    REQUIRE(status.getMessage() == "Conv padding not set");
+  }
 
-  attr.setPadding({0, 0}).setStride({1, 1}).setDilation({1, 1});
+  SECTION("Stride missing") {
+    attr.setPadding({0, 0});
+    ConvFPropNode node(std::move(attr), ctx);
 
-  ConvFPropNode node(std::move(attr), ctx);
-  REQUIRE(isOk(node.preValidateNode()));
+    auto status = node.preValidateNode();
+    REQUIRE(isError(status));
+    REQUIRE(status.getCode() == ErrorCode::AttributeNotSet);
+    REQUIRE(status.getMessage() == "Conv stride not set");
+  }
+
+  SECTION("Dilation missing") {
+    attr.setPadding({0, 0}).setStride({1, 1});
+    ConvFPropNode node(std::move(attr), ctx);
+
+    auto status = node.preValidateNode();
+    REQUIRE(isError(status));
+    REQUIRE(status.getCode() == ErrorCode::AttributeNotSet);
+    REQUIRE(status.getMessage() == "Conv dilation not set");
+  }
+
+  SECTION("Input missing") {
+    attr.setPadding({0, 0}).setStride({1, 1}).setDilation({1, 1});
+    ConvFPropNode node(std::move(attr), ctx);
+
+    auto status = node.preValidateNode();
+    REQUIRE(isError(status));
+    REQUIRE(status.getCode() == ErrorCode::AttributeNotSet);
+    REQUIRE(status.getMessage() == "Conv input tensor X not set");
+  }
+
+  SECTION("Weight missing") {
+    attr.setPadding({0, 0}).setStride({1, 1}).setDilation({1, 1});
+    attr.setX(std::make_shared<TensorAttr>(1.0f));
+    ConvFPropNode node(std::move(attr), ctx);
+
+    auto status = node.preValidateNode();
+    REQUIRE(isError(status));
+    REQUIRE(status.getCode() == ErrorCode::AttributeNotSet);
+    REQUIRE(status.getMessage() == "Conv weight tensor W not set");
+  }
+
+  SECTION("All required attributes present") {
+    attr.setPadding({0, 0}).setStride({1, 1}).setDilation({1, 1});
+    attr.setX(std::make_shared<TensorAttr>(1.0f));
+    attr.setW(std::make_shared<TensorAttr>(2.0f));
+    ConvFPropNode node(std::move(attr), ctx);
+
+    REQUIRE(isOk(node.preValidateNode()));
+  }
 }
 
 TEST_CASE("ConvFPropNode inferPropertiesNode (1D) when Y is fully specified",
@@ -111,7 +155,7 @@ TEST_CASE("ConvFPropNode inferPropertiesNode (4D) when Y is under specified",
   REQUIRE(Y->getStride() == std::vector<int64_t>({k * h * w, h * w, w, 1}));
 }
 
-TEST_CASE("ConvFPropNode postValidate checks on stride validity",
+TEST_CASE("ConvFPropNode postValidate checks on input stride validity",
           "[conv_node]") {
   Context ctx;
   ConvFPropAttr attr;
@@ -130,17 +174,50 @@ TEST_CASE("ConvFPropNode postValidate checks on stride validity",
                                             .setStride({c * r * s, 1, c * s, c})
                                             .setName("W_non_contig"));
 
-  attr.setX(X)
-      .setW(W)
-      // Y is under specified (dim/stride missing).
-      .setY(std::make_shared<TensorAttr>());
+  attr.setX(X).setW(W).setY(std::make_shared<TensorAttr>());
 
   ConvFPropNode node(std::move(attr), ctx);
+
+  auto status = node.preValidateNode();
+  REQUIRE(isError(status));
+  REQUIRE(status.getCode() == ErrorCode::NotImplemented);
+  REQUIRE(status.getMessage() ==
+          "Tensor 'X_non_contig' is not contiguous as defined by its stride");
+}
+
+TEST_CASE("ConvFPropNode postValidate checks on output stride validity",
+          "[conv_node]") {
+  Context ctx;
+  ConvFPropAttr attr;
+
+  int64_t n = 16, c = 128, h = 64, w = 64, k = 256, r = 1, s = 1;
+
+  attr.setPadding({0, 0}).setStride({1, 1}).setDilation({1, 1});
+
+  auto X = std::make_shared<TensorAttr>(TensorAttr()
+                                            .setDim({n, c, h, w})
+                                            .setStride({c * h * w, h * w, w, 1})
+                                            .setName("X_contig"));
+
+  auto W = std::make_shared<TensorAttr>(TensorAttr()
+                                            .setDim({k, c, r, s})
+                                            .setStride({c * r * s, r * s, s, 1})
+                                            .setName("W_contig"));
+
+  auto Y = std::make_shared<TensorAttr>(TensorAttr()
+                                            .setDim({n, k, h, w})
+                                            .setStride({k * h * w, 1, k * w, k})
+                                            .setName("Y_non_contig"));
+  attr.setX(X).setW(W).setY(Y);
+
+  ConvFPropNode node(std::move(attr), ctx);
+
+  REQUIRE(isOk(node.preValidateNode()));
   REQUIRE(isOk(node.inferPropertiesNode()));
 
   auto status = node.postValidateNode();
   REQUIRE(isError(status));
   REQUIRE(status.getCode() == ErrorCode::NotImplemented);
   REQUIRE(status.getMessage() ==
-          "Tensor 'X_non_contig' is not contiguous as defined by its stride");
+          "Tensor 'Y_non_contig' is not contiguous as defined by its stride");
 }

--- a/sharkfuser/tests/test_graph.cpp
+++ b/sharkfuser/tests/test_graph.cpp
@@ -76,7 +76,7 @@ TEST_CASE("Graph validate() fails on missing attributes", "[graph]") {
   auto x = g.tensor(TensorAttr()
                         .setName("X")
                         .setDim({1, 3, 8, 8})
-                        .setStride({128, 64, 8, 1}));
+                        .setStride({192, 64, 8, 1}));
   auto w = g.tensor(
       TensorAttr().setName("W").setDim({4, 3, 3, 3}).setStride({27, 9, 3, 1}));
   ConvFPropAttr attr;

--- a/sharkfuser/tests/test_tensor_attributes.cpp
+++ b/sharkfuser/tests/test_tensor_attributes.cpp
@@ -233,19 +233,15 @@ TEST_CASE("Stride order utils", "[TensorAttr utils]") {
   REQUIRE(getChannelsLastStrideOrder(5) ==
           std::vector<size_t>({4, 0, 3, 2, 1}));
 
-  // Stride order from stride values
-  REQUIRE(getStrideOrderFromStride({12, 3, 1}) ==
-          std::vector<size_t>({2, 1, 0}));
-  REQUIRE(getStrideOrderFromStride({12, 1, 3}) ==
-          std::vector<size_t>({2, 0, 1}));
-  REQUIRE(getStrideOrderFromStride({36, 12, 3, 1}) ==
-          std::vector<size_t>({3, 2, 1, 0}));
-  REQUIRE(getStrideOrderFromStride({36, 1, 12, 3}) ==
-          std::vector<size_t>({3, 0, 2, 1}));
-
   // Generate stride from dim and stride order
   REQUIRE(generateStrideFromDim({10, 3, 12, 12}, {3, 0, 2, 1}) ==
           std::vector<int64_t>({432, 1, 36, 3}));
   REQUIRE(generateStrideFromDim({10, 3, 12, 12}, {3, 2, 1, 0}) ==
           std::vector<int64_t>({432, 144, 12, 1}));
+
+  // Ambiguous case (multiple dims of size 1)
+  REQUIRE(generateStrideFromDim({256, 128, 1, 1}, {3, 0, 2, 1}) ==
+          std::vector<int64_t>({128, 1, 128, 128}));
+  REQUIRE(generateStrideFromDim({256, 128, 1, 1}, {3, 2, 1, 0}) ==
+          std::vector<int64_t>({128, 1, 1, 1}));
 }

--- a/sharkfuser/tests/test_tensor_attributes.cpp
+++ b/sharkfuser/tests/test_tensor_attributes.cpp
@@ -118,27 +118,6 @@ TEST_CASE("TensorAttr validation edge cases", "[TensorAttr]") {
     REQUIRE(t.getVolume() == 0);
   }
 
-  SECTION("Non-contiguous (strided) tensors fail validation") {
-    TensorAttr t1, t2;
-
-    t1.setName("contig").setDim({4, 3}).setStride({3, 1}).setDataType(
-        DataType::Float);
-    REQUIRE(isOk(t1.validate()));
-
-    t2.setName("non_contig")
-        .setDim({4, 3})
-        .setStride({1, 4})
-        .setDataType(DataType::Float);
-    auto status = t2.validate();
-    REQUIRE(isError(status));
-    REQUIRE(status.getCode() == ErrorCode::NotImplemented);
-    REQUIRE(
-        status.getMessage() ==
-        "Tensor 'non_contig' is not contiguous as defined by its stride; "
-        "please specify a stride {A, B, ... Z} where A > B > ... Z and Z == 1. "
-        "This will be supported in a future release");
-  }
-
   SECTION("Virtual and scalar tensors can't coexist") {
     TensorAttr t;
     t.setName("invalid").setDim({1}).setStride({1}).setDataType(

--- a/sharkfuser/tests/test_tensor_attributes.cpp
+++ b/sharkfuser/tests/test_tensor_attributes.cpp
@@ -244,25 +244,25 @@ TEST_CASE("TensorAttr output vs virtual", "[TensorAttr]") {
 
 TEST_CASE("Stride order utils", "[TensorAttr utils]") {
   // Contiguous (channels-first) stride order
-  REQUIRE(getContiguousStrideOrder(3) == std::vector<int64_t>({2, 1, 0}));
-  REQUIRE(getContiguousStrideOrder(4) == std::vector<int64_t>({3, 2, 1, 0}));
-  REQUIRE(getContiguousStrideOrder(5) == std::vector<int64_t>({4, 3, 2, 1, 0}));
+  REQUIRE(getContiguousStrideOrder(3) == std::vector<size_t>({2, 1, 0}));
+  REQUIRE(getContiguousStrideOrder(4) == std::vector<size_t>({3, 2, 1, 0}));
+  REQUIRE(getContiguousStrideOrder(5) == std::vector<size_t>({4, 3, 2, 1, 0}));
 
   // Channels-last stride order
-  REQUIRE(getChannelsLastStrideOrder(3) == std::vector<int64_t>({2, 0, 1}));
-  REQUIRE(getChannelsLastStrideOrder(4) == std::vector<int64_t>({3, 0, 2, 1}));
+  REQUIRE(getChannelsLastStrideOrder(3) == std::vector<size_t>({2, 0, 1}));
+  REQUIRE(getChannelsLastStrideOrder(4) == std::vector<size_t>({3, 0, 2, 1}));
   REQUIRE(getChannelsLastStrideOrder(5) ==
-          std::vector<int64_t>({4, 0, 3, 2, 1}));
+          std::vector<size_t>({4, 0, 3, 2, 1}));
 
   // Stride order from stride values
   REQUIRE(getStrideOrderFromStride({12, 3, 1}) ==
-          std::vector<int64_t>({2, 1, 0}));
+          std::vector<size_t>({2, 1, 0}));
   REQUIRE(getStrideOrderFromStride({12, 1, 3}) ==
-          std::vector<int64_t>({2, 0, 1}));
+          std::vector<size_t>({2, 0, 1}));
   REQUIRE(getStrideOrderFromStride({36, 12, 3, 1}) ==
-          std::vector<int64_t>({3, 2, 1, 0}));
+          std::vector<size_t>({3, 2, 1, 0}));
   REQUIRE(getStrideOrderFromStride({36, 1, 12, 3}) ==
-          std::vector<int64_t>({3, 0, 2, 1}));
+          std::vector<size_t>({3, 0, 2, 1}));
 
   // Generate stride from dim and stride order
   REQUIRE(generateStrideFromDim({10, 3, 12, 12}, {3, 0, 2, 1}) ==


### PR DESCRIPTION
We can't always calculate the stride order from stride, especially in ambiguous (unit dim) cases. For example a tensor of shape `(256, 128, 1, 1)` would have contiguous stride `(128, 1, 1, 1)` but we can't certainly say the stride order for this is `(3, 2, 1, 0)` as it could also be `(3, 0, 1, 2)`.

A more robust way of getting the stride order is to reconstruct the stride from the dims and compare it with the known stride order for contiguous vs channels last.

Apart from this change, the PR also removes the contiguity check from TensorAttr (letting it be more relaxed) and moves it to the pre/post validate checks on the ConvFPropNode itself. This makes sense because certain layout restrictions are op-semantics driven and we should model those in the op specific validations rather than on the generic TensorAttr.

Tests updated accordingly.