### PR TITLE
[sharktank] Llama 3.1 f16 HF import presets

### DIFF
--- a/sharktank/sharktank/tools/import_hf_dataset_from_hub.py
+++ b/sharktank/sharktank/tools/import_hf_dataset_from_hub.py
@@ -11,10 +11,26 @@ from sharktank.utils.hf import import_hf_dataset_from_hub
 
 def main(argv: list[str] | None = None):
 
-    parser = cli.create_parser(description="Import a Hugging Face dataset.")
-    cli.add_output_dataset_options(parser)
+    parser = cli.create_parser(
+        description=(
+            "Import a Hugging Face dataset. "
+            "This includes downloading from the HF hub and transforming the model "
+            "parameters into an IRPA. "
+            "The import can either be specified through the various detailed "
+            "parameters or a preset name can be reference. "
+            "The HF dataset details can also be reference by a named preregistered dataset. "
+            "The HF dataset is only concerned with what files need to be downloaded from the hub."
+        )
+    )
+    parser.add_argument(
+        "--output-irpa-file",
+        type=Path,
+        help="IRPA file to save dataset to",
+    )
     parser.add_argument(
         "repo_id_or_path",
+        nargs="?",
+        default=None,
         type=str,
         help='Local path to the model or Hugging Face repo id, e.g. "meta-llama/Meta-Llama-3-8B-Instruct"',
     )
@@ -36,6 +52,28 @@ def main(argv: list[str] | None = None):
         default=None,
         help="Subpath inside the subfolder for the model config file. Defaults to config.json.",
     )
+    parser.add_argument(
+        "--hf-dataset",
+        type=str,
+        default=None,
+        help=(
+            "A name of a preset HF dataset. "
+            "This is mutually exclusive with specifying repo id or a model path."
+        ),
+    )
+    parser.add_argument(
+        "--preset",
+        type=str,
+        default=None,
+        help=(
+            "A name of a preset to import. "
+            "This is different form a preset HF dataset, which only specifies the HF "
+            "files to download. "
+            "The import preset also specifies the import transformations. "
+            "When using a preset the output directory structure would be relative to "
+            "the current working directory."
+        ),
+    )
     args = cli.parse(parser, args=argv)
 
     import_hf_dataset_from_hub(
@@ -44,6 +82,8 @@ def main(argv: list[str] | None = None):
         subfolder=args.subfolder,
         config_subpath=args.config_subpath,
         output_irpa_file=args.output_irpa_file,
+        hf_dataset=args.hf_dataset,
+        preset=args.preset,
     )
 
 

--- a/sharktank/tests/models/llama/test_llama.py
+++ b/sharktank/tests/models/llama/test_llama.py
@@ -15,6 +15,7 @@ import torch
 from pathlib import Path
 from sharktank.models.llm.llm import PagedLlmModelV1
 from sharktank.models.llama.toy_llama import generate
+from sharktank.utils import chdir
 from sharktank.utils.export_artifacts import IreeCompileException
 from sharktank.utils.testing import (
     is_mi300x,
@@ -210,3 +211,21 @@ def test_import_llama3_8B_instruct(tmp_path: Path):
         ]
     )
     assert irpa_path.exists()
+
+
+@pytest.mark.expensive
+def test_import_llama3_8B_instruct_from_preset(tmp_path: Path):
+    from sharktank.tools.import_hf_dataset_from_hub import main
+
+    irpa_path = tmp_path / "llama3.1/8b/instruct/f16/model.irpa"
+    tokenizer_path = tmp_path / "llama3.1/8b/instruct/f16/tokenizer.json"
+    tokenizer_config_path = tmp_path / "llama3.1/8b/instruct/f16/tokenizer_config.json"
+    with chdir(tmp_path):
+        main(
+            [
+                "--preset=meta_llama3_1_8b_instruct_f16",
+            ]
+        )
+    assert irpa_path.exists()
+    assert tokenizer_path.exists()
+    assert tokenizer_config_path.exists()


### PR DESCRIPTION
Add registry for import presets and populate it with Llama 3.1 f16 models.

Add support for referencing a HF dataset during import. This decouples specification of what needs to be downloaded versus how to import the dataset after it is download.

Expand the HF datasets to specify the model files not completely explicitly, but by using filters like `huggingface_hub.snapshot_download`.

Next steps are:
1. Make the CI use this new mechanism.
2. Add importation of models with more complicated transformations like quantization.