### PR TITLE
Tweak gguf default for rotary embedding format

### DIFF
--- a/sharktank/sharktank/layers/configs/llm_configs.py
+++ b/sharktank/sharktank/layers/configs/llm_configs.py
@@ -93,7 +93,7 @@ class LlamaHParams:
     # RoPE config
     rope_dimension_count: Optional[int] = None
     rope_freq_base: Optional[float] = None
-    rope_interleave_emb: bool = True
+    rope_interleave_emb: bool = False
 
     # MoE config
     expert_count: Optional[int] = None
@@ -140,6 +140,7 @@ class LlamaHParams:
         default_rope_freq_base = 500000.0
         default_rope_dimension_count = 128
         attention_head_count = _int_prop(p, f"{name_prefix}.attention.head_count")
+        default_rope_interleave_emb = "schema" in p and p["schema"] == "GGUF"
         rope_dimension_count = _optional_int_prop(
             p, f"{name_prefix}.rope.dimension_count", default_rope_dimension_count
         )
@@ -178,7 +179,7 @@ class LlamaHParams:
                 p, f"{name_prefix}.rope.freq_base", default_rope_freq_base
             ),
             rope_interleave_emb=_optional_bool_prop(
-                p, f"{name_prefix}.rope.interleave_emb", True
+                p, f"{name_prefix}.rope.interleave_emb", default_rope_interleave_emb
             ),
             no_rope_layer_step=_optional_int_prop(
                 p, f"{name_prefix}.no_rope_layer_step", None

--- a/sharktank/sharktank/models/deepseek/toy_deepseek.py
+++ b/sharktank/sharktank/models/deepseek/toy_deepseek.py
@@ -55,6 +55,7 @@ def generate(
             v_head_dim=128,
             rope_dimension_count=rope_dimension_count,
             rope_freq_base=10000.0,
+            rope_interleave_emb=True,
             expert_count=expert_count,
             expert_used_count=used_experts,
             expert_shared_count=1,

--- a/sharktank/sharktank/models/grok/toy_grok.py
+++ b/sharktank/sharktank/models/grok/toy_grok.py
@@ -37,6 +37,7 @@ def generate(seed):
             feed_forward_length=23,
             rope_dimension_count=rope_dimension_count,
             rope_freq_base=500000.0,
+            rope_interleave_emb=True,
             attention_head_count=attention_head_count,
             attn_head_dim=attn_head_dim,
             attention_layer_norm_rms_epsilon=0.01,

--- a/sharktank/sharktank/models/llama/toy_llama.py
+++ b/sharktank/sharktank/models/llama/toy_llama.py
@@ -41,6 +41,7 @@ def generate(
             feed_forward_length=23,
             rope_dimension_count=rope_dimension_count,
             rope_freq_base=500000.0,
+            rope_interleave_emb=True,
             attention_head_count=attention_head_count,
             attn_head_dim=attn_head_dim,
             attention_layer_norm_rms_epsilon=0.01,


### PR DESCRIPTION
We can identify that the IRPA source was GGUF which allows us to default to interleave rotary embedding.