### PR TITLE
[Fusilli] Don't specify linker type

### DIFF
--- a/.github/workflows/ci-fusilli-plugin.yml
+++ b/.github/workflows/ci-fusilli-plugin.yml
@@ -54,7 +54,6 @@ jobs:
             fusilli-plugin-cmake-options:
               -DCMAKE_C_COMPILER=clang-18
               -DCMAKE_CXX_COMPILER=clang++-18
-              -DCMAKE_LINKER_TYPE=LLD
               -DFUSILLI_SYSTEMS_AMDGPU=ON
 
     steps:

--- a/.github/workflows/ci-sharkfuser.yml
+++ b/.github/workflows/ci-sharkfuser.yml
@@ -53,7 +53,6 @@ jobs:
             cmake-options:
               -DCMAKE_C_COMPILER=clang-18
               -DCMAKE_CXX_COMPILER=clang++-18
-              -DCMAKE_LINKER_TYPE=LLD
               -DFUSILLI_DEBUG_BUILD=OFF
               -DFUSILLI_CODE_COVERAGE=OFF
               -DFUSILLI_SYSTEMS_AMDGPU=ON
@@ -62,7 +61,6 @@ jobs:
             cmake-options:
               -DCMAKE_C_COMPILER=clang-18
               -DCMAKE_CXX_COMPILER=clang++-18
-              -DCMAKE_LINKER_TYPE=LLD
               -DFUSILLI_DEBUG_BUILD=ON
               -DFUSILLI_CODE_COVERAGE=OFF
               -DFUSILLI_SYSTEMS_AMDGPU=OFF
@@ -71,7 +69,6 @@ jobs:
             cmake-options:
               -DCMAKE_C_COMPILER=clang-18
               -DCMAKE_CXX_COMPILER=clang++-18
-              -DCMAKE_LINKER_TYPE=LLD
               -DFUSILLI_DEBUG_BUILD=ON
               -DFUSILLI_CODE_COVERAGE=OFF
               -DFUSILLI_SYSTEMS_AMDGPU=ON

--- a/sharkfuser/README.md
+++ b/sharkfuser/README.md
@@ -31,7 +31,6 @@ Build and test Fusilli as follows:
 cmake -GNinja -S. -Bbuild \
     -DCMAKE_C_COMPILER=clang \
     -DCMAKE_CXX_COMPILER=clang++ \
-    -DCMAKE_LINKER_TYPE=LLD \
     -DFUSILLI_DEBUG_BUILD=ON \
     -DIREERuntime_DIR=</path/to/iree/build/lib/cmake/IREE>
 cmake --build build --target all


### PR DESCRIPTION
Removes `-DCMAKE_LINKER_TYPE=LLD` definition for building fusilli - a header-only library.

Fixes the warning:
```
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_LINKER_TYPE
```