### PR TITLE
[sharktank] Implement unpack for replicated quantized tensors

### DIFF
--- a/sharktank/sharktank/ops/sharded_impls.py
+++ b/sharktank/sharktank/ops/sharded_impls.py
@@ -1779,8 +1779,8 @@ def unflatten_split(
     return SplitPrimitiveTensor(ts=shards, shard_dim=shard_dim)
 
 
-@unpack.override(SplitPrimitiveTensor)
-def unpack_split(input: SplitPrimitiveTensor) -> QuantizedLayout:
+@unpack.override(IsOfType(ReplicatedTensor, SplitPrimitiveTensor))
+def unpack_sharded(input: ReplicatedTensor | SplitPrimitiveTensor) -> QuantizedLayout:
     layouts = [unpack(shard) for shard in input.shards]
     planes_per_leayout = [layout.planes for layout in layouts]
 
@@ -1800,7 +1800,7 @@ def unpack_split(input: SplitPrimitiveTensor) -> QuantizedLayout:
     )
 
     def make_sharded_tensor(shards: list[AnyTensor]) -> ShardedTensor:
-        if len(shards[0].shape) == 0:
+        if isinstance(input, ReplicatedTensor) or len(shards[0].shape) == 0:
             return ReplicatedTensor(ts=shards, devices=input.devices)
         else:
             return SplitPrimitiveTensor(

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -1113,7 +1113,7 @@ def unflatten(input: AnyTensor, dim: int, sizes: Tuple[int]) -> AnyTensor:
     ...
 
 
-@overridable(dispatch_args=(0,))
+@overridable(dispatch_args=(0,), is_trivially_replicable=False)
 def unpack(input: AnyTensor) -> QuantizedLayout:
     ...
 


### PR DESCRIPTION
Fixes https://github.com/nod-ai/shark-ai/issues/2299.

The unpack for quantized replicated tensors should not be trivially replicable. It returns a layout that is not a tensor. But rather contains tensors(planes).

A sharded quantized tensor is a collection of tensors that each is backed by unsharded layout.
But then we must construct a layout that is composed by sharded planes. This transformation is not trivially replicable.

Potentially we could have in the future a more general approach for automatic op replication where we describe how to combine the results of an all-replicated tensor args op. E.g. how to combine a bunch of quantized layouts.
Maybe we should be able to express replicated things (e.g. layouts) and not just tensors.