### PR TITLE
[Fusilli] Bump docker; add security-opt option for memory mapping

### DIFF
--- a/sharkfuser/build_tools/docker/exec_docker_ci.sh
+++ b/sharkfuser/build_tools/docker/exec_docker_ci.sh
@@ -17,7 +17,8 @@ done
 # Bind mounts for the following:
 # - current directory to /workspace in the container
 docker run --rm \
-           ${DOCKER_RUN_DEVICE_OPTS} \
            -v "${PWD}":/workspace \
-           ghcr.io/sjain-stanford/compiler-dev-ubuntu-24.04:main@sha256:5d70805daf1c9e89c3515e888fa54282982ce868784b13bb9c98f09d4fbd1c5b \
+           ${DOCKER_RUN_DEVICE_OPTS} \
+           --security-opt seccomp=unconfined \
+           ghcr.io/sjain-stanford/compiler-dev-ubuntu-24.04:main@sha256:a9775319c278f144946c1b86e4ec5efe14b378a0a93aa85ccaf263058b359934 \
            "$@"


### PR DESCRIPTION
New docker bumps IREE and TheRock to a more recent nightly release (useful for perf benchmarking). Also adds `--security-opt seccomp=unconfined` for memory mapping / perf as recommended by https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/docker.html#accessing-gpus-in-containers. 