### PR TITLE
Remove unpexted check of fp4 gemm asm test

### DIFF
--- a/sharktank/tests/kernels/gemm_fp4_asm_test.py
+++ b/sharktank/tests/kernels/gemm_fp4_asm_test.py
@@ -85,7 +85,6 @@ class TestAsmFp4Gemm:
         assert "func.func @main" in mlir_asm
         assert "util.func private @asm_mxfp4_gemm" in mlir_asm
         assert "util.func private @shuffle_scales" in mlir_asm
-        assert f"util.func private @asm_fp4_gemm" in mlir_asm
 
         mlir_path = tmp_path / "asm_fp4_gemm.mlir"
         with open(str(mlir_path), "w") as f:


### PR DESCRIPTION
The function name is `asm_mxfp4_gemm` instead of `asm_fp4_gemm`.