### PR TITLE
[Fusilli] Add lit tests with padding

### DIFF
--- a/sharkfuser/tests/CMakeLists.txt
+++ b/sharkfuser/tests/CMakeLists.txt
@@ -106,6 +106,7 @@ add_fusilli_lit_test(
   TOOLS
     filecheck
     iree-opt
+    iree-compile
 )
 
 add_fusilli_lit_test(
@@ -116,6 +117,7 @@ add_fusilli_lit_test(
   TOOLS
     filecheck
     iree-opt
+    iree-compile
 )
 
 add_fusilli_lit_test(
@@ -126,6 +128,7 @@ add_fusilli_lit_test(
   TOOLS
     filecheck
     iree-opt
+    iree-compile
 )
 
 add_fusilli_lit_test(
@@ -136,4 +139,27 @@ add_fusilli_lit_test(
   TOOLS
     filecheck
     iree-opt
+    iree-compile
+)
+
+add_fusilli_lit_test(
+  SRC
+    lit/test_conv_asm_emitter_nchw_kcrs_with_pad.cpp
+  DEPS
+    libfusilli
+  TOOLS
+    filecheck
+    iree-opt
+    iree-compile
+)
+
+add_fusilli_lit_test(
+  SRC
+    lit/test_conv_asm_emitter_nhwc_krsc_with_pad.cpp
+  DEPS
+    libfusilli
+  TOOLS
+    filecheck
+    iree-opt
+    iree-compile
 )

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_kcrs.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_kcrs.cpp
@@ -84,17 +84,11 @@ int main() {
   // TORCH-CHECK:     }
   // TORCH-CHECK:   }
   //
-  // LINALG-CHECK:    util.func public @main$async(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view, %arg3: !hal.fence, %arg4: !hal.fence) attributes {inlining_policy = #util.inline.never, iree.abi.model = "coarse-fences", iree.abi.stub} {
-  // LINALG-CHECK:      %cst = arith.constant 0.000000e+00 : f32
-  // LINALG-CHECK:      %0 = hal.tensor.import wait(%arg3) => %arg1 : !hal.buffer_view -> tensor<16x128x64x32xf32>
-  // LINALG-CHECK:      %1 = hal.tensor.import wait(%arg3) => %arg2 : !hal.buffer_view -> tensor<256x128x1x1xf32>
-  // LINALG-CHECK:      %2 = tensor.empty() : tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %4 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%0, %1 : tensor<16x128x64x32xf32>, tensor<256x128x1x1xf32>) outs(%3 : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %5 = hal.tensor.alias wait(%arg3) => %4 : tensor<16x256x64x32xf32> to %arg0 : !hal.buffer_view
-  // LINALG-CHECK:      %6 = hal.tensor.barrier join(%5 : tensor<16x256x64x32xf32>) => %arg4 : !hal.fence
-  // LINALG-CHECK:      util.return
-  // LINALG-CHECK:    }
+  // LINALG-CHECK:    util.func public @main$async(%[[ARG0:.+]]: !hal.buffer_view, %[[ARG1:.+]]: !hal.buffer_view, %[[ARG2:.+]]: !hal.buffer_view, {{.+}}
+  // LINALG-CHECK:      %[[BUF1:.+]] = hal.tensor.import wait(%{{.+}}) => %[[ARG1]] : !hal.buffer_view -> tensor<16x128x64x32xf32>
+  // LINALG-CHECK:      %[[BUF2:.+]] = hal.tensor.import wait(%{{.+}}) => %[[ARG2]] : !hal.buffer_view -> tensor<256x128x1x1xf32>
+  // LINALG-CHECK:      %[[OUT:.+]] = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%[[BUF1]], %[[BUF2]] : tensor<16x128x64x32xf32>, tensor<256x128x1x1xf32>) outs(%{{.+}} : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
+  // LINALG-CHECK:      %{{.+}} = hal.tensor.alias wait(%{{.+}}) => %[[OUT]] : tensor<16x256x64x32xf32> to %[[ARG0]] : !hal.buffer_view
   //
   // clang-format on
 

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_kcrs.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_kcrs.cpp
@@ -84,7 +84,6 @@ int main() {
   // TORCH-CHECK:     }
   // TORCH-CHECK:   }
   //
-  // LINALG-CHECK:  module @module {
   // LINALG-CHECK:    util.func public @main$async(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view, %arg3: !hal.fence, %arg4: !hal.fence) attributes {inlining_policy = #util.inline.never, iree.abi.model = "coarse-fences", iree.abi.stub} {
   // LINALG-CHECK:      %cst = arith.constant 0.000000e+00 : f32
   // LINALG-CHECK:      %0 = hal.tensor.import wait(%arg3) => %arg1 : !hal.buffer_view -> tensor<16x128x64x32xf32>
@@ -96,17 +95,6 @@ int main() {
   // LINALG-CHECK:      %6 = hal.tensor.barrier join(%5 : tensor<16x256x64x32xf32>) => %arg4 : !hal.fence
   // LINALG-CHECK:      util.return
   // LINALG-CHECK:    }
-  // LINALG-CHECK:    util.func public @main(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view) attributes {iree.abi.stub} {
-  // LINALG-CHECK:      %0 = util.null : !hal.fence
-  // LINALG-CHECK:      %c-1_i32 = arith.constant -1 : i32
-  // LINALG-CHECK:      %c0 = arith.constant 0 : index
-  // LINALG-CHECK:      %device_0 = hal.devices.get %c0 : !hal.device
-  // LINALG-CHECK:      %fence = hal.fence.create device(%device_0 : !hal.device) flags("None") : !hal.fence
-  // LINALG-CHECK:      util.call @main$async(%arg0, %arg1, %arg2, %0, %fence) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.fence, !hal.fence) -> ()
-  // LINALG-CHECK:      %status = hal.fence.await until([%fence]) timeout_millis(%c-1_i32) flags("None") : i32
-  // LINALG-CHECK:      util.return
-  // LINALG-CHECK:    }
-  // LINALG-CHECK:  }
   //
   // clang-format on
 

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_kcrs_with_pad.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_kcrs_with_pad.cpp
@@ -84,21 +84,12 @@ int main() {
   // TORCH-CHECK:     }
   // TORCH-CHECK:   }
   //
-  // LINALG-CHECK:    util.func public @main$async(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view, %arg3: !hal.fence, %arg4: !hal.fence) attributes {inlining_policy = #util.inline.never, iree.abi.model = "coarse-fences", iree.abi.stub} {
-  // LINALG-CHECK:      %cst = arith.constant 0.000000e+00 : f32
-  // LINALG-CHECK:      %0 = hal.tensor.import wait(%arg3) => %arg1 : !hal.buffer_view -> tensor<16x128x64x32xf32>
-  // LINALG-CHECK:      %1 = hal.tensor.import wait(%arg3) => %arg2 : !hal.buffer_view -> tensor<256x128x3x3xf32>
-  // LINALG-CHECK:      %padded = tensor.pad %0 low[0, 0, 1, 1] high[0, 0, 1, 1] {
-  // LINALG-CHECK:      ^bb0(%arg5: index, %arg6: index, %arg7: index, %arg8: index):
-  // LINALG-CHECK:        tensor.yield %cst : f32
-  // LINALG-CHECK:      } : tensor<16x128x64x32xf32> to tensor<16x128x66x34xf32>
-  // LINALG-CHECK:      %2 = tensor.empty() : tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %4 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded, %1 : tensor<16x128x66x34xf32>, tensor<256x128x3x3xf32>) outs(%3 : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %5 = hal.tensor.alias wait(%arg3) => %4 : tensor<16x256x64x32xf32> to %arg0 : !hal.buffer_view
-  // LINALG-CHECK:      %6 = hal.tensor.barrier join(%5 : tensor<16x256x64x32xf32>) => %arg4 : !hal.fence
-  // LINALG-CHECK:      util.return
-  // LINALG-CHECK:    }
+  // LINALG-CHECK:    util.func public @main$async(%[[ARG0:.+]]: !hal.buffer_view, %[[ARG1:.+]]: !hal.buffer_view, %[[ARG2:.+]]: !hal.buffer_view, {{.+}}
+  // LINALG-CHECK:      %[[BUF1:.+]] = hal.tensor.import wait(%{{.+}}) => %[[ARG1]] : !hal.buffer_view -> tensor<16x128x64x32xf32>
+  // LINALG-CHECK:      %[[BUF2:.+]] = hal.tensor.import wait(%{{.+}}) => %[[ARG2]] : !hal.buffer_view -> tensor<256x128x3x3xf32>
+  // LINALG-CHECK:      %[[BUF1PAD:.+]] = tensor.pad %[[BUF1]] low[0, 0, 1, 1] high[0, 0, 1, 1] {
+  // LINALG-CHECK:      %[[OUT:.+]] = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%[[BUF1PAD]], %[[BUF2]] : tensor<16x128x66x34xf32>, tensor<256x128x3x3xf32>) outs(%{{.+}} : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
+  // LINALG-CHECK:      %{{.+}} = hal.tensor.alias wait(%{{.+}}) => %[[OUT]] : tensor<16x256x64x32xf32> to %[[ARG0]] : !hal.buffer_view
   //
   // clang-format on
 

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_kcrs_with_pad.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_kcrs_with_pad.cpp
@@ -18,15 +18,15 @@
 using namespace fusilli;
 
 int main() {
-  int64_t n = 16, c = 128, h = 64, w = 32, k = 256, r = 1, s = 1;
+  int64_t n = 16, c = 128, h = 64, w = 32, k = 256, r = 3, s = 3;
   auto graph = std::make_shared<Graph>();
-  graph->setName("conv_asm_emitter_x_nhwc_w_kcrs");
+  graph->setName("conv_asm_emitter_x_nchw_w_kcrs_with_pad");
   graph->setIODataType(DataType::Float).setComputeDataType(DataType::Float);
 
   auto X = graph->tensor(TensorAttr()
                              .setName("arg0_image")
                              .setDim({n, c, h, w})
-                             .setStride({c * h * w, 1, c * w, c})); // NHWC
+                             .setStride({c * h * w, h * w, w, 1})); // NCHW
 
   auto W = graph->tensor(TensorAttr()
                              .setName("arg1_filter")
@@ -34,7 +34,7 @@ int main() {
                              .setStride({c * r * s, r * s, s, 1})); // KCRS
 
   auto conv_attr = ConvFPropAttr()
-                       .setPadding({0, 0})
+                       .setPadding({1, 1})
                        .setStride({1, 1})
                        .setDilation({1, 1})
                        .setName("conv_fprop");
@@ -46,7 +46,7 @@ int main() {
   // clang-format off
   //
   // TORCH-CHECK:   module @module {
-  // TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,64,32,256],f32>, %arg0_image: !torch.vtensor<[16,64,32,128],f32>, %arg1_filter: !torch.vtensor<[256,128,1,1],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+  // TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,256,64,32],f32>, %arg0_image: !torch.vtensor<[16,128,64,32],f32>, %arg1_filter: !torch.vtensor<[256,128,3,3],f32>) attributes {torch.assume_strict_symbolic_shapes} {
   // TORCH-CHECK:       %bias_conv_fprop = torch.constant.none
   // TORCH-CHECK:       %transposed_conv_fprop = torch.constant.bool false
   // TORCH-CHECK:       %output_padding_conv_fprop = torch.prim.ListConstruct  : () -> !torch.list<int>
@@ -54,49 +54,49 @@ int main() {
   // TORCH-CHECK:       %stride_val_0_conv_fprop = torch.constant.int 1
   // TORCH-CHECK:       %stride_val_1_conv_fprop = torch.constant.int 1
   // TORCH-CHECK:       %stride_conv_fprop = torch.prim.ListConstruct %stride_val_0_conv_fprop, %stride_val_1_conv_fprop : (!torch.int, !torch.int) -> !torch.list<int>
-  // TORCH-CHECK:       %padding_val_0_conv_fprop = torch.constant.int 0
-  // TORCH-CHECK:       %padding_val_1_conv_fprop = torch.constant.int 0
+  // TORCH-CHECK:       %padding_val_0_conv_fprop = torch.constant.int 1
+  // TORCH-CHECK:       %padding_val_1_conv_fprop = torch.constant.int 1
   // TORCH-CHECK:       %padding_conv_fprop = torch.prim.ListConstruct %padding_val_0_conv_fprop, %padding_val_1_conv_fprop : (!torch.int, !torch.int) -> !torch.list<int>
   // TORCH-CHECK:       %dilation_val_0_conv_fprop = torch.constant.int 1
   // TORCH-CHECK:       %dilation_val_1_conv_fprop = torch.constant.int 1
   // TORCH-CHECK:       %dilation_conv_fprop = torch.prim.ListConstruct %dilation_val_0_conv_fprop, %dilation_val_1_conv_fprop : (!torch.int, !torch.int) -> !torch.list<int>
   // TORCH-CHECK:       %permute_X_val_0_conv_fprop = torch.constant.int 0
-  // TORCH-CHECK:       %permute_X_val_1_conv_fprop = torch.constant.int 3
-  // TORCH-CHECK:       %permute_X_val_2_conv_fprop = torch.constant.int 1
-  // TORCH-CHECK:       %permute_X_val_3_conv_fprop = torch.constant.int 2
+  // TORCH-CHECK:       %permute_X_val_1_conv_fprop = torch.constant.int 1
+  // TORCH-CHECK:       %permute_X_val_2_conv_fprop = torch.constant.int 2
+  // TORCH-CHECK:       %permute_X_val_3_conv_fprop = torch.constant.int 3
   // TORCH-CHECK:       %permute_X_conv_fprop = torch.prim.ListConstruct %permute_X_val_0_conv_fprop, %permute_X_val_1_conv_fprop, %permute_X_val_2_conv_fprop, %permute_X_val_3_conv_fprop : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
-  // TORCH-CHECK:       %arg0_image_perm = torch.aten.permute %arg0_image, %permute_X_conv_fprop : !torch.vtensor<[16,64,32,128],f32>, !torch.list<int> -> !torch.vtensor<[16,128,64,32],f32>
+  // TORCH-CHECK:       %arg0_image_perm = torch.aten.permute %arg0_image, %permute_X_conv_fprop : !torch.vtensor<[16,128,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,128,64,32],f32>
   // TORCH-CHECK:       %permute_W_val_0_conv_fprop = torch.constant.int 0
   // TORCH-CHECK:       %permute_W_val_1_conv_fprop = torch.constant.int 1
   // TORCH-CHECK:       %permute_W_val_2_conv_fprop = torch.constant.int 2
   // TORCH-CHECK:       %permute_W_val_3_conv_fprop = torch.constant.int 3
   // TORCH-CHECK:       %permute_W_conv_fprop = torch.prim.ListConstruct %permute_W_val_0_conv_fprop, %permute_W_val_1_conv_fprop, %permute_W_val_2_conv_fprop, %permute_W_val_3_conv_fprop : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
-  // TORCH-CHECK:       %arg1_filter_perm = torch.aten.permute %arg1_filter, %permute_W_conv_fprop : !torch.vtensor<[256,128,1,1],f32>, !torch.list<int> -> !torch.vtensor<[256,128,1,1],f32>
-  // TORCH-CHECK:       %result_perm = torch.aten.convolution %arg0_image_perm, %arg1_filter_perm, %bias_conv_fprop, %stride_conv_fprop, %padding_conv_fprop, %dilation_conv_fprop, %transposed_conv_fprop, %output_padding_conv_fprop, %groups_conv_fprop : !torch.vtensor<[16,128,64,32],f32>, !torch.vtensor<[256,128,1,1],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.list<int>, !torch.int -> !torch.vtensor<[16,256,64,32],f32>
+  // TORCH-CHECK:       %arg1_filter_perm = torch.aten.permute %arg1_filter, %permute_W_conv_fprop : !torch.vtensor<[256,128,3,3],f32>, !torch.list<int> -> !torch.vtensor<[256,128,3,3],f32>
+  // TORCH-CHECK:       %result_perm = torch.aten.convolution %arg0_image_perm, %arg1_filter_perm, %bias_conv_fprop, %stride_conv_fprop, %padding_conv_fprop, %dilation_conv_fprop, %transposed_conv_fprop, %output_padding_conv_fprop, %groups_conv_fprop : !torch.vtensor<[16,128,64,32],f32>, !torch.vtensor<[256,128,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.list<int>, !torch.int -> !torch.vtensor<[16,256,64,32],f32>
   // TORCH-CHECK:       %permute_Y_val_0_conv_fprop = torch.constant.int 0
-  // TORCH-CHECK:       %permute_Y_val_1_conv_fprop = torch.constant.int 2
-  // TORCH-CHECK:       %permute_Y_val_2_conv_fprop = torch.constant.int 3
-  // TORCH-CHECK:       %permute_Y_val_3_conv_fprop = torch.constant.int 1
+  // TORCH-CHECK:       %permute_Y_val_1_conv_fprop = torch.constant.int 1
+  // TORCH-CHECK:       %permute_Y_val_2_conv_fprop = torch.constant.int 2
+  // TORCH-CHECK:       %permute_Y_val_3_conv_fprop = torch.constant.int 3
   // TORCH-CHECK:       %permute_Y_conv_fprop = torch.prim.ListConstruct %permute_Y_val_0_conv_fprop, %permute_Y_val_1_conv_fprop, %permute_Y_val_2_conv_fprop, %permute_Y_val_3_conv_fprop : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
-  // TORCH-CHECK:       %result = torch.aten.permute %result_perm, %permute_Y_conv_fprop : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,64,32,256],f32>
-  // TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,64,32,256],f32>, !torch.tensor<[16,64,32,256],f32>
+  // TORCH-CHECK:       %result = torch.aten.permute %result_perm, %permute_Y_conv_fprop : !torch.vtensor<[16,256,64,32],f32>, !torch.list<int> -> !torch.vtensor<[16,256,64,32],f32>
+  // TORCH-CHECK:       torch.overwrite.tensor.contents %result overwrites %result_ : !torch.vtensor<[16,256,64,32],f32>, !torch.tensor<[16,256,64,32],f32>
   // TORCH-CHECK:       return
   // TORCH-CHECK:     }
   // TORCH-CHECK:   }
   //
   // LINALG-CHECK:    util.func public @main$async(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view, %arg3: !hal.fence, %arg4: !hal.fence) attributes {inlining_policy = #util.inline.never, iree.abi.model = "coarse-fences", iree.abi.stub} {
   // LINALG-CHECK:      %cst = arith.constant 0.000000e+00 : f32
-  // LINALG-CHECK:      %0 = hal.tensor.import wait(%arg3) => %arg1 : !hal.buffer_view -> tensor<16x64x32x128xf32>
-  // LINALG-CHECK:      %1 = hal.tensor.import wait(%arg3) => %arg2 : !hal.buffer_view -> tensor<256x128x1x1xf32>
-  // LINALG-CHECK:      %2 = tensor.empty() : tensor<16x128x64x32xf32>
-  // LINALG-CHECK:      %transposed = linalg.transpose ins(%0 : tensor<16x64x32x128xf32>) outs(%2 : tensor<16x128x64x32xf32>) permutation = [0, 3, 1, 2]
-  // LINALG-CHECK:      %3 = tensor.empty() : tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %5 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%transposed, %1 : tensor<16x128x64x32xf32>, tensor<256x128x1x1xf32>) outs(%4 : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %6 = tensor.empty() : tensor<16x64x32x256xf32>
-  // LINALG-CHECK:      %transposed_0 = linalg.transpose ins(%5 : tensor<16x256x64x32xf32>) outs(%6 : tensor<16x64x32x256xf32>) permutation = [0, 2, 3, 1]
-  // LINALG-CHECK:      %7 = hal.tensor.alias wait(%arg3) => %transposed_0 : tensor<16x64x32x256xf32> to %arg0 : !hal.buffer_view
-  // LINALG-CHECK:      %8 = hal.tensor.barrier join(%7 : tensor<16x64x32x256xf32>) => %arg4 : !hal.fence
+  // LINALG-CHECK:      %0 = hal.tensor.import wait(%arg3) => %arg1 : !hal.buffer_view -> tensor<16x128x64x32xf32>
+  // LINALG-CHECK:      %1 = hal.tensor.import wait(%arg3) => %arg2 : !hal.buffer_view -> tensor<256x128x3x3xf32>
+  // LINALG-CHECK:      %padded = tensor.pad %0 low[0, 0, 1, 1] high[0, 0, 1, 1] {
+  // LINALG-CHECK:      ^bb0(%arg5: index, %arg6: index, %arg7: index, %arg8: index):
+  // LINALG-CHECK:        tensor.yield %cst : f32
+  // LINALG-CHECK:      } : tensor<16x128x64x32xf32> to tensor<16x128x66x34xf32>
+  // LINALG-CHECK:      %2 = tensor.empty() : tensor<16x256x64x32xf32>
+  // LINALG-CHECK:      %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
+  // LINALG-CHECK:      %4 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded, %1 : tensor<16x128x66x34xf32>, tensor<256x128x3x3xf32>) outs(%3 : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
+  // LINALG-CHECK:      %5 = hal.tensor.alias wait(%arg3) => %4 : tensor<16x256x64x32xf32> to %arg0 : !hal.buffer_view
+  // LINALG-CHECK:      %6 = hal.tensor.barrier join(%5 : tensor<16x256x64x32xf32>) => %arg4 : !hal.fence
   // LINALG-CHECK:      util.return
   // LINALG-CHECK:    }
   //

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_krsc.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_krsc.cpp
@@ -84,19 +84,12 @@ int main() {
   // TORCH-CHECK:     }
   // TORCH-CHECK:   }
   //
-  // LINALG-CHECK:    util.func public @main$async(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view, %arg3: !hal.fence, %arg4: !hal.fence) attributes {inlining_policy = #util.inline.never, iree.abi.model = "coarse-fences", iree.abi.stub} {
-  // LINALG-CHECK:      %cst = arith.constant 0.000000e+00 : f32
-  // LINALG-CHECK:      %0 = hal.tensor.import wait(%arg3) => %arg1 : !hal.buffer_view -> tensor<16x128x64x32xf32>
-  // LINALG-CHECK:      %1 = hal.tensor.import wait(%arg3) => %arg2 : !hal.buffer_view -> tensor<256x1x1x128xf32>
-  // LINALG-CHECK:      %2 = tensor.empty() : tensor<256x128x1x1xf32>
-  // LINALG-CHECK:      %transposed = linalg.transpose ins(%1 : tensor<256x1x1x128xf32>) outs(%2 : tensor<256x128x1x1xf32>) permutation = [0, 3, 1, 2]
-  // LINALG-CHECK:      %3 = tensor.empty() : tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %5 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%0, %transposed : tensor<16x128x64x32xf32>, tensor<256x128x1x1xf32>) outs(%4 : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %6 = hal.tensor.alias wait(%arg3) => %5 : tensor<16x256x64x32xf32> to %arg0 : !hal.buffer_view
-  // LINALG-CHECK:      %7 = hal.tensor.barrier join(%6 : tensor<16x256x64x32xf32>) => %arg4 : !hal.fence
-  // LINALG-CHECK:      util.return
-  // LINALG-CHECK:    }
+  // LINALG-CHECK:    util.func public @main$async(%[[ARG0:.+]]: !hal.buffer_view, %[[ARG1:.+]]: !hal.buffer_view, %[[ARG2:.+]]: !hal.buffer_view, {{.+}}
+  // LINALG-CHECK:      %[[BUF1:.+]] = hal.tensor.import wait(%{{.+}}) => %[[ARG1]] : !hal.buffer_view -> tensor<16x128x64x32xf32>
+  // LINALG-CHECK:      %[[BUF2:.+]] = hal.tensor.import wait(%{{.+}}) => %[[ARG2]] : !hal.buffer_view -> tensor<256x1x1x128xf32>
+  // LINALG-CHECK:      %[[BUF2T:.+]] = linalg.transpose ins(%[[BUF2]] : tensor<256x1x1x128xf32>) outs(%{{.+}} : tensor<256x128x1x1xf32>) permutation = [0, 3, 1, 2]
+  // LINALG-CHECK:      %[[OUT:.+]] = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%[[BUF1]], %[[BUF2T]] : tensor<16x128x64x32xf32>, tensor<256x128x1x1xf32>) outs(%{{.+}} : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
+  // LINALG-CHECK:      %{{.+}} = hal.tensor.alias wait(%{{.+}}) => %[[OUT]] : tensor<16x256x64x32xf32> to %[[ARG0]] : !hal.buffer_view
   //
   // clang-format on
 

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_krsc.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_krsc.cpp
@@ -84,7 +84,6 @@ int main() {
   // TORCH-CHECK:     }
   // TORCH-CHECK:   }
   //
-  // LINALG-CHECK:  module @module {
   // LINALG-CHECK:    util.func public @main$async(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view, %arg3: !hal.fence, %arg4: !hal.fence) attributes {inlining_policy = #util.inline.never, iree.abi.model = "coarse-fences", iree.abi.stub} {
   // LINALG-CHECK:      %cst = arith.constant 0.000000e+00 : f32
   // LINALG-CHECK:      %0 = hal.tensor.import wait(%arg3) => %arg1 : !hal.buffer_view -> tensor<16x128x64x32xf32>
@@ -98,17 +97,6 @@ int main() {
   // LINALG-CHECK:      %7 = hal.tensor.barrier join(%6 : tensor<16x256x64x32xf32>) => %arg4 : !hal.fence
   // LINALG-CHECK:      util.return
   // LINALG-CHECK:    }
-  // LINALG-CHECK:    util.func public @main(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view) attributes {iree.abi.stub} {
-  // LINALG-CHECK:      %0 = util.null : !hal.fence
-  // LINALG-CHECK:      %c-1_i32 = arith.constant -1 : i32
-  // LINALG-CHECK:      %c0 = arith.constant 0 : index
-  // LINALG-CHECK:      %device_0 = hal.devices.get %c0 : !hal.device
-  // LINALG-CHECK:      %fence = hal.fence.create device(%device_0 : !hal.device) flags("None") : !hal.fence
-  // LINALG-CHECK:      util.call @main$async(%arg0, %arg1, %arg2, %0, %fence) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.fence, !hal.fence) -> ()
-  // LINALG-CHECK:      %status = hal.fence.await until([%fence]) timeout_millis(%c-1_i32) flags("None") : i32
-  // LINALG-CHECK:      util.return
-  // LINALG-CHECK:    }
-  // LINALG-CHECK:  }
   //
   // clang-format on
 

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_kcrs.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_kcrs.cpp
@@ -84,21 +84,13 @@ int main() {
   // TORCH-CHECK:     }
   // TORCH-CHECK:   }
   //
-  // LINALG-CHECK:    util.func public @main$async(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view, %arg3: !hal.fence, %arg4: !hal.fence) attributes {inlining_policy = #util.inline.never, iree.abi.model = "coarse-fences", iree.abi.stub} {
-  // LINALG-CHECK:      %cst = arith.constant 0.000000e+00 : f32
-  // LINALG-CHECK:      %0 = hal.tensor.import wait(%arg3) => %arg1 : !hal.buffer_view -> tensor<16x64x32x128xf32>
-  // LINALG-CHECK:      %1 = hal.tensor.import wait(%arg3) => %arg2 : !hal.buffer_view -> tensor<256x128x1x1xf32>
-  // LINALG-CHECK:      %2 = tensor.empty() : tensor<16x128x64x32xf32>
-  // LINALG-CHECK:      %transposed = linalg.transpose ins(%0 : tensor<16x64x32x128xf32>) outs(%2 : tensor<16x128x64x32xf32>) permutation = [0, 3, 1, 2]
-  // LINALG-CHECK:      %3 = tensor.empty() : tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %5 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%transposed, %1 : tensor<16x128x64x32xf32>, tensor<256x128x1x1xf32>) outs(%4 : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %6 = tensor.empty() : tensor<16x64x32x256xf32>
-  // LINALG-CHECK:      %transposed_0 = linalg.transpose ins(%5 : tensor<16x256x64x32xf32>) outs(%6 : tensor<16x64x32x256xf32>) permutation = [0, 2, 3, 1]
-  // LINALG-CHECK:      %7 = hal.tensor.alias wait(%arg3) => %transposed_0 : tensor<16x64x32x256xf32> to %arg0 : !hal.buffer_view
-  // LINALG-CHECK:      %8 = hal.tensor.barrier join(%7 : tensor<16x64x32x256xf32>) => %arg4 : !hal.fence
-  // LINALG-CHECK:      util.return
-  // LINALG-CHECK:    }
+  // LINALG-CHECK:    util.func public @main$async(%[[ARG0:.+]]: !hal.buffer_view, %[[ARG1:.+]]: !hal.buffer_view, %[[ARG2:.+]]: !hal.buffer_view, {{.+}}
+  // LINALG-CHECK:      %[[BUF1:.+]] = hal.tensor.import wait(%{{.+}}) => %[[ARG1]] : !hal.buffer_view -> tensor<16x64x32x128xf32>
+  // LINALG-CHECK:      %[[BUF2:.+]] = hal.tensor.import wait(%{{.+}}) => %[[ARG2]] : !hal.buffer_view -> tensor<256x128x1x1xf32>
+  // LINALG-CHECK:      %[[BUF1T:.+]] = linalg.transpose ins(%[[BUF1]] : tensor<16x64x32x128xf32>) outs(%{{.+}} : tensor<16x128x64x32xf32>) permutation = [0, 3, 1, 2]
+  // LINALG-CHECK:      %[[OUT:.+]] = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%[[BUF1T]], %[[BUF2]] : tensor<16x128x64x32xf32>, tensor<256x128x1x1xf32>) outs(%{{.+}} : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
+  // LINALG-CHECK:      %[[OUTT:.+]] = linalg.transpose ins(%[[OUT]] : tensor<16x256x64x32xf32>) outs(%{{.+}} : tensor<16x64x32x256xf32>) permutation = [0, 2, 3, 1]
+  // LINALG-CHECK:      %{{.+}} = hal.tensor.alias wait(%{{.+}}) => %[[OUTT]] : tensor<16x64x32x256xf32> to %[[ARG0]] : !hal.buffer_view
   //
   // clang-format on
 

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_krsc.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_krsc.cpp
@@ -84,23 +84,14 @@ int main() {
   // TORCH-CHECK:     }
   // TORCH-CHECK:   }
   //
-  // LINALG-CHECK:    util.func public @main$async(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view, %arg3: !hal.fence, %arg4: !hal.fence) attributes {inlining_policy = #util.inline.never, iree.abi.model = "coarse-fences", iree.abi.stub} {
-  // LINALG-CHECK:      %cst = arith.constant 0.000000e+00 : f32
-  // LINALG-CHECK:      %0 = hal.tensor.import wait(%arg3) => %arg1 : !hal.buffer_view -> tensor<16x64x32x128xf32>
-  // LINALG-CHECK:      %1 = hal.tensor.import wait(%arg3) => %arg2 : !hal.buffer_view -> tensor<256x1x1x128xf32>
-  // LINALG-CHECK:      %2 = tensor.empty() : tensor<16x128x64x32xf32>
-  // LINALG-CHECK:      %transposed = linalg.transpose ins(%0 : tensor<16x64x32x128xf32>) outs(%2 : tensor<16x128x64x32xf32>) permutation = [0, 3, 1, 2]
-  // LINALG-CHECK:      %3 = tensor.empty() : tensor<256x128x1x1xf32>
-  // LINALG-CHECK:      %transposed_0 = linalg.transpose ins(%1 : tensor<256x1x1x128xf32>) outs(%3 : tensor<256x128x1x1xf32>) permutation = [0, 3, 1, 2]
-  // LINALG-CHECK:      %4 = tensor.empty() : tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %5 = linalg.fill ins(%cst : f32) outs(%4 : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %6 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%transposed, %transposed_0 : tensor<16x128x64x32xf32>, tensor<256x128x1x1xf32>) outs(%5 : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %7 = tensor.empty() : tensor<16x64x32x256xf32>
-  // LINALG-CHECK:      %transposed_1 = linalg.transpose ins(%6 : tensor<16x256x64x32xf32>) outs(%7 : tensor<16x64x32x256xf32>) permutation = [0, 2, 3, 1]
-  // LINALG-CHECK:      %8 = hal.tensor.alias wait(%arg3) => %transposed_1 : tensor<16x64x32x256xf32> to %arg0 : !hal.buffer_view
-  // LINALG-CHECK:      %9 = hal.tensor.barrier join(%8 : tensor<16x64x32x256xf32>) => %arg4 : !hal.fence
-  // LINALG-CHECK:      util.return
-  // LINALG-CHECK:    }
+  // LINALG-CHECK:    util.func public @main$async(%[[ARG0:.+]]: !hal.buffer_view, %[[ARG1:.+]]: !hal.buffer_view, %[[ARG2:.+]]: !hal.buffer_view, {{.+}}
+  // LINALG-CHECK:      %[[BUF1:.+]] = hal.tensor.import wait(%{{.+}}) => %[[ARG1]] : !hal.buffer_view -> tensor<16x64x32x128xf32>
+  // LINALG-CHECK:      %[[BUF2:.+]] = hal.tensor.import wait(%{{.+}}) => %[[ARG2]] : !hal.buffer_view -> tensor<256x1x1x128xf32>
+  // LINALG-CHECK:      %[[BUF1T:.+]] = linalg.transpose ins(%[[BUF1]] : tensor<16x64x32x128xf32>) outs(%{{.+}} : tensor<16x128x64x32xf32>) permutation = [0, 3, 1, 2]
+  // LINALG-CHECK:      %[[BUF2T:.+]] = linalg.transpose ins(%[[BUF2]] : tensor<256x1x1x128xf32>) outs(%{{.+}} : tensor<256x128x1x1xf32>) permutation = [0, 3, 1, 2]
+  // LINALG-CHECK:      %[[OUT:.+]] = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%[[BUF1T]], %[[BUF2T]] : tensor<16x128x64x32xf32>, tensor<256x128x1x1xf32>) outs(%{{.+}} : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
+  // LINALG-CHECK:      %[[OUTT:.+]] = linalg.transpose ins(%[[OUT]] : tensor<16x256x64x32xf32>) outs(%{{.+}} : tensor<16x64x32x256xf32>) permutation = [0, 2, 3, 1]
+  // LINALG-CHECK:      %{{.+}} = hal.tensor.alias wait(%{{.+}}) => %[[OUTT]] : tensor<16x64x32x256xf32> to %[[ARG0]] : !hal.buffer_view
   //
   // clang-format on
 

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_krsc_with_pad.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_krsc_with_pad.cpp
@@ -84,27 +84,15 @@ int main() {
   // TORCH-CHECK:     }
   // TORCH-CHECK:   }
   //
-  // LINALG-CHECK:     util.func public @main$async(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view, %arg3: !hal.fence, %arg4: !hal.fence) attributes {inlining_policy = #util.inline.never, iree.abi.model = "coarse-fences", iree.abi.stub} {
-  // LINALG-CHECK:       %cst = arith.constant 0.000000e+00 : f32
-  // LINALG-CHECK:       %0 = hal.tensor.import wait(%arg3) => %arg1 : !hal.buffer_view -> tensor<16x64x32x128xf32>
-  // LINALG-CHECK:       %1 = hal.tensor.import wait(%arg3) => %arg2 : !hal.buffer_view -> tensor<256x3x3x128xf32>
-  // LINALG-CHECK:       %2 = tensor.empty() : tensor<16x128x64x32xf32>
-  // LINALG-CHECK:       %transposed = linalg.transpose ins(%0 : tensor<16x64x32x128xf32>) outs(%2 : tensor<16x128x64x32xf32>) permutation = [0, 3, 1, 2]
-  // LINALG-CHECK:       %3 = tensor.empty() : tensor<256x128x3x3xf32>
-  // LINALG-CHECK:       %transposed_0 = linalg.transpose ins(%1 : tensor<256x3x3x128xf32>) outs(%3 : tensor<256x128x3x3xf32>) permutation = [0, 3, 1, 2]
-  // LINALG-CHECK:       %padded = tensor.pad %transposed low[0, 0, 1, 1] high[0, 0, 1, 1] {
-  // LINALG-CHECK:       ^bb0(%arg5: index, %arg6: index, %arg7: index, %arg8: index):
-  // LINALG-CHECK:         tensor.yield %cst : f32
-  // LINALG-CHECK:       } : tensor<16x128x64x32xf32> to tensor<16x128x66x34xf32>
-  // LINALG-CHECK:       %4 = tensor.empty() : tensor<16x256x64x32xf32>
-  // LINALG-CHECK:       %5 = linalg.fill ins(%cst : f32) outs(%4 : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
-  // LINALG-CHECK:       %6 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded, %transposed_0 : tensor<16x128x66x34xf32>, tensor<256x128x3x3xf32>) outs(%5 : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
-  // LINALG-CHECK:       %7 = tensor.empty() : tensor<16x64x32x256xf32>
-  // LINALG-CHECK:       %transposed_1 = linalg.transpose ins(%6 : tensor<16x256x64x32xf32>) outs(%7 : tensor<16x64x32x256xf32>) permutation = [0, 2, 3, 1]
-  // LINALG-CHECK:       %8 = hal.tensor.alias wait(%arg3) => %transposed_1 : tensor<16x64x32x256xf32> to %arg0 : !hal.buffer_view
-  // LINALG-CHECK:       %9 = hal.tensor.barrier join(%8 : tensor<16x64x32x256xf32>) => %arg4 : !hal.fence
-  // LINALG-CHECK:       util.return
-  // LINALG-CHECK:     }
+  // LINALG-CHECK:     util.func public @main$async(%[[ARG0:.+]]: !hal.buffer_view, %[[ARG1:.+]]: !hal.buffer_view, %[[ARG2:.+]]: !hal.buffer_view, {{.+}}
+  // LINALG-CHECK:       %[[BUF1:.+]] = hal.tensor.import wait(%{{.+}}) => %arg1 : !hal.buffer_view -> tensor<16x64x32x128xf32>
+  // LINALG-CHECK:       %[[BUF2:.+]] = hal.tensor.import wait(%{{.+}}) => %arg2 : !hal.buffer_view -> tensor<256x3x3x128xf32>
+  // LINALG-CHECK:       %[[BUF1T:.+]] = linalg.transpose ins(%[[BUF1]] : tensor<16x64x32x128xf32>) outs(%{{.+}} : tensor<16x128x64x32xf32>) permutation = [0, 3, 1, 2]
+  // LINALG-CHECK:       %[[BUF2T:.+]] = linalg.transpose ins(%[[BUF2]] : tensor<256x3x3x128xf32>) outs(%{{.+}} : tensor<256x128x3x3xf32>) permutation = [0, 3, 1, 2]
+  // LINALG-CHECK:       %[[BUF1TP:.+]] = tensor.pad %[[BUF1T]] low[0, 0, 1, 1] high[0, 0, 1, 1] {
+  // LINALG-CHECK:       %[[OUT:.+]] = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%[[BUF1TP]], %[[BUF2T]] : tensor<16x128x66x34xf32>, tensor<256x128x3x3xf32>) outs(%{{.+}} : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
+  // LINALG-CHECK:       %[[OUTT:.+]] = linalg.transpose ins(%[[OUT]] : tensor<16x256x64x32xf32>) outs(%{{.+}} : tensor<16x64x32x256xf32>) permutation = [0, 2, 3, 1]
+  // LINALG-CHECK:       %{{.+}} = hal.tensor.alias wait(%{{.+}}) => %[[OUTT]] : tensor<16x64x32x256xf32> to %[[ARG0]] : !hal.buffer_view
   //
   // clang-format on
 

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_krsc_with_pad.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_krsc_with_pad.cpp
@@ -18,9 +18,9 @@
 using namespace fusilli;
 
 int main() {
-  int64_t n = 16, c = 128, h = 64, w = 32, k = 256, r = 1, s = 1;
+  int64_t n = 16, c = 128, h = 64, w = 32, k = 256, r = 3, s = 3;
   auto graph = std::make_shared<Graph>();
-  graph->setName("conv_asm_emitter_x_nhwc_w_krsc");
+  graph->setName("conv_asm_emitter_x_nhwc_w_krsc_with_pad");
   graph->setIODataType(DataType::Float).setComputeDataType(DataType::Float);
 
   auto X = graph->tensor(TensorAttr()
@@ -34,7 +34,7 @@ int main() {
                              .setStride({c * r * s, 1, c * s, c})); // KRSC
 
   auto conv_attr = ConvFPropAttr()
-                       .setPadding({0, 0})
+                       .setPadding({1, 1})
                        .setStride({1, 1})
                        .setDilation({1, 1})
                        .setName("conv_fprop");
@@ -46,7 +46,7 @@ int main() {
   // clang-format off
   //
   // TORCH-CHECK:   module @module {
-  // TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,64,32,256],f32>, %arg0_image: !torch.vtensor<[16,64,32,128],f32>, %arg1_filter: !torch.vtensor<[256,1,1,128],f32>) attributes {torch.assume_strict_symbolic_shapes} {
+  // TORCH-CHECK:     func.func @main(%result_: !torch.tensor<[16,64,32,256],f32>, %arg0_image: !torch.vtensor<[16,64,32,128],f32>, %arg1_filter: !torch.vtensor<[256,3,3,128],f32>) attributes {torch.assume_strict_symbolic_shapes} {
   // TORCH-CHECK:       %bias_conv_fprop = torch.constant.none
   // TORCH-CHECK:       %transposed_conv_fprop = torch.constant.bool false
   // TORCH-CHECK:       %output_padding_conv_fprop = torch.prim.ListConstruct  : () -> !torch.list<int>
@@ -54,8 +54,8 @@ int main() {
   // TORCH-CHECK:       %stride_val_0_conv_fprop = torch.constant.int 1
   // TORCH-CHECK:       %stride_val_1_conv_fprop = torch.constant.int 1
   // TORCH-CHECK:       %stride_conv_fprop = torch.prim.ListConstruct %stride_val_0_conv_fprop, %stride_val_1_conv_fprop : (!torch.int, !torch.int) -> !torch.list<int>
-  // TORCH-CHECK:       %padding_val_0_conv_fprop = torch.constant.int 0
-  // TORCH-CHECK:       %padding_val_1_conv_fprop = torch.constant.int 0
+  // TORCH-CHECK:       %padding_val_0_conv_fprop = torch.constant.int 1
+  // TORCH-CHECK:       %padding_val_1_conv_fprop = torch.constant.int 1
   // TORCH-CHECK:       %padding_conv_fprop = torch.prim.ListConstruct %padding_val_0_conv_fprop, %padding_val_1_conv_fprop : (!torch.int, !torch.int) -> !torch.list<int>
   // TORCH-CHECK:       %dilation_val_0_conv_fprop = torch.constant.int 1
   // TORCH-CHECK:       %dilation_val_1_conv_fprop = torch.constant.int 1
@@ -71,8 +71,8 @@ int main() {
   // TORCH-CHECK:       %permute_W_val_2_conv_fprop = torch.constant.int 1
   // TORCH-CHECK:       %permute_W_val_3_conv_fprop = torch.constant.int 2
   // TORCH-CHECK:       %permute_W_conv_fprop = torch.prim.ListConstruct %permute_W_val_0_conv_fprop, %permute_W_val_1_conv_fprop, %permute_W_val_2_conv_fprop, %permute_W_val_3_conv_fprop : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
-  // TORCH-CHECK:       %arg1_filter_perm = torch.aten.permute %arg1_filter, %permute_W_conv_fprop : !torch.vtensor<[256,1,1,128],f32>, !torch.list<int> -> !torch.vtensor<[256,128,1,1],f32>
-  // TORCH-CHECK:       %result_perm = torch.aten.convolution %arg0_image_perm, %arg1_filter_perm, %bias_conv_fprop, %stride_conv_fprop, %padding_conv_fprop, %dilation_conv_fprop, %transposed_conv_fprop, %output_padding_conv_fprop, %groups_conv_fprop : !torch.vtensor<[16,128,64,32],f32>, !torch.vtensor<[256,128,1,1],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.list<int>, !torch.int -> !torch.vtensor<[16,256,64,32],f32>
+  // TORCH-CHECK:       %arg1_filter_perm = torch.aten.permute %arg1_filter, %permute_W_conv_fprop : !torch.vtensor<[256,3,3,128],f32>, !torch.list<int> -> !torch.vtensor<[256,128,3,3],f32>
+  // TORCH-CHECK:       %result_perm = torch.aten.convolution %arg0_image_perm, %arg1_filter_perm, %bias_conv_fprop, %stride_conv_fprop, %padding_conv_fprop, %dilation_conv_fprop, %transposed_conv_fprop, %output_padding_conv_fprop, %groups_conv_fprop : !torch.vtensor<[16,128,64,32],f32>, !torch.vtensor<[256,128,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.bool, !torch.list<int>, !torch.int -> !torch.vtensor<[16,256,64,32],f32>
   // TORCH-CHECK:       %permute_Y_val_0_conv_fprop = torch.constant.int 0
   // TORCH-CHECK:       %permute_Y_val_1_conv_fprop = torch.constant.int 2
   // TORCH-CHECK:       %permute_Y_val_2_conv_fprop = torch.constant.int 3
@@ -84,23 +84,27 @@ int main() {
   // TORCH-CHECK:     }
   // TORCH-CHECK:   }
   //
-  // LINALG-CHECK:    util.func public @main$async(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view, %arg3: !hal.fence, %arg4: !hal.fence) attributes {inlining_policy = #util.inline.never, iree.abi.model = "coarse-fences", iree.abi.stub} {
-  // LINALG-CHECK:      %cst = arith.constant 0.000000e+00 : f32
-  // LINALG-CHECK:      %0 = hal.tensor.import wait(%arg3) => %arg1 : !hal.buffer_view -> tensor<16x64x32x128xf32>
-  // LINALG-CHECK:      %1 = hal.tensor.import wait(%arg3) => %arg2 : !hal.buffer_view -> tensor<256x1x1x128xf32>
-  // LINALG-CHECK:      %2 = tensor.empty() : tensor<16x128x64x32xf32>
-  // LINALG-CHECK:      %transposed = linalg.transpose ins(%0 : tensor<16x64x32x128xf32>) outs(%2 : tensor<16x128x64x32xf32>) permutation = [0, 3, 1, 2]
-  // LINALG-CHECK:      %3 = tensor.empty() : tensor<256x128x1x1xf32>
-  // LINALG-CHECK:      %transposed_0 = linalg.transpose ins(%1 : tensor<256x1x1x128xf32>) outs(%3 : tensor<256x128x1x1xf32>) permutation = [0, 3, 1, 2]
-  // LINALG-CHECK:      %4 = tensor.empty() : tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %5 = linalg.fill ins(%cst : f32) outs(%4 : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %6 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%transposed, %transposed_0 : tensor<16x128x64x32xf32>, tensor<256x128x1x1xf32>) outs(%5 : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
-  // LINALG-CHECK:      %7 = tensor.empty() : tensor<16x64x32x256xf32>
-  // LINALG-CHECK:      %transposed_1 = linalg.transpose ins(%6 : tensor<16x256x64x32xf32>) outs(%7 : tensor<16x64x32x256xf32>) permutation = [0, 2, 3, 1]
-  // LINALG-CHECK:      %8 = hal.tensor.alias wait(%arg3) => %transposed_1 : tensor<16x64x32x256xf32> to %arg0 : !hal.buffer_view
-  // LINALG-CHECK:      %9 = hal.tensor.barrier join(%8 : tensor<16x64x32x256xf32>) => %arg4 : !hal.fence
-  // LINALG-CHECK:      util.return
-  // LINALG-CHECK:    }
+  // LINALG-CHECK:     util.func public @main$async(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view, %arg3: !hal.fence, %arg4: !hal.fence) attributes {inlining_policy = #util.inline.never, iree.abi.model = "coarse-fences", iree.abi.stub} {
+  // LINALG-CHECK:       %cst = arith.constant 0.000000e+00 : f32
+  // LINALG-CHECK:       %0 = hal.tensor.import wait(%arg3) => %arg1 : !hal.buffer_view -> tensor<16x64x32x128xf32>
+  // LINALG-CHECK:       %1 = hal.tensor.import wait(%arg3) => %arg2 : !hal.buffer_view -> tensor<256x3x3x128xf32>
+  // LINALG-CHECK:       %2 = tensor.empty() : tensor<16x128x64x32xf32>
+  // LINALG-CHECK:       %transposed = linalg.transpose ins(%0 : tensor<16x64x32x128xf32>) outs(%2 : tensor<16x128x64x32xf32>) permutation = [0, 3, 1, 2]
+  // LINALG-CHECK:       %3 = tensor.empty() : tensor<256x128x3x3xf32>
+  // LINALG-CHECK:       %transposed_0 = linalg.transpose ins(%1 : tensor<256x3x3x128xf32>) outs(%3 : tensor<256x128x3x3xf32>) permutation = [0, 3, 1, 2]
+  // LINALG-CHECK:       %padded = tensor.pad %transposed low[0, 0, 1, 1] high[0, 0, 1, 1] {
+  // LINALG-CHECK:       ^bb0(%arg5: index, %arg6: index, %arg7: index, %arg8: index):
+  // LINALG-CHECK:         tensor.yield %cst : f32
+  // LINALG-CHECK:       } : tensor<16x128x64x32xf32> to tensor<16x128x66x34xf32>
+  // LINALG-CHECK:       %4 = tensor.empty() : tensor<16x256x64x32xf32>
+  // LINALG-CHECK:       %5 = linalg.fill ins(%cst : f32) outs(%4 : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
+  // LINALG-CHECK:       %6 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%padded, %transposed_0 : tensor<16x128x66x34xf32>, tensor<256x128x3x3xf32>) outs(%5 : tensor<16x256x64x32xf32>) -> tensor<16x256x64x32xf32>
+  // LINALG-CHECK:       %7 = tensor.empty() : tensor<16x64x32x256xf32>
+  // LINALG-CHECK:       %transposed_1 = linalg.transpose ins(%6 : tensor<16x256x64x32xf32>) outs(%7 : tensor<16x64x32x256xf32>) permutation = [0, 2, 3, 1]
+  // LINALG-CHECK:       %8 = hal.tensor.alias wait(%arg3) => %transposed_1 : tensor<16x64x32x256xf32> to %arg0 : !hal.buffer_view
+  // LINALG-CHECK:       %9 = hal.tensor.barrier join(%8 : tensor<16x64x32x256xf32>) => %arg4 : !hal.fence
+  // LINALG-CHECK:       util.return
+  // LINALG-CHECK:     }
   //
   // clang-format on
 


### PR DESCRIPTION
This includes the problematic case of `T -> Pad -> Conv -> T` which iree-compile doesn't optimize well today. Will update the lit test once the compiler pass is available. 

Also removes unnecessary checks from linalg input IR to make them less fragile. Eventually we'll want to clean them up further and possibly relocate to the IREE repo.