### PR TITLE
[Fusilli] Fix release builds and refactor cmake flags

### DIFF
--- a/.github/workflows/ci-fusilli-plugin.yml
+++ b/.github/workflows/ci-fusilli-plugin.yml
@@ -54,6 +54,7 @@ jobs:
             fusilli-plugin-cmake-options:
               -DCMAKE_C_COMPILER=clang-18
               -DCMAKE_CXX_COMPILER=clang++-18
+              -DCMAKE_BUILD_TYPE=Debug
               -DFUSILLI_SYSTEMS_AMDGPU=ON
 
     steps:

--- a/.github/workflows/ci-sharkfuser.yml
+++ b/.github/workflows/ci-sharkfuser.yml
@@ -53,31 +53,29 @@ jobs:
             cmake-options:
               -DCMAKE_C_COMPILER=clang-18
               -DCMAKE_CXX_COMPILER=clang++-18
-              -DFUSILLI_DEBUG_BUILD=OFF
-              -DFUSILLI_CODE_COVERAGE=OFF
+              -DCMAKE_BUILD_TYPE=Release
               -DFUSILLI_SYSTEMS_AMDGPU=ON
           - name: cpu_clang18_debug
             runs-on: azure-cpubuilder-linux-scale
             cmake-options:
               -DCMAKE_C_COMPILER=clang-18
               -DCMAKE_CXX_COMPILER=clang++-18
-              -DFUSILLI_DEBUG_BUILD=ON
-              -DFUSILLI_CODE_COVERAGE=OFF
+              -DCMAKE_BUILD_TYPE=Debug
+              -DFUSILLI_ENABLE_LOGGING=ON
               -DFUSILLI_SYSTEMS_AMDGPU=OFF
           - name: gfx942_clang18_debug
             runs-on: linux-mi325-2gpu-ossci-nod-ai
             cmake-options:
               -DCMAKE_C_COMPILER=clang-18
               -DCMAKE_CXX_COMPILER=clang++-18
-              -DFUSILLI_DEBUG_BUILD=ON
-              -DFUSILLI_CODE_COVERAGE=OFF
+              -DCMAKE_BUILD_TYPE=Debug
+              -DFUSILLI_ENABLE_LOGGING=ON
               -DFUSILLI_SYSTEMS_AMDGPU=ON
           - name: cpu_gcc13_codecov
             runs-on: azure-cpubuilder-linux-scale
             cmake-options:
               -DCMAKE_C_COMPILER=gcc-13
               -DCMAKE_CXX_COMPILER=g++-13
-              -DFUSILLI_DEBUG_BUILD=OFF
               -DFUSILLI_CODE_COVERAGE=ON
               -DFUSILLI_SYSTEMS_AMDGPU=OFF
 

--- a/sharkfuser/CMakeLists.txt
+++ b/sharkfuser/CMakeLists.txt
@@ -101,11 +101,15 @@ target_link_libraries(libfusilli INTERFACE iree_runtime_unified)
 
 # Build options
 option(FUSILLI_BUILD_TESTS "Builds C++ tests and samples" ON)
-option(FUSILLI_DEBUG_BUILD "Enable debug build options" OFF)
 option(FUSILLI_CODE_COVERAGE "Enable code coverage for tests" OFF)
+option(FUSILLI_ENABLE_LOGGING "Enable logging for tests and samples" OFF)
 
-# Debug build
-if(FUSILLI_DEBUG_BUILD OR FUSILLI_CODE_COVERAGE)
+# Build Type - Release/Debug
+if(NOT CMAKE_BUILD_TYPE)
+  message(STATUS "Setting CMAKE_BUILD_TYPE to Release")
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Release build" FORCE)
+endif()
+if(FUSILLI_CODE_COVERAGE)
   message(STATUS "Setting CMAKE_BUILD_TYPE to Debug")
   set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Debug build" FORCE)
 endif()

--- a/sharkfuser/README.md
+++ b/sharkfuser/README.md
@@ -24,14 +24,14 @@ Fusilli interfaces with the IREE compiler through the CLI and with IREE runtime 
 
 Easiest way to get [`lit`](https://llvm.org/docs/CommandGuide/lit.html), [`filecheck`](https://github.com/AntonLydike/filecheck) and the `iree-*` CLI tools is through `pip install`. Everything else should be available via `apt` based install.
 
-### Build and Test (debug build)
+### Build and Test
 
 Build and test Fusilli as follows:
 ```shell
 cmake -GNinja -S. -Bbuild \
     -DCMAKE_C_COMPILER=clang \
     -DCMAKE_CXX_COMPILER=clang++ \
-    -DFUSILLI_DEBUG_BUILD=ON \
+    -DCMAKE_BUILD_TYPE=<Debug|Release|RelWithDebInfo> \
     -DIREERuntime_DIR=</path/to/iree/build/lib/cmake/IREE>
 cmake --build build --target all
 ctest --test-dir build
@@ -97,7 +97,7 @@ To configure logging behavior using environment variables:
 | `FUSILLI_LOG_FILE` set to `stdout` or `stderr`  | no logging             | logging to cout / cerr
 | `FUSILLI_LOG_FILE` set to `/path/to/file.txt`   | no logging             | logging to file.txt
 
-Tests and samples that are built with the cmake flag `-DFUSILLI_DEBUG_BUILD=ON` have their env variables automatically configured for logging to cout.
+Tests and samples that are built with the cmake flag `-DFUSILLI_ENABLE_LOGGING=ON` have their env variables automatically configured for logging to cout.
 
 Alternatively, one may call the logging API directly as needed:
 - Calling `fusilli::isLoggingEnabled() = <true|false>` has the same effect as setting `FUSILLI_LOG_INFO = 1|0`.

--- a/sharkfuser/build_tools/cmake/FusilliTestUtils.cmake
+++ b/sharkfuser/build_tools/cmake/FusilliTestUtils.cmake
@@ -177,7 +177,7 @@ function(_add_fusilli_ctest_target)
   add_test(NAME ${_RULE_NAME} COMMAND ${_RULE_NAME})
 
   # Set logging environment variables
-  if(FUSILLI_DEBUG_BUILD)
+  if(FUSILLI_ENABLE_LOGGING)
     set_tests_properties(
       ${_RULE_NAME} PROPERTIES
       ENVIRONMENT "FUSILLI_LOG_INFO=1;FUSILLI_LOG_FILE=stdout"

--- a/sharkfuser/include/fusilli/attributes/tensor_attributes.h
+++ b/sharkfuser/include/fusilli/attributes/tensor_attributes.h
@@ -99,6 +99,7 @@
 #include "fusilli/graph/context.h"
 #include "fusilli/support/logging.h"
 
+#include <cassert>
 #include <cstdint>
 #include <memory>
 #include <numeric>

--- a/sharkfuser/include/fusilli/graph/graph.h
+++ b/sharkfuser/include/fusilli/graph/graph.h
@@ -26,7 +26,6 @@
 #include "fusilli/support/extras.h"
 #include "fusilli/support/logging.h"
 
-#include <cassert>
 #include <cstdlib>
 #include <filesystem>
 #include <memory>

--- a/sharkfuser/samples/convolution/conv_fprop_nchw_kcrs.cpp
+++ b/sharkfuser/samples/convolution/conv_fprop_nchw_kcrs.cpp
@@ -12,6 +12,8 @@
 #include <cstdint>
 #include <memory>
 #include <tuple>
+#include <unordered_map>
+#include <vector>
 
 using namespace fusilli;
 

--- a/sharkfuser/samples/convolution/conv_fprop_nhwc_krsc.cpp
+++ b/sharkfuser/samples/convolution/conv_fprop_nhwc_krsc.cpp
@@ -12,6 +12,8 @@
 #include <cstdint>
 #include <memory>
 #include <tuple>
+#include <unordered_map>
+#include <vector>
 
 using namespace fusilli;
 

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_kcrs.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_kcrs.cpp
@@ -11,13 +11,12 @@
 
 #include <fusilli.h>
 
-#include <cassert>
 #include <iostream>
 #include <memory>
 
 using namespace fusilli;
 
-int main() {
+ErrorObject test_conv_asm_emitter_x_nchw_w_kcrs() {
   int64_t n = 16, c = 128, h = 64, w = 32, k = 256, r = 1, s = 1;
   auto graph = std::make_shared<Graph>();
   graph->setName("conv_asm_emitter_x_nchw_w_kcrs");
@@ -92,10 +91,17 @@ int main() {
   //
   // clang-format on
 
-  assert(isOk(graph->validate()) && "Graph is invalid");
-  ErrorOr<std::string> errorOrAsm = graph->emitAsm();
-  assert(isOk(errorOrAsm) && "Graph ASM emission failed");
-  std::cout << *errorOrAsm << std::endl;
+  FUSILLI_CHECK_ERROR(graph->validate());
+  std::cout << FUSILLI_TRY(graph->emitAsm()) << std::endl;
 
+  return ok();
+}
+
+int main() {
+  auto status = test_conv_asm_emitter_x_nchw_w_kcrs();
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
   return 0;
 }

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_kcrs_with_pad.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_kcrs_with_pad.cpp
@@ -11,13 +11,12 @@
 
 #include <fusilli.h>
 
-#include <cassert>
 #include <iostream>
 #include <memory>
 
 using namespace fusilli;
 
-int main() {
+ErrorObject test_conv_asm_emitter_x_nchw_w_kcrs_with_pad() {
   int64_t n = 16, c = 128, h = 64, w = 32, k = 256, r = 3, s = 3;
   auto graph = std::make_shared<Graph>();
   graph->setName("conv_asm_emitter_x_nchw_w_kcrs_with_pad");
@@ -93,10 +92,17 @@ int main() {
   //
   // clang-format on
 
-  assert(isOk(graph->validate()) && "Graph is invalid");
-  ErrorOr<std::string> errorOrAsm = graph->emitAsm();
-  assert(isOk(errorOrAsm) && "Graph ASM emission failed");
-  std::cout << *errorOrAsm << std::endl;
+  FUSILLI_CHECK_ERROR(graph->validate());
+  std::cout << FUSILLI_TRY(graph->emitAsm()) << std::endl;
 
+  return ok();
+}
+
+int main() {
+  auto status = test_conv_asm_emitter_x_nchw_w_kcrs_with_pad();
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
   return 0;
 }

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_krsc.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_krsc.cpp
@@ -11,13 +11,12 @@
 
 #include <fusilli.h>
 
-#include <cassert>
 #include <iostream>
 #include <memory>
 
 using namespace fusilli;
 
-int main() {
+ErrorObject test_conv_asm_emitter_x_nchw_w_krsc() {
   int64_t n = 16, c = 128, h = 64, w = 32, k = 256, r = 1, s = 1;
   auto graph = std::make_shared<Graph>();
   graph->setName("conv_asm_emitter_x_nchw_w_krsc");
@@ -93,10 +92,17 @@ int main() {
   //
   // clang-format on
 
-  assert(isOk(graph->validate()) && "Graph is invalid");
-  ErrorOr<std::string> errorOrAsm = graph->emitAsm();
-  assert(isOk(errorOrAsm) && "Graph ASM emission failed");
-  std::cout << *errorOrAsm << std::endl;
+  FUSILLI_CHECK_ERROR(graph->validate());
+  std::cout << FUSILLI_TRY(graph->emitAsm()) << std::endl;
 
+  return ok();
+}
+
+int main() {
+  auto status = test_conv_asm_emitter_x_nchw_w_krsc();
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
   return 0;
 }

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_kcrs.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_kcrs.cpp
@@ -11,13 +11,12 @@
 
 #include <fusilli.h>
 
-#include <cassert>
 #include <iostream>
 #include <memory>
 
 using namespace fusilli;
 
-int main() {
+ErrorObject test_conv_asm_emitter_x_nhwc_w_kcrs() {
   int64_t n = 16, c = 128, h = 64, w = 32, k = 256, r = 1, s = 1;
   auto graph = std::make_shared<Graph>();
   graph->setName("conv_asm_emitter_x_nhwc_w_kcrs");
@@ -94,10 +93,17 @@ int main() {
   //
   // clang-format on
 
-  assert(isOk(graph->validate()) && "Graph is invalid");
-  ErrorOr<std::string> errorOrAsm = graph->emitAsm();
-  assert(isOk(errorOrAsm) && "Graph ASM emission failed");
-  std::cout << *errorOrAsm << std::endl;
+  FUSILLI_CHECK_ERROR(graph->validate());
+  std::cout << FUSILLI_TRY(graph->emitAsm()) << std::endl;
 
+  return ok();
+}
+
+int main() {
+  auto status = test_conv_asm_emitter_x_nhwc_w_kcrs();
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
   return 0;
 }

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_krsc.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_krsc.cpp
@@ -11,13 +11,12 @@
 
 #include <fusilli.h>
 
-#include <cassert>
 #include <iostream>
 #include <memory>
 
 using namespace fusilli;
 
-int main() {
+ErrorObject test_conv_asm_emitter_x_nhwc_w_krsc() {
   int64_t n = 16, c = 128, h = 64, w = 32, k = 256, r = 1, s = 1;
   auto graph = std::make_shared<Graph>();
   graph->setName("conv_asm_emitter_x_nhwc_w_krsc");
@@ -95,10 +94,17 @@ int main() {
   //
   // clang-format on
 
-  assert(isOk(graph->validate()) && "Graph is invalid");
-  ErrorOr<std::string> errorOrAsm = graph->emitAsm();
-  assert(isOk(errorOrAsm) && "Graph ASM emission failed");
-  std::cout << *errorOrAsm << std::endl;
+  FUSILLI_CHECK_ERROR(graph->validate());
+  std::cout << FUSILLI_TRY(graph->emitAsm()) << std::endl;
 
+  return ok();
+}
+
+int main() {
+  auto status = test_conv_asm_emitter_x_nhwc_w_krsc();
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
   return 0;
 }

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_krsc_with_pad.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_krsc_with_pad.cpp
@@ -11,13 +11,12 @@
 
 #include <fusilli.h>
 
-#include <cassert>
 #include <iostream>
 #include <memory>
 
 using namespace fusilli;
 
-int main() {
+ErrorObject test_conv_asm_emitter_x_nhwc_w_krsc_with_pad() {
   int64_t n = 16, c = 128, h = 64, w = 32, k = 256, r = 3, s = 3;
   auto graph = std::make_shared<Graph>();
   graph->setName("conv_asm_emitter_x_nhwc_w_krsc_with_pad");
@@ -96,10 +95,17 @@ int main() {
   //
   // clang-format on
 
-  assert(isOk(graph->validate()) && "Graph is invalid");
-  ErrorOr<std::string> errorOrAsm = graph->emitAsm();
-  assert(isOk(errorOrAsm) && "Graph ASM emission failed");
-  std::cout << *errorOrAsm << std::endl;
+  FUSILLI_CHECK_ERROR(graph->validate());
+  std::cout << FUSILLI_TRY(graph->emitAsm()) << std::endl;
 
+  return ok();
+}
+
+int main() {
+  auto status = test_conv_asm_emitter_x_nhwc_w_krsc_with_pad();
+  if (isError(status)) {
+    std::cerr << "Test failed: " << status << std::endl;
+    return 1;
+  }
   return 0;
 }


### PR DESCRIPTION
There is a bug in this code which caused the release builds to never be exercised before:
```cmake
if(FUSILLI_DEBUG_BUILD OR FUSILLI_CODE_COVERAGE)
  message(STATUS "Setting CMAKE_BUILD_TYPE to Debug")
  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Debug build" FORCE)
endif()
```

When `-DFUSILLI_DEBUG_BUILD=OFF` (and `-DFUSILLI_CODE_COVERAGE=OFF`), the `CMAKE_BUILD_TYPE` is left unset. If not, it is set to `Debug`. So it is never being set to `Release`.

We probably want something like this:

```cmake
if(NOT CMAKE_BUILD_TYPE)
  message(STATUS "Setting CMAKE_BUILD_TYPE to Release")
  set(CMAKE_BUILD_TYPE Release CACHE STRING "Release build" FORCE)
endif()
if(FUSILLI_CODE_COVERAGE)
  message(STATUS "Setting CMAKE_BUILD_TYPE to Debug")
  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Debug build" FORCE)
endif()
```

With this fixed, it exposed a latent bug that made the lit test drivers to be unusable for release builds, because it did validate/emitAsm as part of the assert which are optimized away in release builds:
```c++
  assert(isOk(graph->validate()) && "Graph is invalid");
  ErrorOr<std::string> errorOrAsm = graph->emitAsm();
  assert(isOk(errorOrAsm) && "Graph ASM emission failed");
  std::cout << *errorOrAsm << std::endl;
```

This led to the following (somewhat cryptic) error:

```
13: /home/srajeshk/code/shark-ai/sharkfuser/build/bin/lit/test_conv_asm_emitter_nhwc_krsc_with_pad | iree-opt --verify-roundtrip
13: # executed command: /home/srajeshk/code/shark-ai/sharkfuser/build/bin/lit/test_conv_asm_emitter_nhwc_krsc_with_pad
13: # .---command stderr------------
13: # | terminate called after throwing an instance of 'std::bad_variant_access'
13: # |   what():  std::get: wrong index for variant
13: # `-----------------------------
13: # error: command failed with exit status: -6
13: # executed command: iree-opt --verify-roundtrip
13: # .---command stdout------------
13: # | module {
13: # | }
13: # | 
13: # `-----------------------------
```

This PR 
- fixes the lit drivers to use `FUSILLI_CHECK_ERROR` and `FUSILLI_TRY` macros instead of the raw asserts,
- removes the redundant `FUSILLI_DEBUG_BUILD ` flag
- adds a new `FUSILLI_ENABLE_LOGGING` flag to set the logging env vars for tests/samples automatically.