### PR TITLE
[Fusilli] Improve error reporting

### DIFF
--- a/sharkfuser/include/fusilli/support/logging.h
+++ b/sharkfuser/include/fusilli/support/logging.h
@@ -218,7 +218,7 @@ public:
 // access exception.
 #define ASSERT_HASVALUE()                                                      \
   do {                                                                         \
-    if (!hasValue()) {                                                         \
+    if (!hasValue()) [[unlikely]] { /*C++20*/                                  \
       std::cerr << ACCESSOR_ERROR_MSG << std::endl;                            \
       std::abort();                                                            \
     }                                                                          \

--- a/sharkfuser/include/fusilli/support/logging.h
+++ b/sharkfuser/include/fusilli/support/logging.h
@@ -211,18 +211,31 @@ public:
   "cannot be dereferenced. ErrorOr<T> state should be checked with "           \
   "isOk() or isError() utility methods before dereferencing."
 
+// Equivalent to `assert(hasValue() && ACCESSOR_ERROR_MSG);` but unlike the
+// assert, this will remain in release builds. If the underlying std::variant
+// doesn't contain a value the dereference call will always cause a crash, this
+// ensure's it's a crash with a reasonable error message rather than an variant
+// access exception.
+#define ASSERT_HASVALUE()                                                      \
+  do {                                                                         \
+    if (!hasValue()) {                                                         \
+      std::cerr << ACCESSOR_ERROR_MSG << std::endl;                            \
+      std::abort();                                                            \
+    }                                                                          \
+  } while (false)
+
   // Dereference operator - returns a reference to the contained value. The
   // ErrorOr must be in success state (checked via isOk()) before calling
   // accessor methods.
   T &operator*() {
-    assert(hasValue() && ACCESSOR_ERROR_MSG);
+    ASSERT_HASVALUE();
     return std::get<T>(storage_);
   }
 
   // Const dereference operator. The ErrorOr must be in success state (checked
   // via isOk()) before calling accessor methods.
   const T &operator*() const {
-    assert(hasValue() && ACCESSOR_ERROR_MSG);
+    ASSERT_HASVALUE();
     return std::get<T>(storage_);
   }
 
@@ -230,17 +243,18 @@ public:
   // ErrorOr must be in success state (checked via isOk()) before calling
   // accessor methods.
   T *operator->() {
-    assert(hasValue() && ACCESSOR_ERROR_MSG);
+    ASSERT_HASVALUE();
     return &std::get<T>(storage_);
   }
 
   // Const member access operator. The ErrorOr must be in success state (checked
   // via isOk()) before calling accessor methods.
   const T *operator->() const {
-    assert(hasValue() && ACCESSOR_ERROR_MSG);
+    ASSERT_HASVALUE();
     return &std::get<T>(storage_);
   }
 #undef ACCESSOR_ERROR_MSG
+#undef ASSERT_HASVALUE
 
 private:
   using Storage = std::variant<T, ErrorObject>;


### PR DESCRIPTION
In release builds the assert + error message on bad `ErrorOr<T>` access is compiled out, the reported error message is rather cryptic. 
```
/home/srajeshk/code/shark-ai/sharkfuser/build/bin/lit/test_conv_asm_emitter_nhwc_krsc_with_pad | iree-opt --verify-roundtrip
# executed command: /home/srajeshk/code/shark-ai/sharkfuser/build/bin/lit/test_conv_asm_emitter_nhwc_krsc_with_pad
# .---command stderr------------
# | terminate called after throwing an instance of 'std::bad_variant_access'
# |   what():  std::get: wrong index for variant
# `-----------------------------
# error: command failed with exit status: -6
# executed command: iree-opt --verify-roundtrip
# .---command stdout------------
# | module {
# | }
# | 
# `-----------------------------
```
This PR moves from assert for crash + error reporting to an if check, which will not be compiled out. The above error message becomes:
```
/home/astgeorg/Dev/python/shark-ai/sharkfuser/build/bin/lit/test_conv_asm_emitter_nhwc_kcrs | iree-opt --verify-roundtrip
# executed command: /home/astgeorg/Dev/python/shark-ai/sharkfuser/build/bin/lit/test_conv_asm_emitter_nhwc_kcrs
# .---command stderr------------
# | ErrorOr<T> is in error state (it holds an ErrorObject rather than T) and cannot be dereferenced. ErrorOr<T> state should be checked with isOk() or isError() utility methods before dereferencing.
# `-----------------------------
# error: command failed with exit status: -6
# executed command: iree-opt --verify-roundtrip
# .---command stdout------------
# | module {
# | }
# | 
# `-----------------------------
```