### PR TITLE
[Fusilli] Use range concept for TensorAttr::setPadding, etc.

### DIFF
--- a/sharkfuser/include/fusilli/attributes/conv_attributes.h
+++ b/sharkfuser/include/fusilli/attributes/conv_attributes.h
@@ -19,10 +19,19 @@
 
 #include <cstdint>
 #include <memory>
+#include <ranges>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
 namespace fusilli {
+
+// Concept that will accept any type that models a range (something with
+// .begin(), and .end()) with value type of int64_t.
+template <typename R>
+concept Int64Range =
+    std::ranges::forward_range<R> &&
+    std::is_same_v<std::ranges::range_value_t<R>, int64_t>; // C++ 20
 
 class ConvFPropAttr : public AttributesCRTP<ConvFPropAttr> {
 public:
@@ -38,18 +47,18 @@ public:
   FUSILLI_GENERIC_INPUT_TENSOR_SETTER(ConvFPropAttr, InputNames, W)
   FUSILLI_GENERIC_OUTPUT_TENSOR_SETTER(ConvFPropAttr, OutputNames, Y)
 
-  ConvFPropAttr &setPadding(const std::vector<int64_t> &padding) {
-    padding_ = padding;
+  ConvFPropAttr &setPadding(Int64Range auto &&padding) {
+    padding_.assign(padding.begin(), padding.end());
     return *this;
   }
 
-  ConvFPropAttr &setStride(const std::vector<int64_t> &stride) {
-    stride_ = stride;
+  ConvFPropAttr &setStride(Int64Range auto &&stride) {
+    stride_.assign(stride.begin(), stride.end());
     return *this;
   }
 
-  ConvFPropAttr &setDilation(const std::vector<int64_t> &dilation) {
-    dilation_ = dilation;
+  ConvFPropAttr &setDilation(Int64Range auto &&dilation) {
+    dilation_.assign(dilation.begin(), dilation.end());
     return *this;
   }
 

--- a/sharkfuser/samples/convolution/conv_fprop_nchw_kcrs.cpp
+++ b/sharkfuser/samples/convolution/conv_fprop_nchw_kcrs.cpp
@@ -37,9 +37,9 @@ TEST_CASE("Convolution fprop; X (NCHW), W (KCRS); 1x1 conv; no padding",
                                .setStride({c * r * s, r * s, s, 1})); // KCRS
 
     auto conv_attr = ConvFPropAttr()
-                         .setPadding({0, 0})
-                         .setStride({1, 1})
-                         .setDilation({1, 1})
+                         .setPadding(std::vector<int64_t>{0, 0})
+                         .setStride(std::vector<int64_t>{1, 1})
+                         .setDilation(std::vector<int64_t>{1, 1})
                          .setName("conv_fprop");
 
     auto Y = graph->convFProp(X, W, conv_attr);

--- a/sharkfuser/samples/convolution/conv_fprop_nhwc_krsc.cpp
+++ b/sharkfuser/samples/convolution/conv_fprop_nhwc_krsc.cpp
@@ -37,9 +37,9 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 1x1 conv; no padding",
                                .setStride({c * r * s, 1, c * s, c})); // KRSC
 
     auto conv_attr = ConvFPropAttr()
-                         .setPadding({0, 0})
-                         .setStride({1, 1})
-                         .setDilation({1, 1})
+                         .setPadding(std::vector<int64_t>{0, 0})
+                         .setStride(std::vector<int64_t>{1, 1})
+                         .setDilation(std::vector<int64_t>{1, 1})
                          .setName("conv_fprop");
 
     auto Y = graph->convFProp(X, W, conv_attr);
@@ -137,9 +137,9 @@ TEST_CASE("Convolution fprop; X (NHWC), W (KRSC); 3x3 conv; same padding",
                                .setStride({c * r * s, 1, c * s, c})); // KRSC
 
     auto conv_attr = ConvFPropAttr()
-                         .setPadding({1, 1})
-                         .setStride({1, 1})
-                         .setDilation({1, 1})
+                         .setPadding(std::vector<int64_t>{1, 1})
+                         .setStride(std::vector<int64_t>{1, 1})
+                         .setDilation(std::vector<int64_t>{1, 1})
                          .setName("conv_fprop");
 
     auto Y = graph->convFProp(X, W, conv_attr);

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_kcrs.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_kcrs.cpp
@@ -33,9 +33,9 @@ ErrorObject test_conv_asm_emitter_x_nchw_w_kcrs() {
                              .setStride({c * r * s, r * s, s, 1})); // KCRS
 
   auto conv_attr = ConvFPropAttr()
-                       .setPadding({0, 0})
-                       .setStride({1, 1})
-                       .setDilation({1, 1})
+                       .setPadding(std::vector<int64_t>{0, 0})
+                       .setStride(std::vector<int64_t>{1, 1})
+                       .setDilation(std::vector<int64_t>{1, 1})
                        .setName("conv_fprop");
 
   auto Y = graph->convFProp(X, W, conv_attr);

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_kcrs_with_pad.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_kcrs_with_pad.cpp
@@ -33,9 +33,9 @@ ErrorObject test_conv_asm_emitter_x_nchw_w_kcrs_with_pad() {
                              .setStride({c * r * s, r * s, s, 1})); // KCRS
 
   auto conv_attr = ConvFPropAttr()
-                       .setPadding({1, 1})
-                       .setStride({1, 1})
-                       .setDilation({1, 1})
+                       .setPadding(std::vector<int64_t>{1, 1})
+                       .setStride(std::vector<int64_t>{1, 1})
+                       .setDilation(std::vector<int64_t>{1, 1})
                        .setName("conv_fprop");
 
   auto Y = graph->convFProp(X, W, conv_attr);

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_krsc.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_krsc.cpp
@@ -33,9 +33,9 @@ ErrorObject test_conv_asm_emitter_x_nchw_w_krsc() {
                              .setStride({c * r * s, 1, c * s, c})); // KRSC
 
   auto conv_attr = ConvFPropAttr()
-                       .setPadding({0, 0})
-                       .setStride({1, 1})
-                       .setDilation({1, 1})
+                       .setPadding(std::vector<int64_t>{0, 0})
+                       .setStride(std::vector<int64_t>{1, 1})
+                       .setDilation(std::vector<int64_t>{1, 1})
                        .setName("conv_fprop");
 
   auto Y = graph->convFProp(X, W, conv_attr);

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_kcrs.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_kcrs.cpp
@@ -33,9 +33,9 @@ ErrorObject test_conv_asm_emitter_x_nhwc_w_kcrs() {
                              .setStride({c * r * s, r * s, s, 1})); // KCRS
 
   auto conv_attr = ConvFPropAttr()
-                       .setPadding({0, 0})
-                       .setStride({1, 1})
-                       .setDilation({1, 1})
+                       .setPadding(std::vector<int64_t>{0, 0})
+                       .setStride(std::vector<int64_t>{1, 1})
+                       .setDilation(std::vector<int64_t>{1, 1})
                        .setName("conv_fprop");
 
   auto Y = graph->convFProp(X, W, conv_attr);

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_krsc.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_krsc.cpp
@@ -33,9 +33,9 @@ ErrorObject test_conv_asm_emitter_x_nhwc_w_krsc() {
                              .setStride({c * r * s, 1, c * s, c})); // KRSC
 
   auto conv_attr = ConvFPropAttr()
-                       .setPadding({0, 0})
-                       .setStride({1, 1})
-                       .setDilation({1, 1})
+                       .setPadding(std::vector<int64_t>{0, 0})
+                       .setStride(std::vector<int64_t>{1, 1})
+                       .setDilation(std::vector<int64_t>{1, 1})
                        .setName("conv_fprop");
 
   auto Y = graph->convFProp(X, W, conv_attr);

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_krsc_with_pad.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_krsc_with_pad.cpp
@@ -33,9 +33,9 @@ ErrorObject test_conv_asm_emitter_x_nhwc_w_krsc_with_pad() {
                              .setStride({c * r * s, 1, c * s, c})); // KRSC
 
   auto conv_attr = ConvFPropAttr()
-                       .setPadding({1, 1})
-                       .setStride({1, 1})
-                       .setDilation({1, 1})
+                       .setPadding(std::vector<int64_t>{1, 1})
+                       .setStride(std::vector<int64_t>{1, 1})
+                       .setDilation(std::vector<int64_t>{1, 1})
                        .setName("conv_fprop");
 
   auto Y = graph->convFProp(X, W, conv_attr);

--- a/sharkfuser/tests/test_conv_node.cpp
+++ b/sharkfuser/tests/test_conv_node.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <cstdint>
 #include <fusilli.h>
 
 #include <catch2/catch_test_macros.hpp>
@@ -37,7 +38,7 @@ TEST_CASE("ConvFPropNode preValidateNode detects missing attributes",
   }
 
   SECTION("Stride missing") {
-    attr.setPadding({0, 0});
+    attr.setPadding(std::vector<int64_t>{0, 0});
     ConvFPropNode node(std::move(attr), ctx);
 
     auto status = node.preValidateNode();
@@ -47,7 +48,8 @@ TEST_CASE("ConvFPropNode preValidateNode detects missing attributes",
   }
 
   SECTION("Dilation missing") {
-    attr.setPadding({0, 0}).setStride({1, 1});
+    attr.setPadding(std::vector<int64_t>{0, 0})
+        .setStride(std::vector<int64_t>{1, 1});
     ConvFPropNode node(std::move(attr), ctx);
 
     auto status = node.preValidateNode();
@@ -57,7 +59,9 @@ TEST_CASE("ConvFPropNode preValidateNode detects missing attributes",
   }
 
   SECTION("Input missing") {
-    attr.setPadding({0, 0}).setStride({1, 1}).setDilation({1, 1});
+    attr.setPadding(std::vector<int64_t>{0, 0})
+        .setStride(std::vector<int64_t>{1, 1})
+        .setDilation(std::vector<int64_t>{1, 1});
     ConvFPropNode node(std::move(attr), ctx);
 
     auto status = node.preValidateNode();
@@ -67,7 +71,9 @@ TEST_CASE("ConvFPropNode preValidateNode detects missing attributes",
   }
 
   SECTION("Weight missing") {
-    attr.setPadding({0, 0}).setStride({1, 1}).setDilation({1, 1});
+    attr.setPadding(std::vector<int64_t>{0, 0})
+        .setStride(std::vector<int64_t>{1, 1})
+        .setDilation(std::vector<int64_t>{1, 1});
     attr.setX(std::make_shared<TensorAttr>(1.0f));
     ConvFPropNode node(std::move(attr), ctx);
 
@@ -78,7 +84,9 @@ TEST_CASE("ConvFPropNode preValidateNode detects missing attributes",
   }
 
   SECTION("All required attributes present") {
-    attr.setPadding({0, 0}).setStride({1, 1}).setDilation({1, 1});
+    attr.setPadding(std::vector<int64_t>{0, 0})
+        .setStride(std::vector<int64_t>{1, 1})
+        .setDilation(std::vector<int64_t>{1, 1});
     attr.setX(std::make_shared<TensorAttr>(1.0f));
     attr.setW(std::make_shared<TensorAttr>(2.0f));
     ConvFPropNode node(std::move(attr), ctx);
@@ -92,7 +100,9 @@ TEST_CASE("ConvFPropNode inferPropertiesNode (1D) when Y is fully specified",
   Context ctx;
   ConvFPropAttr attr;
 
-  attr.setPadding({0, 0}).setStride({1, 1}).setDilation({1, 1});
+  attr.setPadding(std::vector<int64_t>{0, 0})
+      .setStride(std::vector<int64_t>{1, 1})
+      .setDilation(std::vector<int64_t>{1, 1});
 
   attr.setX(std::make_shared<TensorAttr>(1.0f))
       .setW(std::make_shared<TensorAttr>(2.0f))
@@ -112,7 +122,9 @@ TEST_CASE("ConvFPropNode inferPropertiesNode (1D) when Y is under specified",
   Context ctx;
   ConvFPropAttr attr;
 
-  attr.setPadding({0, 0}).setStride({1, 1}).setDilation({1, 1});
+  attr.setPadding(std::vector<int64_t>{0, 0})
+      .setStride(std::vector<int64_t>{1, 1})
+      .setDilation(std::vector<int64_t>{1, 1});
 
   attr.setX(std::make_shared<TensorAttr>(1.0f))
       .setW(std::make_shared<TensorAttr>(2.0f))
@@ -134,7 +146,9 @@ TEST_CASE("ConvFPropNode inferPropertiesNode (4D) when Y is under specified",
 
   int64_t n = 16, c = 128, h = 64, w = 64, k = 256, r = 1, s = 1;
 
-  attr.setPadding({0, 0}).setStride({1, 1}).setDilation({1, 1});
+  attr.setPadding(std::vector<int64_t>{0, 0})
+      .setStride(std::vector<int64_t>{1, 1})
+      .setDilation(std::vector<int64_t>{1, 1});
 
   auto X = std::make_shared<TensorAttr>(
       TensorAttr().setDim({n, c, h, w}).setStride({c * h * w, h * w, w, 1}));
@@ -162,7 +176,9 @@ TEST_CASE("ConvFPropNode preValidate checks on input stride validity",
 
   int64_t n = 16, c = 128, h = 64, w = 64, k = 256, r = 1, s = 1;
 
-  attr.setPadding({0, 0}).setStride({1, 1}).setDilation({1, 1});
+  attr.setPadding(std::vector<int64_t>{0, 0})
+      .setStride(std::vector<int64_t>{1, 1})
+      .setDilation(std::vector<int64_t>{1, 1});
 
   auto X = std::make_shared<TensorAttr>(TensorAttr()
                                             .setDim({n, c, h, w})
@@ -193,7 +209,9 @@ TEST_CASE("ConvFPropNode postValidate checks on output stride validity",
 
   int64_t n = 16, c = 128, h = 64, w = 64, k = 256, r = 1, s = 1;
 
-  attr.setPadding({0, 0}).setStride({1, 1}).setDilation({1, 1});
+  attr.setPadding(std::vector<int64_t>{0, 0})
+      .setStride(std::vector<int64_t>{1, 1})
+      .setDilation(std::vector<int64_t>{1, 1});
 
   auto X = std::make_shared<TensorAttr>(TensorAttr()
                                             .setDim({n, c, h, w})

--- a/sharkfuser/tests/test_graph.cpp
+++ b/sharkfuser/tests/test_graph.cpp
@@ -42,7 +42,9 @@ TEST_CASE("Graph conv_fprop() adds ConvFPropNode and output tensor",
       g.tensor(TensorAttr().setDim({1, 8, 8, 3}).setStride({192, 24, 3, 1}));
   auto w = g.tensor(TensorAttr().setDim({4, 3, 3, 3}).setStride({27, 9, 3, 1}));
   ConvFPropAttr attr;
-  attr.setPadding({0, 0}).setStride({1, 1}).setDilation({1, 1});
+  attr.setPadding(std::vector<int64_t>{0, 0})
+      .setStride(std::vector<int64_t>{1, 1})
+      .setDilation(std::vector<int64_t>{1, 1});
   auto y = g.convFProp(x, w, attr);
 
   // Names for inputs are auto-populated when not set.
@@ -80,7 +82,10 @@ TEST_CASE("Graph validate() fails on missing attributes", "[graph]") {
   auto w = g.tensor(
       TensorAttr().setName("W").setDim({4, 3, 3, 3}).setStride({27, 9, 3, 1}));
   ConvFPropAttr attr;
-  attr.setPadding({0, 0}).setStride({1, 1}).setDilation({1, 1}).setName("conv");
+  attr.setPadding(std::vector<int64_t>{0, 0})
+      .setStride(std::vector<int64_t>{1, 1})
+      .setDilation(std::vector<int64_t>{1, 1})
+      .setName("conv");
   auto y = g.convFProp(x, w, attr);
 
   // shape and strides of output tensor are not inferred yet
@@ -112,9 +117,9 @@ Graph testGraph(bool validate) {
                         .setDim({k, c, r, s})
                         .setStride({c * r * s, r * s, s, 1}));
   auto conv = ConvFPropAttr()
-                  .setPadding({0, 0})
-                  .setStride({1, 1})
-                  .setDilation({1, 1})
+                  .setPadding(std::vector<int64_t>{0, 0})
+                  .setStride(std::vector<int64_t>{1, 1})
+                  .setDilation(std::vector<int64_t>{1, 1})
                   .setName("conv_fprop");
   auto Y = g.convFProp(X, W, conv);
   Y->setDim({n, k, h, w}).setStride({k * h * w, h * w, w, 1});
@@ -337,9 +342,9 @@ TEST_CASE("Graph `execute`", "[graph]") {
                                .setStride({c * r * s, r * s, s, 1}));
 
     auto conv_attr = ConvFPropAttr()
-                         .setPadding({0, 0})
-                         .setStride({1, 1})
-                         .setDilation({1, 1})
+                         .setPadding(std::vector<int64_t>{0, 0})
+                         .setStride(std::vector<int64_t>{1, 1})
+                         .setDilation(std::vector<int64_t>{1, 1})
                          .setName("conv_fprop");
 
     auto Y = graph->convFProp(X, W, conv_attr);

--- a/sharkfuser/tests/test_ssa_validation.cpp
+++ b/sharkfuser/tests/test_ssa_validation.cpp
@@ -37,17 +37,21 @@ TEST_CASE("Multiple outputs use same name", "[graph][ssa]") {
   auto x = g.tensor(TensorAttr().setName("arg0").setDim({1}).setStride({1}));
   auto w = g.tensor(TensorAttr().setName("arg1").setDim({1}).setStride({1}));
 
-  auto y = g.convFProp(
-      x, w,
-      ConvFPropAttr().setPadding({0}).setStride({1}).setDilation({1}).setName(
-          "conv1"));
+  auto y = g.convFProp(x, w,
+                       ConvFPropAttr()
+                           .setPadding(std::vector<int64_t>{0})
+                           .setStride(std::vector<int64_t>{1})
+                           .setDilation(std::vector<int64_t>{1})
+                           .setName("conv1"));
   // y's name is overridden to "result".
   y->setDim({1}).setStride({1}).setName("result");
 
-  auto z = g.convFProp(
-      y, w,
-      ConvFPropAttr().setPadding({0}).setStride({1}).setDilation({1}).setName(
-          "conv2"));
+  auto z = g.convFProp(y, w,
+                       ConvFPropAttr()
+                           .setPadding(std::vector<int64_t>{0})
+                           .setStride(std::vector<int64_t>{1})
+                           .setDilation(std::vector<int64_t>{1})
+                           .setName("conv2"));
   // z's name is also overridden to "result" which isn't valid.
   z->setDim({1}).setStride({1}).setName("result");
   z->setOutput(true);
@@ -70,17 +74,21 @@ TEST_CASE("Multiple outputs use same inferred name from producing nodes",
   auto w = g.tensor(TensorAttr().setName("arg1").setDim({1}).setStride({1}));
 
   // This infers the name `conv_Y` (based on node name).
-  auto y = g.convFProp(
-      x, w,
-      ConvFPropAttr().setPadding({0}).setStride({1}).setDilation({1}).setName(
-          "conv"));
+  auto y = g.convFProp(x, w,
+                       ConvFPropAttr()
+                           .setPadding(std::vector<int64_t>{0})
+                           .setStride(std::vector<int64_t>{1})
+                           .setDilation(std::vector<int64_t>{1})
+                           .setName("conv"));
   y->setDim({1}).setStride({1});
 
   // This also infers the name `conv_Y` (based on node name).
-  auto z = g.convFProp(
-      y, w,
-      ConvFPropAttr().setPadding({0}).setStride({1}).setDilation({1}).setName(
-          "conv"));
+  auto z = g.convFProp(y, w,
+                       ConvFPropAttr()
+                           .setPadding(std::vector<int64_t>{0})
+                           .setStride(std::vector<int64_t>{1})
+                           .setDilation(std::vector<int64_t>{1})
+                           .setName("conv"));
   z->setDim({1}).setStride({1});
   z->setOutput(true);
 
@@ -100,19 +108,23 @@ TEST_CASE("Multiple nodes use same name", "[graph][ssa]") {
   auto x = g.tensor(TensorAttr().setName("arg0").setDim({1}).setStride({1}));
   auto w = g.tensor(TensorAttr().setName("arg1").setDim({1}).setStride({1}));
 
-  auto y = g.convFProp(
-      x, w,
-      ConvFPropAttr().setPadding({0}).setStride({1}).setDilation({1}).setName(
-          "conv"));
+  auto y = g.convFProp(x, w,
+                       ConvFPropAttr()
+                           .setPadding(std::vector<int64_t>{0})
+                           .setStride(std::vector<int64_t>{1})
+                           .setDilation(std::vector<int64_t>{1})
+                           .setName("conv"));
   // y is inferred to `conv_Y` based on node name.
   y->setDim({1}).setStride({1});
 
   // Both conv nodes use the same name which is invalid as it'd break SSA
   // for the internal ops it'd generated (e.g. stride, padding etc).
-  auto z = g.convFProp(
-      y, w,
-      ConvFPropAttr().setPadding({0}).setStride({1}).setDilation({1}).setName(
-          "conv"));
+  auto z = g.convFProp(y, w,
+                       ConvFPropAttr()
+                           .setPadding(std::vector<int64_t>{0})
+                           .setStride(std::vector<int64_t>{1})
+                           .setDilation(std::vector<int64_t>{1})
+                           .setName("conv"));
   z->setDim({1}).setStride({1}).setName("result");
   z->setOutput(true);
 
@@ -132,16 +144,20 @@ TEST_CASE("Input and outputs use same name", "[graph][ssa]") {
   auto x = g.tensor(TensorAttr().setName("arg0").setDim({1}).setStride({1}));
   auto w = g.tensor(TensorAttr().setName("arg1").setDim({1}).setStride({1}));
 
-  auto y = g.convFProp(
-      x, w,
-      ConvFPropAttr().setPadding({0}).setStride({1}).setDilation({1}).setName(
-          "conv"));
+  auto y = g.convFProp(x, w,
+                       ConvFPropAttr()
+                           .setPadding(std::vector<int64_t>{0})
+                           .setStride(std::vector<int64_t>{1})
+                           .setDilation(std::vector<int64_t>{1})
+                           .setName("conv"));
   y->setDim({1}).setStride({1});
 
-  auto z = g.convFProp(
-      y, w,
-      ConvFPropAttr().setPadding({0}).setStride({1}).setDilation({1}).setName(
-          "conv"));
+  auto z = g.convFProp(y, w,
+                       ConvFPropAttr()
+                           .setPadding(std::vector<int64_t>{0})
+                           .setStride(std::vector<int64_t>{1})
+                           .setDilation(std::vector<int64_t>{1})
+                           .setName("conv"));
   z->setDim({1}).setStride({1}).setName("arg0");
   z->setOutput(true);
 
@@ -161,16 +177,20 @@ TEST_CASE("Input and nodes use same name", "[graph][ssa]") {
   auto x = g.tensor(TensorAttr().setName("arg0").setDim({1}).setStride({1}));
   auto w = g.tensor(TensorAttr().setName("arg1").setDim({1}).setStride({1}));
 
-  auto y = g.convFProp(
-      x, w,
-      ConvFPropAttr().setPadding({0}).setStride({1}).setDilation({1}).setName(
-          "arg0"));
+  auto y = g.convFProp(x, w,
+                       ConvFPropAttr()
+                           .setPadding(std::vector<int64_t>{0})
+                           .setStride(std::vector<int64_t>{1})
+                           .setDilation(std::vector<int64_t>{1})
+                           .setName("arg0"));
   y->setDim({1}).setStride({1});
 
-  auto z = g.convFProp(
-      y, w,
-      ConvFPropAttr().setPadding({0}).setStride({1}).setDilation({1}).setName(
-          "conv"));
+  auto z = g.convFProp(y, w,
+                       ConvFPropAttr()
+                           .setPadding(std::vector<int64_t>{0})
+                           .setStride(std::vector<int64_t>{1})
+                           .setDilation(std::vector<int64_t>{1})
+                           .setName("conv"));
   z->setDim({1}).setStride({1});
   z->setOutput(true);
 
@@ -190,12 +210,18 @@ TEST_CASE("Unnamed graph with all names inferred", "[graph][ssa]") {
   auto x = g.tensor(TensorAttr().setDim({1}).setStride({1}));
   auto w = g.tensor(TensorAttr().setDim({1}).setStride({1}));
 
-  auto y = g.convFProp(
-      x, w, ConvFPropAttr().setPadding({0}).setStride({1}).setDilation({1}));
+  auto y = g.convFProp(x, w,
+                       ConvFPropAttr()
+                           .setPadding(std::vector<int64_t>{0})
+                           .setStride(std::vector<int64_t>{1})
+                           .setDilation(std::vector<int64_t>{1}));
   y->setDim({1}).setStride({1});
 
-  auto z = g.convFProp(
-      y, w, ConvFPropAttr().setPadding({0}).setStride({1}).setDilation({1}));
+  auto z = g.convFProp(y, w,
+                       ConvFPropAttr()
+                           .setPadding(std::vector<int64_t>{0})
+                           .setStride(std::vector<int64_t>{1})
+                           .setDilation(std::vector<int64_t>{1}));
   z->setDim({1}).setStride({1});
   z->setOutput(true);
 


### PR DESCRIPTION
This PR changes TensorAttr::setPadding and other similar methods to accept a range rather than a fixed std::vector. This is more flexible, but it does require some annoying spelling out of types. It's unclear to me if this is preferable or not.