### PR TITLE
[Tuner] use custom transform op for matching contraction op

### DIFF
--- a/sharktuner/sharktuner/spec_builder.py
+++ b/sharktuner/sharktuner/spec_builder.py
@@ -89,10 +89,9 @@ def build_td_spec(
         ]
 
         dims_equal_checks = []
-        if batch_dims:
-            dims_equal_checks.append(
-                f"transform.iree.match.dims_equal %batch, {batch_dims} : !transform.param<i64>"
-            )
+        dims_equal_checks.append(
+            f"transform.iree.match.dims_equal %batch, {batch_dims} : !transform.param<i64>"
+        )
         dims_equal_checks.append(
             f"transform.iree.match.dims_equal %m, {m_dims} : !transform.param<i64>"
         )
@@ -110,7 +109,6 @@ def build_td_spec(
                 {{indexing_maps = [{indexing_maps_str}]}} :
                 (!transform.any_op) -> (!transform.param<i64>, !transform.param<i64>, !transform.param<i64>, !transform.param<i64>)
             {dims_equal_block}"""
-        print(matcher_block)
     else:
         # Get the names ssa names of operands to make sure they match in the
         # template after string formatting.

--- a/sharktuner/tests/spec_builder_test.py
+++ b/sharktuner/tests/spec_builder_test.py
@@ -82,6 +82,66 @@ def create_generic_module(tuner_ctx: common.TunerContext) -> None:
         return module
 
 
+def create_batch_matmul_module(tuner_ctx: common.TunerContext) -> ir.Module:
+    ctx = tuner_ctx.mlir_ctx
+    with ir.Location.unknown(ctx):
+        module = ir.Module.create()
+        with ir.InsertionPoint(module.body):
+            f16 = ir.F16Type.get()
+            f32 = ir.F32Type.get()
+
+            lhs_type = ir.RankedTensorType.get([4, 1024, 512], f16)
+            rhs_type = ir.RankedTensorType.get([4, 2048, 512], f16)
+            output_type = ir.RankedTensorType.get([4, 1024, 2048], f32)
+
+            dim0 = ir.AffineDimExpr.get(0)
+            dim1 = ir.AffineDimExpr.get(1)
+            dim2 = ir.AffineDimExpr.get(2)
+            dim3 = ir.AffineDimExpr.get(3)
+
+            a_map = ir.AffineMap.get(4, 0, [dim0, dim1, dim3])
+            b_map = ir.AffineMap.get(4, 0, [dim0, dim2, dim3])
+            c_map = ir.AffineMap.get(4, 0, [dim0, dim1, dim2])
+
+            indexing_maps = ir.ArrayAttr.get(
+                [
+                    ir.AffineMapAttr.get(a_map),
+                    ir.AffineMapAttr.get(b_map),
+                    ir.AffineMapAttr.get(c_map),
+                ]
+            )
+
+            iterator_types_attr = ir.ArrayAttr.get(
+                [
+                    ir.Attribute.parse("#linalg.iterator_type<parallel>"),
+                    ir.Attribute.parse("#linalg.iterator_type<parallel>"),
+                    ir.Attribute.parse("#linalg.iterator_type<parallel>"),
+                    ir.Attribute.parse("#linalg.iterator_type<reduction>"),  # K
+                ]
+            )
+
+            @func.FuncOp.from_py_func(lhs_type, rhs_type, output_type)
+            def batch_matmul_func(arg0, arg1, arg2):
+                generic_op = linalg.GenericOp(
+                    result_tensors=[output_type],
+                    inputs=[arg0, arg1],
+                    outputs=[arg2],
+                    indexing_maps=indexing_maps,
+                    iterator_types=iterator_types_attr,
+                )
+                generic_op.operation.attributes["root_op"] = ir.UnitAttr.get()
+
+                block = generic_op.regions[0].blocks.append(f16, f16, f32)
+                with ir.InsertionPoint(block):
+                    ext0 = arith.ExtFOp(f32, block.arguments[0]).result
+                    ext1 = arith.ExtFOp(f32, block.arguments[1]).result
+                    mul = arith.MulFOp(ext0, ext1)
+                    add = arith.AddFOp(block.arguments[2], mul)
+                    linalg.YieldOp([add])
+
+        return module
+
+
 def test_spec_builder(tuner_ctx: common.TunerContext) -> None:
     module = create_generic_module(tuner_ctx)
     root_ops = iree_codegen.get_tuner_root_ops(module)
@@ -117,6 +177,7 @@ def test_spec_builder(tuner_ctx: common.TunerContext) -> None:
     assert "lhs_type =" in spec_str
     assert "rhs_type =" in spec_str
     assert "output_type =" in spec_str
+    assert "transform.iree.match.dims_equal %batch_dims, []" in spec_str
     assert "transform.iree.match.dims_equal %m_dims, [1024]" in spec_str
     assert "transform.iree.match.dims_equal %n_dims, [2048]" in spec_str
     assert "transform.iree.match.dims_equal %k_dims, [512]" in spec_str
@@ -169,3 +230,50 @@ def test_spec_builder(tuner_ctx: common.TunerContext) -> None:
     assert "@match_matmul -> @apply_op_config" in spec_str
     assert 'transform.annotate %arg0 "compilation_info" = %arg1' in spec_str
     assert 'transform.annotate %arg0 "decomposition_config" = %arg2' in spec_str
+
+
+def test_spec_builder_with_batch_dims(tuner_ctx: common.TunerContext) -> None:
+    module = create_batch_matmul_module(tuner_ctx)
+    root_ops = iree_codegen.get_tuner_root_ops(module)
+    assert len(root_ops) == 1, "Expected exactly one root op"
+    root_op = root_ops[0]
+
+    attributes = ir.DictAttr.get({"reduction": ir.ArrayAttr.get([])})
+    lowering_config = iree_gpu.LoweringConfigAttr.get(attributes)
+    pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
+        iree_codegen.DispatchLoweringPassPipeline.None_
+    )
+    translation_info = iree_codegen.TranslationInfoAttr.get(pipeline_attr)
+    compilation_info = iree_codegen.CompilationInfoAttr.get(
+        lowering_config, translation_info
+    )
+
+    spec_module = spec_builder.build_td_spec(
+        tuner_ctx.mlir_ctx,
+        root_op,
+        [
+            common.TuningConfiguration(
+                name="compilation_info", configuration=compilation_info
+            )
+        ],
+        "match_batch_matmul",
+    )
+    assert spec_module
+    assert isinstance(spec_module, ir.Module)
+    spec_str = str(spec_module)
+
+    assert "@match_batch_matmul -> @apply_op_config" in spec_str
+    assert 'transform.annotate %arg0 "compilation_info" = %arg1' in spec_str
+    assert "transform.iree.match.contraction" in spec_str
+    assert "lhs_type =" in spec_str
+    assert "rhs_type =" in spec_str
+    assert "output_type =" in spec_str
+
+    assert "transform.iree.match.dims_equal %batch_dims, [4]" in spec_str
+    assert "transform.iree.match.dims_equal %m_dims, [1024]" in spec_str
+    assert "transform.iree.match.dims_equal %n_dims, [2048]" in spec_str
+    assert "transform.iree.match.dims_equal %k_dims, [512]" in spec_str
+
+    assert "lhs_type = f16" in spec_str
+    assert "rhs_type = f16" in spec_str
+    assert "output_type = f32" in spec_str


### PR DESCRIPTION
This PR updates the contraction matching logic to use the newly defined transform ops `transform.iree.match.contraction` and `transform.iree.match.dims_equal` instead of relying on `transform.iree.match.cast_compatible_dag_from_root`.

The current change is intended as a temporary solution to demonstrate the functionality of the new transform ops. Once similar transform ops are defined for convolution and attention (following the same design), and the custom ops are properly registered with the Python bindings, the `build_td_spec `function will be fully rewritten using python bindings instead of textual strings.

FYI, tuning log for matmul based on this PR: https://gist.github.com/bangtianliu/0c33db3225757ec722d6eb7d03b2d989.