### PR TITLE
[Fusilli] Use LLVM's FileCheck

### DIFF
--- a/.github/workflows/ci-fusilli-plugin.yml
+++ b/.github/workflows/ci-fusilli-plugin.yml
@@ -56,7 +56,6 @@ jobs:
               -DCMAKE_CXX_COMPILER=clang++-18
               -DCMAKE_BUILD_TYPE=Debug
               -DFUSILLI_SYSTEMS_AMDGPU=ON
-              -DCMAKE_BUILD_TYPE=Debug
               -DIREERuntime_DIR=/workspace/.cache/docker/iree/build/lib/cmake/IREE
 
     steps:

--- a/sharkfuser/README.md
+++ b/sharkfuser/README.md
@@ -16,13 +16,13 @@ Although optional, we recommend docker as the canonical development setup for a 
 
 If you prefer a custom setup instead, the following dependencies need to be brought in to build/test Fusilli:
 
-**Build Requirements:** cmake, ninja-build, clang, lld, IREE
+**Build Requirements:** cmake, ninja-build, clang, IREE
 
-**Test Requirements:** catch2, lit, filecheck, iree-opt, iree-compile
+**Test Requirements:** catch2, lit, FileCheck, iree-opt, iree-compile
 
 Fusilli interfaces with the IREE compiler through the CLI and with IREE runtime through its C-API. In the future we may want an alternate C-API integration for the compiler as well but for now running it as a tool with process isolation is useful for general developer ergonomics. The IREE compiler is a heavy dependency to build (due to MLIR/LLVM), so we recommend using a prebuilt release either from a python nightly package or shared library distribution. The IREE runtime on the other hand is much more lightweight and is designed to be built from source and statically linked in. IREE does not export a shared runtime library to allow for maximum flexibility with low-level and toolchain specific (LTO style) optimizations.
 
-Easiest way to get [`lit`](https://llvm.org/docs/CommandGuide/lit.html), [`filecheck`](https://github.com/AntonLydike/filecheck) and the `iree-*` CLI tools is through `pip install`. Everything else should be available via `apt` based install.
+Easiest way to get [`lit`](https://llvm.org/docs/CommandGuide/lit.html), and the `iree-*` CLI tools is through `pip install`. [`FileCheck`](https://llvm.org/docs/CommandGuide/FileCheck.html) comes packaged with clang / llvm distributions. Everything else should be available via `apt` based install.
 
 ### Build and Test
 

--- a/sharkfuser/build_tools/docker/exec_docker_ci.sh
+++ b/sharkfuser/build_tools/docker/exec_docker_ci.sh
@@ -20,5 +20,5 @@ docker run --rm \
            -v "${PWD}":/workspace \
            ${DOCKER_RUN_DEVICE_OPTS} \
            --security-opt seccomp=unconfined \
-           ghcr.io/sjain-stanford/compiler-dev-ubuntu-24.04:main@sha256:a9775319c278f144946c1b86e4ec5efe14b378a0a93aa85ccaf263058b359934 \
+           ghcr.io/sjain-stanford/compiler-dev-ubuntu-24.04:main@sha256:01b8aaed0240a64ebae947d68cb4910300e50ba3ef029635e526764e6d7c37e0 \
            "$@"

--- a/sharkfuser/tests/CMakeLists.txt
+++ b/sharkfuser/tests/CMakeLists.txt
@@ -7,11 +7,11 @@
 # Find lit program
 fusilli_find_program(lit "Please install lit (e.g., pip install lit).")
 
-# Find filecheck program
-fusilli_find_program(filecheck "Please install filecheck (e.g., pip install filecheck).")
-
 # Find iree-opt program
 fusilli_find_program(iree-opt "Please install iree-opt (e.g., pip install iree-base-compiler).")
+
+# Find FileCheck program
+fusilli_find_program(FileCheck "Please install FileCheck.")
 
 # Enable HIP tests if AMD GPU is enabled (ensures GPU detected) and HIP is found
 if(FUSILLI_SYSTEMS_AMDGPU)
@@ -95,7 +95,7 @@ add_fusilli_lit_test(
   DEPS
     libfusilli
   TOOLS
-    filecheck
+    FileCheck
 )
 
 add_fusilli_lit_test(
@@ -104,7 +104,7 @@ add_fusilli_lit_test(
   DEPS
     libfusilli
   TOOLS
-    filecheck
+    FileCheck
     iree-opt
     iree-compile
 )
@@ -115,7 +115,7 @@ add_fusilli_lit_test(
   DEPS
     libfusilli
   TOOLS
-    filecheck
+    FileCheck
     iree-opt
     iree-compile
 )
@@ -126,7 +126,7 @@ add_fusilli_lit_test(
   DEPS
     libfusilli
   TOOLS
-    filecheck
+    FileCheck
     iree-opt
     iree-compile
 )
@@ -137,7 +137,7 @@ add_fusilli_lit_test(
   DEPS
     libfusilli
   TOOLS
-    filecheck
+    FileCheck
     iree-opt
     iree-compile
 )
@@ -148,7 +148,7 @@ add_fusilli_lit_test(
   DEPS
     libfusilli
   TOOLS
-    filecheck
+    FileCheck
     iree-opt
     iree-compile
 )
@@ -159,7 +159,7 @@ add_fusilli_lit_test(
   DEPS
     libfusilli
   TOOLS
-    filecheck
+    FileCheck
     iree-opt
     iree-compile
 )

--- a/sharkfuser/tests/lit/test_asm_emitter.cpp
+++ b/sharkfuser/tests/lit/test_asm_emitter.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// RUN: %test_exe | filecheck %s
+// RUN: %test_exe | FileCheck %s
 
 #include <fusilli.h>
 

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_kcrs.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_kcrs.cpp
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // RUN: %test_exe | iree-opt --verify-roundtrip
-// RUN: %test_exe | filecheck %s --check-prefix=TORCH-CHECK
+// RUN: %test_exe | FileCheck %s --check-prefix=TORCH-CHECK
 // RUN: %test_exe | iree-compile - --compile-to=input | \
-// RUN:             filecheck %s --check-prefix=LINALG-CHECK
+// RUN:             FileCheck %s --check-prefix=LINALG-CHECK
 
 #include <fusilli.h>
 

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_kcrs_with_pad.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_kcrs_with_pad.cpp
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // RUN: %test_exe | iree-opt --verify-roundtrip
-// RUN: %test_exe | filecheck %s --check-prefix=TORCH-CHECK
+// RUN: %test_exe | FileCheck %s --check-prefix=TORCH-CHECK
 // RUN: %test_exe | iree-compile - --compile-to=input | \
-// RUN:             filecheck %s --check-prefix=LINALG-CHECK
+// RUN:             FileCheck %s --check-prefix=LINALG-CHECK
 
 #include <fusilli.h>
 

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_krsc.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nchw_krsc.cpp
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // RUN: %test_exe | iree-opt --verify-roundtrip
-// RUN: %test_exe | filecheck %s --check-prefix=TORCH-CHECK
+// RUN: %test_exe | FileCheck %s --check-prefix=TORCH-CHECK
 // RUN: %test_exe | iree-compile - --compile-to=input | \
-// RUN:             filecheck %s --check-prefix=LINALG-CHECK
+// RUN:             FileCheck %s --check-prefix=LINALG-CHECK
 
 #include <fusilli.h>
 

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_kcrs.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_kcrs.cpp
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // RUN: %test_exe | iree-opt --verify-roundtrip
-// RUN: %test_exe | filecheck %s --check-prefix=TORCH-CHECK
+// RUN: %test_exe | FileCheck %s --check-prefix=TORCH-CHECK
 // RUN: %test_exe | iree-compile - --compile-to=input | \
-// RUN:             filecheck %s --check-prefix=LINALG-CHECK
+// RUN:             FileCheck %s --check-prefix=LINALG-CHECK
 
 #include <fusilli.h>
 

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_krsc.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_krsc.cpp
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // RUN: %test_exe | iree-opt --verify-roundtrip
-// RUN: %test_exe | filecheck %s --check-prefix=TORCH-CHECK
+// RUN: %test_exe | FileCheck %s --check-prefix=TORCH-CHECK
 // RUN: %test_exe | iree-compile - --compile-to=input | \
-// RUN:             filecheck %s --check-prefix=LINALG-CHECK
+// RUN:             FileCheck %s --check-prefix=LINALG-CHECK
 
 #include <fusilli.h>
 

--- a/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_krsc_with_pad.cpp
+++ b/sharkfuser/tests/lit/test_conv_asm_emitter_nhwc_krsc_with_pad.cpp
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // RUN: %test_exe | iree-opt --verify-roundtrip
-// RUN: %test_exe | filecheck %s --check-prefix=TORCH-CHECK
+// RUN: %test_exe | FileCheck %s --check-prefix=TORCH-CHECK
 // RUN: %test_exe | iree-compile - --compile-to=input | \
-// RUN:             filecheck %s --check-prefix=LINALG-CHECK
+// RUN:             FileCheck %s --check-prefix=LINALG-CHECK
 
 #include <fusilli.h>
 


### PR DESCRIPTION
The python [filecheck ](https://github.com/AntonLydike/filecheck) does have sharp edges in terms of supported options / maturity. Hit an issue today with `--dump-input` not working as expected and exposing an odd arg parsing bug. Based on https://github.com/AntonLydike/filecheck/pull/36 it looks like not all options are supported.

LLVM's FileCheck is pre-packaged in the clang distribution we depend on so it wasn't too difficult to switch over.