### PR TITLE
[CI] Run fewer pull_rquest checks on unrelated changes

### DIFF
--- a/.github/workflows/ci-fusilli-plugin.yml
+++ b/.github/workflows/ci-fusilli-plugin.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/ci-sharfuser.yml'
+      - 'sharkfuser/**'
+      - 'fusilli-plugin/**'
   push:
     branches:
       - main

--- a/.github/workflows/ci-fusilli-plugin.yml
+++ b/.github/workflows/ci-fusilli-plugin.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - main
     paths:
-      - '.github/workflows/ci-sharkfuser.yml'
+      - '.github/workflows/ci-fusilli-plugin.yml'
       - 'sharkfuser/**'
       - 'fusilli-plugin/**'
   push:

--- a/.github/workflows/ci-fusilli-plugin.yml
+++ b/.github/workflows/ci-fusilli-plugin.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - main
     paths:
-      - '.github/workflows/ci-sharfuser.yml'
+      - '.github/workflows/ci-sharkfuser.yml'
       - 'sharkfuser/**'
       - 'fusilli-plugin/**'
   push:

--- a/.github/workflows/ci-libshortfin.yml
+++ b/.github/workflows/ci-libshortfin.yml
@@ -9,6 +9,11 @@ name: CI - shortfin
 on:
   workflow_dispatch:
   pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/ci-libshortfin.yml'
+      - 'shortfin/**'
   push:
     branches:
       - main

--- a/.github/workflows/ci-sharkfuser.yml
+++ b/.github/workflows/ci-sharkfuser.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/ci-sharfuser.yml'
+      - 'sharkfuser/**'
+      - 'fusilli-plugin/**'
   push:
     branches:
       - main

--- a/.github/workflows/ci-sharkfuser.yml
+++ b/.github/workflows/ci-sharkfuser.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - main
     paths:
-      - '.github/workflows/ci-sharfuser.yml'
+      - '.github/workflows/ci-sharkfuser.yml'
       - 'sharkfuser/**'
       - 'fusilli-plugin/**'
   push:

--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - main
     paths:
-      - '.github/workflows/ci-shartank.yml'
+      - '.github/workflows/ci-sharktank.yml'
       - 'sharktank/**'
   push:
     branches:

--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -9,6 +9,11 @@ name: CI - sharktank
 on:
   workflow_dispatch:
   pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/ci-shartank.yml'
+      - 'sharktank/**'
   push:
     branches:
       - main


### PR DESCRIPTION
The intention is to stop running sharktank, sharkfuser/fusilli, and shortfin CI checks on sharktuner pull requests.

Tuner changes should never affect the other projects.