### PR TITLE
[sharktank] make IreeInstance expose LlamaModelConfig to be consistent with TorchInstance

### DIFF
--- a/sharktank/sharktank/utils/llm_artifacts.py
+++ b/sharktank/sharktank/utils/llm_artifacts.py
@@ -48,4 +48,9 @@ class LlmArtifactBuilder:
         )
         index = builder.index
 
-        return IreeInstance(devices=devices, vmfb=self._vmfb, parameters=index)
+        return IreeInstance(
+            devices=devices,
+            vmfb=self._vmfb,
+            parameters=index,
+            config=self._llama_config,
+        )


### PR DESCRIPTION
Although these two classes do not inherit an ABC explicitly now, they need to have the same interface.