### PR TITLE
Revert "[CI] Run fewer pull_rquest checks on unrelated changes"

### DIFF
--- a/.github/workflows/ci-fusilli-plugin.yml
+++ b/.github/workflows/ci-fusilli-plugin.yml
@@ -11,10 +11,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - '.github/workflows/ci-fusilli-plugin.yml'
-      - 'sharkfuser/**'
-      - 'fusilli-plugin/**'
   push:
     branches:
       - main

--- a/.github/workflows/ci-libshortfin.yml
+++ b/.github/workflows/ci-libshortfin.yml
@@ -9,11 +9,6 @@ name: CI - shortfin
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/ci-libshortfin.yml'
-      - 'shortfin/**'
   push:
     branches:
       - main

--- a/.github/workflows/ci-sharkfuser.yml
+++ b/.github/workflows/ci-sharkfuser.yml
@@ -11,10 +11,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - '.github/workflows/ci-sharkfuser.yml'
-      - 'sharkfuser/**'
-      - 'fusilli-plugin/**'
   push:
     branches:
       - main

--- a/.github/workflows/ci-sharktank.yml
+++ b/.github/workflows/ci-sharktank.yml
@@ -9,11 +9,6 @@ name: CI - sharktank
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/ci-sharktank.yml'
-      - 'sharktank/**'
   push:
     branches:
       - main


### PR DESCRIPTION
Reverts nod-ai/shark-ai#2367

This is causing a deadlock on all PRs (https://github.com/nod-ai/shark-ai/pull/2359, https://github.com/nod-ai/shark-ai/pull/2381) as the disabled checks are actually "required" in status checks. 

<img width="827" height="363" alt="image" src="https://github.com/user-attachments/assets/deaee5be-1749-4694-8dd2-04da6eb8f555" />
