### PR TITLE
[Sharktank docs] add wave-lang in install development packages

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -97,7 +97,7 @@ pip install -r requirements.txt -e sharktank/ -e shortfin/
 # Install the latest nightly release of iree-turbine, alond with
 # nightly versions of iree-base-compiler and iree-base-runtime.
 pip install -f https://iree.dev/pip-release-links.html --upgrade --pre \
-  iree-base-compiler iree-base-runtime iree-turbine
+  iree-base-compiler iree-base-runtime iree-turbine wave-lang
 ```
 
 You can also install an editable iree-turbine dep:


### PR DESCRIPTION
In order to use `precompile_sdxl.sh`, I used the instructions here https://github.com/nod-ai/shark-ai/blob/main/docs/developer_guide.md to build. However, I noticed that I also needed to install `wave-lang` in order to get past an error (`wave_lang` missing error) 