### PR TITLE
Fix unintended logs

### DIFF
--- a/.github/workflows/pkgci_shark_ai.yml
+++ b/.github/workflows/pkgci_shark_ai.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           source ${VENV_DIR}/bin/activate
           uv pip install sentence_transformers
-      - name: (Test) pip freeze to see why sentence_transformers is not found
+      - name: Log Package Versions
         run: |
           source ${VENV_DIR}/bin/activate
           uv pip freeze

--- a/shortfin/setup.py
+++ b/shortfin/setup.py
@@ -257,7 +257,6 @@ class CMakeBuildPy(_build_py):
 
         # Only build using cmake if not in prebuild mode.
         if is_cpp_prebuilt():
-            print("SNB: Pre-built mode, skipping building cpp extensions")
             return
 
         try:


### PR DESCRIPTION
- Rename step in `pkcci_shark_ai`, where we do a `uv pip freeze`
- Remove gross line I accidentally added in `setup.py` at some point
    - I think I added this when I was trying to figure out the paths that build c++ one day... my bad