### PR TITLE
[LLM Server] Embed in batches for 8b Accuracy Test

### DIFF
--- a/app_tests/integration_tests/llm/shortfin/accuracy/accuracy_test.py
+++ b/app_tests/integration_tests/llm/shortfin/accuracy/accuracy_test.py
@@ -1,8 +1,10 @@
 import concurrent.futures
 import json
 import logging
+import numpy as np
 import pytest
 import requests
+from torch import Tensor
 
 pytest.importorskip("sentence_transformers")
 
@@ -102,11 +104,13 @@ class TestLLMAccuracy:
         resp = requests.get(f"{base_url}/health")
         assert resp.status_code == 200
 
-    def _compute_similarity(
-        self, comparison_model: SentenceTransformer, sentence_1: str, sentence_2: str
-    ):
-        embeddings = comparison_model.encode([sentence_1, sentence_2])
-        return util.pytorch_cos_sim(embeddings[0], embeddings[1]).item()
+    def _get_embeddings(
+        self, comparison_model: SentenceTransformer, sentences: List[str]
+    ) -> np.ndarray:
+        return comparison_model.encode(sentences)
+
+    def _compute_similarity(self, embedding_1: Tensor, embedding_2: Tensor):
+        return util.pytorch_cos_sim(embedding_1, embedding_2).item()
 
     def _validate_response(
         self,
@@ -119,35 +123,60 @@ class TestLLMAccuracy:
         total_incorrect = 0
         incorrect_prompts = []
 
+        # Gather prompts and expected generations
+        expected_generations = []
+        prompts = []
+        actual_generations = []
         for result in results:
             responses = result["responses"]
             for response in responses:
                 prompt = response["prompt"]
-
-                expected_generation = dataset.get_expected_generation(prompt)
                 actual_generation = response["responses"][0]["text"]
+                actual_generations.append(actual_generation)
+                expected_generation = dataset.get_expected_generation(prompt)
+                prompts.append(prompt)
+                expected_generations.append(expected_generation)
 
-                accuracy = self._compute_similarity(
-                    comparison_model, expected_generation, actual_generation
+        assert (
+            len(prompts)
+            == len(actual_generations)
+            == len(expected_generations)
+            == total_prompts
+        )
+
+        # Get embeddings for expected generations
+        expected_embeddings = self._get_embeddings(
+            comparison_model, expected_generations
+        )
+        # Get embeddings for actual generations
+        actual_embeddings = self._get_embeddings(comparison_model, actual_generations)
+
+        for index, (actual_generation, expected_generation) in enumerate(
+            zip(actual_generations, expected_generations)
+        ):
+            prompt = prompts[index]
+            expected_embedding = expected_embeddings[index]
+            actual_embedding = actual_embeddings[index]
+
+            accuracy = self._compute_similarity(expected_embedding, actual_embedding)
+            if accuracy < ACCURACY_THRESHOLD:
+                logger.error(
+                    f"Mismatch for prompt: {prompt}\n, With Accuracy: {accuracy:.2f}\n"
+                    f"{'-' * 80} Expected {'-' * 80}\n{expected_generation}\n"
+                    f"{'-' * 80} Actual {'-' * 80}\n{actual_generation}\n"
                 )
-                if accuracy < ACCURACY_THRESHOLD:
-                    logger.error(
-                        f"Mismatch for prompt: {prompt}\n, With Accuracy: {accuracy:.2f}\n"
-                        f"{'-' * 80} Expected {'-' * 80}\n{expected_generation}\n"
-                        f"{'-' * 80} Actual {'-' * 80}\n{actual_generation}\n"
+                total_incorrect += 1
+                incorrect_prompts.append(
+                    IncorrectPrompt(
+                        prompt=prompt,
+                        expected=expected_generation,
+                        actual=actual_generation,
+                        accuracy=accuracy,
                     )
-                    total_incorrect += 1
-                    incorrect_prompts.append(
-                        IncorrectPrompt(
-                            prompt=prompt,
-                            expected=expected_generation,
-                            actual=actual_generation,
-                            accuracy=accuracy,
-                        )
-                    )
-                    continue
+                )
+                continue
 
-                total_correct += 1
+            total_correct += 1
 
         return AccuracyResults(
             total_prompts=total_prompts,


### PR DESCRIPTION
We were wasting a lot of time by embedding the `expected_generation` and `actual_generation` one-by-one.

Should cut down on the total test time by gathering them and embedding them each in a single batch, then doing our comparisons.