### PR TITLE
[LLM Server] Update help message for `--chunk_block_size`

### DIFF
--- a/shortfin/python/shortfin_apps/llm/server.py
+++ b/shortfin/python/shortfin_apps/llm/server.py
@@ -117,7 +117,7 @@ def add_service_args(parser: argparse.ArgumentParser):
         "--chunk_block_size",
         type=int,
         default=None,
-        help="*Block-aligned* Chunk size to use for chunked prefill. Required if --use_chunked is set.",
+        help="*Block-aligned* Chunk size to use for chunked prefill.",
     )
 
 


### PR DESCRIPTION
- Update `help` message for `--chunk_block_size`, since we don't use `--use_chunked` arg anymore