### PR TITLE
[Fusilli] Switch GPU builds to clang-20 in CI

### DIFF
--- a/.github/workflows/ci-fusilli-plugin.yml
+++ b/.github/workflows/ci-fusilli-plugin.yml
@@ -51,13 +51,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["gfx942_clang18_debug"]
+        name: ["gfx942_clang20_debug"]
         include:
-          - name: gfx942_clang18_debug
+          - name: gfx942_clang20_debug
             runs-on: linux-mi325-2gpu-ossci-nod-ai
             fusilli-plugin-cmake-options:
-              -DCMAKE_C_COMPILER=clang-18
-              -DCMAKE_CXX_COMPILER=clang++-18
+              -DCMAKE_C_COMPILER=clang-20
+              -DCMAKE_CXX_COMPILER=clang++-20
               -DCMAKE_BUILD_TYPE=Debug
               -DFUSILLI_SYSTEMS_AMDGPU=ON
               -DIREERuntime_DIR=/workspace/.cache/docker/iree/build/lib/cmake/IREE

--- a/.github/workflows/ci-sharkfuser.yml
+++ b/.github/workflows/ci-sharkfuser.yml
@@ -49,28 +49,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["gfx942_clang18_release", "cpu_clang18_debug", "gfx942_clang18_debug", "cpu_gcc13_codecov"]
+        name: ["gfx942_clang20_release", "cpu_clang20_debug", "gfx942_clang20_debug", "cpu_gcc13_codecov"]
         include:
-          - name: gfx942_clang18_release
+          - name: gfx942_clang20_release
             runs-on: linux-mi325-2gpu-ossci-nod-ai
             cmake-options:
-              -DCMAKE_C_COMPILER=clang-18
-              -DCMAKE_CXX_COMPILER=clang++-18
+              -DCMAKE_C_COMPILER=clang-20
+              -DCMAKE_CXX_COMPILER=clang++-20
               -DCMAKE_BUILD_TYPE=Release
               -DFUSILLI_SYSTEMS_AMDGPU=ON
-          - name: cpu_clang18_debug
+          - name: cpu_clang20_debug
             runs-on: azure-cpubuilder-linux-scale
             cmake-options:
-              -DCMAKE_C_COMPILER=clang-18
-              -DCMAKE_CXX_COMPILER=clang++-18
+              -DCMAKE_C_COMPILER=clang-20
+              -DCMAKE_CXX_COMPILER=clang++-20
               -DCMAKE_BUILD_TYPE=Debug
               -DFUSILLI_ENABLE_LOGGING=ON
               -DFUSILLI_SYSTEMS_AMDGPU=OFF
-          - name: gfx942_clang18_debug
+          - name: gfx942_clang20_debug
             runs-on: linux-mi325-2gpu-ossci-nod-ai
             cmake-options:
-              -DCMAKE_C_COMPILER=clang-18
-              -DCMAKE_CXX_COMPILER=clang++-18
+              -DCMAKE_C_COMPILER=clang-20
+              -DCMAKE_CXX_COMPILER=clang++-20
               -DCMAKE_BUILD_TYPE=Debug
               -DFUSILLI_ENABLE_LOGGING=ON
               -DFUSILLI_SYSTEMS_AMDGPU=ON

--- a/.github/workflows/ci-sharkfuser.yml
+++ b/.github/workflows/ci-sharkfuser.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: ["gfx942_clang20_release", "cpu_clang20_debug", "gfx942_clang20_debug", "cpu_gcc13_codecov"]
+        name: ["gfx942_clang20_release", "cpu_clang18_debug", "gfx942_clang20_debug", "cpu_gcc13_codecov"]
         include:
           - name: gfx942_clang20_release
             runs-on: linux-mi325-2gpu-ossci-nod-ai
@@ -58,11 +58,11 @@ jobs:
               -DCMAKE_CXX_COMPILER=clang++-20
               -DCMAKE_BUILD_TYPE=Release
               -DFUSILLI_SYSTEMS_AMDGPU=ON
-          - name: cpu_clang20_debug
+          - name: cpu_clang18_debug
             runs-on: azure-cpubuilder-linux-scale
             cmake-options:
-              -DCMAKE_C_COMPILER=clang-20
-              -DCMAKE_CXX_COMPILER=clang++-20
+              -DCMAKE_C_COMPILER=clang-18
+              -DCMAKE_CXX_COMPILER=clang++-18
               -DCMAKE_BUILD_TYPE=Debug
               -DFUSILLI_ENABLE_LOGGING=ON
               -DFUSILLI_SYSTEMS_AMDGPU=OFF

--- a/sharkfuser/build_tools/docker/exec_docker_ci.sh
+++ b/sharkfuser/build_tools/docker/exec_docker_ci.sh
@@ -20,5 +20,5 @@ docker run --rm \
            -v "${PWD}":/workspace \
            ${DOCKER_RUN_DEVICE_OPTS} \
            --security-opt seccomp=unconfined \
-           ghcr.io/sjain-stanford/compiler-dev-ubuntu-24.04:main@sha256:32893ff9db762f5f1561db657d7eb6020ee6a3898b70c92766887d38bda55058 \
+           ghcr.io/sjain-stanford/compiler-dev-ubuntu-24.04:main@sha256:9ba47b2260f958c7cd912ea16c4a36d6437bdc640a7c05293841a8c82d373cee \
            "$@"


### PR DESCRIPTION
The docker bump makes it so that clang-20 is the default even for local dev, to keep things in sync with CI.