### PR TITLE
[Fusilli] Benchmark Driver 1/N

### DIFF
--- a/.github/workflows/ci-fusilli-plugin.yml
+++ b/.github/workflows/ci-fusilli-plugin.yml
@@ -55,11 +55,13 @@ jobs:
         include:
           - name: gfx942_clang20_debug
             runs-on: linux-mi325-2gpu-ossci-nod-ai
+            # TODO(aaron): Debug CI failure and enable `-DFUSILLI_BUILD_BENCHMARKS=ON`
             fusilli-plugin-cmake-options:
               -DCMAKE_C_COMPILER=clang-20
               -DCMAKE_CXX_COMPILER=clang++-20
               -DCMAKE_BUILD_TYPE=Debug
               -DFUSILLI_SYSTEMS_AMDGPU=ON
+              -DFUSILLI_BUILD_BENCHMARKS=OFF
               -DIREERuntime_DIR=/workspace/.cache/docker/iree/build/lib/cmake/IREE
 
     steps:

--- a/sharkfuser/CMakeLists.txt
+++ b/sharkfuser/CMakeLists.txt
@@ -101,6 +101,7 @@ target_link_libraries(libfusilli INTERFACE iree_runtime_unified)
 
 # Build options
 option(FUSILLI_BUILD_TESTS "Builds C++ tests and samples" ON)
+option(FUSILLI_BUILD_BENCHMARKS "Builds C++ benchmarks" ON)
 option(FUSILLI_CODE_COVERAGE "Enable code coverage for tests" OFF)
 option(FUSILLI_ENABLE_LOGGING "Enable logging for tests and samples" OFF)
 
@@ -150,6 +151,24 @@ if(FUSILLI_BUILD_TESTS)
 
   # Activate CTest integration
   enable_testing()
+endif()
+
+# Build benchmarks
+if(FUSILLI_BUILD_BENCHMARKS)
+  message(STATUS "Building Fusilli benchmarks")
+
+  # Get CLI11 (argparse library for C++)
+  include(FetchContent)
+  FetchContent_Declare(
+    cli11_proj
+    QUIET
+    GIT_REPOSITORY https://github.com/CLIUtils/CLI11.git
+    GIT_TAG v2.5.0
+  )
+  FetchContent_MakeAvailable(cli11_proj)
+
+  # Add benchmarks sub directory
+  add_subdirectory(benchmarks)
 endif()
 
 # Add libfusilli target to export set

--- a/sharkfuser/benchmarks/CMakeLists.txt
+++ b/sharkfuser/benchmarks/CMakeLists.txt
@@ -5,9 +5,9 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 add_fusilli_benchmark(
-  NAME driver
+  NAME fusilli_driver
   ARGS
-    conv
+    conv -n 100 -c 3 -H 32 -W 32 -k 32 -y 3 -x 3 -u 1 -v 1 -p 0 -q 0 -l 1 -j 1
   SRCS driver.cpp
   DEPS
     libfusilli

--- a/sharkfuser/benchmarks/CMakeLists.txt
+++ b/sharkfuser/benchmarks/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+add_fusilli_benchmark(
+  NAME driver
+  ARGS
+    conv
+  SRCS driver.cpp
+  DEPS
+    libfusilli
+    libutils
+    CLI11::CLI11
+)

--- a/sharkfuser/benchmarks/driver.cpp
+++ b/sharkfuser/benchmarks/driver.cpp
@@ -20,7 +20,7 @@ ErrorObject benchmark_conv_fprop(int64_t n, int64_t c, int64_t h, int64_t w,
                                  int64_t k, int64_t r, int64_t s, int64_t u,
                                  int64_t v, int64_t p, int64_t q, int64_t l,
                                  int64_t j) {
-#ifdef FUSILLI_SYSTEMS_AMDGPU
+#ifdef FUSILLI_ENABLE_AMDGPU
   Handle handle = FUSILLI_TRY(Handle::create(Backend::GFX942));
 #else
   Handle handle = FUSILLI_TRY(Handle::create(Backend::CPU));

--- a/sharkfuser/benchmarks/driver.cpp
+++ b/sharkfuser/benchmarks/driver.cpp
@@ -10,11 +10,18 @@
 
 #include <CLI/CLI.hpp>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <unordered_map>
 #include <vector>
 
 using namespace fusilli;
+
+// For CLI11 Range Validators
+const auto NonNegativeInteger =
+    CLI::Range(int64_t{0}, std::numeric_limits<int64_t>::max());
+const auto PositiveInteger =
+    CLI::Range(int64_t{1}, std::numeric_limits<int64_t>::max());
 
 ErrorObject benchmark_conv_fprop(int64_t n, int64_t c, int64_t h, int64_t w,
                                  int64_t k, int64_t r, int64_t s, int64_t u,
@@ -97,47 +104,46 @@ int main(int argc, char **argv) {
   // https://github.com/ROCm/rocm-libraries/blob/db0544fb61f2c7bd5a86dce98d4963420c1c741a/projects/miopen/driver/conv_driver.hpp#L878
   CLI::App *convApp =
       mainApp.add_subcommand("conv", "Fusilli Benchmark Forward Convolution");
-  int64_t n = 100, c = 3, h = 32, w = 32, k = 32, r = 3, s = 3, u = 1, v = 1,
-          p = 0, q = 0, l = 1, j = 1;
-  convApp
-      ->add_option("--batchsize,-n", n, "Input batch size") //
-      ->capture_default_str();
-  convApp
-      ->add_option("--in_channels,-c", c, "Input channels") //
-      ->capture_default_str();
-  convApp
-      ->add_option("--in_h,-H", h, "Input height") //
-      ->capture_default_str();
-  convApp
-      ->add_option("--in_w,-W", w, "Input width") //
-      ->capture_default_str();
-  convApp
-      ->add_option("--out_channels,-k", k, "Output channels") //
-      ->capture_default_str();
-  convApp
-      ->add_option("--fil_h,-y", r, "Filter height") //
-      ->capture_default_str();
-  convApp
-      ->add_option("--fil_w,-x", s, "Filter width") //
-      ->capture_default_str();
-  convApp
-      ->add_option("--conv_stride_h,-u", u, "Conv stride height") //
-      ->capture_default_str();
-  convApp
-      ->add_option("--conv_stride_w,-v", v, "Conv stride width") //
-      ->capture_default_str();
-  convApp
-      ->add_option("--pad_h,-p", p, "Conv padding height") //
-      ->capture_default_str();
-  convApp
-      ->add_option("--pad_w,-q", q, "Conv padding width") //
-      ->capture_default_str();
-  convApp
-      ->add_option("--dilation_h,-l", l, "Conv dilation height") //
-      ->capture_default_str();
-  convApp
-      ->add_option("--dilation_w,-j", j, "Conv dilation width") //
-      ->capture_default_str();
+  int64_t n, c, h, w, k, r, s, u, v, p, q, l, j;
+  convApp->add_option("--batchsize,-n", n, "Input batch size")
+      ->required()
+      ->check(PositiveInteger);
+  convApp->add_option("--in_channels,-c", c, "Input channels")
+      ->required()
+      ->check(PositiveInteger);
+  convApp->add_option("--in_h,-H", h, "Input height")
+      ->required()
+      ->check(PositiveInteger);
+  convApp->add_option("--in_w,-W", w, "Input width")
+      ->required()
+      ->check(PositiveInteger);
+  convApp->add_option("--out_channels,-k", k, "Output channels")
+      ->required()
+      ->check(PositiveInteger);
+  convApp->add_option("--fil_h,-y", r, "Filter height")
+      ->required()
+      ->check(PositiveInteger);
+  convApp->add_option("--fil_w,-x", s, "Filter width")
+      ->required()
+      ->check(PositiveInteger);
+  convApp->add_option("--conv_stride_h,-u", u, "Conv stride height")
+      ->required()
+      ->check(PositiveInteger);
+  convApp->add_option("--conv_stride_w,-v", v, "Conv stride width")
+      ->required()
+      ->check(PositiveInteger);
+  convApp->add_option("--pad_h,-p", p, "Conv padding height")
+      ->required()
+      ->check(NonNegativeInteger);
+  convApp->add_option("--pad_w,-q", q, "Conv padding width")
+      ->required()
+      ->check(NonNegativeInteger);
+  convApp->add_option("--dilation_h,-l", l, "Conv dilation height")
+      ->required()
+      ->check(PositiveInteger);
+  convApp->add_option("--dilation_w,-j", j, "Conv dilation width")
+      ->required()
+      ->check(PositiveInteger);
 
   CLI11_PARSE(mainApp, argc, argv);
 

--- a/sharkfuser/benchmarks/driver.cpp
+++ b/sharkfuser/benchmarks/driver.cpp
@@ -1,0 +1,156 @@
+// Copyright 2025 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <fusilli.h>
+
+#include "utils.h"
+
+#include <CLI/CLI.hpp>
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+using namespace fusilli;
+
+ErrorObject benchmark_conv_fprop(int64_t n, int64_t c, int64_t h, int64_t w,
+                                 int64_t k, int64_t r, int64_t s, int64_t u,
+                                 int64_t v, int64_t p, int64_t q, int64_t l,
+                                 int64_t j) {
+#ifdef FUSILLI_SYSTEMS_AMDGPU
+  Handle handle = FUSILLI_TRY(Handle::create(Backend::GFX942));
+#else
+  Handle handle = FUSILLI_TRY(Handle::create(Backend::CPU));
+#endif
+
+  // Build graph for the given handle (device), validate and compile it.
+  auto graph = std::make_shared<Graph>();
+  graph->setName("benchmark_conv_fprop");
+  graph->setIODataType(DataType::Half).setComputeDataType(DataType::Float);
+
+  auto X = graph->tensor(TensorAttr()
+                             .setName("image")
+                             .setDim({n, c, h, w})
+                             .setStride({c * h * w, h * w, w, 1})); // NCHW
+
+  auto W = graph->tensor(TensorAttr()
+                             .setName("filter")
+                             .setDim({k, c, r, s})
+                             .setStride({c * r * s, r * s, s, 1})); // KCRS
+
+  auto conv_attr = ConvFPropAttr()
+                       .setStride({u, v})
+                       .setPadding({p, q})
+                       .setDilation({l, j})
+                       .setName("conv_fprop");
+
+  auto Y = graph->convFProp(X, W, conv_attr);
+  Y->setOutput(true);
+
+  // Validate, infer missing properties
+  FUSILLI_CHECK_ERROR(graph->validate());
+
+  // Compile
+  FUSILLI_CHECK_ERROR(graph->compile(handle, /*remove=*/true));
+
+  // Allocate input buffer.
+  auto xBuf = std::make_shared<Buffer>(FUSILLI_TRY(
+      Buffer::allocate(handle,
+                       /*shape=*/castToSizeT({n, c, h, w}),
+                       /*data=*/std::vector<half>(n * c * h * w, half(1.0f)))));
+
+  // Allocate weight buffer.
+  auto wBuf = std::make_shared<Buffer>(FUSILLI_TRY(
+      Buffer::allocate(handle,
+                       /*shape=*/castToSizeT({k, c, r, s}),
+                       /*data=*/std::vector<half>(k * c * r * s, half(1.0f)))));
+
+  // Allocate output buffer.
+  auto yBuf = std::make_shared<Buffer>(FUSILLI_TRY(
+      Buffer::allocate(handle,
+                       /*shape=*/castToSizeT({n, k, h, w}),
+                       /*data=*/std::vector<half>(n * k * h * w, half(0.0f)))));
+
+  // Create variant pack.
+  const std::unordered_map<std::shared_ptr<TensorAttr>, std::shared_ptr<Buffer>>
+      variantPack = {
+          {X, xBuf},
+          {W, wBuf},
+          {Y, yBuf},
+      };
+
+  // Execute graph a few times.
+  for (size_t i = 0; i < 100; i++)
+    FUSILLI_CHECK_ERROR(graph->execute(variantPack));
+
+  return ok();
+}
+
+int main(int argc, char **argv) {
+  CLI::App mainApp{"Fusilli Benchmark Driver"};
+  mainApp.require_subcommand(1);
+
+  // Conv flags are kept in sync with MIOpen's ConvDriver:
+  // https://github.com/ROCm/rocm-libraries/blob/db0544fb61f2c7bd5a86dce98d4963420c1c741a/projects/miopen/driver/conv_driver.hpp#L878
+  CLI::App *convApp =
+      mainApp.add_subcommand("conv", "Fusilli Benchmark Forward Convolution");
+  int64_t n = 100, c = 3, h = 32, w = 32, k = 32, r = 3, s = 3, u = 1, v = 1,
+          p = 0, q = 0, l = 1, j = 1;
+  convApp
+      ->add_option("--batchsize,-n", n, "Input batch size") //
+      ->capture_default_str();
+  convApp
+      ->add_option("--in_channels,-c", c, "Input channels") //
+      ->capture_default_str();
+  convApp
+      ->add_option("--in_h,-H", h, "Input height") //
+      ->capture_default_str();
+  convApp
+      ->add_option("--in_w,-W", w, "Input width") //
+      ->capture_default_str();
+  convApp
+      ->add_option("--out_channels,-k", k, "Output channels") //
+      ->capture_default_str();
+  convApp
+      ->add_option("--fil_h,-y", r, "Filter height") //
+      ->capture_default_str();
+  convApp
+      ->add_option("--fil_w,-x", s, "Filter width") //
+      ->capture_default_str();
+  convApp
+      ->add_option("--conv_stride_h,-u", u, "Conv stride height") //
+      ->capture_default_str();
+  convApp
+      ->add_option("--conv_stride_w,-v", v, "Conv stride width") //
+      ->capture_default_str();
+  convApp
+      ->add_option("--pad_h,-p", p, "Conv padding height") //
+      ->capture_default_str();
+  convApp
+      ->add_option("--pad_w,-q", q, "Conv padding width") //
+      ->capture_default_str();
+  convApp
+      ->add_option("--dilation_h,-l", l, "Conv dilation height") //
+      ->capture_default_str();
+  convApp
+      ->add_option("--dilation_w,-j", j, "Conv dilation width") //
+      ->capture_default_str();
+
+  CLI11_PARSE(mainApp, argc, argv);
+
+  std::cout << "Fusilli Benchmark started..." << std::endl;
+
+  if (convApp->parsed()) {
+    auto status = benchmark_conv_fprop(n, c, h, w, k, r, s, u, v, p, q, l, j);
+    if (isError(status)) {
+      std::cerr << "Fusilli Benchmark failed: " << status << std::endl;
+      return 1;
+    }
+  }
+
+  std::cout << "Fusilli Benchmark complete!" << std::endl;
+  return 0;
+}

--- a/sharkfuser/build_tools/cmake/FusilliTestUtils.cmake
+++ b/sharkfuser/build_tools/cmake/FusilliTestUtils.cmake
@@ -46,7 +46,7 @@ endfunction()
 # Creates a fusilli C++ sample.
 #
 #  add_fusilli_sample(
-#    NAME <test-name>
+#    NAME <sample-name>
 #    SRCS <file> [<file> ...]
 #    [DEPS <dep> [<dep> ...]]
 #  )
@@ -77,6 +77,49 @@ function(add_fusilli_sample)
     SRCS ${_RULE_SRCS}
     DEPS ${_RULE_DEPS}
     BIN_SUBDIR samples
+  )
+endfunction()
+
+
+# Creates a fusilli C++ benchmark.
+#
+#  add_fusilli_benchmark(
+#    NAME <benchmark-name>
+#    SRCS <file> [<file> ...]
+#    [DEPS <dep> [<dep> ...]]
+#    ARGS <args>
+#  )
+#
+# NAME
+#  The name of the executable target to create (required).
+#
+# SRCS
+#  Source files to compile into the executable (required).
+#
+# DEPS
+#  Library dependencies to be linked to this target.
+#
+# ARGS
+#  Arguments to the benchmark driver (required).
+function(add_fusilli_benchmark)
+  if(NOT FUSILLI_BUILD_BENCHMARKS)
+    return()
+  endif()
+
+  cmake_parse_arguments(
+    _RULE               # prefix
+    ""                  # options
+    "NAME"              # one value keywords
+    "SRCS;DEPS;ARGS"    # multi-value keywords
+    ${ARGN}             # extra arguments
+  )
+
+  _add_fusilli_ctest_target(
+    NAME ${_RULE_NAME}
+    SRCS ${_RULE_SRCS}
+    DEPS ${_RULE_DEPS}
+    BIN_SUBDIR benchmarks
+    TEST_ARGS ${_RULE_ARGS}
   )
 endfunction()
 
@@ -162,15 +205,18 @@ endfunction()
 # DEPS
 #  Library dependencies to be linked to this target.
 #
+# TEST_ARGS
+#  Extra args to the test command.
+#
 # BIN_SUBDIR
 #  Subdirectory under build/bin/ where the executable will be placed.
 function(_add_fusilli_ctest_target)
   cmake_parse_arguments(
-    _RULE               # prefix
-    ""                  # options
-    "NAME;BIN_SUBDIR"   # one value keywords
-    "SRCS;DEPS"         # multi-value keywords
-    ${ARGN}             # extra arguments
+    _RULE                 # prefix
+    ""                    # options
+    "NAME;BIN_SUBDIR"     # one value keywords
+    "SRCS;DEPS;TEST_ARGS" # multi-value keywords
+    ${ARGN}               # extra arguments
   )
 
   # Create the target first.
@@ -182,7 +228,7 @@ function(_add_fusilli_ctest_target)
   )
 
   # Add the CTest test.
-  add_test(NAME ${_RULE_NAME} COMMAND ${_RULE_NAME})
+  add_test(NAME ${_RULE_NAME} COMMAND ${_RULE_NAME} ${_RULE_TEST_ARGS})
 
   # Configure cache dir and logging flags.
   # Pass `FUSILLI_CACHE_DIR=/tmp` to configure the compilation cache to be


### PR DESCRIPTION
Adds a master benchmark driver (with CLI11 for arg parsing) that supports subcommands for benchmarking different ops (with different set of flags). Also adds CMake support to easily add benchmark suites to CI. 

Example invocation:
```
./driver conv -n 128 -c 384 -H 24 -W 48 -k 384 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 
```
(in the future)
```
./driver sdpa <flags>
```

In a follow-on (2/N...), I'll add:
- [ ] support for choosing layouts
- [ ] support for 3D spatial dims
- [ ] support for varying types - `convfp16`, `convbf16`