### PR TITLE
[fusilli] Add pointwise attribute and node

### DIFF
--- a/sharkfuser/include/fusilli.h
+++ b/sharkfuser/include/fusilli.h
@@ -30,6 +30,7 @@
 // Nodes:
 #include "fusilli/node/conv_node.h"
 #include "fusilli/node/node.h"
+#include "fusilli/node/pointwise_node.h"
 
 // Backend:
 #include "fusilli/backend/backend.h"

--- a/sharkfuser/include/fusilli.h
+++ b/sharkfuser/include/fusilli.h
@@ -23,6 +23,7 @@
 // Attributes / Types:
 #include "fusilli/attributes/attributes.h"
 #include "fusilli/attributes/conv_attributes.h"
+#include "fusilli/attributes/pointwise_attributes.h"
 #include "fusilli/attributes/tensor_attributes.h"
 #include "fusilli/attributes/types.h"
 

--- a/sharkfuser/include/fusilli/attributes/pointwise_attributes.h
+++ b/sharkfuser/include/fusilli/attributes/pointwise_attributes.h
@@ -43,6 +43,7 @@ public:
   // Setters:
   FUSILLI_GENERIC_INPUT_TENSOR_SETTER(PointwiseAttr, InputNames, IN_0)
   FUSILLI_GENERIC_INPUT_TENSOR_SETTER(PointwiseAttr, InputNames, IN_1)
+  FUSILLI_GENERIC_INPUT_TENSOR_SETTER(PointwiseAttr, InputNames, IN_2)
   FUSILLI_GENERIC_OUTPUT_TENSOR_SETTER(PointwiseAttr, OutputNames, OUT)
 
   PointwiseAttr &setMode(Mode mode) {
@@ -53,9 +54,22 @@ public:
   // Getters:
   FUSILLI_GENERIC_INPUT_TENSOR_GETTER(InputNames, IN_0)
   FUSILLI_GENERIC_INPUT_TENSOR_GETTER(InputNames, IN_1)
+  FUSILLI_GENERIC_INPUT_TENSOR_GETTER(InputNames, IN_2)
   FUSILLI_GENERIC_OUTPUT_TENSOR_GETTER(OutputNames, OUT)
 
   Mode getMode() const { return mode_; }
+
+  // Utility function to convert enum to string
+  static std::string modeToString(Mode mode) {
+    switch (mode) {
+    case Mode::RELU:
+      return "RELU";
+    case Mode::ADD:
+      return "ADD";
+    default:
+      return "UNKNOWN";
+    }
+  }
 
 private:
   Mode mode_ = Mode::NOT_SET;

--- a/sharkfuser/include/fusilli/attributes/pointwise_attributes.h
+++ b/sharkfuser/include/fusilli/attributes/pointwise_attributes.h
@@ -1,0 +1,66 @@
+// Copyright 2025 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===----------------------------------------------------------------------===//
+//
+// This file contains attributes (compile-time constant metadata) for
+// pointwise nodes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FUSILLI_ATTRIBUTES_POINTWISE_ATTRIBUTES_H
+#define FUSILLI_ATTRIBUTES_POINTWISE_ATTRIBUTES_H
+
+#include "fusilli/attributes/attributes.h"
+#include "fusilli/attributes/tensor_attributes.h"
+
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace fusilli {
+
+class PointwiseAttr : public AttributesCRTP<PointwiseAttr> {
+public:
+  // Names for Tensor Inputs and Outputs. Pointwise can have a maximum of three
+  // inputs.
+  enum class InputNames { IN_0, IN_1, IN_2 };
+  enum class OutputNames { OUT };
+
+  enum class Mode {
+    NOT_SET,
+    ADD,
+    RELU,
+  };
+
+  std::unordered_map<InputNames, std::shared_ptr<TensorAttr>> inputs;
+  std::unordered_map<OutputNames, std::shared_ptr<TensorAttr>> outputs;
+
+  // Setters:
+  FUSILLI_GENERIC_INPUT_TENSOR_SETTER(PointwiseAttr, InputNames, IN_0)
+  FUSILLI_GENERIC_INPUT_TENSOR_SETTER(PointwiseAttr, InputNames, IN_1)
+  FUSILLI_GENERIC_OUTPUT_TENSOR_SETTER(PointwiseAttr, OutputNames, OUT)
+
+  PointwiseAttr &setMode(Mode mode) {
+    mode_ = mode;
+    return *this;
+  }
+
+  // Getters:
+  FUSILLI_GENERIC_INPUT_TENSOR_GETTER(InputNames, IN_0)
+  FUSILLI_GENERIC_INPUT_TENSOR_GETTER(InputNames, IN_1)
+  FUSILLI_GENERIC_OUTPUT_TENSOR_GETTER(OutputNames, OUT)
+
+  Mode getMode() const { return mode_; }
+
+private:
+  Mode mode_ = Mode::NOT_SET;
+};
+
+} // namespace fusilli
+
+#endif // FUSILLI_ATTRIBUTES_POINTWISE_ATTRIBUTES_H

--- a/sharkfuser/include/fusilli/node/node.h
+++ b/sharkfuser/include/fusilli/node/node.h
@@ -30,6 +30,7 @@ public:
   enum class Type {
     Composite,
     Convolution,
+    Pointwise,
   };
 
   explicit INode(const Context &ctx) : context(ctx) {}

--- a/sharkfuser/include/fusilli/node/pointwise_node.h
+++ b/sharkfuser/include/fusilli/node/pointwise_node.h
@@ -1,0 +1,137 @@
+// Copyright 2025 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===----------------------------------------------------------------------===//
+//
+// This file contains definitions for the pointwise nodes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FUSILLI_NODE_POINTWISE_NODE_H
+#define FUSILLI_NODE_POINTWISE_NODE_H
+
+#include "fusilli/attributes/pointwise_attributes.h"
+#include "fusilli/attributes/tensor_attributes.h"
+#include "fusilli/graph/context.h"
+#include "fusilli/node/node.h"
+#include "fusilli/support/logging.h"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace fusilli {
+
+class PointwiseNode : public NodeCRTP<PointwiseNode> {
+public:
+  PointwiseAttr pointwiseAttr;
+
+  PointwiseNode(PointwiseAttr attr, const Context &ctx)
+      : NodeCRTP(ctx), pointwiseAttr(std::move(attr)) {}
+
+  // MLIR assembly emitter helper methods.
+  std::string emitNodePreAsm() const override final { return ""; };
+  std::string getOperandNamesAsm() const override final { return ""; };
+  std::string getOperandTypesAsm() const override final { return ""; };
+  std::string getResultNamesAsm() const override final { return ""; };
+  std::string getResultTypesAsm() const override final { return ""; };
+  std::string getResultNamesAndTypesAsm() const override final { return ""; };
+
+  const std::string &getName() const override final {
+    return pointwiseAttr.getName();
+  }
+  Type getType() const override final { return Type::Pointwise; }
+
+  ErrorObject preValidateNode() const override final {
+    FUSILLI_LOG_LABEL_ENDL("INFO: Pre-Validating PointwiseNode '"
+                           << pointwiseAttr.getName() << "'");
+    FUSILLI_RETURN_ERROR_IF(
+        pointwiseAttr.getMode() == PointwiseAttr::Mode::NOT_SET,
+        ErrorCode::AttributeNotSet, "Pointwise mode not set");
+
+    // Validate inputs based on mode
+    PointwiseAttr::Mode mode = pointwiseAttr.getMode();
+
+    static const std::unordered_map<PointwiseAttr::Mode, int>
+        requiredInputCount = {{PointwiseAttr::Mode::RELU, 1},
+                              {PointwiseAttr::Mode::ADD, 2}};
+    int requiredCount = requiredInputCount.at(mode);
+
+    // Validate input requirements (required inputs must exist, unnecessary ones
+    // must not)
+    constexpr int maxInputs = 3;
+    for (int i = 0; i < maxInputs; ++i) {
+      auto inputName = static_cast<PointwiseAttr::InputNames>(i);
+      bool hasInput = pointwiseAttr.inputs.contains(inputName) &&
+                      pointwiseAttr.inputs.at(inputName) != nullptr;
+
+      if (i < requiredCount) {
+        FUSILLI_RETURN_ERROR_IF(!hasInput, ErrorCode::AttributeNotSet,
+                                PointwiseAttr::modeToString(mode) +
+                                    " mode requires IN" + std::to_string(i) +
+                                    " input");
+      } else {
+        FUSILLI_RETURN_ERROR_IF(hasInput, ErrorCode::InvalidAttribute,
+                                PointwiseAttr::modeToString(mode) +
+                                    " mode should not have IN" +
+                                    std::to_string(i) + " input set");
+      }
+    }
+
+    // Validate output
+    FUSILLI_RETURN_ERROR_IF(!pointwiseAttr.getOUT(), ErrorCode::AttributeNotSet,
+                            "Pointwise operation requires output");
+
+    return ok();
+  }
+
+  ErrorObject inferPropertiesNode() override final {
+    FUSILLI_LOG_LABEL_ENDL("INFO: Inferring properties for PointwiseNode '"
+                           << pointwiseAttr.getName() << "'");
+
+    // Fill missing properties from context (including data types)
+    pointwiseAttr.fillFromContext(context);
+
+    const auto &outTensor = pointwiseAttr.getOUT();
+    if (outTensor->getDim().empty()) {
+      std::vector<std::vector<int64_t>> inputShapes;
+      for (const auto &[inName, inTensor] : pointwiseAttr.inputs) {
+        if (inTensor) {
+          inputShapes.push_back(inTensor->getDim());
+        }
+      }
+      ErrorOr<std::vector<int64_t>> shape = computeBroadcastShapes(inputShapes);
+      FUSILLI_CHECK_ERROR(shape);
+      outTensor->setDim(std::move(*shape));
+    }
+
+    if (outTensor->getStride().empty()) {
+      for (const auto &[inName, inTensor] : pointwiseAttr.inputs) {
+        if (!inTensor) {
+          continue;
+        }
+        if (inTensor->getDim() != outTensor->getDim()) {
+          continue;
+        }
+        outTensor->setStride(inTensor->getStride());
+      }
+      FUSILLI_RETURN_ERROR_IF(outTensor->getStride().empty(),
+                              ErrorCode::InvalidAttribute,
+                              "Pointwise output strides could not be computed");
+    }
+
+    return ok();
+  }
+
+  ErrorObject postValidateNode() const override final {
+    FUSILLI_LOG_LABEL_ENDL("INFO: Post-Validating PointwiseNode '"
+                           << pointwiseAttr.getName() << "'");
+    return ok();
+  }
+};
+} // namespace fusilli
+
+#endif // FUSILLI_NODE_POINTWISE_NODE_H

--- a/sharkfuser/tests/CMakeLists.txt
+++ b/sharkfuser/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_fusilli_test(
     test_attributes.cpp
     test_tensor_attributes.cpp
     test_conv_attributes.cpp
+    test_pointwise_attributes.cpp
   DEPS
     libfusilli
     Catch2::Catch2WithMain

--- a/sharkfuser/tests/CMakeLists.txt
+++ b/sharkfuser/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ add_fusilli_test(
   NAME fusilli_node_tests
   SRCS
     test_conv_node.cpp
+    test_pointwise_node.cpp
   DEPS
     libfusilli
     Catch2::Catch2WithMain

--- a/sharkfuser/tests/test_pointwise_attributes.cpp
+++ b/sharkfuser/tests/test_pointwise_attributes.cpp
@@ -1,0 +1,66 @@
+// Copyright 2025 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <fusilli.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+using namespace fusilli;
+
+TEST_CASE("PointwiseAttr default constructor", "[pointwise_attr]") {
+  PointwiseAttr attr;
+  REQUIRE(attr.getMode() == PointwiseAttr::Mode::NOT_SET);
+  REQUIRE(attr.inputs.empty());
+  REQUIRE(attr.outputs.empty());
+}
+
+TEST_CASE("PointwiseAttr setters and getters", "[pointwise_attr]") {
+  PointwiseAttr attr;
+  PointwiseAttr::Mode mode = PointwiseAttr::Mode::ADD;
+
+  attr.setMode(mode);
+
+  REQUIRE(attr.getMode() == mode);
+
+  REQUIRE(attr.inputs.empty());
+  REQUIRE(attr.outputs.empty());
+
+  auto in0 = std::make_shared<TensorAttr>(1.0f);
+  auto in1 = std::make_shared<TensorAttr>(2.0f);
+  auto out = std::make_shared<TensorAttr>(3.0f);
+
+  attr.setIN_0(in0).setIN_1(in1).setOUT(out);
+
+  REQUIRE(attr.inputs.size() == 2);
+  REQUIRE(attr.outputs.size() == 1);
+
+  REQUIRE(attr.getIN_0() == in0);
+  REQUIRE(attr.getIN_1() == in1);
+  REQUIRE(attr.getOUT() == out);
+
+  REQUIRE(attr.getIN_0()->getDataType() == DataType::Float);
+  REQUIRE(attr.getIN_1()->getDataType() == DataType::Float);
+  REQUIRE(attr.getOUT()->getDataType() == DataType::Float);
+
+  REQUIRE(attr.getIN_0()->getDim() == std::vector<int64_t>{1});
+  REQUIRE(attr.getIN_1()->getDim() == std::vector<int64_t>{1});
+  REQUIRE(attr.getOUT()->getDim() == std::vector<int64_t>{1});
+
+  REQUIRE(attr.getIN_0()->getStride() == std::vector<int64_t>{1});
+  REQUIRE(attr.getIN_1()->getStride() == std::vector<int64_t>{1});
+  REQUIRE(attr.getOUT()->getStride() == std::vector<int64_t>{1});
+
+  REQUIRE(attr.getIN_0()->isScalar() == true);
+  REQUIRE(attr.getIN_1()->isScalar() == true);
+  REQUIRE(attr.getOUT()->isScalar() == true);
+
+  REQUIRE(attr.getIN_0()->isVirtual() == false);
+  REQUIRE(attr.getIN_1()->isVirtual() == false);
+  REQUIRE(attr.getOUT()->isVirtual() == false);
+}

--- a/sharkfuser/tests/test_pointwise_node.cpp
+++ b/sharkfuser/tests/test_pointwise_node.cpp
@@ -1,0 +1,220 @@
+// Copyright 2025 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <fusilli.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <vector>
+
+using namespace fusilli;
+
+TEST_CASE("PointwiseNode getName correctly propagates the attribute name",
+          "[pointwise_node]") {
+  Context ctx;
+  PointwiseAttr attr;
+  attr.setName("foo_pointwise");
+
+  PointwiseNode node(std::move(attr), ctx);
+  REQUIRE(node.getName() == "foo_pointwise");
+}
+
+TEST_CASE("PointwiseNode getType returns correct type", "[pointwise_node]") {
+  Context ctx;
+  PointwiseAttr attr;
+  attr.setMode(PointwiseAttr::Mode::RELU);
+
+  PointwiseNode node(std::move(attr), ctx);
+  REQUIRE(node.getType() == INode::Type::Pointwise);
+}
+
+TEST_CASE("PointwiseNode preValidateNode detects missing mode",
+          "[pointwise_node]") {
+  Context ctx;
+
+  SECTION("Mode not set") {
+    PointwiseAttr attr;
+    PointwiseNode node(std::move(attr), ctx);
+
+    auto status = node.preValidateNode();
+    REQUIRE(isError(status));
+    REQUIRE(status.getCode() == ErrorCode::AttributeNotSet);
+    REQUIRE(status.getMessage() == "Pointwise mode not set");
+  }
+
+  SECTION("Mode set to RELU without inputs") {
+    PointwiseAttr attr;
+    attr.setMode(PointwiseAttr::Mode::RELU);
+    PointwiseNode node(std::move(attr), ctx);
+
+    auto status = node.preValidateNode();
+    REQUIRE(isError(status));
+    REQUIRE(status.getCode() == ErrorCode::AttributeNotSet);
+    REQUIRE(status.getMessage() == "RELU mode requires IN0 input");
+  }
+
+  SECTION("Mode set to ADD without second input") {
+    PointwiseAttr attr;
+    attr.setMode(PointwiseAttr::Mode::ADD);
+    auto in0 = std::make_shared<TensorAttr>(1.0f);
+    attr.setIN_0(in0);
+    PointwiseNode node(std::move(attr), ctx);
+
+    auto status = node.preValidateNode();
+    REQUIRE(isError(status));
+    REQUIRE(status.getCode() == ErrorCode::AttributeNotSet);
+    REQUIRE(status.getMessage() == "ADD mode requires IN1 input");
+  }
+
+  SECTION("Mode set to RELU with too many inputs") {
+    PointwiseAttr attr;
+    attr.setMode(PointwiseAttr::Mode::RELU);
+    auto in0 = std::make_shared<TensorAttr>(1.0f);
+    auto in1 = std::make_shared<TensorAttr>(2.0f);
+    attr.setIN_0(in0).setIN_1(in1);
+    PointwiseNode node(std::move(attr), ctx);
+
+    auto status = node.preValidateNode();
+    REQUIRE(isError(status));
+    REQUIRE(status.getCode() == ErrorCode::InvalidAttribute);
+    REQUIRE(status.getMessage() == "RELU mode should not have IN1 input set");
+  }
+
+  SECTION("Mode set to ADD with too many inputs") {
+    PointwiseAttr attr;
+    attr.setMode(PointwiseAttr::Mode::ADD);
+    auto in0 = std::make_shared<TensorAttr>(1.0f);
+    auto in1 = std::make_shared<TensorAttr>(2.0f);
+    auto in2 = std::make_shared<TensorAttr>(3.0f);
+    attr.setIN_0(in0).setIN_1(in1).setIN_2(in2);
+    PointwiseNode node(std::move(attr), ctx);
+
+    auto status = node.preValidateNode();
+    REQUIRE(isError(status));
+    REQUIRE(status.getCode() == ErrorCode::InvalidAttribute);
+    REQUIRE(status.getMessage() == "ADD mode should not have IN2 input set");
+  }
+}
+
+TEST_CASE("PointwiseNode postValidateNode works correctly",
+          "[pointwise_node]") {
+  Context ctx;
+  PointwiseAttr attr;
+  attr.setMode(PointwiseAttr::Mode::RELU);
+
+  PointwiseNode node(std::move(attr), ctx);
+
+  auto status = node.postValidateNode();
+  REQUIRE(!isError(status));
+}
+
+TEST_CASE("PointwiseNode with tensor attributes", "[pointwise_node]") {
+  Context ctx;
+  PointwiseAttr attr;
+
+  attr.setMode(PointwiseAttr::Mode::RELU);
+
+  auto in0 = std::make_shared<TensorAttr>(1.0f);
+  auto in1 = std::make_shared<TensorAttr>(2.0f);
+  auto out = std::make_shared<TensorAttr>(3.0f);
+
+  attr.setIN_0(in0).setIN_1(in1).setOUT(out);
+
+  PointwiseNode node(std::move(attr), ctx);
+
+  // Verify the node has access to the attributes
+  REQUIRE(node.pointwiseAttr.getIN_0() == in0);
+  REQUIRE(node.pointwiseAttr.getIN_1() == in1);
+  REQUIRE(node.pointwiseAttr.getOUT() == out);
+  REQUIRE(node.pointwiseAttr.getMode() == PointwiseAttr::Mode::RELU);
+
+  // Verify tensor properties
+  REQUIRE(node.pointwiseAttr.getIN_0()->getDataType() == DataType::Float);
+  REQUIRE(node.pointwiseAttr.getIN_1()->getDataType() == DataType::Float);
+  REQUIRE(node.pointwiseAttr.getOUT()->getDataType() == DataType::Float);
+
+  REQUIRE(node.pointwiseAttr.getIN_0()->getDim() == std::vector<int64_t>{1});
+  REQUIRE(node.pointwiseAttr.getIN_1()->getDim() == std::vector<int64_t>{1});
+  REQUIRE(node.pointwiseAttr.getOUT()->getDim() == std::vector<int64_t>{1});
+}
+
+TEST_CASE("PointwiseNode with ADD mode", "[pointwise_node]") {
+  Context ctx;
+  ctx.setIODataType(DataType::Float);
+  PointwiseAttr attr;
+  attr.setMode(PointwiseAttr::Mode::ADD);
+
+  auto in0 = std::make_shared<TensorAttr>(1.0f);
+  auto in1 = std::make_shared<TensorAttr>(2.0f);
+  auto out = std::make_shared<TensorAttr>();
+
+  attr.setIN_0(in0).setIN_1(in1).setOUT(out);
+
+  PointwiseNode node(std::move(attr), ctx);
+  REQUIRE(!isError(node.preValidateNode()));
+  REQUIRE(!isError(node.inferPropertiesNode()));
+  REQUIRE(!isError(node.postValidateNode()));
+
+  out = node.pointwiseAttr.getOUT();
+  REQUIRE(out != nullptr);
+  REQUIRE(out->getDim() == std::vector<int64_t>{1});
+  REQUIRE(out->getDataType() == DataType::Float);
+  REQUIRE(out->getStride() == std::vector<int64_t>{1});
+}
+
+TEST_CASE("PointwiseNode with ADD mode broadcast", "[pointwise_node]") {
+  Context ctx;
+  ctx.setIODataType(DataType::Float);
+  PointwiseAttr attr;
+  attr.setMode(PointwiseAttr::Mode::ADD);
+
+  int64_t dim0 = 16;
+  int64_t dim1 = 32;
+  int64_t dim2 = 64;
+  int64_t dim3 = 128;
+
+  auto in0 = std::make_shared<TensorAttr>();
+  in0->setDim({dim0, dim1, dim2, dim3})
+      .setStride({dim1 * dim2 * dim3, dim2 * dim3, dim3, 1});
+  auto in1 = std::make_shared<TensorAttr>();
+  in1->setDim({1, dim1, 1, 1}).setStride({0, dim1, 0, 0});
+  auto out = std::make_shared<TensorAttr>();
+
+  attr.setIN_0(in0).setIN_1(in1).setOUT(out);
+
+  PointwiseNode node(std::move(attr), ctx);
+  REQUIRE(!isError(node.preValidateNode()));
+  REQUIRE(!isError(node.inferPropertiesNode()));
+  REQUIRE(!isError(node.postValidateNode()));
+
+  out = node.pointwiseAttr.getOUT();
+  REQUIRE(out != nullptr);
+  REQUIRE(out->getDim() == in0->getDim());
+  REQUIRE(out->getDataType() == DataType::Float);
+  REQUIRE(out->getStride() == in0->getStride());
+}
+
+TEST_CASE("PointwiseNode with ADD mode invalid broadcast", "[pointwise_node]") {
+  Context ctx;
+  ctx.setIODataType(DataType::Float);
+  PointwiseAttr attr;
+  attr.setMode(PointwiseAttr::Mode::ADD);
+
+  int64_t dim0 = 16;
+  int64_t dim1 = 32;
+
+  auto in0 = std::make_shared<TensorAttr>();
+  in0->setDim({dim0}).setStride({1});
+  auto in1 = std::make_shared<TensorAttr>();
+  in1->setDim({dim1}).setStride({1});
+  auto out = std::make_shared<TensorAttr>();
+
+  attr.setIN_0(in0).setIN_1(in1).setOUT(out);
+
+  PointwiseNode node(std::move(attr), ctx);
+  REQUIRE(!isError(node.preValidateNode()));
+  REQUIRE(isError(node.inferPropertiesNode()));
+}

--- a/sharkfuser/tests/test_tensor_attributes.cpp
+++ b/sharkfuser/tests/test_tensor_attributes.cpp
@@ -308,3 +308,149 @@ TEST_CASE("Permute order utils", "[TensorAttr utils]") {
   REQUIRE(getContiguousToChannelsLastPermuteOrder(5) ==
           std::vector<int64_t>({0, 2, 3, 4, 1}));
 }
+
+TEST_CASE("computeBroadcastShapes", "[TensorAttr utils]") {
+  SECTION("Empty inputs") {
+    SECTION("All shapes empty") {
+      std::vector<std::vector<int64_t>> shapes = {{}, {}, {}};
+      auto result = computeBroadcastShapes(shapes);
+      ErrorObject err = result;
+      REQUIRE(isError(err));
+      REQUIRE(err.getCode() == ErrorCode::CompileFailure);
+      REQUIRE(err.getMessage() == "All input shapes are empty");
+    }
+
+    SECTION("No shapes") {
+      std::vector<std::vector<int64_t>> shapes = {};
+      auto result = computeBroadcastShapes(shapes);
+      ErrorObject err = result;
+      REQUIRE(isError(err));
+      REQUIRE(err.getCode() == ErrorCode::CompileFailure);
+      REQUIRE(err.getMessage() == "All input shapes are empty");
+    }
+  }
+
+  SECTION("Single shape") {
+    SECTION("Single 1D shape") {
+      std::vector<std::vector<int64_t>> shapes = {{5}};
+      auto result = computeBroadcastShapes(shapes);
+      REQUIRE(isOk(result));
+      REQUIRE(*result == std::vector<int64_t>{5});
+    }
+
+    SECTION("Single 4D shape") {
+      std::vector<std::vector<int64_t>> shapes = {{16, 32, 64, 128}};
+      auto result = computeBroadcastShapes(shapes);
+      REQUIRE(isOk(result));
+      REQUIRE(*result == std::vector<int64_t>{16, 32, 64, 128});
+    }
+  }
+
+  SECTION("Identical shapes") {
+    SECTION("Two identical shapes") {
+      std::vector<std::vector<int64_t>> shapes = {{3, 4}, {3, 4}};
+      auto result = computeBroadcastShapes(shapes);
+      REQUIRE(isOk(result));
+      REQUIRE(*result == std::vector<int64_t>{3, 4});
+    }
+
+    SECTION("Three identical shapes") {
+      std::vector<std::vector<int64_t>> shapes = {
+          {2, 3, 4}, {2, 3, 4}, {2, 3, 4}};
+      auto result = computeBroadcastShapes(shapes);
+      REQUIRE(isOk(result));
+      REQUIRE(*result == std::vector<int64_t>{2, 3, 4});
+    }
+  }
+
+  SECTION("Different rank shapes") {
+    SECTION("1D + 2D") {
+      std::vector<std::vector<int64_t>> shapes = {{4}, {3, 4}};
+      auto result = computeBroadcastShapes(shapes);
+      REQUIRE(isOk(result));
+      REQUIRE(*result == std::vector<int64_t>{3, 4});
+    }
+
+    SECTION("2D + 3D") {
+      std::vector<std::vector<int64_t>> shapes = {{4, 5}, {2, 4, 5}};
+      auto result = computeBroadcastShapes(shapes);
+      REQUIRE(isOk(result));
+      REQUIRE(*result == std::vector<int64_t>{2, 4, 5});
+    }
+
+    SECTION("1D + 2D + 3D") {
+      std::vector<std::vector<int64_t>> shapes = {{5}, {3, 5}, {2, 3, 5}};
+      auto result = computeBroadcastShapes(shapes);
+      REQUIRE(isOk(result));
+      REQUIRE(*result == std::vector<int64_t>{2, 3, 5});
+    }
+  }
+
+  SECTION("Unit dimension broadcasting") {
+    SECTION("Broadcasting with 1s") {
+      std::vector<std::vector<int64_t>> shapes = {{1, 4}, {3, 1}, {3, 1}};
+      auto result = computeBroadcastShapes(shapes);
+      REQUIRE(isOk(result));
+      REQUIRE(*result == std::vector<int64_t>{3, 4});
+    }
+
+    SECTION("Complex broadcasting - PyTorch style") {
+      std::vector<std::vector<int64_t>> shapes = {{16, 32, 64, 128},
+                                                  {1, 32, 1, 1}};
+      auto result = computeBroadcastShapes(shapes);
+      REQUIRE(isOk(result));
+      REQUIRE(*result == std::vector<int64_t>{16, 32, 64, 128});
+    }
+
+    SECTION("Single element tensors") {
+      std::vector<std::vector<int64_t>> shapes = {{1}, {1}};
+      auto result = computeBroadcastShapes(shapes);
+      REQUIRE(isOk(result));
+      REQUIRE(*result == std::vector<int64_t>{1});
+    }
+  }
+
+  SECTION("Incompatible dimensions") {
+    SECTION("Incompatible dimensions") {
+      std::vector<std::vector<int64_t>> shapes = {{3}, {4}};
+      auto result = computeBroadcastShapes(shapes);
+      ErrorObject err = result;
+      REQUIRE(isError(err));
+      REQUIRE(err.getCode() == ErrorCode::CompileFailure);
+      REQUIRE(err.getMessage() == "Cannot broadcast two non unit dimensions");
+    }
+
+    SECTION("Complex incompatible case") {
+      std::vector<std::vector<int64_t>> shapes = {{2, 3, 4}, {2, 5, 4}};
+      auto result = computeBroadcastShapes(shapes);
+      ErrorObject err = result;
+      REQUIRE(isError(err));
+      REQUIRE(err.getMessage() == "Cannot broadcast two non unit dimensions");
+    }
+
+    SECTION("Unit vs non-unit mismatch") {
+      std::vector<std::vector<int64_t>> shapes = {{1, 3}, {2, 4}};
+      auto result = computeBroadcastShapes(shapes);
+      ErrorObject err = result;
+      REQUIRE(isError(err));
+      REQUIRE(err.getMessage() == "Cannot broadcast two non unit dimensions");
+    }
+  }
+
+  SECTION("Mixed empty and non-empty") {
+    SECTION("Empty shapes filtered out") {
+      std::vector<std::vector<int64_t>> shapes = {
+          {}, {3, 4}, {1}, {3, 1}, {1, 4}};
+      auto result = computeBroadcastShapes(shapes);
+      REQUIRE(isOk(result));
+      REQUIRE(*result == std::vector<int64_t>{3, 4});
+    }
+
+    SECTION("All empty except one") {
+      std::vector<std::vector<int64_t>> shapes = {{}, {}, {5, 6, 7}, {}};
+      auto result = computeBroadcastShapes(shapes);
+      REQUIRE(isOk(result));
+      REQUIRE(*result == std::vector<int64_t>{5, 6, 7});
+    }
+  }
+}


### PR DESCRIPTION
This change implements attribute and node for pointwise op types. This does not implement the ASM emitter for `PointwiseNode`. That will be done in a followup PR.