### PR TITLE
Fix offset prefill and add toy llama test

### DIFF
--- a/sharktank/sharktank/layers/paged_attention.py
+++ b/sharktank/sharktank/layers/paged_attention.py
@@ -906,11 +906,15 @@ class PagedMHAttention(PagedAttention):
 
         is_prefill = q.shape[1] != 1
         if is_prefill:
+            source_len = seq_block_ids.shape[1] * self.block_seq_stride
+            target_len = q.shape[1]
             # q, k, v, x, and h all have the same .shape[1] (batch_seqlen)
-            input_mask = ops.input_mask(seq_lens, q.shape[1])
+            input_mask = ops.input_mask(seq_lens, source_len)
             mask = ops.attention_mask(
                 input_mask,
                 start_positions,
+                source_len=source_len,
+                target_len=target_len,
                 attention_dtype=self.activation_dtype,
             )
             use_chunked_attention_mask = self.attention_chunk_size is not None

--- a/sharktank/sharktank/ops/default_impls.py
+++ b/sharktank/sharktank/ops/default_impls.py
@@ -102,6 +102,8 @@ def attention_mask_default(
     boolean_input_mask: torch.Tensor,
     start_positions: torch.Tensor | None,
     *,
+    source_len: int,
+    target_len: int,
     attention_dtype: torch.dtype,
 ) -> torch.Tensor:
     device = boolean_input_mask.device
@@ -110,11 +112,9 @@ def attention_mask_default(
     dtype = (
         torch.float32 if attention_dtype == torch.float8_e4m3fnuz else attention_dtype
     )
-    _, batch_seq_len = boolean_input_mask.shape
-
     causal_mask = create_causal_context_mask(
-        src_len=batch_seq_len,
-        target_len=batch_seq_len,
+        src_len=source_len,
+        target_len=target_len,
         start_positions=start_positions,
         device=device,
     )

--- a/sharktank/sharktank/ops/signatures.py
+++ b/sharktank/sharktank/ops/signatures.py
@@ -165,6 +165,8 @@ def attention_mask(
     boolean_input_mask: AnyTensor,
     start_positions: AnyTensor | None = None,
     *,
+    source_len: int,
+    target_len: int,
     attention_dtype: torch.dtype,
 ) -> torch.Tensor:
     """
@@ -185,6 +187,8 @@ def _attention_mask_trampoline(
     boolean_input_mask: AnyTensor,
     start_positions: AnyTensor | None = None,
     *,
+    source_len: int,
+    target_len: int,
     attention_dtype: torch.dtype,
 ):
     tensors = [boolean_input_mask]
@@ -192,7 +196,7 @@ def _attention_mask_trampoline(
         tensors.append(start_positions)
     for override in d.find_overrides(tensors):
         result = override(
-            boolean_input_mask, start_positions, attention_dtype=attention_dtype
+            boolean_input_mask, start_positions, source_len=source_len, target_len=target_len, attention_dtype=attention_dtype
         )
         if result is not NotImplemented:
             return override, result


### PR DESCRIPTION
Mask generation is incorrect causing incorrect numerics for offset prefill. Updated functions to get correct numerics and include a llama test that validates offset prefill works.