### PR TITLE
[Tuner] Add sorting function for contraction in candidate_gen and benchmark phases

### DIFF
--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -41,6 +41,8 @@ tune_logger = logging.getLogger("tune")
 
 
 class DispatchTuner(dispatch_parser.DispatchParser):
+    dispatch_kind: common.DispatchKind
+
     @abstractmethod
     def get_td_spec(
         self,
@@ -97,6 +99,8 @@ class DispatchTunerRegistry:
 class ContractionOpInterfaceTuner(
     DispatchTuner, dispatch_parser.ContractionOpInterfaceParser
 ):
+    dispatch_kind = common.DispatchKind.contraction
+
     def __init__(self, root_op: ir.Operation):
         super().__init__(root_op)
 
@@ -128,6 +132,8 @@ class ContractionOpInterfaceTuner(
 class ConvolutionOpInterfaceTuner(
     DispatchTuner, dispatch_parser.ConvolutionOpInterfaceParser
 ):
+    dispatch_kind = common.DispatchKind.conv
+
     def __init__(self, root_op: ir.Operation):
         super().__init__(root_op)
 
@@ -150,6 +156,8 @@ class ConvolutionOpInterfaceTuner(
 class AttentionOpInterfaceTuner(
     DispatchTuner, dispatch_parser.AttentionOpInterfaceParser
 ):
+    dispatch_kind = common.DispatchKind.attention
+
     def __init__(self, root_op: ir.Operation):
         super().__init__(root_op)
 
@@ -175,16 +183,7 @@ def get_default_output_dir() -> str:
     return "tuning_" + datetime.now().strftime("%Y_%m_%d_%H_%M")
 
 
-def generate_configs_and_td_specs(
-    input_module: ir.Module,  # Path to the mlir file to be tuned
-    tuner_context: common.TunerContext,
-    limit: int = 4096,  # Max candidates to be generated
-    sorting: common.SortMethods = common.SortMethods.no_sort,
-    num_subgroups: int = 4,  # GPU spec, used to determine candidate generation constraints
-    allowed_waves_per_eu: list[int] = [2],
-    pipeline_options_search_space: dispatch_constraints.PipelineOptionsSearchSpace = dispatch_constraints.PipelineOptionsSearchSpace(),
-    codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline = iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute,
-) -> list[common.CandidateProfile]:
+def set_dispatch_tuner(input_module: ir.Module) -> DispatchTuner:
     dispatch_tuners: list[type[DispatchTuner]] = [
         ContractionOpInterfaceTuner,
         ConvolutionOpInterfaceTuner,
@@ -213,12 +212,18 @@ def generate_configs_and_td_specs(
 
     assert dispatch_tuner, "No suitable dispatch tuner found"
 
-    candidate_profiles: list[common.CandidateProfile] = []
+    return dispatch_tuner
 
-    # Index 0 is reserved for default config, so it gets a placeholder spec.
-    candidate_profiles.append(common.CandidateProfile(td_spec_module=spec_builder.get_placeholder_spec(input_module.context),
-    solution_trace=None))
-
+def generate_configs_and_td_specs(
+    input_module: ir.Module,  # Path to the mlir file to be tuned
+    tuner_context: common.TunerContext,
+    limit: int = 4096,  # Max candidates to be generated
+    sorting: common.SortMethods = common.SortMethods.no_sort,
+    num_subgroups: int = 4,  # GPU spec, used to determine candidate generation constraints
+    allowed_waves_per_eu: list[int] = [2],
+    pipeline_options_search_space: dispatch_constraints.PipelineOptionsSearchSpace = dispatch_constraints.PipelineOptionsSearchSpace(),
+    codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline = iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute,
+) -> list[common.CandidateProfile]:
     # Get GPU target information from the executable variant operation.
     variant_op_list = iree_codegen.get_executable_variant_ops(input_module)
     assert len(variant_op_list) == 1, "Expect one executable variant op"
@@ -230,6 +235,7 @@ def generate_configs_and_td_specs(
     if target_info.arch not in ["gfx942", "gfx1100"]:
         print(f"Warning: Untested architecture '{target_info.arch}'.")
 
+    dispatch_tuner = set_dispatch_tuner(input_module)
     constraint_generator = dispatch_tuner.get_constraint_generator()
 
     solutions = list(
@@ -245,6 +251,11 @@ def generate_configs_and_td_specs(
     traces = [dispatch_tuner.get_solution_trace(s) for s in solutions]
     sorted_order = dispatch_tuner.sort_solutions(traces, sorting)
     solutions = [solutions[i] for i in sorted_order]
+
+    candidate_profiles: list[common.CandidateProfile] = []
+    # Index 0 is reserved for default config, so it gets a placeholder spec.
+    candidate_profiles.append(common.CandidateProfile(td_spec_module=spec_builder.get_placeholder_spec(input_module.context),
+    solution_trace=None))
 
     for i, config in enumerate(solutions[:limit]):
         tune_logger.debug(f"Solution #{i+1}: {config}")

--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -60,6 +60,17 @@ class DispatchTuner(dispatch_parser.DispatchParser):
         """Returns a ConstraintGenerator associated with this dispatch root op."""
         pass
 
+    @abstractmethod
+    def get_solution_trace(
+        self,
+        config_list: list[common.TuningConfiguration],
+    ) -> common.SolutionTrace:
+        """
+        Return a SolutionTrace that records the feature values of a single candidate,
+        retrieved from the `solution_trace` attribute of its TuningConfiguration.
+        """
+        pass
+
 
 class DispatchTunerRegistry:
     def __init__(self):
@@ -96,6 +107,12 @@ class ContractionOpInterfaceTuner(
         return spec_builder.build_td_spec(
             contraction_op.context, contraction_op, config_list, func_name
         )
+
+    def get_solution_trace(
+        self,
+        config_list: list[common.TuningConfiguration],
+    ) -> list[common.ContractionSolutionTrace]:
+        return config_list[0].solution_trace
 
 
 class ConvolutionOpInterfaceTuner(
@@ -156,7 +173,7 @@ def generate_configs_and_td_specs(
     allowed_waves_per_eu: list[int] = [2],
     pipeline_options_search_space: dispatch_constraints.PipelineOptionsSearchSpace = dispatch_constraints.PipelineOptionsSearchSpace(),
     codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline = iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute,
-) -> list[ir.Module]:
+) -> list[common.CandidateProfile]:
     dispatch_tuners: list[type[DispatchTuner]] = [
         ContractionOpInterfaceTuner,
         ConvolutionOpInterfaceTuner,
@@ -185,10 +202,11 @@ def generate_configs_and_td_specs(
 
     assert dispatch_tuner, "No suitable dispatch tuner found"
 
+    candidate_profiles: list[common.CandidateProfile] = []
+
     # Index 0 is reserved for default config, so it gets a placeholder spec.
-    config_specs: list[ir.Module] = [
-        spec_builder.get_placeholder_spec(input_module.context)
-    ]
+    candidate_profiles.append(common.CandidateProfile(td_spec_module=spec_builder.get_placeholder_spec(input_module.context),
+    solution_trace=None))
 
     # Get GPU target information from the executable variant operation.
     variant_op_list = iree_codegen.get_executable_variant_ops(input_module)
@@ -213,16 +231,19 @@ def generate_configs_and_td_specs(
             pipeline_options_search_space=pipeline_options_search_space,
         )
     )
-    random.shuffle(solutions) # Shuffle the full set of generated solutions.
-
+    # solutions = common.smart_sort()
     for i, config in enumerate(solutions[:limit]):
         tune_logger.debug(f"Solution #{i+1}: {config}")
         td_spec_module = dispatch_tuner.get_td_spec(config)
         assert td_spec_module, "Failed to generate transform dialect spec"
-        config_specs.append(td_spec_module)
+        solution_trace = dispatch_tuner.get_solution_trace(config)
+        assert solution_trace, "Failed to retrive solution feature values"
+        candidate_profiles.append(common.CandidateProfile(
+            td_spec_module = td_spec_module, solution_trace=solution_trace
+        ))
 
-    tune_logger.debug(f"Generated {len(config_specs)} tuning specs")
-    return config_specs
+    tune_logger.debug(f"Generated {len(candidate_profiles)} tuning specs")
+    return candidate_profiles
 
 
 @dataclass
@@ -373,7 +394,7 @@ def main() -> None:
             prefetch_shared_memory=args.prefetch_shared_memory_options,
             no_reduce_shared_memory_bank_conflicts=args.no_reduce_shared_memory_bank_conflicts_options,
         )
-        specs: list[ir.Module] = generate_configs_and_td_specs(
+        candidate_profiles: list[common.CandidateProfile] = generate_configs_and_td_specs(
             mlir_module,
             tuner_ctx,
             args.limit,
@@ -382,6 +403,7 @@ def main() -> None:
             pipeline_options_search_space,
             iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse,
         )
+        specs: list[ir.Module] = [i.tg_spec_module for i in candidate_profiles]
         for candidate_num, spec in enumerate(specs):
             spec_dir = Path(args.output)
             spec_path = spec_dir / f"{candidate_num}_spec.mlir"

--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -203,7 +203,7 @@ def generate_configs_and_td_specs(
 
     constraint_generator = dispatch_tuner.get_constraint_generator()
 
-    for i, config in enumerate(
+    solutions = list(
         constraint_generator.generate_solutions(
             tuner_context,
             target_info,
@@ -212,9 +212,10 @@ def generate_configs_and_td_specs(
             allowed_waves_per_eu=allowed_waves_per_eu,
             pipeline_options_search_space=pipeline_options_search_space,
         )
-    ):
-        if i >= limit:
-            break
+    )
+    random.shuffle(solutions) # Shuffle the full set of generated solutions.
+
+    for i, config in enumerate(solutions[:limit]):
         tune_logger.debug(f"Solution #{i+1}: {config}")
         td_spec_module = dispatch_tuner.get_td_spec(config)
         assert td_spec_module, "Failed to generate transform dialect spec"

--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -71,6 +71,13 @@ class DispatchTuner(dispatch_parser.DispatchParser):
         """
         pass
 
+    @abstractmethod
+    def sort_solutions(self, traces: list[common.SolutionTrace], method:common.SortMethods)->list[int]:
+        """
+        Calling the sorting_handler() function to sort the candidate list.
+        """
+        pass
+
 
 class DispatchTunerRegistry:
     def __init__(self):
@@ -113,6 +120,9 @@ class ContractionOpInterfaceTuner(
         config_list: list[common.TuningConfiguration],
     ) -> list[common.ContractionSolutionTrace]:
         return config_list[0].solution_trace
+    
+    def sort_solutions(self, traces: list[common.ContractionSolutionTrace], method:common.SortMethods)->list[int]:
+        return common.sorting_handler(traces, method, common.ContractionSortCandidateKey)
 
 
 class ConvolutionOpInterfaceTuner(
@@ -169,6 +179,7 @@ def generate_configs_and_td_specs(
     input_module: ir.Module,  # Path to the mlir file to be tuned
     tuner_context: common.TunerContext,
     limit: int = 4096,  # Max candidates to be generated
+    sorting: common.SortMethods = common.SortMethods.no_sort,
     num_subgroups: int = 4,  # GPU spec, used to determine candidate generation constraints
     allowed_waves_per_eu: list[int] = [2],
     pipeline_options_search_space: dispatch_constraints.PipelineOptionsSearchSpace = dispatch_constraints.PipelineOptionsSearchSpace(),
@@ -231,7 +242,10 @@ def generate_configs_and_td_specs(
             pipeline_options_search_space=pipeline_options_search_space,
         )
     )
-    # solutions = common.smart_sort()
+    traces = [dispatch_tuner.get_solution_trace(s) for s in solutions]
+    sorted_order = dispatch_tuner.sort_solutions(traces, sorting)
+    solutions = [solutions[i] for i in sorted_order]
+
     for i, config in enumerate(solutions[:limit]):
         tune_logger.debug(f"Solution #{i+1}: {config}")
         td_spec_module = dispatch_tuner.get_td_spec(config)
@@ -403,7 +417,7 @@ def main() -> None:
             pipeline_options_search_space,
             iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse,
         )
-        specs: list[ir.Module] = [i.tg_spec_module for i in candidate_profiles]
+        specs: list[ir.Module] = [i.td_spec_module for i in candidate_profiles]
         for candidate_num, spec in enumerate(specs):
             spec_dir = Path(args.output)
             spec_path = spec_dir / f"{candidate_num}_spec.mlir"

--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -61,8 +61,8 @@ class DispatchTuner(dispatch_parser.DispatchParser):
     def get_constraint_generator(self) -> constraint_generator.ConstraintGenerator:
         """Returns a ConstraintGenerator associated with this dispatch root op."""
         pass
-    
-    # TODO: Uncomment after completing the sort function for atten and conv 
+
+    # TODO: Uncomment after completing the sort function for atten and conv
     # @abstractmethod
     # def get_solution_trace(
     #     self,
@@ -125,9 +125,13 @@ class ContractionOpInterfaceTuner(
         config_list: list[common.TuningConfiguration],
     ) -> list[common.ContractionSolutionTrace]:
         return config_list[0].solution_trace
-    
-    def sort_solutions(self, traces: list[common.ContractionSolutionTrace], method:common.SortMethods)->list[int]:
-        return common.sorting_handler(traces, method, common.ContractionSortCandidateKey)
+
+    def sort_solutions(
+        self, traces: list[common.ContractionSolutionTrace], method: common.SortMethods
+    ) -> list[int]:
+        return common.sorting_handler(
+            traces, method, common.ContractionSortCandidateKey
+        )
 
 
 class ConvolutionOpInterfaceTuner(
@@ -215,6 +219,7 @@ def set_dispatch_tuner(input_module: ir.Module) -> DispatchTuner:
 
     return dispatch_tuner
 
+
 def generate_configs_and_td_specs(
     input_module: ir.Module,  # Path to the mlir file to be tuned
     tuner_context: common.TunerContext,
@@ -249,7 +254,7 @@ def generate_configs_and_td_specs(
             pipeline_options_search_space=pipeline_options_search_space,
         )
     )
-    
+
     if dispatch_tuner.dispatch_kind == common.DispatchKind.contraction:
         traces = [dispatch_tuner.get_solution_trace(s) for s in solutions]
         sorted_order = dispatch_tuner.sort_solutions(traces, sorting)
@@ -257,8 +262,12 @@ def generate_configs_and_td_specs(
 
     candidate_profiles: list[common.CandidateProfile] = []
     # Index 0 is reserved for default config, so it gets a placeholder spec.
-    candidate_profiles.append(common.CandidateProfile(td_spec_module=spec_builder.get_placeholder_spec(input_module.context),
-    solution_trace=None))
+    candidate_profiles.append(
+        common.CandidateProfile(
+            td_spec_module=spec_builder.get_placeholder_spec(input_module.context),
+            solution_trace=None,
+        )
+    )
 
     for i, config in enumerate(solutions[:limit]):
         tune_logger.debug(f"Solution #{i+1}: {config}")
@@ -266,9 +275,11 @@ def generate_configs_and_td_specs(
         assert td_spec_module, "Failed to generate transform dialect spec"
         solution_trace = dispatch_tuner.get_solution_trace(config)
         assert solution_trace, "Failed to retrive solution feature values"
-        candidate_profiles.append(common.CandidateProfile(
-            td_spec_module = td_spec_module, solution_trace=solution_trace
-        ))
+        candidate_profiles.append(
+            common.CandidateProfile(
+                td_spec_module=td_spec_module, solution_trace=solution_trace
+            )
+        )
 
     tune_logger.debug(f"Generated {len(candidate_profiles)} tuning specs")
     return candidate_profiles
@@ -422,7 +433,9 @@ def main() -> None:
             prefetch_shared_memory=args.prefetch_shared_memory_options,
             no_reduce_shared_memory_bank_conflicts=args.no_reduce_shared_memory_bank_conflicts_options,
         )
-        candidate_profiles: list[common.CandidateProfile] = generate_configs_and_td_specs(
+        candidate_profiles: list[
+            common.CandidateProfile
+        ] = generate_configs_and_td_specs(
             mlir_module,
             tuner_ctx,
             args.limit,

--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -61,24 +61,25 @@ class DispatchTuner(dispatch_parser.DispatchParser):
     def get_constraint_generator(self) -> constraint_generator.ConstraintGenerator:
         """Returns a ConstraintGenerator associated with this dispatch root op."""
         pass
+    
+    # TODO: Uncomment after completing the sort function for atten and conv 
+    # @abstractmethod
+    # def get_solution_trace(
+    #     self,
+    #     config_list: list[common.TuningConfiguration],
+    # ) -> common.SolutionTrace:
+    #     """
+    #     Return a SolutionTrace that records the feature values of a single candidate,
+    #     retrieved from the `solution_trace` attribute of its TuningConfiguration.
+    #     """
+    #     pass
 
-    @abstractmethod
-    def get_solution_trace(
-        self,
-        config_list: list[common.TuningConfiguration],
-    ) -> common.SolutionTrace:
-        """
-        Return a SolutionTrace that records the feature values of a single candidate,
-        retrieved from the `solution_trace` attribute of its TuningConfiguration.
-        """
-        pass
-
-    @abstractmethod
-    def sort_solutions(self, traces: list[common.SolutionTrace], method:common.SortMethods)->list[int]:
-        """
-        Calling the sorting_handler() function to sort the candidate list.
-        """
-        pass
+    # @abstractmethod
+    # def sort_solutions(self, traces: list[common.SolutionTrace], method:common.SortMethods)->list[int]:
+    #     """
+    #     Calling the sorting_handler() function to sort the candidate list.
+    #     """
+    #     pass
 
 
 class DispatchTunerRegistry:
@@ -248,9 +249,11 @@ def generate_configs_and_td_specs(
             pipeline_options_search_space=pipeline_options_search_space,
         )
     )
-    traces = [dispatch_tuner.get_solution_trace(s) for s in solutions]
-    sorted_order = dispatch_tuner.sort_solutions(traces, sorting)
-    solutions = [solutions[i] for i in sorted_order]
+    
+    if dispatch_tuner.dispatch_kind == common.DispatchKind.contraction:
+        traces = [dispatch_tuner.get_solution_trace(s) for s in solutions]
+        sorted_order = dispatch_tuner.sort_solutions(traces, sorting)
+        solutions = [solutions[i] for i in sorted_order]
 
     candidate_profiles: list[common.CandidateProfile] = []
     # Index 0 is reserved for default config, so it gets a placeholder spec.

--- a/sharktuner/sharktuner/common.py
+++ b/sharktuner/sharktuner/common.py
@@ -595,6 +595,7 @@ def ContractionSortCandidateKey(t: ContractionSolutionTrace):
 def pick_sort_key(dispatch_kind: DispatchKind) -> callable:
     if dispatch_kind == DispatchKind.contraction:
         return ContractionSortCandidateKey
+    # TODO: Add key() for conv and atten
 
 
 def sorting_handler(

--- a/sharktuner/sharktuner/common.py
+++ b/sharktuner/sharktuner/common.py
@@ -17,6 +17,7 @@ import os
 import time
 import random
 from abc import ABC, abstractmethod
+import math
 
 from iree.compiler import ir  # type: ignore
 
@@ -101,7 +102,7 @@ class SolutionTrace(ABC):
     """A SolutionTrace is a record of tuning parameters values from constraint_generator"""
     @property
     @abstractmethod
-    def kind(self) -> ["contraction", "other_kind"]:
+    def kind(self) -> Literal["contraction", "convolution", "attention", "other_kind"]:
         pass
 
 
@@ -559,6 +560,46 @@ def get_attention_decomposition_config(
 
     return ir.DictAttr.get(decomposition_config_dict, context=ctx)
 
-def smart_sort(l:list[TuningConfiguration]):
-    random.shuffle(l) # Shuffle the full set of generated solutions.
 
+def ContractionSortCandidateKey(t: ContractionSolutionTrace):
+    is_pow2 = lambda v: 0 if (v > 0 and (v & (v - 1)) == 0) else 1 # 0 if is power of 2
+    is_mult_simd_num = lambda x, simd_num=4: 0 if (x % simd_num == 0) else 1 # 0 if is a multiple of 4 (number of SIMDs in a CU)
+    num_flops = lambda x, y, z: 2 * x * y * z
+    num_byte_access = lambda x, y, z: 2 * (x * y + y * z + x * z)
+    arith_intensity = lambda x, y, z: num_flops(x, y, z) / num_byte_access(x, y, z)
+    wg = lambda t: (t.M / t.m) * (t.N / t.n) # WG = M/m * N/n
+    # quantization Inefficency = [ceil(WG/CU) - WG/CU] / ceil(WG/CU), ~0 is good
+    quantization_inefficiency = lambda t, cu_num=304: (math.ceil(wg(t)/cu_num) - wg(t)/cu_num) / math.ceil(wg(t)/cu_num)
+
+    return (
+        is_pow2(t.k),
+        is_mult_simd_num(t.sg_m_cnt * t.sg_m_cnt),
+        arith_intensity(t.intrinsic_mn, t.intrinsic_mn, t.intrinsic_k), # lower is better
+        quantization_inefficiency(t) # lower is better
+    )
+
+def sorting_handler(l:list[SolutionTrace], sorting:SortMethods, key_fn: callable) -> list[int]:
+    """
+    Sorts the given list in place.
+    Returns a list of indices representing the new order relative to the original list.
+
+    Example: ['a', 'b', 'c'] -> ['b', 'a', 'c'], return [1, 0, 2]
+    """
+    if sorting == SortMethods.no_sort or not l:
+        return list(range(len(l)))  # identity mapping
+
+    if sorting == SortMethods.shuffle:
+        indices = list(range(len(l)))
+        random.shuffle(indices)
+        l[:] = [l[i] for i in indices]
+        return indices
+
+    if sorting == SortMethods.heuristic:
+        indexed_list = list(enumerate(l))
+        indexed_list.sort(key=lambda pair: key_fn(pair[1]))
+        indices = [i for i, _ in indexed_list]
+        # Reorder l in place
+        l[:] = [trace for _, trace in indexed_list]
+        return indices
+
+    return list(range(len(l)))

--- a/sharktuner/sharktuner/common.py
+++ b/sharktuner/sharktuner/common.py
@@ -245,7 +245,7 @@ class ContractionSolutionTrace(SolutionTrace):
     subgroup_size: int
 
     # Options/flags
-    mma_attr: Any
+    # mma_attr: Any # TODO: Fix TypeError: cannot pickle 'MMAAttr' object when passing candidate_trackers to multiprocessing handler
     promote_operands: Any
     codegen_pipeline: Any
     pipeline_options_search_space: Any
@@ -577,6 +577,10 @@ def ContractionSortCandidateKey(t: ContractionSolutionTrace):
         arith_intensity(t.intrinsic_mn, t.intrinsic_mn, t.intrinsic_k), # lower is better
         quantization_inefficiency(t) # lower is better
     )
+
+def pick_sort_key(dispatch_kind: DispatchKind) -> callable:
+    if dispatch_kind == DispatchKind.contraction:
+        return ContractionSortCandidateKey
 
 def sorting_handler(l:list[SolutionTrace], sorting:SortMethods, key_fn: callable) -> list[int]:
     """

--- a/sharktuner/sharktuner/common.py
+++ b/sharktuner/sharktuner/common.py
@@ -100,10 +100,8 @@ class TimeBudget:
 @dataclass
 class SolutionTrace(ABC):
     """A SolutionTrace is a record of tuning parameters values from constraint_generator"""
-    @property
-    @abstractmethod
-    def kind(self) -> Literal["contraction", "convolution", "attention", "other_kind"]:
-        pass
+
+    pass
 
 
 @dataclass
@@ -128,6 +126,7 @@ class CandidateProfile:
     """
     A CandidateProfile contains info of each candidate that need to be passed to libtuner.
     """
+
     td_spec_module: ir.Module
     solution_trace: Optional[SolutionTrace] = None
 
@@ -228,18 +227,30 @@ class AttentionOpInfo:
     k1_dims: list[int]
     k2_dims: list[int]
 
+
 @dataclass
 class ContractionSolutionTrace(SolutionTrace):
     # Problem sizes
-    M: int; N: int; K: int
-    lhs_type_bitwidth: int; rhs_type_bitwidth: int
+    M: int
+    N: int
+    K: int
+    lhs_type_bitwidth: int
+    rhs_type_bitwidth: int
 
     # Z3 numeric selections
-    m: int; n: int; k: int
-    wg_x: int; wg_y: int; wg_z: int
-    sg_m_cnt: int; sg_n_cnt: int
-    intrinsic_mn: int; intrinsic_k: int
-    subgroup_m: int; subgroup_n: int; subgroup_k: int
+    m: int
+    n: int
+    k: int
+    wg_x: int
+    wg_y: int
+    wg_z: int
+    sg_m_cnt: int
+    sg_n_cnt: int
+    intrinsic_mn: int
+    intrinsic_k: int
+    subgroup_m: int
+    subgroup_n: int
+    subgroup_k: int
 
     # Hardware specific
     subgroup_size: int
@@ -260,10 +271,6 @@ class ContractionSolutionTrace(SolutionTrace):
     # workgroups: Optional[int] = None
     # subgroups: Optional[int] = None
     # quantization_inefficiency: Optional[float] = None
-
-    @property
-    def kind(self) -> Literal["contraction"]:
-        return "contraction"
 
 
 def get_map_result_dim_positions(map: ir.AffineMap) -> Optional[list[int]]:
@@ -562,27 +569,37 @@ def get_attention_decomposition_config(
 
 
 def ContractionSortCandidateKey(t: ContractionSolutionTrace):
-    is_pow2 = lambda v: 0 if (v > 0 and (v & (v - 1)) == 0) else 1 # 0 if is power of 2
-    is_mult_simd_num = lambda x, simd_num=4: 0 if (x % simd_num == 0) else 1 # 0 if is a multiple of 4 (number of SIMDs in a CU)
+    is_pow2 = lambda v: 0 if (v > 0 and (v & (v - 1)) == 0) else 1  # 0 if is power of 2
+    is_mult_simd_num = (
+        lambda x, simd_num=4: 0 if (x % simd_num == 0) else 1
+    )  # 0 if is a multiple of 4 (number of SIMDs in a CU)
     num_flops = lambda x, y, z: 2 * x * y * z
     num_byte_access = lambda x, y, z: 2 * (x * y + y * z + x * z)
     arith_intensity = lambda x, y, z: num_flops(x, y, z) / num_byte_access(x, y, z)
-    wg = lambda t: (t.M / t.m) * (t.N / t.n) # WG = M/m * N/n
+    wg = lambda t: (t.M / t.m) * (t.N / t.n)  # WG = M/m * N/n
     # quantization Inefficency = [ceil(WG/CU) - WG/CU] / ceil(WG/CU), ~0 is good
-    quantization_inefficiency = lambda t, cu_num=304: (math.ceil(wg(t)/cu_num) - wg(t)/cu_num) / math.ceil(wg(t)/cu_num)
+    quantization_inefficiency = lambda t, cu_num=304: (
+        math.ceil(wg(t) / cu_num) - wg(t) / cu_num
+    ) / math.ceil(wg(t) / cu_num)
 
     return (
         is_pow2(t.k),
         is_mult_simd_num(t.sg_m_cnt * t.sg_m_cnt),
-        arith_intensity(t.intrinsic_mn, t.intrinsic_mn, t.intrinsic_k), # lower is better
-        quantization_inefficiency(t) # lower is better
+        arith_intensity(
+            t.intrinsic_mn, t.intrinsic_mn, t.intrinsic_k
+        ),  # lower is better
+        quantization_inefficiency(t),  # lower is better
     )
+
 
 def pick_sort_key(dispatch_kind: DispatchKind) -> callable:
     if dispatch_kind == DispatchKind.contraction:
         return ContractionSortCandidateKey
 
-def sorting_handler(l:list[SolutionTrace], sorting:SortMethods, key_fn: callable) -> list[int]:
+
+def sorting_handler(
+    l: list[SolutionTrace], sorting: SortMethods, key_fn: callable
+) -> list[int]:
     """
     Sorts the given list in place.
     Returns a list of indices representing the new order relative to the original list.

--- a/sharktuner/sharktuner/common.py
+++ b/sharktuner/sharktuner/common.py
@@ -10,13 +10,13 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import Enum
 from types import TracebackType
-from typing import Optional
-from typing import Any
+from typing import Optional, Any, Literal
 import subprocess
 import tempfile
 import os
 import time
 import random
+from abc import ABC, abstractmethod
 
 from iree.compiler import ir  # type: ignore
 
@@ -101,7 +101,7 @@ class SolutionTrace(ABC):
     """A SolutionTrace is a record of tuning parameters values from constraint_generator"""
     @property
     @abstractmethod
-    def kind(self) -> str:  # could also use Literal in subclasses for narrowing
+    def kind(self) -> ["contraction", "other_kind"]:
         pass
 
 
@@ -121,10 +121,20 @@ class TuningConfiguration:
     configuration: ir.Attribute
     solution_trace: Optional[SolutionTrace] = None
 
+
+@dataclass
+class CandidateProfile:
+    """
+    A CandidateProfile contains info of each candidate that need to be passed to libtuner.
+    """
+    td_spec_module: ir.Module
+    solution_trace: Optional[SolutionTrace] = None
+
+
 class SortMethods(str, Enum):
     no_sort = "no-sort"
     shuffle = "shuffle"
-    rfr_rank = "rfr-rank"
+    heuristic = "heuristic"
 
 
 class DispatchKind(Enum):
@@ -241,14 +251,14 @@ class ContractionSolutionTrace(SolutionTrace):
     allowed_waves_per_eu: Any
     padding: Any
 
-    # Engineered features
-    mma_attr_map: Optional[int] = None
-    lhs_tile_size: Optional[int] = None
-    rhs_tile_size: Optional[int] = None
-    lds_utilization: Optional[float] = None
-    workgroups: Optional[int] = None
-    subgroups: Optional[int] = None
-    quantization_inefficiency: Optional[float] = None
+    # # Engineered features
+    # mma_attr_map: Optional[int] = None
+    # lhs_tile_size: Optional[int] = None
+    # rhs_tile_size: Optional[int] = None
+    # lds_utilization: Optional[float] = None
+    # workgroups: Optional[int] = None
+    # subgroups: Optional[int] = None
+    # quantization_inefficiency: Optional[float] = None
 
     @property
     def kind(self) -> Literal["contraction"]:
@@ -548,3 +558,7 @@ def get_attention_decomposition_config(
     }
 
     return ir.DictAttr.get(decomposition_config_dict, context=ctx)
+
+def smart_sort(l:list[TuningConfiguration]):
+    random.shuffle(l) # Shuffle the full set of generated solutions.
+

--- a/sharktuner/sharktuner/common.py
+++ b/sharktuner/sharktuner/common.py
@@ -16,6 +16,7 @@ import subprocess
 import tempfile
 import os
 import time
+import random
 
 from iree.compiler import ir  # type: ignore
 
@@ -109,6 +110,11 @@ class TuningConfiguration:
 
     name: str
     configuration: ir.Attribute
+
+class SortMethods(str, Enum):
+    no_sort = "no-sort"
+    shuffle = "shuffle"
+    rfr_rank = "rfr-rank"
 
 
 class DispatchKind(Enum):

--- a/sharktuner/sharktuner/common.py
+++ b/sharktuner/sharktuner/common.py
@@ -97,6 +97,15 @@ class TimeBudget:
 
 
 @dataclass
+class SolutionTrace(ABC):
+    """A SolutionTrace is a record of tuning parameters values from constraint_generator"""
+    @property
+    @abstractmethod
+    def kind(self) -> str:  # could also use Literal in subclasses for narrowing
+        pass
+
+
+@dataclass
 class TuningConfiguration:
     """
     A TuningConfiguration contains an attribute that will be set on an op as a
@@ -110,6 +119,7 @@ class TuningConfiguration:
 
     name: str
     configuration: ir.Attribute
+    solution_trace: Optional[SolutionTrace] = None
 
 class SortMethods(str, Enum):
     no_sort = "no-sort"
@@ -206,6 +216,43 @@ class AttentionOpInfo:
     n_dims: list[int]
     k1_dims: list[int]
     k2_dims: list[int]
+
+@dataclass
+class ContractionSolutionTrace(SolutionTrace):
+    # Problem sizes
+    M: int; N: int; K: int
+    lhs_type_bitwidth: int; rhs_type_bitwidth: int
+
+    # Z3 numeric selections
+    m: int; n: int; k: int
+    wg_x: int; wg_y: int; wg_z: int
+    sg_m_cnt: int; sg_n_cnt: int
+    intrinsic_mn: int; intrinsic_k: int
+    subgroup_m: int; subgroup_n: int; subgroup_k: int
+
+    # Hardware specific
+    subgroup_size: int
+
+    # Options/flags
+    mma_attr: Any
+    promote_operands: Any
+    codegen_pipeline: Any
+    pipeline_options_search_space: Any
+    allowed_waves_per_eu: Any
+    padding: Any
+
+    # Engineered features
+    mma_attr_map: Optional[int] = None
+    lhs_tile_size: Optional[int] = None
+    rhs_tile_size: Optional[int] = None
+    lds_utilization: Optional[float] = None
+    workgroups: Optional[int] = None
+    subgroups: Optional[int] = None
+    quantization_inefficiency: Optional[float] = None
+
+    @property
+    def kind(self) -> Literal["contraction"]:
+        return "contraction"
 
 
 def get_map_result_dim_positions(map: ir.AffineMap) -> Optional[list[int]]:

--- a/sharktuner/sharktuner/constraint_generator.py
+++ b/sharktuner/sharktuner/constraint_generator.py
@@ -256,9 +256,42 @@ def generate_generic_contraction_solutions(
         i += 1
 
         for compilation_info in compilation_infos:
+
+
+        for compilation_info in compilation_infos:
+            solution_trace = common.ContractionSolutionTrace(
+                M=int(math.prod(M)),
+                N=int(math.prod(N)),
+                K=int(math.prod(K)),
+                lhs_type_bitwidth=lhs_type.bitwidth,
+                rhs_type_bitwidth=rhs_type.bitwidth,
+
+                m=workgroup_tile_sizes[0],
+                n=workgroup_tile_sizes[1],
+                k=reduction_tile_sizes[2],
+                wg_x=lookup(wg_x),
+                wg_y=lookup(wg_y),
+                wg_z=lookup(wg_z),
+                sg_m_cnt=lookup(sg_m_cnt),
+                sg_n_cnt=lookup(sg_n_cnt),
+                intrinsic_mn=lookup(intrinsic_mn),
+                intrinsic_k=lookup(intrinsic_k),
+                subgroup_tile_m=subgroup_tile_sizes[0],
+                subgroup_tile_n=subgroup_tile_sizes[1],
+                subgroup_tile_k=subgroup_tile_sizes[2],
+
+                subgroup_size=lookup(subgroup_size),
+                
+                mma_attr=mma_attr,
+                promote_operands=promote_operands,
+                codegen_pipeline=codegen_pipeline,
+                pipeline_options_search_space=pipeline_options_search_space,
+                allowed_waves_per_eu=allowed_waves_per_eu,
+                padding=padding,
+            )
             yield [
                 common.TuningConfiguration(
-                    name="compilation_info", configuration=compilation_info
+                    name="compilation_info", configuration=compilation_info, solution_trace=solution_trace
                 )
             ]
 

--- a/sharktuner/sharktuner/constraint_generator.py
+++ b/sharktuner/sharktuner/constraint_generator.py
@@ -262,7 +262,6 @@ def generate_generic_contraction_solutions(
                 K=int(math.prod(K)),
                 lhs_type_bitwidth=lhs_type.bitwidth,
                 rhs_type_bitwidth=rhs_type.bitwidth,
-
                 m=workgroup_tile_sizes[0],
                 n=workgroup_tile_sizes[1],
                 k=reduction_tile_sizes[2],
@@ -276,9 +275,7 @@ def generate_generic_contraction_solutions(
                 subgroup_m=subgroup_tile_sizes[0],
                 subgroup_n=subgroup_tile_sizes[1],
                 subgroup_k=subgroup_tile_sizes[2],
-
                 subgroup_size=lookup(subgroup_size),
-                
                 # mma_attr=mma_attr,
                 promote_operands=promote_operands,
                 codegen_pipeline=codegen_pipeline,
@@ -288,7 +285,9 @@ def generate_generic_contraction_solutions(
             )
             yield [
                 common.TuningConfiguration(
-                    name="compilation_info", configuration=compilation_info, solution_trace=solution_trace
+                    name="compilation_info",
+                    configuration=compilation_info,
+                    solution_trace=solution_trace,
                 )
             ]
 

--- a/sharktuner/sharktuner/constraint_generator.py
+++ b/sharktuner/sharktuner/constraint_generator.py
@@ -279,7 +279,7 @@ def generate_generic_contraction_solutions(
 
                 subgroup_size=lookup(subgroup_size),
                 
-                mma_attr=mma_attr,
+                # mma_attr=mma_attr,
                 promote_operands=promote_operands,
                 codegen_pipeline=codegen_pipeline,
                 pipeline_options_search_space=pipeline_options_search_space,

--- a/sharktuner/sharktuner/constraint_generator.py
+++ b/sharktuner/sharktuner/constraint_generator.py
@@ -256,9 +256,6 @@ def generate_generic_contraction_solutions(
         i += 1
 
         for compilation_info in compilation_infos:
-
-
-        for compilation_info in compilation_infos:
             solution_trace = common.ContractionSolutionTrace(
                 M=int(math.prod(M)),
                 N=int(math.prod(N)),
@@ -276,9 +273,9 @@ def generate_generic_contraction_solutions(
                 sg_n_cnt=lookup(sg_n_cnt),
                 intrinsic_mn=lookup(intrinsic_mn),
                 intrinsic_k=lookup(intrinsic_k),
-                subgroup_tile_m=subgroup_tile_sizes[0],
-                subgroup_tile_n=subgroup_tile_sizes[1],
-                subgroup_tile_k=subgroup_tile_sizes[2],
+                subgroup_m=subgroup_tile_sizes[0],
+                subgroup_n=subgroup_tile_sizes[1],
+                subgroup_k=subgroup_tile_sizes[2],
 
                 subgroup_size=lookup(subgroup_size),
                 

--- a/sharktuner/sharktuner/libtuner.py
+++ b/sharktuner/sharktuner/libtuner.py
@@ -111,6 +111,7 @@ class TuningClient(ABC):
     def __init__(self, tuner_context: common.TunerContext):
         self.tuner_context = tuner_context
         self.candidate_trackers: list[CandidateTracker] = []
+        self.dispatch_kind: Optional[common.DispatchKind] = None
 
     @abstractmethod
     def get_iree_compile_flags(self) -> list[str]:
@@ -757,6 +758,7 @@ def generate_candidate_specs(
         if args.starter_td_spec:
             with open(args.starter_td_spec, "r") as f:
                 starter_td_spec = ir.Module.parse(f.read())
+        tuning_client.dispatch_kind = candidate_gen.set_dispatch_tuner(mlir_module).dispatch_kind
         candidate_profiles = candidate_gen.generate_configs_and_td_specs(
             input_module=mlir_module,
             tuner_context=tuning_client.tuner_context,
@@ -809,7 +811,7 @@ def generate_candidate_specs(
                 candidate_id=candidate_num,
                 spec_path=spec_path,
                 td_spec_str=td_spec_str,
-                feature_trace=candidate_profiles.solution_trace,
+                feature_trace=candidate_profile.solution_trace,
             )
             tuning_client.candidate_trackers.append(new_candidate)
     except Exception as e:
@@ -1138,6 +1140,11 @@ def benchmark(
         logging.warning("Baseline run failed.")
 
     candidate_indices = [i for i in compiled_candidates if i != 0]
+    # Sort candidate starting order in the benchmark list
+    traces = [tuning_client.candidate_trackers[i].feature_trace for i in candidate_indices]
+    sorted_order = common.sorting_handler(l=traces, sorting=args.candidate_sort,key_fn=common.pick_sort_key(tuning_client.dispatch_kind))
+    candidate_indices = [candidate_indices[i] for i in sorted_order]
+
     candidate_results = benchmark_candidates(
         candidate_indices=candidate_indices,
         devices=args.devices,

--- a/sharktuner/sharktuner/libtuner.py
+++ b/sharktuner/sharktuner/libtuner.py
@@ -70,6 +70,7 @@ class CandidateTracker:
     compiled_vmfb_path: Optional[Path] = None
     spec_path: Optional[Path] = None
     td_spec_str: Optional[str] = None
+    feature_trace: Optional[common.SolutionTrace] = None
 
 
 @dataclass()
@@ -756,10 +757,11 @@ def generate_candidate_specs(
         if args.starter_td_spec:
             with open(args.starter_td_spec, "r") as f:
                 starter_td_spec = ir.Module.parse(f.read())
-        config_specs: list[ir.Module] = candidate_gen.generate_configs_and_td_specs(
+        candidate_profiles = candidate_gen.generate_configs_and_td_specs(
             input_module=mlir_module,
             tuner_context=tuning_client.tuner_context,
             limit=args.num_candidates,
+            sorting=args.candidate_sort,
             num_subgroups=args.num_subgroups,
             allowed_waves_per_eu=args.waves_per_eu_options,
             pipeline_options_search_space=pipeline_options_search_space,
@@ -767,12 +769,13 @@ def generate_candidate_specs(
         )
         logging.debug("candidate_gen.py ends")
         handle_error(
-            condition=(len(config_specs) <= 1), msg="Failed to generate any candidates"
+            condition=(len(candidate_profiles) <= 1), msg="Failed to generate any candidates"
         )
 
         # Create candidate trackers.
         candidates = []
-        for candidate_num, spec in enumerate(config_specs):
+        for candidate_num, candidate_profile in enumerate(candidate_profiles):
+            spec = candidate_profile.td_spec_module
             candidates.append(candidate_num)
             # Move the specs to the canonical path_config location.
             spec_path = path_config.specs_dir / path_config.get_candidate_spec_filename(
@@ -806,6 +809,7 @@ def generate_candidate_specs(
                 candidate_id=candidate_num,
                 spec_path=spec_path,
                 td_spec_str=td_spec_str,
+                feature_trace=candidate_profiles.solution_trace,
             )
             tuning_client.candidate_trackers.append(new_candidate)
     except Exception as e:

--- a/sharktuner/sharktuner/libtuner.py
+++ b/sharktuner/sharktuner/libtuner.py
@@ -759,6 +759,7 @@ def generate_candidate_specs(
             with open(args.starter_td_spec, "r") as f:
                 starter_td_spec = ir.Module.parse(f.read())
         tuning_client.dispatch_kind = candidate_gen.set_dispatch_tuner(mlir_module).dispatch_kind
+        logging.warning("Candidate sorting feature is only enabled for contraction")
         candidate_profiles = candidate_gen.generate_configs_and_td_specs(
             input_module=mlir_module,
             tuner_context=tuning_client.tuner_context,
@@ -769,7 +770,7 @@ def generate_candidate_specs(
             pipeline_options_search_space=pipeline_options_search_space,
             codegen_pipeline=get_iree_codegen_pipeline(args.codegen_pipeline),
         )
-        logging.debug("candidate_gen.py ends")
+        logging.debug("candidate_gen.generate_configs_and_td_specs() ends")
         handle_error(
             condition=(len(candidate_profiles) <= 1), msg="Failed to generate any candidates"
         )
@@ -1141,9 +1142,10 @@ def benchmark(
 
     candidate_indices = [i for i in compiled_candidates if i != 0]
     # Sort candidate starting order in the benchmark list
-    traces = [tuning_client.candidate_trackers[i].feature_trace for i in candidate_indices]
-    sorted_order = common.sorting_handler(l=traces, sorting=args.candidate_sort,key_fn=common.pick_sort_key(tuning_client.dispatch_kind))
-    candidate_indices = [candidate_indices[i] for i in sorted_order]
+    if tuning_client.dispatch_kind == common.DispatchKind.contraction:
+        traces = [tuning_client.candidate_trackers[i].feature_trace for i in candidate_indices]
+        sorted_order = common.sorting_handler(l=traces, sorting=args.candidate_sort,key_fn=common.pick_sort_key(tuning_client.dispatch_kind))
+        candidate_indices = [candidate_indices[i] for i in sorted_order]
 
     candidate_results = benchmark_candidates(
         candidate_indices=candidate_indices,

--- a/sharktuner/sharktuner/libtuner.py
+++ b/sharktuner/sharktuner/libtuner.py
@@ -729,7 +729,7 @@ def generate_candidates(
 
     return []
 
-    
+
 def generate_candidate_specs(
     args: argparse.Namespace,
     path_config: PathConfig,
@@ -758,7 +758,9 @@ def generate_candidate_specs(
         if args.starter_td_spec:
             with open(args.starter_td_spec, "r") as f:
                 starter_td_spec = ir.Module.parse(f.read())
-        tuning_client.dispatch_kind = candidate_gen.set_dispatch_tuner(mlir_module).dispatch_kind
+        tuning_client.dispatch_kind = candidate_gen.set_dispatch_tuner(
+            mlir_module
+        ).dispatch_kind
         logging.warning("Candidate sorting feature is only enabled for contraction")
         candidate_profiles = candidate_gen.generate_configs_and_td_specs(
             input_module=mlir_module,
@@ -772,7 +774,8 @@ def generate_candidate_specs(
         )
         logging.debug("candidate_gen.generate_configs_and_td_specs() ends")
         handle_error(
-            condition=(len(candidate_profiles) <= 1), msg="Failed to generate any candidates"
+            condition=(len(candidate_profiles) <= 1),
+            msg="Failed to generate any candidates",
         )
 
         # Create candidate trackers.
@@ -1143,8 +1146,14 @@ def benchmark(
     candidate_indices = [i for i in compiled_candidates if i != 0]
     # Sort candidate starting order in the benchmark list
     if tuning_client.dispatch_kind == common.DispatchKind.contraction:
-        traces = [tuning_client.candidate_trackers[i].feature_trace for i in candidate_indices]
-        sorted_order = common.sorting_handler(l=traces, sorting=args.candidate_sort,key_fn=common.pick_sort_key(tuning_client.dispatch_kind))
+        traces = [
+            tuning_client.candidate_trackers[i].feature_trace for i in candidate_indices
+        ]
+        sorted_order = common.sorting_handler(
+            l=traces,
+            sorting=args.candidate_sort,
+            key_fn=common.pick_sort_key(tuning_client.dispatch_kind),
+        )
         candidate_indices = [candidate_indices[i] for i in sorted_order]
 
     candidate_results = benchmark_candidates(

--- a/sharktuner/sharktuner/libtuner.py
+++ b/sharktuner/sharktuner/libtuner.py
@@ -712,6 +712,22 @@ def get_iree_codegen_pipeline(pipeline: CodegenPipelines):
             assert False, "unexpected codegen pipeline"
 
 
+def generate_candidates(
+    args: argparse.Namespace,
+    path_config: PathConfig,
+    tuning_client: TuningClient,
+) -> list[int]:
+    logging.debug("generate_candidates()")
+
+    path_config.specs_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(args.input_file, path_config.template_mlir)
+    tune_logger = logging.getLogger("tune")
+
+    generate_candidate_specs(args, path_config, tuning_client)
+
+    return []
+
+    
 def generate_candidate_specs(
     args: argparse.Namespace,
     path_config: PathConfig,

--- a/sharktuner/sharktuner/libtuner.py
+++ b/sharktuner/sharktuner/libtuner.py
@@ -346,6 +346,12 @@ def parse_arguments(
             "if fully covered."
         ),
     )
+    general_args.add_argument(
+        "--candidate-sort",
+        choices=[s.value for s in common.SortMethods],
+        default=common.SortMethods.no_sort,
+        help="Select the sorting method to determine the order of candidate benchmarking",
+    )
 
     return parser.parse_args()
 


### PR DESCRIPTION
common.py:
- Added `SolutionTrace`, to track variable values that generated from z3 constraints; the contraction type is `ContractionSolutionTrace`.
- Modified `TuningConfiguration`, added a new attr to store `SolutionTrace`.
- Added `CandidateProfile`, to pass needed candidate info from candidate_gen.py to libtuner.py.
- Added `sorting_handler()`, sorted list in place and return orders.
- Added `SortMethods`.

constraints_generator.py:
- Modified `generate_generic_contraction_solutions()`, attach `SolutionTrace` to `TuningConfiguration` when return.
- Modified `DispatchTuner`, added new methods; added a attr `dispatch_kind` for future flexibility.

candidate_gen.py:
- Modified `generate_configs_and_td_specs()`, which retrieves `SolutionTrace` from `TuningConfiguration`, sorts generated solutions, attaches `SolutionTrace` to `CandidateProfile` and return to libtuner.py.

libtuner.py:
- Modified `TuningClient`, to track `dispatch_kind` during tuning for future flexibility.
- Added sorting args
- Added sorting to `benchmark()`