### PR TITLE
[Tuner] Add `SolutionTrace` to track z3 feature vars in candidate generation

### DIFF
--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -60,6 +60,17 @@ class DispatchTuner(dispatch_parser.DispatchParser):
         """Returns a ConstraintGenerator associated with this dispatch root op."""
         pass
 
+    @abstractmethod
+    def get_solution_trace(
+        self,
+        config_list: list[common.TuningConfiguration],
+    ) -> common.SolutionTrace:
+        """
+        Return a SolutionTrace that records the feature values of a single candidate,
+        retrieved from the `solution_trace` attribute of its TuningConfiguration.
+        """
+        pass
+
 
 class DispatchTunerRegistry:
     def __init__(self):
@@ -96,6 +107,12 @@ class ContractionOpInterfaceTuner(
         return spec_builder.build_td_spec(
             contraction_op.context, contraction_op, config_list, func_name
         )
+
+    def get_solution_trace(
+        self,
+        config_list: list[common.TuningConfiguration],
+    ) -> list[common.ContractionSolutionTrace]:
+        return config_list[0].solution_trace
 
 
 class ConvolutionOpInterfaceTuner(
@@ -156,7 +173,7 @@ def generate_configs_and_td_specs(
     allowed_waves_per_eu: list[int] = [2],
     pipeline_options_search_space: dispatch_constraints.PipelineOptionsSearchSpace = dispatch_constraints.PipelineOptionsSearchSpace(),
     codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline = iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute,
-) -> list[ir.Module]:
+) -> list[common.CandidateProfile]:
     dispatch_tuners: list[type[DispatchTuner]] = [
         ContractionOpInterfaceTuner,
         ConvolutionOpInterfaceTuner,
@@ -185,10 +202,11 @@ def generate_configs_and_td_specs(
 
     assert dispatch_tuner, "No suitable dispatch tuner found"
 
+    candidate_profiles: list[common.CandidateProfile] = []
+
     # Index 0 is reserved for default config, so it gets a placeholder spec.
-    config_specs: list[ir.Module] = [
-        spec_builder.get_placeholder_spec(input_module.context)
-    ]
+    candidate_profiles.append(common.CandidateProfile(td_spec_module=spec_builder.get_placeholder_spec(input_module.context),
+    solution_trace=None))
 
     # Get GPU target information from the executable variant operation.
     variant_op_list = iree_codegen.get_executable_variant_ops(input_module)
@@ -203,8 +221,7 @@ def generate_configs_and_td_specs(
 
     constraint_generator = dispatch_tuner.get_constraint_generator()
 
-    for i, config in enumerate(
-        constraint_generator.generate_solutions(
+    solutions = constraint_generator.generate_solutions(
             tuner_context,
             target_info,
             codegen_pipeline,
@@ -212,16 +229,19 @@ def generate_configs_and_td_specs(
             allowed_waves_per_eu=allowed_waves_per_eu,
             pipeline_options_search_space=pipeline_options_search_space,
         )
-    ):
-        if i >= limit:
-            break
+
+    for i, config in enumerate(solutions[:limit]):
         tune_logger.debug(f"Solution #{i+1}: {config}")
         td_spec_module = dispatch_tuner.get_td_spec(config)
         assert td_spec_module, "Failed to generate transform dialect spec"
-        config_specs.append(td_spec_module)
+        solution_trace = dispatch_tuner.get_solution_trace(config)
+        assert solution_trace, "Failed to retrive solution feature values"
+        candidate_profiles.append(common.CandidateProfile(
+            td_spec_module = td_spec_module, solution_trace=solution_trace
+        ))
 
-    tune_logger.debug(f"Generated {len(config_specs)} tuning specs")
-    return config_specs
+    tune_logger.debug(f"Generated {len(candidate_profiles)} tuning specs")
+    return candidate_profiles
 
 
 @dataclass
@@ -372,7 +392,7 @@ def main() -> None:
             prefetch_shared_memory=args.prefetch_shared_memory_options,
             no_reduce_shared_memory_bank_conflicts=args.no_reduce_shared_memory_bank_conflicts_options,
         )
-        specs: list[ir.Module] = generate_configs_and_td_specs(
+        candidate_profiles: list[common.CandidateProfile] = generate_configs_and_td_specs(
             mlir_module,
             tuner_ctx,
             args.limit,
@@ -381,6 +401,7 @@ def main() -> None:
             pipeline_options_search_space,
             iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse,
         )
+        specs: list[ir.Module] = [i.tg_spec_module for i in candidate_profiles]
         for candidate_num, spec in enumerate(specs):
             spec_dir = Path(args.output)
             spec_path = spec_dir / f"{candidate_num}_spec.mlir"

--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -214,6 +214,35 @@ def generate_configs_and_td_specs(
     return dispatch_tuner
 
 
+def set_dispatch_tuner(input_module: ir.Module) -> DispatchTuner:
+    dispatch_tuners: list[type[DispatchTuner]] = [
+        ContractionOpInterfaceTuner,
+        ConvolutionOpInterfaceTuner,
+        AttentionOpInterfaceTuner,
+    ]
+    root_op_list = iree_codegen.get_tuner_root_ops(input_module)
+    if len(root_op_list) == 0:
+        tune_logger.error(
+            "No root ops found. Did you forget to pass "
+            "--iree-config-add-tuner-attributes during compilation?"
+        )
+        return []
+    elif len(root_op_list) > 1:
+        tune_logger.error("Multiple root ops found. Only one is currently supported.")
+        return []
+    root_op = root_op_list[0]
+    dispatch_tuner: Optional[DispatchTuner] = None
+    for tuner_class in dispatch_tuners:
+        tuner = tuner_class(root_op)
+        if tuner.has_valid_root_op():
+            dispatch_tuner = tuner
+            break
+
+    assert dispatch_tuner, "No suitable dispatch tuner found"
+
+    return dispatch_tuner
+
+
 def generate_configs_and_td_specs(
     input_module: ir.Module,  # Path to the mlir file to be tuned
     tuner_context: common.TunerContext,
@@ -237,7 +266,8 @@ def generate_configs_and_td_specs(
     dispatch_tuner = set_dispatch_tuner(input_module)
     constraint_generator = dispatch_tuner.get_constraint_generator()
 
-    solutions = constraint_generator.generate_solutions(
+    solutions = list(
+        constraint_generator.generate_solutions(
             tuner_context,
             target_info,
             codegen_pipeline,
@@ -245,6 +275,7 @@ def generate_configs_and_td_specs(
             allowed_waves_per_eu=allowed_waves_per_eu,
             pipeline_options_search_space=pipeline_options_search_space,
         )
+    )
 
     candidate_profiles: list[common.CandidateProfile] = []
     # Index 0 is reserved for default config, so it gets a placeholder spec.
@@ -430,7 +461,7 @@ def main() -> None:
             pipeline_options_search_space,
             iree_codegen.DispatchLoweringPassPipeline.LLVMGPUTileAndFuse,
         )
-        specs: list[ir.Module] = [i.tg_spec_module for i in candidate_profiles]
+        specs: list[ir.Module] = [i.td_spec_module for i in candidate_profiles]
         for candidate_num, spec in enumerate(specs):
             spec_dir = Path(args.output)
             spec_path = spec_dir / f"{candidate_num}_spec.mlir"

--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -41,6 +41,8 @@ tune_logger = logging.getLogger("tune")
 
 
 class DispatchTuner(dispatch_parser.DispatchParser):
+    dispatch_kind: common.DispatchKind
+
     @abstractmethod
     def get_td_spec(
         self,
@@ -90,6 +92,8 @@ class DispatchTunerRegistry:
 class ContractionOpInterfaceTuner(
     DispatchTuner, dispatch_parser.ContractionOpInterfaceParser
 ):
+    dispatch_kind = common.DispatchKind.contraction
+
     def __init__(self, root_op: ir.Operation):
         super().__init__(root_op)
 
@@ -118,6 +122,8 @@ class ContractionOpInterfaceTuner(
 class ConvolutionOpInterfaceTuner(
     DispatchTuner, dispatch_parser.ConvolutionOpInterfaceParser
 ):
+    dispatch_kind = common.DispatchKind.conv
+
     def __init__(self, root_op: ir.Operation):
         super().__init__(root_op)
 
@@ -140,6 +146,8 @@ class ConvolutionOpInterfaceTuner(
 class AttentionOpInterfaceTuner(
     DispatchTuner, dispatch_parser.AttentionOpInterfaceParser
 ):
+    dispatch_kind = common.DispatchKind.attention
+
     def __init__(self, root_op: ir.Operation):
         super().__init__(root_op)
 
@@ -202,12 +210,18 @@ def generate_configs_and_td_specs(
 
     assert dispatch_tuner, "No suitable dispatch tuner found"
 
-    candidate_profiles: list[common.CandidateProfile] = []
+    return dispatch_tuner
 
-    # Index 0 is reserved for default config, so it gets a placeholder spec.
-    candidate_profiles.append(common.CandidateProfile(td_spec_module=spec_builder.get_placeholder_spec(input_module.context),
-    solution_trace=None))
-
+def generate_configs_and_td_specs(
+    input_module: ir.Module,  # Path to the mlir file to be tuned
+    tuner_context: common.TunerContext,
+    limit: int = 4096,  # Max candidates to be generated
+    sorting: common.SortMethods = common.SortMethods.no_sort,
+    num_subgroups: int = 4,  # GPU spec, used to determine candidate generation constraints
+    allowed_waves_per_eu: list[int] = [2],
+    pipeline_options_search_space: dispatch_constraints.PipelineOptionsSearchSpace = dispatch_constraints.PipelineOptionsSearchSpace(),
+    codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline = iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute,
+) -> list[common.CandidateProfile]:
     # Get GPU target information from the executable variant operation.
     variant_op_list = iree_codegen.get_executable_variant_ops(input_module)
     assert len(variant_op_list) == 1, "Expect one executable variant op"
@@ -219,6 +233,7 @@ def generate_configs_and_td_specs(
     if target_info.arch not in ["gfx942", "gfx1100"]:
         print(f"Warning: Untested architecture '{target_info.arch}'.")
 
+    dispatch_tuner = set_dispatch_tuner(input_module)
     constraint_generator = dispatch_tuner.get_constraint_generator()
 
     solutions = constraint_generator.generate_solutions(
@@ -229,6 +244,11 @@ def generate_configs_and_td_specs(
             allowed_waves_per_eu=allowed_waves_per_eu,
             pipeline_options_search_space=pipeline_options_search_space,
         )
+
+    candidate_profiles: list[common.CandidateProfile] = []
+    # Index 0 is reserved for default config, so it gets a placeholder spec.
+    candidate_profiles.append(common.CandidateProfile(td_spec_module=spec_builder.get_placeholder_spec(input_module.context),
+    solution_trace=None))
 
     for i, config in enumerate(solutions[:limit]):
         tune_logger.debug(f"Solution #{i+1}: {config}")

--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -61,17 +61,18 @@ class DispatchTuner(dispatch_parser.DispatchParser):
     def get_constraint_generator(self) -> constraint_generator.ConstraintGenerator:
         """Returns a ConstraintGenerator associated with this dispatch root op."""
         pass
-
-    @abstractmethod
-    def get_solution_trace(
-        self,
-        config_list: list[common.TuningConfiguration],
-    ) -> common.SolutionTrace:
-        """
-        Return a SolutionTrace that records the feature values of a single candidate,
-        retrieved from the `solution_trace` attribute of its TuningConfiguration.
-        """
-        pass
+    
+    # TODO: Uncomment after completing the sort function for atten and conv 
+    # @abstractmethod
+    # def get_solution_trace(
+    #     self,
+    #     config_list: list[common.TuningConfiguration],
+    # ) -> common.SolutionTrace:
+    #     """
+    #     Return a SolutionTrace that records the feature values of a single candidate,
+    #     retrieved from the `solution_trace` attribute of its TuningConfiguration.
+    #     """
+    #     pass
 
 
 class DispatchTunerRegistry:
@@ -216,7 +217,6 @@ def generate_configs_and_td_specs(
     input_module: ir.Module,  # Path to the mlir file to be tuned
     tuner_context: common.TunerContext,
     limit: int = 4096,  # Max candidates to be generated
-    sorting: common.SortMethods = common.SortMethods.no_sort,
     num_subgroups: int = 4,  # GPU spec, used to determine candidate generation constraints
     allowed_waves_per_eu: list[int] = [2],
     pipeline_options_search_space: dispatch_constraints.PipelineOptionsSearchSpace = dispatch_constraints.PipelineOptionsSearchSpace(),

--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -41,8 +41,6 @@ tune_logger = logging.getLogger("tune")
 
 
 class DispatchTuner(dispatch_parser.DispatchParser):
-    dispatch_kind: common.DispatchKind
-
     @abstractmethod
     def get_td_spec(
         self,
@@ -62,7 +60,12 @@ class DispatchTuner(dispatch_parser.DispatchParser):
         """Returns a ConstraintGenerator associated with this dispatch root op."""
         pass
 
-    # TODO: Uncomment after completing the sort function for atten and conv
+    @abstractmethod
+    def get_dispatch_kind(self) -> common.DispatchKind:
+        """Returns dispatch kind"""
+        pass
+
+    # TODO: Uncomment after completing the solution trace for atten and conv
     # @abstractmethod
     # def get_solution_trace(
     #     self,
@@ -93,8 +96,6 @@ class DispatchTunerRegistry:
 class ContractionOpInterfaceTuner(
     DispatchTuner, dispatch_parser.ContractionOpInterfaceParser
 ):
-    dispatch_kind = common.DispatchKind.contraction
-
     def __init__(self, root_op: ir.Operation):
         super().__init__(root_op)
 
@@ -113,6 +114,9 @@ class ContractionOpInterfaceTuner(
             contraction_op.context, contraction_op, config_list, func_name
         )
 
+    def get_dispatch_kind(self) -> common.DispatchKind:
+        return common.DispatchKind.contraction
+
     def get_solution_trace(
         self,
         config_list: list[common.TuningConfiguration],
@@ -123,8 +127,6 @@ class ContractionOpInterfaceTuner(
 class ConvolutionOpInterfaceTuner(
     DispatchTuner, dispatch_parser.ConvolutionOpInterfaceParser
 ):
-    dispatch_kind = common.DispatchKind.conv
-
     def __init__(self, root_op: ir.Operation):
         super().__init__(root_op)
 
@@ -143,12 +145,13 @@ class ConvolutionOpInterfaceTuner(
             conv_op.context, conv_op, config_list, func_name
         )
 
+    def get_dispatch_kind(self) -> common.DispatchKind:
+        return common.DispatchKind.conv
+
 
 class AttentionOpInterfaceTuner(
     DispatchTuner, dispatch_parser.AttentionOpInterfaceParser
 ):
-    dispatch_kind = common.DispatchKind.attention
-
     def __init__(self, root_op: ir.Operation):
         super().__init__(root_op)
 
@@ -166,6 +169,9 @@ class AttentionOpInterfaceTuner(
         return spec_builder.build_td_spec(
             attention_op.context, attention_op, config_list, func_name
         )
+
+    def get_dispatch_kind(self) -> common.DispatchKind:
+        return common.DispatchKind.attention
 
 
 def get_default_output_dir() -> str:

--- a/sharktuner/sharktuner/candidate_gen.py
+++ b/sharktuner/sharktuner/candidate_gen.py
@@ -61,8 +61,8 @@ class DispatchTuner(dispatch_parser.DispatchParser):
     def get_constraint_generator(self) -> constraint_generator.ConstraintGenerator:
         """Returns a ConstraintGenerator associated with this dispatch root op."""
         pass
-    
-    # TODO: Uncomment after completing the sort function for atten and conv 
+
+    # TODO: Uncomment after completing the sort function for atten and conv
     # @abstractmethod
     # def get_solution_trace(
     #     self,
@@ -213,6 +213,7 @@ def generate_configs_and_td_specs(
 
     return dispatch_tuner
 
+
 def generate_configs_and_td_specs(
     input_module: ir.Module,  # Path to the mlir file to be tuned
     tuner_context: common.TunerContext,
@@ -247,8 +248,12 @@ def generate_configs_and_td_specs(
 
     candidate_profiles: list[common.CandidateProfile] = []
     # Index 0 is reserved for default config, so it gets a placeholder spec.
-    candidate_profiles.append(common.CandidateProfile(td_spec_module=spec_builder.get_placeholder_spec(input_module.context),
-    solution_trace=None))
+    candidate_profiles.append(
+        common.CandidateProfile(
+            td_spec_module=spec_builder.get_placeholder_spec(input_module.context),
+            solution_trace=None,
+        )
+    )
 
     for i, config in enumerate(solutions[:limit]):
         tune_logger.debug(f"Solution #{i+1}: {config}")
@@ -256,9 +261,11 @@ def generate_configs_and_td_specs(
         assert td_spec_module, "Failed to generate transform dialect spec"
         solution_trace = dispatch_tuner.get_solution_trace(config)
         assert solution_trace, "Failed to retrive solution feature values"
-        candidate_profiles.append(common.CandidateProfile(
-            td_spec_module = td_spec_module, solution_trace=solution_trace
-        ))
+        candidate_profiles.append(
+            common.CandidateProfile(
+                td_spec_module=td_spec_module, solution_trace=solution_trace
+            )
+        )
 
     tune_logger.debug(f"Generated {len(candidate_profiles)} tuning specs")
     return candidate_profiles
@@ -412,7 +419,9 @@ def main() -> None:
             prefetch_shared_memory=args.prefetch_shared_memory_options,
             no_reduce_shared_memory_bank_conflicts=args.no_reduce_shared_memory_bank_conflicts_options,
         )
-        candidate_profiles: list[common.CandidateProfile] = generate_configs_and_td_specs(
+        candidate_profiles: list[
+            common.CandidateProfile
+        ] = generate_configs_and_td_specs(
             mlir_module,
             tuner_ctx,
             args.limit,

--- a/sharktuner/sharktuner/common.py
+++ b/sharktuner/sharktuner/common.py
@@ -99,10 +99,8 @@ class TimeBudget:
 @dataclass
 class SolutionTrace(ABC):
     """A SolutionTrace is a record of tuning parameters values from constraint_generator"""
-    @property
-    @abstractmethod
-    def kind(self) -> ["contraction", "other_kind"]:
-        pass
+
+    pass
 
 
 @dataclass
@@ -127,6 +125,7 @@ class CandidateProfile:
     """
     A CandidateProfile contains info of each candidate that need to be passed to libtuner.
     """
+
     td_spec_module: ir.Module
     solution_trace: Optional[SolutionTrace] = None
 
@@ -221,18 +220,30 @@ class AttentionOpInfo:
     k1_dims: list[int]
     k2_dims: list[int]
 
+
 @dataclass
 class ContractionSolutionTrace(SolutionTrace):
     # Problem sizes
-    M: int; N: int; K: int
-    lhs_type_bitwidth: int; rhs_type_bitwidth: int
+    M: int
+    N: int
+    K: int
+    lhs_type_bitwidth: int
+    rhs_type_bitwidth: int
 
     # Z3 numeric selections
-    m: int; n: int; k: int
-    wg_x: int; wg_y: int; wg_z: int
-    sg_m_cnt: int; sg_n_cnt: int
-    intrinsic_mn: int; intrinsic_k: int
-    subgroup_m: int; subgroup_n: int; subgroup_k: int
+    m: int
+    n: int
+    k: int
+    wg_x: int
+    wg_y: int
+    wg_z: int
+    sg_m_cnt: int
+    sg_n_cnt: int
+    intrinsic_mn: int
+    intrinsic_k: int
+    subgroup_m: int
+    subgroup_n: int
+    subgroup_k: int
 
     # Hardware specific
     subgroup_size: int
@@ -253,10 +264,6 @@ class ContractionSolutionTrace(SolutionTrace):
     # workgroups: Optional[int] = None
     # subgroups: Optional[int] = None
     # quantization_inefficiency: Optional[float] = None
-
-    @property
-    def kind(self) -> Literal["contraction"]:
-        return "contraction"
 
 
 def get_map_result_dim_positions(map: ir.AffineMap) -> Optional[list[int]]:

--- a/sharktuner/sharktuner/common.py
+++ b/sharktuner/sharktuner/common.py
@@ -10,12 +10,16 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import Enum
 from types import TracebackType
-from typing import Optional
-from typing import Any
+from typing import Optional, Any, Literal
 import subprocess
 import tempfile
 import os
 import time
+<<<<<<< HEAD
+=======
+import random
+from abc import ABC, abstractmethod
+>>>>>>> 1c2dfcd20 (Add classes in common to enable tracking solution features)
 
 from iree.compiler import ir  # type: ignore
 
@@ -100,7 +104,7 @@ class SolutionTrace(ABC):
     """A SolutionTrace is a record of tuning parameters values from constraint_generator"""
     @property
     @abstractmethod
-    def kind(self) -> str:  # could also use Literal in subclasses for narrowing
+    def kind(self) -> ["contraction", "other_kind"]:
         pass
 
 
@@ -118,6 +122,15 @@ class TuningConfiguration:
 
     name: str
     configuration: ir.Attribute
+    solution_trace: Optional[SolutionTrace] = None
+
+
+@dataclass
+class CandidateProfile:
+    """
+    A CandidateProfile contains info of each candidate that need to be passed to libtuner.
+    """
+    td_spec_module: ir.Module
     solution_trace: Optional[SolutionTrace] = None
 
 
@@ -235,14 +248,14 @@ class ContractionSolutionTrace(SolutionTrace):
     allowed_waves_per_eu: Any
     padding: Any
 
-    # Engineered features
-    mma_attr_map: Optional[int] = None
-    lhs_tile_size: Optional[int] = None
-    rhs_tile_size: Optional[int] = None
-    lds_utilization: Optional[float] = None
-    workgroups: Optional[int] = None
-    subgroups: Optional[int] = None
-    quantization_inefficiency: Optional[float] = None
+    # # Engineered features
+    # mma_attr_map: Optional[int] = None
+    # lhs_tile_size: Optional[int] = None
+    # rhs_tile_size: Optional[int] = None
+    # lds_utilization: Optional[float] = None
+    # workgroups: Optional[int] = None
+    # subgroups: Optional[int] = None
+    # quantization_inefficiency: Optional[float] = None
 
     @property
     def kind(self) -> Literal["contraction"]:
@@ -542,3 +555,4 @@ def get_attention_decomposition_config(
     }
 
     return ir.DictAttr.get(decomposition_config_dict, context=ctx)
+

--- a/sharktuner/sharktuner/common.py
+++ b/sharktuner/sharktuner/common.py
@@ -559,4 +559,3 @@ def get_attention_decomposition_config(
     }
 
     return ir.DictAttr.get(decomposition_config_dict, context=ctx)
-

--- a/sharktuner/sharktuner/common.py
+++ b/sharktuner/sharktuner/common.py
@@ -15,11 +15,8 @@ import subprocess
 import tempfile
 import os
 import time
-<<<<<<< HEAD
-=======
 import random
 from abc import ABC, abstractmethod
->>>>>>> 1c2dfcd20 (Add classes in common to enable tracking solution features)
 
 from iree.compiler import ir  # type: ignore
 
@@ -241,7 +238,7 @@ class ContractionSolutionTrace(SolutionTrace):
     subgroup_size: int
 
     # Options/flags
-    mma_attr: Any
+    # mma_attr: Any # TODO: Fix TypeError: cannot pickle 'MMAAttr' object when passing candidate_trackers to multiprocessing handler
     promote_operands: Any
     codegen_pipeline: Any
     pipeline_options_search_space: Any

--- a/sharktuner/sharktuner/constraint_generator.py
+++ b/sharktuner/sharktuner/constraint_generator.py
@@ -256,9 +256,42 @@ def generate_generic_contraction_solutions(
         i += 1
 
         for compilation_info in compilation_infos:
+
+
+        for compilation_info in compilation_infos:
+            solution_trace = common.ContractionSolutionTrace(
+                M=int(math.prod(M)),
+                N=int(math.prod(N)),
+                K=int(math.prod(K)),
+                lhs_type_bitwidth=lhs_type.bitwidth,
+                rhs_type_bitwidth=rhs_type.bitwidth,
+
+                m=workgroup_tile_sizes[0],
+                n=workgroup_tile_sizes[1],
+                k=reduction_tile_sizes[2],
+                wg_x=lookup(wg_x),
+                wg_y=lookup(wg_y),
+                wg_z=lookup(wg_z),
+                sg_m_cnt=lookup(sg_m_cnt),
+                sg_n_cnt=lookup(sg_n_cnt),
+                intrinsic_mn=lookup(intrinsic_mn),
+                intrinsic_k=lookup(intrinsic_k),
+                subgroup_tile_m=subgroup_tile_sizes[0],
+                subgroup_tile_n=subgroup_tile_sizes[1],
+                subgroup_tile_k=subgroup_tile_sizes[2],
+
+                subgroup_size=lookup(subgroup_size),
+                
+                mma_attr=mma_attr,
+                promote_operands=promote_operands,
+                codegen_pipeline=codegen_pipeline,
+                pipeline_options_search_space=pipeline_options_search_space,
+                allowed_waves_per_eu=allowed_waves_per_eu,
+                padding=padding,
+            )
             yield [
                 common.TuningConfiguration(
-                    name="compilation_info", configuration=compilation_info
+                    name="compilation_info", configuration=compilation_info, solution_trace=solution_trace
                 )
             ]
 

--- a/sharktuner/sharktuner/constraint_generator.py
+++ b/sharktuner/sharktuner/constraint_generator.py
@@ -262,7 +262,6 @@ def generate_generic_contraction_solutions(
                 K=int(math.prod(K)),
                 lhs_type_bitwidth=lhs_type.bitwidth,
                 rhs_type_bitwidth=rhs_type.bitwidth,
-
                 m=workgroup_tile_sizes[0],
                 n=workgroup_tile_sizes[1],
                 k=reduction_tile_sizes[2],
@@ -276,9 +275,7 @@ def generate_generic_contraction_solutions(
                 subgroup_m=subgroup_tile_sizes[0],
                 subgroup_n=subgroup_tile_sizes[1],
                 subgroup_k=subgroup_tile_sizes[2],
-
                 subgroup_size=lookup(subgroup_size),
-                
                 # mma_attr=mma_attr,
                 promote_operands=promote_operands,
                 codegen_pipeline=codegen_pipeline,
@@ -288,7 +285,9 @@ def generate_generic_contraction_solutions(
             )
             yield [
                 common.TuningConfiguration(
-                    name="compilation_info", configuration=compilation_info, solution_trace=solution_trace
+                    name="compilation_info",
+                    configuration=compilation_info,
+                    solution_trace=solution_trace,
                 )
             ]
 

--- a/sharktuner/sharktuner/constraint_generator.py
+++ b/sharktuner/sharktuner/constraint_generator.py
@@ -279,7 +279,7 @@ def generate_generic_contraction_solutions(
 
                 subgroup_size=lookup(subgroup_size),
                 
-                mma_attr=mma_attr,
+                # mma_attr=mma_attr,
                 promote_operands=promote_operands,
                 codegen_pipeline=codegen_pipeline,
                 pipeline_options_search_space=pipeline_options_search_space,

--- a/sharktuner/sharktuner/constraint_generator.py
+++ b/sharktuner/sharktuner/constraint_generator.py
@@ -256,9 +256,6 @@ def generate_generic_contraction_solutions(
         i += 1
 
         for compilation_info in compilation_infos:
-
-
-        for compilation_info in compilation_infos:
             solution_trace = common.ContractionSolutionTrace(
                 M=int(math.prod(M)),
                 N=int(math.prod(N)),
@@ -276,9 +273,9 @@ def generate_generic_contraction_solutions(
                 sg_n_cnt=lookup(sg_n_cnt),
                 intrinsic_mn=lookup(intrinsic_mn),
                 intrinsic_k=lookup(intrinsic_k),
-                subgroup_tile_m=subgroup_tile_sizes[0],
-                subgroup_tile_n=subgroup_tile_sizes[1],
-                subgroup_tile_k=subgroup_tile_sizes[2],
+                subgroup_m=subgroup_tile_sizes[0],
+                subgroup_n=subgroup_tile_sizes[1],
+                subgroup_k=subgroup_tile_sizes[2],
 
                 subgroup_size=lookup(subgroup_size),
                 

--- a/sharktuner/sharktuner/libtuner.py
+++ b/sharktuner/sharktuner/libtuner.py
@@ -754,7 +754,7 @@ def generate_candidate_specs(
                 starter_td_spec = ir.Module.parse(f.read())
         tuning_client.dispatch_kind = candidate_gen.set_dispatch_tuner(
             mlir_module
-        ).dispatch_kind
+        ).get_dispatch_kind()
 
         candidate_profiles = candidate_gen.generate_configs_and_td_specs(
             input_module=mlir_module,

--- a/sharktuner/sharktuner/libtuner.py
+++ b/sharktuner/sharktuner/libtuner.py
@@ -706,6 +706,22 @@ def get_iree_codegen_pipeline(pipeline: CodegenPipelines):
             assert False, "unexpected codegen pipeline"
 
 
+def generate_candidates(
+    args: argparse.Namespace,
+    path_config: PathConfig,
+    tuning_client: TuningClient,
+) -> list[int]:
+    logging.debug("generate_candidates()")
+
+    path_config.specs_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(args.input_file, path_config.template_mlir)
+    tune_logger = logging.getLogger("tune")
+
+    generate_candidate_specs(args, path_config, tuning_client)
+
+    return []
+
+    
 def generate_candidate_specs(
     args: argparse.Namespace,
     path_config: PathConfig,

--- a/sharktuner/sharktuner/libtuner.py
+++ b/sharktuner/sharktuner/libtuner.py
@@ -761,7 +761,7 @@ def generate_candidate_specs(
             pipeline_options_search_space=pipeline_options_search_space,
             codegen_pipeline=get_iree_codegen_pipeline(args.codegen_pipeline),
         )
-        logging.debug("candidate_gen.py ends")
+        logging.debug("candidate_gen.generate_configs_and_td_specs() ends")
         handle_error(
             condition=(len(candidate_profiles) <= 1), msg="Failed to generate any candidates"
         )
@@ -1132,11 +1132,6 @@ def benchmark(
         logging.warning("Baseline run failed.")
 
     candidate_indices = [i for i in compiled_candidates if i != 0]
-    # Sort candidate starting order in the benchmark list
-    traces = [tuning_client.candidate_trackers[i].feature_trace for i in candidate_indices]
-    sorted_order = common.sorting_handler(l=traces, sorting=args.candidate_sort,key_fn=common.pick_sort_key(tuning_client.dispatch_kind))
-    candidate_indices = [candidate_indices[i] for i in sorted_order]
-
     candidate_results = benchmark_candidates(
         candidate_indices=candidate_indices,
         devices=args.devices,

--- a/sharktuner/sharktuner/libtuner.py
+++ b/sharktuner/sharktuner/libtuner.py
@@ -70,6 +70,7 @@ class CandidateTracker:
     compiled_vmfb_path: Optional[Path] = None
     spec_path: Optional[Path] = None
     td_spec_str: Optional[str] = None
+    feature_trace: Optional[common.SolutionTrace] = None
 
 
 @dataclass()
@@ -754,7 +755,7 @@ def generate_candidate_specs(
         tuning_client.dispatch_kind = candidate_gen.set_dispatch_tuner(
             mlir_module
         ).dispatch_kind
-        logging.warning("Candidate sorting feature is only enabled for contraction")
+
         candidate_profiles = candidate_gen.generate_configs_and_td_specs(
             input_module=mlir_module,
             tuner_context=tuning_client.tuner_context,

--- a/sharktuner/sharktuner/libtuner.py
+++ b/sharktuner/sharktuner/libtuner.py
@@ -722,7 +722,7 @@ def generate_candidates(
 
     return []
 
-    
+
 def generate_candidate_specs(
     args: argparse.Namespace,
     path_config: PathConfig,
@@ -751,7 +751,10 @@ def generate_candidate_specs(
         if args.starter_td_spec:
             with open(args.starter_td_spec, "r") as f:
                 starter_td_spec = ir.Module.parse(f.read())
-        tuning_client.dispatch_kind = candidate_gen.set_dispatch_tuner(mlir_module).dispatch_kind
+        tuning_client.dispatch_kind = candidate_gen.set_dispatch_tuner(
+            mlir_module
+        ).dispatch_kind
+        logging.warning("Candidate sorting feature is only enabled for contraction")
         candidate_profiles = candidate_gen.generate_configs_and_td_specs(
             input_module=mlir_module,
             tuner_context=tuning_client.tuner_context,
@@ -763,7 +766,8 @@ def generate_candidate_specs(
         )
         logging.debug("candidate_gen.generate_configs_and_td_specs() ends")
         handle_error(
-            condition=(len(candidate_profiles) <= 1), msg="Failed to generate any candidates"
+            condition=(len(candidate_profiles) <= 1),
+            msg="Failed to generate any candidates",
         )
 
         # Create candidate trackers.

--- a/sharktuner/sharktuner/libtuner.py
+++ b/sharktuner/sharktuner/libtuner.py
@@ -110,6 +110,7 @@ class TuningClient(ABC):
     def __init__(self, tuner_context: common.TunerContext):
         self.tuner_context = tuner_context
         self.candidate_trackers: list[CandidateTracker] = []
+        self.dispatch_kind: Optional[common.DispatchKind] = None
 
     @abstractmethod
     def get_iree_compile_flags(self) -> list[str]:
@@ -750,7 +751,8 @@ def generate_candidate_specs(
         if args.starter_td_spec:
             with open(args.starter_td_spec, "r") as f:
                 starter_td_spec = ir.Module.parse(f.read())
-        config_specs: list[ir.Module] = candidate_gen.generate_configs_and_td_specs(
+        tuning_client.dispatch_kind = candidate_gen.set_dispatch_tuner(mlir_module).dispatch_kind
+        candidate_profiles = candidate_gen.generate_configs_and_td_specs(
             input_module=mlir_module,
             tuner_context=tuning_client.tuner_context,
             limit=args.num_candidates,
@@ -761,12 +763,13 @@ def generate_candidate_specs(
         )
         logging.debug("candidate_gen.py ends")
         handle_error(
-            condition=(len(config_specs) <= 1), msg="Failed to generate any candidates"
+            condition=(len(candidate_profiles) <= 1), msg="Failed to generate any candidates"
         )
 
         # Create candidate trackers.
         candidates = []
-        for candidate_num, spec in enumerate(config_specs):
+        for candidate_num, candidate_profile in enumerate(candidate_profiles):
+            spec = candidate_profile.td_spec_module
             candidates.append(candidate_num)
             # Move the specs to the canonical path_config location.
             spec_path = path_config.specs_dir / path_config.get_candidate_spec_filename(
@@ -800,6 +803,7 @@ def generate_candidate_specs(
                 candidate_id=candidate_num,
                 spec_path=spec_path,
                 td_spec_str=td_spec_str,
+                feature_trace=candidate_profile.solution_trace,
             )
             tuning_client.candidate_trackers.append(new_candidate)
     except Exception as e:
@@ -1128,6 +1132,11 @@ def benchmark(
         logging.warning("Baseline run failed.")
 
     candidate_indices = [i for i in compiled_candidates if i != 0]
+    # Sort candidate starting order in the benchmark list
+    traces = [tuning_client.candidate_trackers[i].feature_trace for i in candidate_indices]
+    sorted_order = common.sorting_handler(l=traces, sorting=args.candidate_sort,key_fn=common.pick_sort_key(tuning_client.dispatch_kind))
+    candidate_indices = [candidate_indices[i] for i in sorted_order]
+
     candidate_results = benchmark_candidates(
         candidate_indices=candidate_indices,
         devices=args.devices,


### PR DESCRIPTION
common.py:
- Added `SolutionTrace`, to track variable values that generated from z3 constraints; the contraction type is `ContractionSolutionTrace`.
- Modified `TuningConfiguration`, added a new attr to store `SolutionTrace`.
- Added `CandidateProfile`, to pass needed candidate info from candidate_gen.py to libtuner.py.

constraints_generator.py:
- Modified `generate_generic_contraction_solutions()`, attach `SolutionTrace` to `TuningConfiguration` when return.
- Modified `DispatchTuner`, added new methods

candidate_gen.py:
- Modified `generate_configs_and_td_specs()`, which retrieves `SolutionTrace` from `TuningConfiguration` and attaches to `CandidateProfile`, and returns as a list to libtuner.py.

libtuner.py:
- Modified `TuningClient`, to track `dispatch_kind` during tuning for future flexibility.