### PR TITLE
[Fusilli,FusilliPlugin] Fix missing `utils.h` in `fusilli-plugin` build.

### DIFF
--- a/.github/workflows/ci-fusilli-plugin.yml
+++ b/.github/workflows/ci-fusilli-plugin.yml
@@ -55,13 +55,10 @@ jobs:
         include:
           - name: gfx942_clang20_debug
             runs-on: linux-mi325-2gpu-ossci-nod-ai
-            # TODO(aaron): Debug CI failure and enable `-DFUSILLI_BUILD_BENCHMARKS=ON`
             fusilli-plugin-cmake-options:
               -DCMAKE_C_COMPILER=clang-20
               -DCMAKE_CXX_COMPILER=clang++-20
               -DCMAKE_BUILD_TYPE=Debug
-              -DFUSILLI_SYSTEMS_AMDGPU=ON
-              -DFUSILLI_BUILD_BENCHMARKS=OFF
               -DIREERuntime_DIR=/workspace/.cache/docker/iree/build/lib/cmake/IREE
 
     steps:

--- a/fusilli-plugin/build_tools/cmake/FusilliPluginDependencyUtils.cmake
+++ b/fusilli-plugin/build_tools/cmake/FusilliPluginDependencyUtils.cmake
@@ -217,5 +217,7 @@ macro(_fetch_Fusilli)
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../sharkfuser
     )
     set(FUSILLI_BUILD_TESTS OFF)
+    set(FUSILLI_BUILD_BENCHMARKS OFF)
+    set(FUSILLI_SYSTEMS_AMDGPU ON)
     FetchContent_MakeAvailable(Fusilli)
 endmacro()

--- a/sharkfuser/CMakeLists.txt
+++ b/sharkfuser/CMakeLists.txt
@@ -134,16 +134,19 @@ if(FUSILLI_SYSTEMS_AMDGPU)
   endif()
 endif()
 
+# Both tests and benchmarks depend on libutils
+if(FUSILLI_BUILD_TESTS OR FUSILLI_BUILD_BENCHMARKS)
+  # Add library for tests/utils.h
+  add_library(libutils INTERFACE)
+  target_include_directories(libutils INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+endif()
+
 # Build tests and samples
 if(FUSILLI_BUILD_TESTS)
   message(STATUS "Building Fusilli tests and samples")
 
   # Find prebuilt Catch2 library
   find_package(Catch2 3 REQUIRED)
-
-  # Add library for tests/utils.h
-  add_library(libutils INTERFACE)
-  target_include_directories(libutils INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
 
   # Add tests and samples sub directories
   add_subdirectory(tests)


### PR DESCRIPTION
This PR fixes `fusilli-plugin` build failure when fusilli benchmarking (`FUSILLI_BUILD_BENCHMARKS`) was enabled, but fusilli testing (`FUSILLI_BUILD_TESTS`) was disabled: [link to CI failure](https://github.com/nod-ai/shark-ai/actions/runs/18206945208/job/51839515287?pr=2410). Both _should_ be disabled, but ideally the build wouldn't break if one wasn't.  The issue was: both fusilli tests and fusilli benchmarks depend on `libutils`, but the target was only defined if tests were enabled.