### PR TITLE
[sharktuner] Add explicit return type

### DIFF
--- a/sharktuner/tests/spec_builder_test.py
+++ b/sharktuner/tests/spec_builder_test.py
@@ -24,7 +24,7 @@ from sharktuner import spec_builder
 from sharktuner.test_utils import tuner_ctx
 
 
-def create_generic_module(tuner_ctx: common.TunerContext):
+def create_generic_module(tuner_ctx: common.TunerContext) -> ir.Module:
     ctx = tuner_ctx.mlir_ctx
     with ir.Location.unknown(ctx):
         module = ir.Module.create()


### PR DESCRIPTION
The return type was removed in 070075f40 as it was incorrect, but we should always use explicit return types as mypy will default to `Any` otherwise.

Unfortunately this doesn't improve much in this case, as the IREE imports are all `type: ignore`d.