### PR TITLE
[LLM Server] Fix typo in `chunked prefill` section

### DIFF
--- a/docs/shortfin/llm/user/llama_serving.md
+++ b/docs/shortfin/llm/user/llama_serving.md
@@ -328,7 +328,6 @@ starting the server.
 ### Re-export the model with `--has-prefill-position`
 
 ```bash
-```bash
 python -m sharktank.examples.export_paged_llm_v1 \
   --gguf-file=$MODEL_PARAMS_PATH \
   --output-mlir=$MLIR_PATH \


### PR DESCRIPTION
- Fix typo where I accidentally repeated to ``bash line twice in `chunked prefill` section