### PR TITLE
[Fusilli] Disable concurrent tests in CI

### DIFF
--- a/.github/workflows/ci-sharkfuser.yml
+++ b/.github/workflows/ci-sharkfuser.yml
@@ -100,7 +100,7 @@ jobs:
       working-directory: ${{ env.FUSILLI_DIR }}
       run: |
         build_tools/docker/exec_docker_ci.sh \
-        bash -c "ctest --test-dir build --output-on-failure --extra-verbose --timeout 120 -j 16 && \
+        bash -c "ctest --test-dir build --output-on-failure --extra-verbose --timeout 120 && \
                  tests/test_cache_empty.sh"
 
     - name: Run code coverage


### PR DESCRIPTION
I'm seeing some more flakes related to LIT (not Fusilli) when running things with -j in CI: https://github.com/nod-ai/shark-ai/actions/runs/18418615853/job/52488044771

Didn't dig much further than that, but until we do, perhaps it's best if we switch to serial execution in CI for now (and just use this for local).

```
13: PASS: fusilli :: lit/test_conv_asm_emitter_nhwc_krsc_with_pad.cpp (1 of 1)
13: Traceback (most recent call last):
13:   File "/workspace/.cache/docker/venv/bin/lit", line 8, in <module>
13:     sys.exit(main())
13:              ^^^^^^
13:   File "/workspace/.cache/docker/venv/lib/python3.12/site-packages/lit/main.py", line 127, in main
13:     record_test_times(selected_tests, lit_config)
13:   File "/workspace/.cache/docker/venv/lib/python3.12/site-packages/lit/TestTimes.py", line 24, in record_test_times
13:     times_by_suite[t.suite.exec_root] = read_test_times(t.suite)
13:                                         ^^^^^^^^^^^^^^^^^^^^^^^^
13:   File "/workspace/.cache/docker/venv/lib/python3.12/site-packages/lit/TestTimes.py", line 12, in read_test_times
13:     time, path = line.split(maxsplit=1)
13:     ^^^^^^^^^^
13: ValueError: not enough values to unpack (expected 2, got 1)
17/21 Test #13: test_conv_asm_emitter_nhwc_krsc_with_pad ....***Failed    1.05 sec
```