### PR TITLE
[CI] Workflow To Upload IR And Update IR In Iree

### DIFF
--- a/.github/workflows/ci_upload_ir.yml
+++ b/.github/workflows/ci_upload_ir.yml
@@ -151,7 +151,7 @@ jobs:
               --irpa=${IRPA} \
               --tokenizer=${TOKENIZER} \
               --dataset=${DATASET} \
-              --expected-err=9e-2 \
+              --expected-err=1e-2 \
               --min-context=10
             echo " Torch model evaluation passed."
 
@@ -167,7 +167,7 @@ jobs:
               --dataset=${DATASET} \
               --vmfb=output_artifacts/output_${{ matrix.model.model_name }}/output.vmfb \
               --config=output_artifacts/output_${{ matrix.model.model_name }}/config_attn.json \
-              --expected-err=9e-2 \
+              --expected-err=5e-2 \
               --min-context=10 \
               --iree-hal-target-device=hip \
               --iree-hip-target=gfx942
@@ -239,21 +239,3 @@ jobs:
           signoff: true
           add-paths: |
             ${{ matrix.model.json_path }}
-      # - name: Create Pull Request
-      #   if: env.UPDATE_MLIR == 'true'
-      #   id: cpr
-      #   uses: peter-evans/create-pull-request@v7
-      #   with:
-      #     token: ${{ secrets.REPO_B_TOKEN_TEST }}
-      #     commit-message: "Update MLIR URL for ${{ matrix.model.model_name }}"
-      #     title: "Update MLIR URL for ${{ matrix.model.model_name }}"
-      #     body: |
-      #       This PR updates the MLIR URL in the JSON file for model **${{ matrix.model.model_name }}**.
-      #       - New MLIR URL: `${{ env.NEW_MLIR_URL }}`
-      #       - Updated file: `${{ matrix.model.json_path }}`
-      #     branch: "update-mlir-${{ matrix.model.model_name }}-${{ github.run_id }}"
-      #     delete-branch: true
-      #     signoff: true
-      #     add-paths: |
-      #       ${{ matrix.model.json_path }}
-      #     base: main


### PR DESCRIPTION
Workflow To Upload IR and Update IR In Json Files For Iree Test Suite for Llama 8b Models

What this workflow does:
1. extracts the mlir currently being used in the json files in the IREE tests, 
2. export mlir using sharktank
3. checks if there is diff between the two mlirs, if yes then we do the perplexity tests(as suggested by Kunwar) and then create a pr updating the mlir url in the iree test json files in the iree-org/iree repository.

An example pr looks like [this](https://github.com/yash-amd/iree/pull/7)

** For this a iree secret token has to be placed in the shark-ai repository for checking out in iree-org/iree repository and creating the pull requests.