### PR TITLE
Raise an Exception when allocate buffer fail

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/invocation.py
+++ b/shortfin/python/shortfin_apps/llm/components/invocation.py
@@ -229,7 +229,7 @@ class PrefillTask(LlmTask):
                 [batch_size, block_count], int_dtype
             )
         except Exception as e:
-            error_msg = f"Device buffer allocation failed: {e}"
+            error_msg = f"Device buffer allocation failed for prefill: {e}"
             logger.error(error_msg)
             raise RuntimeError(error_msg) from e
 
@@ -346,7 +346,7 @@ class DecodeTask(LlmTask):
                 [batch_size, block_count], int_dtype
             )
         except Exception as e:
-            error_msg = f"Device buffer allocation failed: {e}"
+            error_msg = f"Device buffer allocation failed for decode: {e}"
             logger.error(error_msg)
             raise RuntimeError(error_msg) from e
 


### PR DESCRIPTION
Why:
When buffer allocation fail, it is hard to know what is going on when running harness with shortfin
How:
Raise an exception together with error log so it is easier to know that the "out of memory" is caused by shortfin