### PR TITLE
[Fusilli] De-duplicate benchmark driver binary creation

### DIFF
--- a/sharkfuser/benchmarks/CMakeLists.txt
+++ b/sharkfuser/benchmarks/CMakeLists.txt
@@ -20,33 +20,21 @@ set_target_properties(
 # Add some benchmark configurations for CI coverage.
 add_fusilli_benchmark(
   NAME fusilli_benchmark_conv2d_nchw_fp32
+  DRIVER fusilli_benchmark_driver
   ARGS
     --iter 10 conv -n 100 -c 3 -H 32 -W 32 -k 32 -y 3 -x 3 -u 1 -v 1 -p 0 -q 0 -l 1 -j 1 --in_layout "NCHW" --fil_layout "NCHW" --out_layout "NCHW" --spatial_dim 2
-  SRCS driver.cpp
-  DEPS
-    libfusilli
-    libutils
-    CLI11::CLI11
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_conv2d_nhwc_fp16
+  DRIVER fusilli_benchmark_driver
   ARGS
     --iter 10 conv --fp16 -n 16 -c 48 -H 48 -W 32 -k 48 -y 3 -x 3 -p 2 -q 2 -u 1 -v 1 -l 2 -j 2 --in_layout "NHWC" --out_layout "NHWC" --fil_layout "NHWC" --spatial_dim 2
-  SRCS driver.cpp
-  DEPS
-    libfusilli
-    libutils
-    CLI11::CLI11
 )
 
 add_fusilli_benchmark(
   NAME fusilli_benchmark_conv3d_ndhwc_bf16
+  DRIVER fusilli_benchmark_driver
   ARGS
     --iter 10 conv --bf16 -n 16 -c 288 --in_d 2 -H 48 -W 32 -k 288 --fil_d 2 -y 1 -x 1 --pad_d 0 -p 0 -q 0 --conv_stride_d 2 -u 1 -v 1 --dilation_d 1 -l 1 -j 1 --in_layout "NDHWC" --out_layout "NDHWC" --fil_layout "NDHWC" --spatial_dim 3
-  SRCS driver.cpp
-  DEPS
-    libfusilli
-    libutils
-    CLI11::CLI11
 )

--- a/sharkfuser/build_tools/cmake/FusilliTestUtils.cmake
+++ b/sharkfuser/build_tools/cmake/FusilliTestUtils.cmake
@@ -121,11 +121,8 @@ endfunction()
 # NAME
 #  The name of the executable target to create (required).
 #
-# SRCS
-#  Source files to compile into the executable (required).
-#
-# DEPS
-#  Library dependencies to be linked to this target.
+# DRIVER
+#  The benchmark driver to use (required).
 #
 # ARGS
 #  Arguments to the benchmark driver (required).
@@ -137,8 +134,8 @@ function(add_fusilli_benchmark)
   cmake_parse_arguments(
     _RULE               # prefix
     ""                  # options
-    "NAME"              # one value keywords
-    "SRCS;DEPS;ARGS"    # multi-value keywords
+    "NAME;DRIVER"       # one value keywords
+    "ARGS"              # multi-value keywords
     ${ARGN}             # extra arguments
   )
 
@@ -146,17 +143,15 @@ function(add_fusilli_benchmark)
     message(FATAL_ERROR "add_fusilli_benchmark: NAME is required")
   endif()
 
-  if(NOT DEFINED _RULE_SRCS)
-    message(FATAL_ERROR "add_fusilli_benchmark: SRCS is required")
+  if(NOT DEFINED _RULE_DRIVER)
+    message(FATAL_ERROR "add_fusilli_benchmark: DRIVER is required")
   endif()
 
-  _add_fusilli_ctest_target(
-    NAME ${_RULE_NAME}
-    SRCS ${_RULE_SRCS}
-    DEPS ${_RULE_DEPS}
-    BIN_SUBDIR benchmarks
-    TEST_ARGS ${_RULE_ARGS}
-  )
+  if(NOT DEFINED _RULE_ARGS)
+    message(FATAL_ERROR "add_fusilli_benchmark: ARGS is required")
+  endif()
+
+  add_test(NAME ${_RULE_NAME} COMMAND ${_RULE_DRIVER} ${_RULE_ARGS})
 endfunction()
 
 
@@ -241,9 +236,6 @@ endfunction()
 # DEPS
 #  Library dependencies to be linked to this target.
 #
-# TEST_ARGS
-#  Extra args to the test command.
-#
 # BIN_SUBDIR
 #  Subdirectory under build/bin/ where the executable will be placed.
 function(_add_fusilli_ctest_target)
@@ -251,7 +243,7 @@ function(_add_fusilli_ctest_target)
     _RULE                 # prefix
     ""                    # options
     "NAME;BIN_SUBDIR"     # one value keywords
-    "SRCS;DEPS;TEST_ARGS" # multi-value keywords
+    "SRCS;DEPS" # multi-value keywords
     ${ARGN}               # extra arguments
   )
 
@@ -264,7 +256,7 @@ function(_add_fusilli_ctest_target)
   )
 
   # Add the CTest test.
-  add_test(NAME ${_RULE_NAME} COMMAND ${_RULE_NAME} ${_RULE_TEST_ARGS})
+  add_test(NAME ${_RULE_NAME} COMMAND ${_RULE_NAME})
 
   # Configure cache dir and logging flags.
   # Pass `FUSILLI_CACHE_DIR=/tmp` to configure the compilation cache to be


### PR DESCRIPTION
Previously, every `add_fusilli_benchmark` would (unnecessarily) register a separate executable for the driver.cpp, link deps etc even though the only difference was how the executable was being invoked in the test. This de-duplicates the same, so now the `build/bin/benchmarks` dir has a single driver.