### PR TITLE
Enable code to start logging using environment variable

### DIFF
--- a/shortfin/python/shortfin_apps/llm/components/lifecycle.py
+++ b/shortfin/python/shortfin_apps/llm/components/lifecycle.py
@@ -26,6 +26,8 @@ from .tokenizer import Tokenizer
 from typing import TYPE_CHECKING
 from fastapi import FastAPI
 
+import os
+
 
 logger = logging.getLogger(__name__)
 # Get the logging level from the environment variable, default to WARNING


### PR DESCRIPTION
Why:
When running the MLPerf harness with Shortfin, it's crucial to have access to debug-level logs for troubleshooting. Currently, the harness and Shortfin use separate logging configurations, which makes it difficult to unify and consistently capture detailed logs.
How:
This change forces and reconfigures the logger to use DEBUG level when the environment variable SHORTFIN_APPS_LOG_LEVEL=DEBUG is set. It ensures consistent logging behavior across both the harness and Shortfin components.