### PR TITLE
[CI] Remove Continue On Error In E2E Tests

### DIFF
--- a/.github/workflows/ci_e2e_llm_model_test.yml
+++ b/.github/workflows/ci_e2e_llm_model_test.yml
@@ -8,10 +8,6 @@ name: CI - E2E Model Tests
 
 on:
   workflow_dispatch:
-  pull_request:
-  push:
-    branches:
-      - main
   schedule:
     - cron: "0 12 * * *"
 


### PR DESCRIPTION
Remove Continue On Error From CI So That The Workflow Fails If a Model Fails.