### PR TITLE
[Fusilli] Check for consistency in ConvWGradNode's input/output shapes

### DIFF
--- a/sharkfuser/tests/test_conv_node.cpp
+++ b/sharkfuser/tests/test_conv_node.cpp
@@ -679,6 +679,7 @@ TEST_CASE("ConvWGradNode postValidateNode dimension validation",
   ConvWGradNode node(std::move(attr), ctx);
 
   // First pass pre-validation
+  FUSILLI_REQUIRE_OK(node.preValidateNode());
   FUSILLI_REQUIRE_OK(node.inferPropertiesNode());
 
   // Post-validation should fail due to incorrect dimensions
@@ -686,5 +687,6 @@ TEST_CASE("ConvWGradNode postValidateNode dimension validation",
   REQUIRE(isError(postStatus));
   REQUIRE(postStatus.getCode() == ErrorCode::InvalidAttribute);
   REQUIRE(postStatus.getMessage() ==
-          "ConvWGrad output dimensions do not match input dimensions");
+          "ConvWGrad output DW dimensions do not match the expected shapes "
+          "inferred based on input dimensions");
 }


### PR DESCRIPTION
Refactors conv output shape inference logic into a helper function `getConvInferredOutputShape` so that it can be used by `ConvWGradNode` to verify that the Y/DX/DW tensors have consistent shapes.


This is motivated by a strange error I was hitting in `iree-compile` that ended up being because I specified the wrong shape for `DW`. This change should make the source of the problem more clear.
