### PR TITLE
Update tokenizers and transformers package versions

### DIFF
--- a/shortfin/requirements-tests.txt
+++ b/shortfin/requirements-tests.txt
@@ -20,10 +20,10 @@ wheel
 
 # Deps needed for shortfin_apps.llm
 dataclasses-json
-tokenizers
+tokenizers>=0.13.0
 huggingface_hub[cli]
 sentencepiece
 
 # Deps needed for shortfin_apps.sd
 pillow
-transformers
+transformers>=4.30.0


### PR DESCRIPTION
This is to fix CI build issues like [here](https://github.com/nod-ai/shark-ai/actions/runs/18845744595/job/53769376328?pr=2602)

CI has been failing for all PRs today.