### PR TITLE
[Fusilli] [NFC] Consistent benchmark name

### DIFF
--- a/sharkfuser/benchmarks/CMakeLists.txt
+++ b/sharkfuser/benchmarks/CMakeLists.txt
@@ -40,21 +40,21 @@ add_fusilli_benchmark(
 )
 
 add_fusilli_benchmark(
-  NAME benchmark_conv2d_nchw_fp32_bias
+  NAME fusilli_benchmark_conv2d_nchw_fp32_bias
   DRIVER fusilli_benchmark_driver
   ARGS
     --iter 10 conv -n 100 -c 3 -H 32 -W 32 -k 32 -y 3 -x 3 -u 1 -v 1 -p 0 -q 0 -l 1 -j 1 --in_layout "NCHW" --fil_layout "NCHW" --out_layout "NCHW" --spatial_dim 2 --bias
 )
 
 add_fusilli_benchmark(
-  NAME benchmark_conv3d_ndhwc_bf16_bias
+  NAME fusilli_benchmark_conv3d_ndhwc_bf16_bias
   DRIVER fusilli_benchmark_driver
   ARGS
     --iter 10 conv --bf16 -n 16 -c 288 --in_d 2 -H 48 -W 32 -k 288 --fil_d 2 -y 1 -x 1 --pad_d 0 -p 0 -q 0 --conv_stride_d 2 -u 1 -v 1 --dilation_d 1 -l 1 -j 1 --in_layout "NDHWC" --out_layout "NDHWC" --fil_layout "NDHWC" --spatial_dim 3 --bias
 )
 
 add_fusilli_benchmark(
-  NAME benchmark_conv2d_nhwc_fp16_bias
+  NAME fusilli_benchmark_conv2d_nhwc_fp16_bias
   DRIVER fusilli_benchmark_driver
   ARGS
     --iter 10 conv --fp16 -n 16 -c 48 -H 48 -W 32 -k 48 -y 3 -x 3 -p 2 -q 2 -u 1 -v 1 -l 2 -j 2 --in_layout "NHWC" --out_layout "NHWC" --fil_layout "NHWC" --spatial_dim 2 --bias


### PR DESCRIPTION
Noticed this when looking at the "illegal instruction" CI failures from arch incompatibility.