### PR TITLE
[Fusilli] Disable `iree-llvmcpu-target-cpu` flag to mitigate ILLEGAL instruction errors on CPU runners

### DIFF
--- a/sharkfuser/include/fusilli/backend/backend.h
+++ b/sharkfuser/include/fusilli/backend/backend.h
@@ -65,7 +65,9 @@ static const std::unordered_map<Backend, std::vector<std::string>>
             Backend::CPU,
             {
                 "--iree-hal-target-backends=llvm-cpu",
-                "--iree-llvmcpu-target-cpu=host",
+                // TODO(iree-org/iree#22451): Re-enable after ILLEGAL exception
+                // issue is resolved in IREE.
+                // "--iree-llvmcpu-target-cpu=host",
             },
         },
         {


### PR DESCRIPTION
Re-enable once https://github.com/iree-org/iree/issues/22451 is resolved.