### PR TITLE
[tuner] set prefetch shared memory option based on layout matching for attention ops

### DIFF
--- a/sharktuner/tests/constraint_generator_test.py
+++ b/sharktuner/tests/constraint_generator_test.py
@@ -217,16 +217,17 @@ def test_generate_attention_solutions(
         )
         assert isinstance(config_list[1].configuration, ir.DictAttr)
 
-        # Verify that prefetch_shared_memory is False for attention operations.
+        # Verify that prefetch_shared_memory is set based on layout matching.
         compilation_info = config_list[0].configuration
         translation_info = compilation_info.translation_info
         if translation_info.configuration:
             pipeline_options = translation_info.configuration[
                 common.GPU_PIPELINE_OPTIONS_KEY
             ]
-            assert (
-                not pipeline_options.prefetch_shared_memory
-            ), "Attention operations should have prefetch_shared_memory=False"
+            # prefetch_shared_memory should be explicitly set to a boolean (not None).
+            assert isinstance(
+                pipeline_options.prefetch_shared_memory, bool
+            ), "prefetch_shared_memory must be explicitly set to True or False"
 
 
 def test_generate_solutions_tile_and_fuse_contraction_padding(

--- a/sharktuner/tests/dispatch_constraints_test.py
+++ b/sharktuner/tests/dispatch_constraints_test.py
@@ -436,6 +436,7 @@ def test_generate_attention_vector_distribute_constraints(
 
     subgroup_m_count = z3.Int("subgroup_m_count")
     subgroup_n_count = z3.Int("subgroup_n_count")
+    can_reuse_qk_output_for_pv_input = z3.Bool("can_reuse_qk_output_for_pv_input")
 
     constraints = dispatch_constraints.generate_attention_vector_distribute_constraints(
         qk_matmul=qk_matmul,
@@ -450,6 +451,7 @@ def test_generate_attention_vector_distribute_constraints(
         pv_intrinsic_size=pv_intrinsic_size,
         subgroup_m_count=subgroup_m_count,
         subgroup_n_count=subgroup_n_count,
+        can_reuse_qk_output_for_pv_input=can_reuse_qk_output_for_pv_input,
         gpu_target_info=gpu_target_info,
     )
 


### PR DESCRIPTION
This PR fixes the `prefetch_shared_memory` handling for attention operations by conditionally enabling it only when the QK accumulator layout matches the PV input layout.

According to [IREE's kernel config logic](https://github.com/iree-org/iree/blob/main/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp#L974-L976), `prefetch_shared_memory` should be enabled for attention ops only when layout reuse is possible. The implementation uses a Z3 boolean variable `can_reuse_qk_output_for_pv_input` to track this condition during constraint solving and sets the pipeline option accordingly for each solution.

The shared memory calculation was also corrected to properly account for conditional operand reuse between the QK and PV matmuls.

After applying this change, the compilation success rate improves significantly — from 3/30 to 16/30 and 8/100 to 60/100 in tested cases. 

I’ll revisit the constraint generation logic for the attention op.

Issue: #2274