### PR TITLE
[doc] update docs/model_cookbook.md

### DIFF
--- a/docs/model_cookbook.md
+++ b/docs/model_cookbook.md
@@ -122,6 +122,8 @@ python -m sharktank.examples.paged_llm_v1 \
   --gguf-file=/tmp/mistral-7b-v0.1-f32.gguf \
   --tokenizer-config-json=/tmp/mistral-7b/tokenizer_config.json \
   --prompt "Write a story about llamas" \
+  --max-decode-steps=128 \
+  --add-start-token \
   --device='cuda:0'
 
 # Export as MLIR

--- a/sharktank/sharktank/examples/paged_llm_v1.py
+++ b/sharktank/sharktank/examples/paged_llm_v1.py
@@ -125,7 +125,7 @@ def main(cli_args: list[str] | None = None):
             device=model._model.device,
         ).tolist()
     else:
-        token_ids = tokenizer.encode(texts=args.prompt, add_start_token=False)[0]
+        token_ids = tokenizer.encode(texts=args.prompt, add_start_token=args.add_start_token)[0]
 
     results = decoder.greedy_decode(token_ids, args.max_decode_steps)
     print(f":: Result tokens: {results}")

--- a/sharktank/sharktank/utils/cli.py
+++ b/sharktank/sharktank/utils/cli.py
@@ -337,6 +337,11 @@ def add_tokenizer_options(parser: argparse.ArgumentParser):
         help="Direct path to a tokenizer_config.json file",
         type=Path,
     )
+    parser.add_argument(
+        "--add-start-token",
+        help="Adds start token to the prompt",
+        action="store_true",
+    )
 
 
 def add_log_options(parser: argparse.ArgumentParser):


### PR DESCRIPTION
**Changes:**
1. Added `--max-decode-steps=128`. Without `max-decode-steps` specified, the command failed with the following error: 

`
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/asuslov/projects/shark-ai/sharktank/sharktank/examples/paged_llm_v1.py", line 136, in <module>
    main()
  File "/home/asuslov/projects/shark-ai/sharktank/sharktank/examples/paged_llm_v1.py", line 130, in main
    results = decoder.greedy_decode(token_ids, args.max_decode_steps)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/asuslov/projects/shark-ai/sharktank/sharktank/utils/llm_utils.py", line 575, in greedy_decode
    page_ids = [
               ^
  File "/home/asuslov/projects/shark-ai/sharktank/sharktank/utils/llm_utils.py", line 576, in <listcomp>
    self._runner.allocate(token_count=len(req) + steps) for req in requests
                                      ~~~~~~~~~^~~~~~~
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
`

2. Added `--add-start-token` cli argument. mistral-7b-v0.1 requires start token, without it, the model cyclically returns the promt.

`:: Result: ['.\n\nWrite a story about a llama.\n\nWrite a story about a llama.\n\nWrite a story about a llama.\n\nWrite a story about a llama.\n\nWrite a story about a llama.\n\nWrite a story about a llama.\n\nWrite a story about a llama.\n\nWrite a story about a llama.\n\nWrite a story about a llama.\n\nWrite a story about a llama.\n\nWrite a story about a llama.\n\nWrite a story about a llama.\n\nWrite a story about a']`