### PR TITLE
[tuner] use igemm bindings

### DIFF
--- a/amdsharktuner/amdsharktuner/constraint_generator.py
+++ b/amdsharktuner/amdsharktuner/constraint_generator.py
@@ -7,7 +7,7 @@
 import z3  # type: ignore
 import math
 from abc import ABC, abstractmethod
-from typing import Iterator
+from typing import Iterator, Optional
 
 from iree.compiler.dialects import iree_codegen, iree_gpu, linalg  # type: ignore
 
@@ -20,7 +20,7 @@ def adjust_problem_size_for_pipeline(
     dispatch_kind: common.DispatchKind,
     pipeline_options_search_space: dispatch_constraints.PipelineOptionsSearchSpace,
     codegen_pipeline: iree_codegen.DispatchLoweringPassPipeline,
-    igemm_details=None,
+    igemm_details: Optional[iree_codegen.IGEMMGenericConvDetails] = None,
 ):
     # Adjustment is only needed for IGEMM. Fail if the problem is not a conv
     # going down the TileAndFuse pipeline.
@@ -56,7 +56,6 @@ def adjust_problem_size_for_pipeline(
         matmul_size.M = [bounds[i] for i in contraction_dims.m]
         matmul_size.N = [bounds[i] for i in contraction_dims.n]
         matmul_size.K = [bounds[i] for i in contraction_dims.k]
-        print(f"matmul_size.K: {matmul_size.K}")
         matmul_size.B = [bounds[i] for i in contraction_dims.batch]
 
         return
@@ -81,7 +80,7 @@ def generate_generic_contraction_solutions(
     num_subgroups: int = 4,
     allowed_waves_per_eu: list[int] = [2],
     pipeline_options_search_space: dispatch_constraints.PipelineOptionsSearchSpace = dispatch_constraints.PipelineOptionsSearchSpace(),
-    igemm_details=None,
+    igemm_details: Optional[iree_codegen.IGEMMGenericConvDetails] = None,
 ) -> Iterator[list[common.TuningConfiguration]]:
     adjust_problem_size_for_pipeline(
         contraction_dims,

--- a/amdsharktuner/amdsharktuner/dispatch_parser.py
+++ b/amdsharktuner/amdsharktuner/dispatch_parser.py
@@ -9,7 +9,7 @@
 
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Optional
 
 from iree.compiler import ir  # type: ignore
 from iree.compiler.dialects import func, iree_codegen, linalg  # type: ignore
@@ -73,7 +73,7 @@ class ConvolutionOpInfo(OpInfo):
     dilations: list[int]
 
     # IGEMM details for TileAndFuse pipeline (None if not available).
-    igemm_details: Any = None
+    igemm_details: Optional[iree_codegen.IGEMMGenericConvDetails] = None
 
 
 @dataclass
@@ -270,7 +270,7 @@ class ConvolutionOpInterfaceParser(DispatchParser):
         rhs_type = root_op.operands[1].type
         res_type = root_op.operands[2].type
 
-        # Get IGEMM details for potential use with TileAndFuse pipeline.
+        # Get IGEMM details for potential use with the TileAndFuse pipeline.
         # This provides flattened K dimensions and proper M/N/K categorization
         # for any convolution layout (nhwc_hwcf, nchw_fchw, etc.).
         igemm_details = iree_codegen.get_igemm_generic_conv_details(root_op)


### PR DESCRIPTION
This PR integrates the new `get_igemm_generic_conv_details` Python binding (from [IREE PR #22598](https://github.com/iree-org/iree/pull/22598)) into the Tuner to enable robust convolution tuning.

## Motivation

The current convolution tuner relies on manual dimension inference and flattening, which can be fragile and layout-specific. The new IGEMM binding provides a principled way to:
- Extract accurate M/N/K dimensions for any convolution layout
- Get pre-computed flattened IGEMM loop bounds

## Implementation Plan

This PR is the **first step** in a three-phase rollout:

1. **Phase 1 (This PR)**: Ensure existing `conv_2d_nhwc_hwcf` tuning continues to work correctly using `igemm_details` from the binding
   - Integrate binding into parser and constraint generator
   - Make IGEMM usage pipeline-aware (`LLVMGPUTileAndFuse` only)
   - Add tests to validate the IGEMM transformation path

2. **Phase 2**: Add padding support for unaligned convolution cases

3. **Phase 3**: Validate and extend support for other layouts.