### PR TITLE
[Tuner] Use python library shlex to convert cmd str

### DIFF
--- a/amdsharktuner/amdsharktuner/process_utils.py
+++ b/amdsharktuner/amdsharktuner/process_utils.py
@@ -12,6 +12,7 @@ import subprocess
 import logging
 import signal
 import sys
+import shlex
 from tqdm import tqdm
 from typing import Optional
 from dataclasses import dataclass
@@ -148,7 +149,7 @@ def run_command(run_pack: RunPack) -> RunResult:
     is_timeout = False
     try:
         # Convert the command list to a command string for logging.
-        command_str = " ".join(command)
+        command_str = shlex.join(command)
         logging.debug(f"Run: {command_str}")
 
         # Add timeout to subprocess.run call.


### PR DESCRIPTION
This PR switches to `shlex.join()` to ensure that command strings recorded in logs can be directly copy-pasted into shell and executed. https://github.com/nod-ai/amd-shark-ai/pull/2718#discussion_r2604041302