### PR TITLE
[Tuner] Resolve the pytest warnings caused by new added process utils and expand test content

### DIFF
--- a/amdsharktuner/tests/process_utils_test.py
+++ b/amdsharktuner/tests/process_utils_test.py
@@ -4,8 +4,6 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import pytest
-
 from amdsharktuner import process_utils
 
 


### PR DESCRIPTION
This PR is a follow-up PR addresses the issue in https://github.com/nod-ai/amd-shark-ai/pull/2718#issuecomment-3634017722.
The problem occurs because Python emits a warning when fork() (invoked by `multiprocessing.Manager()`) is used in a multi-threaded environment (running pytest).