### PR TITLE
[Tuner] Modify CI pytest cmd to convert warnings to errors

### DIFF
--- a/.github/workflows/ci-amdsharktuner.yml
+++ b/.github/workflows/ci-amdsharktuner.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Run amdsharktuner tests with coverage
         run: |
-          pytest amdsharktuner/ \
+          pytest -W error::pytest.PytestWarning amdsharktuner/ \
             --cov=amdsharktuner \
             --cov-report xml:amdsharktuner-cov.xml \
             --cov-config=.coveragerc \


### PR DESCRIPTION
In this PR, `ci-amdsharktuner.yml` now fails if any pytest warnings are generated.
See new cmd test result: https://github.com/RattataKing/amd-shark-ai/pull/4