### PR TITLE
[Tuner] Fix tuning_records bugs

### DIFF
--- a/amdsharktuner/amdsharktuner/candidate_ordering.py
+++ b/amdsharktuner/amdsharktuner/candidate_ordering.py
@@ -138,10 +138,12 @@ def build_tuning_records_from_order(
     knobs: list[Optional[common.KnobAssignment]], sorted_order: list[int]
 ) -> list[TuningRecord]:
     tuning_records: list[TuningRecord] = []
-    # candidate_id = 0 is the baseline and is not included in tuning_records.
+    # Insert baseline entry (always candidate_id = 0, gen_id = 0).
+    tuning_records.append(TuningRecord(gen_id=0, candidate_id=0, knob=None))
     for sorted_position, original_gen_index in enumerate(sorted_order, start=1):
         tr = TuningRecord(
-            gen_id=original_gen_index,
+            gen_id=original_gen_index
+            + 1,  # Shift by 1 to reserve gen_id=0 for baseline.
             candidate_id=sorted_position,
             knob=knobs[original_gen_index],
         )
@@ -162,6 +164,9 @@ def flatten_records(
     """
     rows = []
     for tuning_record in tuning_records:
+        # Drop the baseline entry due to missing knob info.
+        if not tuning_record.knob:
+            continue
         row = {}
         for attr, val in vars(tuning_record).items():
             if isinstance(val, common.KnobAssignment):

--- a/amdsharktuner/tests/candidate_ordering_test.py
+++ b/amdsharktuner/tests/candidate_ordering_test.py
@@ -162,18 +162,23 @@ def test_reorder_assignments(
 def test_build_tuning_records_from_order(
     sample_knobs: list[Optional[common.KnobAssignment]],
 ) -> None:
+    baseline_tr = candidate_ordering.TuningRecord(
+        gen_id=0,
+        candidate_id=0,
+        knob=None,
+    )
     tr1 = candidate_ordering.TuningRecord(
-        gen_id=2,
+        gen_id=3,
         candidate_id=1,
         knob=sample_knobs[2],
     )
     tr2 = candidate_ordering.TuningRecord(
-        gen_id=0,
+        gen_id=1,
         candidate_id=2,
         knob=sample_knobs[0],
     )
     tr3 = candidate_ordering.TuningRecord(
-        gen_id=1,
+        gen_id=2,
         candidate_id=3,
         knob=sample_knobs[1],
     )
@@ -182,12 +187,17 @@ def test_build_tuning_records_from_order(
         sample_knobs, sorted_order
     )
 
-    assert tuning_records == [tr1, tr2, tr3]
+    assert tuning_records == [baseline_tr, tr1, tr2, tr3]
 
 
 def test_flatten_records(
     sample_knobs: list[Optional[common.KnobAssignment]],
 ):
+    baseline_tr = candidate_ordering.TuningRecord(
+        gen_id=0,
+        candidate_id=0,
+        knob=None,
+    )
     tr1 = candidate_ordering.TuningRecord(
         gen_id=2,
         candidate_id=1,
@@ -205,7 +215,7 @@ def test_flatten_records(
         to_benchmark=True,
         benchmark_time_us=153.56,
     )
-    sample_tuning_records = [tr1, tr2]
+    sample_tuning_records = [baseline_tr, tr1, tr2]
 
     rows = candidate_ordering.flatten_records(sample_tuning_records)
 


### PR DESCRIPTION
### Problem
Set flag `--num-candidates` with a value >= max number of candidates in entire search space, e.g. SMT solver has total 1265 solutions for `dispatch_sample.mlir`, invoke tuner with `--num-candidates=4096` will crash at `def compile()` phase with `IndexError: list index out of range`.

### Root Cause
Issue is caused by #2434 and #2744 :
In file `candidate_ordering.py`, func `build_tuning_records_from_order()` is designed to create the `tuning_records` without baseline entry.
```
len(tuning_client.tuning_records) = all candidates - baseline
```
PR #2434 unintentionally dropped the last candidates, masked the index issue.

### Solution
Add baseline entry to `tuning_records`, match list index to the candidate id, and skip the baseline entry when converting to csv.