### PR TITLE
[Tuner] Refactor: Extract rocm_common.py from common.py (2/3)

### DIFF
--- a/amdsharktuner/amdsharktuner/candidate_ordering.py
+++ b/amdsharktuner/amdsharktuner/candidate_ordering.py
@@ -10,6 +10,7 @@ from typing import Optional, Callable
 from iree.compiler.dialects import iree_gpu  # type: ignore
 
 from . import common
+from .rocm import rocm_common
 
 
 class CandidateOrderKind(str, Enum):
@@ -36,7 +37,7 @@ def arith_intensity(x: int, y: int, z: int) -> float:
 
 def llvm_gpu_vector_distribute_contraction_sort_key(
     target_info: iree_gpu.TargetInfo,
-    knob: common.LLVMGPUVectorDistributeContractionKnobs,
+    knob: rocm_common.LLVMGPUVectorDistributeContractionKnobs,
 ) -> tuple[bool, bool, float]:
     return (
         not is_pow2(knob.tile_k),
@@ -50,7 +51,7 @@ def llvm_gpu_vector_distribute_contraction_sort_key(
 
 
 SORT_KEY_MAP: dict[type[common.KnobAssignment | None], Callable | None] = {
-    common.LLVMGPUVectorDistributeContractionKnobs: llvm_gpu_vector_distribute_contraction_sort_key,
+    rocm_common.LLVMGPUVectorDistributeContractionKnobs: llvm_gpu_vector_distribute_contraction_sort_key,
     type(None): None,
     # TODO: Add key() for conv, attention, and other dispatch kinds.
 }

--- a/amdsharktuner/amdsharktuner/common.py
+++ b/amdsharktuner/amdsharktuner/common.py
@@ -217,39 +217,6 @@ class MatmulShapeType:
     acc_type: ir.IntegerType | ir.FloatType
 
 
-@dataclass
-class LLVMGPUVectorDistributeContractionKnobs(KnobAssignment):
-    # Problem Size.
-    M: int
-    N: int
-    K: int
-
-    # Z3 numeric selections.
-    tile_m: int
-    tile_n: int
-    tile_k: int
-    wg_x: int
-    wg_y: int
-    wg_z: int
-    subgroup_m_cnt: int
-    subgroup_n_cnt: int
-    intrinsic_mn: int
-    intrinsic_k: int
-    subgroup_m: int
-    subgroup_n: int
-    subgroup_k: int
-
-
-@dataclass
-class ConvolutionKnobs(KnobAssignment):
-    pass
-
-
-@dataclass
-class AttentionKnobs(KnobAssignment):
-    pass
-
-
 def is_affine_expr_function_of_dim(expr: ir.AffineExpr, position: int) -> bool:
     """
     Return True if the expression depends on the dimension at the given position.
@@ -279,42 +246,10 @@ def get_map_result_dim_positions(map: ir.AffineMap) -> Optional[list[int]]:
     return [ir.AffineDimExpr(expr).position for expr in map.results]
 
 
-def get_compatible_mma_intrinsics(
-    lhs_type: ShapedType,
-    rhs_type: ShapedType,
-    res_type: ShapedType,
-    mma_intrinsics: list[iree_gpu.MMAIntrinsic | iree_gpu.VirtualMMAIntrinsic],
-    allow_virtual_mma: bool = False,
-) -> list[iree_gpu.MMAIntrinsic | iree_gpu.VirtualMMAIntrinsic]:
-    def is_compatible(
-        mma: iree_gpu.MMAIntrinsic | iree_gpu.VirtualMMAIntrinsic,
-    ) -> bool:
-        # Filter out virtual intrinsics unless explicitly allowed (for attention ops).
-        is_virtual = isinstance(mma, iree_gpu.VirtualMMAIntrinsic)
-        if is_virtual and not allow_virtual_mma:
-            return False
-
-        mma_attr = (
-            iree_gpu.VirtualMMAAttr.get(mma)
-            if is_virtual
-            else iree_gpu.MMAAttr.get(mma)
-        )
-        a_type, b_type, c_type = mma_attr.abc_element_types
-        return (
-            lhs_type.element_type == a_type
-            and rhs_type.element_type == b_type
-            and res_type.element_type == c_type
-        )
-
-    return list(filter(is_compatible, mma_intrinsics))
-
-
 # The key name for GPUPipelineOptionsAttr in the translation info config dictionary.
 GPU_PIPELINE_OPTIONS_KEY = "gpu_pipeline_options"
 # The key name for llvm_func_attrs attribute in the translation info config dictionary.
 LLVM_FUNC_ATTRS_KEY = "llvm_func_attrs"
-# The Key name for the 'amdgpu-waves-per-eu' within the llvm_func_attrs attribute.
-WAVES_PER_EU_KEY = "amdgpu-waves-per-eu"
 
 
 def get_lowering_config(
@@ -360,36 +295,6 @@ def get_lowering_config(
         lowering_config_dict[key] = promoted_value
     lowering_config_attrs = ir.DictAttr.get(lowering_config_dict)
     return iree_gpu.LoweringConfigAttr.get(lowering_config_attrs)
-
-
-# Generate a config dictionary used in translation_info attribute.
-def get_translation_info_config(
-    pipeline_options: iree_gpu.PipelineOptionsAttr, waves_per_eu: int
-) -> ir.DictAttr:
-    """
-    Example IR
-    translation_info = #iree_codegen.translation_info<
-                    pipeline = LLVMGPUVectorDistribute workgroup_size = [512, 1, 1] subgroup_size = 64,
-                    {gpu_pipeline_options = #iree_gpu.pipeline_options<...>,
-                     llvm_func_attrs = {"amdgpu-waves-per-eu" = "3"}
-                    }
-                >
-    """
-    waves_per_eu_str = str(waves_per_eu)
-
-    # Create the waves_per_eu dictionary attribute.
-    waves_per_eu_dict = ir.DictAttr.get(
-        {WAVES_PER_EU_KEY: ir.StringAttr.get(waves_per_eu_str)}
-    )
-
-    config_dict = ir.DictAttr.get(
-        {
-            GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
-            LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
-        }
-    )
-
-    return config_dict
 
 
 def combine_tuning_specs(
@@ -528,37 +433,6 @@ def determine_td_specs_to_link(
     return [current_td_spec]
 
 
-def get_attention_decomposition_config(
-    tuner_ctx: TunerContext,
-    qk_lowering_config: iree_gpu.LoweringConfigAttr,
-    pv_lowering_config: iree_gpu.LoweringConfigAttr,
-) -> ir.DictAttr:
-    """
-    Constructs the decomposition config for an attention op, embedding
-    separate lowering configs for QK and PV matmuls.
-    """
-
-    ctx = tuner_ctx.mlir_ctx
-    qk_attrs_dict = {
-        "attention_qk_matmul": ir.UnitAttr.get(ctx),
-        "lowering_config": qk_lowering_config,
-    }
-    qk_attr_dict = ir.DictAttr.get(qk_attrs_dict, context=ctx)
-
-    pv_attrs_dict = {
-        "attention_pv_matmul": ir.UnitAttr.get(ctx),
-        "lowering_config": pv_lowering_config,
-    }
-    pv_attr_dict = ir.DictAttr.get(pv_attrs_dict, context=ctx)
-
-    decomposition_config_dict = {
-        "qk_attrs": qk_attr_dict,
-        "pv_attrs": pv_attr_dict,
-    }
-
-    return ir.DictAttr.get(decomposition_config_dict, context=ctx)
-
-
 def get_target_info(input_module: ir.Module) -> iree_gpu.TargetInfo:
     # Get GPU target information from the executable variant operation.
     variant_op_list = iree_codegen.get_executable_variant_ops(input_module)
@@ -608,104 +482,6 @@ def get_dim_bounds(
             result.append(dim)
 
     return result
-
-
-# Implemented the logic from IREE side:
-# https://github.com/iree-org/iree/blob/8ae91ebb0e555e660b8a6898f6071476f7a1f20b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp#L382-L467
-def get_padding_conv_sizes(
-    bounds: list[int],
-    padding_sizes: list[int],
-    igemm_loop_iterators: list[str],
-    conv_to_igemm_info: ConvToIgemmInfo,
-) -> Optional[list[int]]:
-    """
-    Computes padding_conv by mapping padding from IGEMM space to convolution space.
-
-    Args:
-        bounds: Loop bounds for each dimension.
-        padding_sizes: Padding sizes in IGEMM dimension space (M, N, K).
-        igemm_loop_iterators: IGEMM loop iterator type strings ('"reduction"' or '"parallel"').
-        conv_to_igemm_info: Convolution to IGEMM transformation info.
-
-    Returns:
-        Padding sizes in convolution dimension space, or None if no padding
-        is needed along original convolution dimensions.
-    """
-    # Skip padding convolution for NCHW layout (spatial dimensions are last).
-    if conv_to_igemm_info.is_spatial_dim_last:
-        return None
-
-    conv_to_igemm_map = conv_to_igemm_info.conv_to_igemm_dim_map
-    padded_igemm_dims = set()
-    conv_dims = conv_to_igemm_info.conv_dims
-    input_channel_dims = set(conv_dims.input_channel)
-
-    padding_conv_sizes = [0] * len(conv_to_igemm_map)
-
-    # For batch-last layout (e.g., CHWN), only pad the batch dimension to avoid
-    # introducing pad op as the producer of collapse_shape op which may cause fusion problem.
-    if conv_to_igemm_info.is_batch_dim_last:
-        last_batch_dim = conv_dims.batch[-1]
-        igemm_batch_pos = conv_to_igemm_map[last_batch_dim]
-
-        if (
-            padding_sizes[igemm_batch_pos]
-            and bounds[igemm_batch_pos] % padding_sizes[igemm_batch_pos] == 0
-        ):
-            return None
-
-        padding_conv_sizes[last_batch_dim] = padding_sizes[igemm_batch_pos]
-        return padding_conv_sizes
-
-    for conv_dim, igemm_pos in conv_to_igemm_map.items():
-        if igemm_loop_iterators[igemm_pos] == '"reduction"':
-            # Skip filter loop dimensions (reduction dims that aren't input channels).
-            # Only pad input channel dims. If we need to pad filter dims, then we
-            # would rather just do padding on the IGEMM instead.
-            if conv_dim not in input_channel_dims:
-                continue
-
-            # Skip conv padding for input channel dims if already divisible by padding size.
-            if (
-                padding_sizes[igemm_pos]
-                and bounds[igemm_pos] % padding_sizes[igemm_pos] == 0
-            ):
-                padded_igemm_dims.add(igemm_pos)
-                continue
-
-            # Multiple input channel dims for a single IGEMMPos is not supported.
-            if igemm_pos in padded_igemm_dims:
-                return None
-
-            input_channel_size = conv_to_igemm_info.input_channel_dim_to_size.get(
-                conv_dim, 0
-            )
-            is_input_channel_size_small = (
-                padding_sizes[igemm_pos] // input_channel_size > 2
-            )
-
-            # If the input channel dimension is much smaller than the padding size,
-            # skip padding along that dimension while still padding the others.
-            if is_input_channel_size_small:
-                padding_conv_sizes[conv_dim] = 0
-            else:
-                padding_conv_sizes[conv_dim] = padding_sizes[igemm_pos]
-
-            padded_igemm_dims.add(igemm_pos)
-            continue
-
-        # Multiple padded parallel dims mapping to the same IGEMM dim is not supported.
-        if padding_sizes[igemm_pos] and igemm_pos in padded_igemm_dims:
-            return None
-
-        padding_conv_sizes[conv_dim] = padding_sizes[igemm_pos]
-        padded_igemm_dims.add(igemm_pos)
-
-    # Ensure that all dimensions have been padded.
-    if len(padded_igemm_dims) != len(padding_sizes):
-        return None
-
-    return padding_conv_sizes
 
 
 def calculate_padded_dimensions(

--- a/amdsharktuner/amdsharktuner/constraint_generator.py
+++ b/amdsharktuner/amdsharktuner/constraint_generator.py
@@ -14,7 +14,7 @@ from iree.compiler import ir  # type: ignore
 from iree.compiler.dialects import iree_codegen, iree_gpu, linalg  # type: ignore
 
 from . import common, dispatch_parser, process_utils
-from .rocm import rocm_dispatch_constraints
+from .rocm import rocm_common, rocm_dispatch_constraints
 
 
 TScalar = TypeVar("TScalar", int, z3.ExprRef)
@@ -574,7 +574,7 @@ def generate_generic_contraction_solutions(
                 igemm_iterator_types = [
                     str(it) for it in igemm_details.igemm_loop_iterators
                 ]
-                padding_conv = common.get_padding_conv_sizes(
+                padding_conv = rocm_common.get_padding_conv_sizes(
                     bounds,
                     padding_tile_sizes,
                     igemm_iterator_types,
@@ -613,7 +613,7 @@ def generate_generic_contraction_solutions(
                 codegen_pipeline
                 == iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
             ):
-                knob_assignment = common.LLVMGPUVectorDistributeContractionKnobs(
+                knob_assignment = rocm_common.LLVMGPUVectorDistributeContractionKnobs(
                     M=int(math.prod(M)),
                     N=int(math.prod(N)),
                     K=int(math.prod(K)),
@@ -794,7 +794,7 @@ def generate_attention_solutions(
             tuner_ctx=tuner_ctx, **pv_config
         )
 
-        decomposition_config = common.get_attention_decomposition_config(
+        decomposition_config = rocm_common.get_attention_decomposition_config(
             tuner_ctx, qk_lowering_config, pv_lowering_config
         )
 

--- a/amdsharktuner/amdsharktuner/rocm/__init__.py
+++ b/amdsharktuner/amdsharktuner/rocm/__init__.py
@@ -5,3 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 """ROCm-specific tuning implementations for amdsharktuner."""
+
+from . import rocm_common
+from . import rocm_dispatch_constraints

--- a/amdsharktuner/amdsharktuner/rocm/rocm_common.py
+++ b/amdsharktuner/amdsharktuner/rocm/rocm_common.py
@@ -1,0 +1,239 @@
+# Copyright 2026 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from dataclasses import dataclass
+from typing import Optional
+
+from iree.compiler import ir  # type: ignore
+from iree.compiler.dialects import iree_gpu  # type: ignore
+
+from .. import common
+
+
+# The Key name for the 'amdgpu-waves-per-eu' within the llvm_func_attrs attribute.
+WAVES_PER_EU_KEY = "amdgpu-waves-per-eu"
+
+
+@dataclass
+class LLVMGPUVectorDistributeContractionKnobs(common.KnobAssignment):
+    # Problem Size.
+    M: int
+    N: int
+    K: int
+
+    # Z3 numeric selections.
+    tile_m: int
+    tile_n: int
+    tile_k: int
+    wg_x: int
+    wg_y: int
+    wg_z: int
+    subgroup_m_cnt: int
+    subgroup_n_cnt: int
+    intrinsic_mn: int
+    intrinsic_k: int
+    subgroup_m: int
+    subgroup_n: int
+    subgroup_k: int
+
+
+@dataclass
+class ConvolutionKnobs(common.KnobAssignment):
+    pass
+
+
+@dataclass
+class AttentionKnobs(common.KnobAssignment):
+    pass
+
+
+def get_compatible_mma_intrinsics(
+    lhs_type: common.ShapedType,
+    rhs_type: common.ShapedType,
+    res_type: common.ShapedType,
+    mma_intrinsics: list[iree_gpu.MMAIntrinsic | iree_gpu.VirtualMMAIntrinsic],
+    allow_virtual_mma: bool = False,
+) -> list[iree_gpu.MMAIntrinsic | iree_gpu.VirtualMMAIntrinsic]:
+    def is_compatible(
+        mma: iree_gpu.MMAIntrinsic | iree_gpu.VirtualMMAIntrinsic,
+    ) -> bool:
+        # Filter out virtual intrinsics unless explicitly allowed (for attention ops).
+        is_virtual = isinstance(mma, iree_gpu.VirtualMMAIntrinsic)
+        if is_virtual and not allow_virtual_mma:
+            return False
+
+        mma_attr = (
+            iree_gpu.VirtualMMAAttr.get(mma)
+            if is_virtual
+            else iree_gpu.MMAAttr.get(mma)
+        )
+        a_type, b_type, c_type = mma_attr.abc_element_types
+        return (
+            lhs_type.element_type == a_type
+            and rhs_type.element_type == b_type
+            and res_type.element_type == c_type
+        )
+
+    return list(filter(is_compatible, mma_intrinsics))
+
+
+# Generate a config dictionary used in translation_info attribute.
+def get_translation_info_config(
+    pipeline_options: iree_gpu.PipelineOptionsAttr, waves_per_eu: int
+) -> ir.DictAttr:
+    """
+    Example IR
+    translation_info = #iree_codegen.translation_info<
+                    pipeline = LLVMGPUVectorDistribute workgroup_size = [512, 1, 1] subgroup_size = 64,
+                    {gpu_pipeline_options = #iree_gpu.pipeline_options<...>,
+                     llvm_func_attrs = {"amdgpu-waves-per-eu" = "3"}
+                    }
+                >
+    """
+    waves_per_eu_str = str(waves_per_eu)
+
+    # Create the waves_per_eu dictionary attribute.
+    waves_per_eu_dict = ir.DictAttr.get(
+        {WAVES_PER_EU_KEY: ir.StringAttr.get(waves_per_eu_str)}
+    )
+
+    config_dict = ir.DictAttr.get(
+        {
+            common.GPU_PIPELINE_OPTIONS_KEY: pipeline_options,
+            common.LLVM_FUNC_ATTRS_KEY: waves_per_eu_dict,
+        }
+    )
+
+    return config_dict
+
+
+def get_attention_decomposition_config(
+    tuner_ctx: common.TunerContext,
+    qk_lowering_config: iree_gpu.LoweringConfigAttr,
+    pv_lowering_config: iree_gpu.LoweringConfigAttr,
+) -> ir.DictAttr:
+    """
+    Constructs the decomposition config for an attention op, embedding
+    separate lowering configs for QK and PV matmuls.
+    """
+
+    ctx = tuner_ctx.mlir_ctx
+    qk_attrs_dict = {
+        "attention_qk_matmul": ir.UnitAttr.get(ctx),
+        "lowering_config": qk_lowering_config,
+    }
+    qk_attr_dict = ir.DictAttr.get(qk_attrs_dict, context=ctx)
+
+    pv_attrs_dict = {
+        "attention_pv_matmul": ir.UnitAttr.get(ctx),
+        "lowering_config": pv_lowering_config,
+    }
+    pv_attr_dict = ir.DictAttr.get(pv_attrs_dict, context=ctx)
+
+    decomposition_config_dict = {
+        "qk_attrs": qk_attr_dict,
+        "pv_attrs": pv_attr_dict,
+    }
+
+    return ir.DictAttr.get(decomposition_config_dict, context=ctx)
+
+
+# Implemented the logic from IREE side:
+# https://github.com/iree-org/iree/blob/8ae91ebb0e555e660b8a6898f6071476f7a1f20b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp#L382-L467.
+def get_padding_conv_sizes(
+    bounds: list[int],
+    padding_sizes: list[int],
+    igemm_loop_iterators: list[str],
+    conv_to_igemm_info: common.ConvToIgemmInfo,
+) -> Optional[list[int]]:
+    """
+    Computes padding_conv by mapping padding from IGEMM space to convolution space.
+
+    Args:
+        bounds: Loop bounds for each dimension.
+        padding_sizes: Padding sizes in IGEMM dimension space (M, N, K).
+        igemm_loop_iterators: IGEMM loop iterator type strings ('"reduction"' or '"parallel"').
+        conv_to_igemm_info: Convolution to IGEMM transformation info.
+
+    Returns:
+        Padding sizes in convolution dimension space, or None if no padding
+        is needed along original convolution dimensions.
+    """
+    # Skip padding convolution for NCHW layout (spatial dimensions are last).
+    if conv_to_igemm_info.is_spatial_dim_last:
+        return None
+
+    conv_to_igemm_map = conv_to_igemm_info.conv_to_igemm_dim_map
+    padded_igemm_dims = set()
+    conv_dims = conv_to_igemm_info.conv_dims
+    input_channel_dims = set(conv_dims.input_channel)
+
+    padding_conv_sizes = [0] * len(conv_to_igemm_map)
+
+    # For batch-last layout (e.g., CHWN), only pad the batch dimension to avoid
+    # introducing pad op as the producer of collapse_shape op which may cause fusion problem.
+    if conv_to_igemm_info.is_batch_dim_last:
+        last_batch_dim = conv_dims.batch[-1]
+        igemm_batch_pos = conv_to_igemm_map[last_batch_dim]
+
+        if (
+            padding_sizes[igemm_batch_pos]
+            and bounds[igemm_batch_pos] % padding_sizes[igemm_batch_pos] == 0
+        ):
+            return None
+
+        padding_conv_sizes[last_batch_dim] = padding_sizes[igemm_batch_pos]
+        return padding_conv_sizes
+
+    for conv_dim, igemm_pos in conv_to_igemm_map.items():
+        if igemm_loop_iterators[igemm_pos] == '"reduction"':
+            # Skip filter loop dimensions (reduction dims that aren't input channels).
+            # Only pad input channel dims. If we need to pad filter dims, then we
+            # would rather just do padding on the IGEMM instead.
+            if conv_dim not in input_channel_dims:
+                continue
+
+            # Skip conv padding for input channel dims if already divisible by padding size.
+            if (
+                padding_sizes[igemm_pos]
+                and bounds[igemm_pos] % padding_sizes[igemm_pos] == 0
+            ):
+                padded_igemm_dims.add(igemm_pos)
+                continue
+
+            # Multiple input channel dims for a single IGEMMPos is not supported.
+            if igemm_pos in padded_igemm_dims:
+                return None
+
+            input_channel_size = conv_to_igemm_info.input_channel_dim_to_size.get(
+                conv_dim, 0
+            )
+            is_input_channel_size_small = (
+                padding_sizes[igemm_pos] // input_channel_size > 2
+            )
+
+            # If the input channel dimension is much smaller than the padding size,
+            # skip padding along that dimension while still padding the others.
+            if is_input_channel_size_small:
+                padding_conv_sizes[conv_dim] = 0
+            else:
+                padding_conv_sizes[conv_dim] = padding_sizes[igemm_pos]
+
+            padded_igemm_dims.add(igemm_pos)
+            continue
+
+        # Multiple padded parallel dims mapping to the same IGEMM dim is not supported.
+        if padding_sizes[igemm_pos] and igemm_pos in padded_igemm_dims:
+            return None
+
+        padding_conv_sizes[conv_dim] = padding_sizes[igemm_pos]
+        padded_igemm_dims.add(igemm_pos)
+
+    # Ensure that all dimensions have been padded.
+    if len(padded_igemm_dims) != len(padding_sizes):
+        return None
+
+    return padding_conv_sizes

--- a/amdsharktuner/amdsharktuner/rocm/rocm_dispatch_constraints.py
+++ b/amdsharktuner/amdsharktuner/rocm/rocm_dispatch_constraints.py
@@ -17,6 +17,7 @@ from iree.compiler import ir  # type: ignore
 from iree.compiler.dialects import iree_codegen, iree_gpu  # type: ignore
 
 from .. import common
+from . import rocm_common
 
 
 @dataclass
@@ -76,7 +77,7 @@ def get_mma_intrinsic_constraints_list(
     acc_layout: MMASingleSubgroupLayout | None = None,
     allow_virtual_mma: bool = False,
 ) -> list[z3.BoolRef]:
-    compatible_intrinsics = common.get_compatible_mma_intrinsics(
+    compatible_intrinsics = rocm_common.get_compatible_mma_intrinsics(
         lhs_type, rhs_type, res_type, mma_intrinsics, allow_virtual_mma
     )
     assert len(compatible_intrinsics) > 0, "No compatible intrinsics found"
@@ -742,7 +743,7 @@ def generate_compilation_infos(
     compilation_infos = []
     for pipeline_options in pipeline_options_list:
         for waves_per_eu in allowed_waves_per_eu:
-            config_dict = common.get_translation_info_config(
+            config_dict = rocm_common.get_translation_info_config(
                 pipeline_options, waves_per_eu
             )
             translation_info = iree_codegen.TranslationInfoAttr.get(

--- a/amdsharktuner/tests/candidate_gen_test.py
+++ b/amdsharktuner/tests/candidate_gen_test.py
@@ -12,6 +12,7 @@ from iree.compiler import ir  # type: ignore
 from iree.compiler.dialects import iree_codegen, iree_gpu, transform  # type: ignore
 
 from amdsharktuner import candidate_gen, common
+from amdsharktuner.rocm import rocm_common
 
 from amdsharktuner.test_utils import tuner_ctx
 
@@ -77,7 +78,9 @@ def test_get_td_spec_contraction(tuner_ctx: common.TunerContext) -> None:
         iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
     pipeline_options = iree_gpu.PipelineOptionsAttr.get(prefetch_num_stages=2)
-    config_dict = common.get_translation_info_config(pipeline_options, waves_per_eu=8)
+    config_dict = rocm_common.get_translation_info_config(
+        pipeline_options, waves_per_eu=8
+    )
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [16, 16, 1], 16, config_dict
     )
@@ -160,7 +163,9 @@ def test_get_td_spec_convolution(tuner_ctx: common.TunerContext) -> None:
         iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
     pipeline_options = iree_gpu.PipelineOptionsAttr.get(prefetch_num_stages=0)
-    config_dict = common.get_translation_info_config(pipeline_options, waves_per_eu=2)
+    config_dict = rocm_common.get_translation_info_config(
+        pipeline_options, waves_per_eu=2
+    )
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [256, 1, 1], 64, config_dict
     )

--- a/amdsharktuner/tests/candidate_ordering_test.py
+++ b/amdsharktuner/tests/candidate_ordering_test.py
@@ -12,11 +12,12 @@ from iree.compiler import ir  # type: ignore
 from iree.compiler.dialects import iree_gpu  # type: ignore
 
 from amdsharktuner import candidate_ordering, common
+from amdsharktuner.rocm import rocm_common
 
 
 @pytest.fixture
 def sample_knobs() -> list[Optional[common.KnobAssignment]]:
-    knob_1 = common.LLVMGPUVectorDistributeContractionKnobs(
+    knob_1 = rocm_common.LLVMGPUVectorDistributeContractionKnobs(
         M=2048,
         N=10240,
         K=1280,
@@ -34,7 +35,7 @@ def sample_knobs() -> list[Optional[common.KnobAssignment]]:
         subgroup_n=0,
         subgroup_k=0,
     )
-    knob_2 = common.LLVMGPUVectorDistributeContractionKnobs(
+    knob_2 = rocm_common.LLVMGPUVectorDistributeContractionKnobs(
         M=2048,
         N=10240,
         K=1280,
@@ -52,7 +53,7 @@ def sample_knobs() -> list[Optional[common.KnobAssignment]]:
         subgroup_n=0,
         subgroup_k=0,
     )
-    knob_3 = common.LLVMGPUVectorDistributeContractionKnobs(
+    knob_3 = rocm_common.LLVMGPUVectorDistributeContractionKnobs(
         M=2048,
         N=10240,
         K=1280,

--- a/amdsharktuner/tests/common_test.py
+++ b/amdsharktuner/tests/common_test.py
@@ -10,12 +10,11 @@ Usage: python -m pytest common_test.py
 
 import pytest
 from dataclasses import dataclass
-from types import SimpleNamespace
 
 from iree.compiler import ir  # type: ignore
-from iree.compiler.dialects import _builtin_ops_gen, func, iree_codegen, iree_gpu, linalg, transform  # type: ignore
+from iree.compiler.dialects import _builtin_ops_gen, iree_codegen, iree_gpu, transform  # type: ignore
 
-from amdsharktuner import common, dispatch_parser
+from amdsharktuner import common
 from amdsharktuner.test_utils import tuner_ctx
 
 
@@ -76,94 +75,6 @@ def test_get_map_result_dim_positions(tuner_ctx: common.TunerContext) -> None:
     assert result is None, "Expected None for non-projected permutation"
 
 
-def test_get_pipeline_config(tuner_ctx: common.TunerContext) -> None:
-    mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16
-    mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
-    lowering_config = common.get_lowering_config(
-        tuner_ctx=tuner_ctx,
-        mma_kind=mma_attr,
-        workgroup=[4, 8, 0],
-        reduction=[0, 0, 16],
-        subgroup_basis=[[1, 1, 1], [0, 1, 2]],
-    )
-    pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
-    )
-    pipeline_options = iree_gpu.PipelineOptionsAttr.get()
-    config_dict = common.get_translation_info_config(pipeline_options, 2)
-    translation_info = iree_codegen.TranslationInfoAttr.get(
-        pipeline_attr, None, [16, 16, 1], 32, config_dict
-    )
-    compilation_info = iree_codegen.CompilationInfoAttr.get(
-        lowering_config, translation_info
-    )
-    config1_str: str = str(
-        compilation_info.translation_info.configuration[common.LLVM_FUNC_ATTRS_KEY]
-    )
-    assert config1_str == '{"amdgpu-waves-per-eu" = "2"}'
-
-    pipeline_options = iree_gpu.PipelineOptionsAttr.get(prefetch_num_stages=2)
-    config_dict = common.get_translation_info_config(pipeline_options, 4)
-    translation_info = iree_codegen.TranslationInfoAttr.get(
-        pipeline_attr, None, [16, 16, 1], 32, config_dict
-    )
-    compilation_info = iree_codegen.CompilationInfoAttr.get(
-        lowering_config, translation_info
-    )
-    config2_str: str = str(compilation_info.translation_info.configuration)
-    assert (
-        config2_str
-        == '{gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}}'
-    )
-
-
-def test_get_compatible_mma_intrinsics(tuner_ctx: common.TunerContext) -> None:
-    all_intrinsics = [
-        iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
-        iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
-        iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
-        iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
-    ]
-
-    lhs = common.ShapedType([2048, 1280], tuner_ctx.type.f16)
-    rhs = common.ShapedType([1280, 1280], tuner_ctx.type.f16)
-    res = common.ShapedType([2048, 1280], tuner_ctx.type.f32)
-    assert common.get_compatible_mma_intrinsics(lhs, rhs, res, all_intrinsics) == [
-        iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
-        iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
-    ]
-
-    lhs = common.ShapedType([2048, 1280], tuner_ctx.type.i8)
-    rhs = common.ShapedType([1280, 1280], tuner_ctx.type.i8)
-    res = common.ShapedType([2048, 1280], tuner_ctx.type.i32)
-    assert common.get_compatible_mma_intrinsics(lhs, rhs, res, all_intrinsics) == [
-        iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
-        iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
-    ]
-
-    lhs = common.ShapedType([64, 968, 640], tuner_ctx.type.f32)
-    rhs = common.ShapedType([64, 640, 320], tuner_ctx.type.f32)
-    res = common.ShapedType([64, 968, 320], tuner_ctx.type.f32)
-    assert common.get_compatible_mma_intrinsics(lhs, rhs, res, all_intrinsics) == []
-
-    intrinsics_with_virtual = [
-        iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
-        iree_gpu.VirtualMMAIntrinsic.VMFMA_F32_32x32x16_F8E4M3FNUZ,
-    ]
-
-    lhs = common.ShapedType([32, 16], tuner_ctx.type.f8E4M3FNUZ)
-    rhs = common.ShapedType([16, 32], tuner_ctx.type.f8E4M3FNUZ)
-    res = common.ShapedType([32, 32], tuner_ctx.type.f32)
-    assert (
-        common.get_compatible_mma_intrinsics(lhs, rhs, res, intrinsics_with_virtual)
-        == []
-    )
-
-    assert common.get_compatible_mma_intrinsics(
-        lhs, rhs, res, intrinsics_with_virtual, allow_virtual_mma=True
-    ) == [iree_gpu.VirtualMMAIntrinsic.VMFMA_F32_32x32x16_F8E4M3FNUZ]
-
-
 def test_get_lowering_config(tuner_ctx: common.TunerContext) -> None:
     lowering_config = common.get_lowering_config(
         tuner_ctx=tuner_ctx,
@@ -177,20 +88,20 @@ def test_get_lowering_config(tuner_ctx: common.TunerContext) -> None:
         == "#iree_gpu.lowering_config<{reduction = [0, 0, 16], subgroup_basis = [[1, 1, 1], [0, 1, 2]], workgroup = [4, 8, 0]}>"
     )
 
-    pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
-    )
-    pipeline_options = iree_gpu.PipelineOptionsAttr.get()
-    config_dict = common.get_translation_info_config(pipeline_options, 2)
-    translation_info = iree_codegen.TranslationInfoAttr.get(
-        pipeline_attr, None, [16, 16, 1], 32, config_dict
-    )
-    compilation_info = iree_codegen.CompilationInfoAttr.get(
-        lowering_config, translation_info
+    # Test with mma_kind
+    mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16
+    mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
+    lowering_config_with_mma = common.get_lowering_config(
+        tuner_ctx=tuner_ctx,
+        mma_kind=mma_attr,
+        workgroup=[4, 8, 0],
+        reduction=[0, 0, 16],
+        subgroup_basis=[[1, 1, 1], [0, 1, 2]],
     )
 
-    assert compilation_info.lowering_config.mma_kind is None
-    assert compilation_info.lowering_config.subgroup_basis == ([1, 1, 1], [0, 1, 2])
+    assert lowering_config_with_mma is not None
+    assert lowering_config.mma_kind is None
+    assert lowering_config.subgroup_basis == ([1, 1, 1], [0, 1, 2])
 
 
 def test_combine_tuning_specs(tuner_ctx: common.TunerContext) -> None:
@@ -610,191 +521,3 @@ def test_is_affine_expr_function_of_dim(tuner_ctx: common.TunerContext) -> None:
         complex_expr = (d0 + d1) * 2
         assert common.is_affine_expr_function_of_dim(complex_expr, 0)
         assert common.is_affine_expr_function_of_dim(complex_expr, 1)
-
-
-def test_get_padding_conv_sizes(tuner_ctx: common.TunerContext) -> None:
-    # Note: Using SimpleNamespace to create lightweight mock objects for conv_dims.
-    # The actual linalg.ConvolutionDimensions is a C++-backed type from IREE's
-    # Python bindings, so we mock it with SimpleNamespace for testing convenience.
-
-    # Spatial dimension last (NCHW layout).
-    conv_to_igemm_info = common.ConvToIgemmInfo(
-        is_batch_dim_last=False,
-        is_spatial_dim_last=True,
-        conv_dims=SimpleNamespace(batch=[0], input_channel=[1]),
-        conv_to_igemm_dim_map={0: 0, 1: 1, 2: 2},
-        input_channel_dim_to_size={1: 64},
-    )
-    result = common.get_padding_conv_sizes(
-        bounds=[128, 64, 56],
-        padding_sizes=[256, 128, 64],
-        igemm_loop_iterators=['"parallel"', '"parallel"', '"parallel"'],
-        conv_to_igemm_info=conv_to_igemm_info,
-    )
-    assert result is None
-
-    # Batch dimension last (CHWN layout).
-    conv_to_igemm_info = common.ConvToIgemmInfo(
-        is_batch_dim_last=True,
-        is_spatial_dim_last=False,
-        conv_dims=SimpleNamespace(batch=[0, 3], input_channel=[1]),
-        conv_to_igemm_dim_map={0: 0, 1: 1, 2: 2, 3: 3},
-        input_channel_dim_to_size={1: 64},
-    )
-    result = common.get_padding_conv_sizes(
-        bounds=[128, 64, 56, 32],
-        padding_sizes=[256, 128, 64, 64],
-        igemm_loop_iterators=['"parallel"', '"parallel"', '"parallel"', '"parallel"'],
-        conv_to_igemm_info=conv_to_igemm_info,
-    )
-    assert result == [0, 0, 0, 64]
-
-    # Batch dimension last with bounds divisible by padding.
-    conv_to_igemm_info = common.ConvToIgemmInfo(
-        is_batch_dim_last=True,
-        is_spatial_dim_last=False,
-        conv_dims=SimpleNamespace(batch=[0, 3], input_channel=[1]),
-        conv_to_igemm_dim_map={0: 0, 1: 1, 2: 2, 3: 3},
-        input_channel_dim_to_size={1: 64},
-    )
-    result = common.get_padding_conv_sizes(
-        bounds=[128, 64, 56, 64],
-        padding_sizes=[256, 128, 64, 64],
-        igemm_loop_iterators=['"parallel"', '"parallel"', '"parallel"', '"parallel"'],
-        conv_to_igemm_info=conv_to_igemm_info,
-    )
-    assert result is None
-
-    # Normal convolution with parallel and reduction dimensions.
-    conv_to_igemm_info = common.ConvToIgemmInfo(
-        is_batch_dim_last=False,
-        is_spatial_dim_last=False,
-        conv_dims=SimpleNamespace(batch=[0], input_channel=[3]),
-        conv_to_igemm_dim_map={0: 0, 1: 1, 2: 2, 3: 3},
-        input_channel_dim_to_size={3: 64},
-    )
-    result = common.get_padding_conv_sizes(
-        bounds=[128, 56, 56, 64],
-        padding_sizes=[256, 64, 64, 128],
-        igemm_loop_iterators=['"parallel"', '"parallel"', '"parallel"', '"reduction"'],
-        conv_to_igemm_info=conv_to_igemm_info,
-    )
-    assert result == [256, 64, 64, 128]
-
-    # Reduction dimension with bounds divisible by padding.
-    conv_to_igemm_info = common.ConvToIgemmInfo(
-        is_batch_dim_last=False,
-        is_spatial_dim_last=False,
-        conv_dims=SimpleNamespace(batch=[0], input_channel=[3]),
-        conv_to_igemm_dim_map={0: 0, 1: 1, 2: 2, 3: 3},
-        input_channel_dim_to_size={3: 128},
-    )
-    result = common.get_padding_conv_sizes(
-        bounds=[128, 56, 56, 128],
-        padding_sizes=[256, 64, 64, 128],
-        igemm_loop_iterators=['"parallel"', '"parallel"', '"parallel"', '"reduction"'],
-        conv_to_igemm_info=conv_to_igemm_info,
-    )
-    assert result == [256, 64, 64, 0]
-
-    # Input channel size is small compared to padding size.
-    conv_to_igemm_info = common.ConvToIgemmInfo(
-        is_batch_dim_last=False,
-        is_spatial_dim_last=False,
-        conv_dims=SimpleNamespace(batch=[0], input_channel=[3]),
-        conv_to_igemm_dim_map={0: 0, 1: 1, 2: 2, 3: 3},
-        input_channel_dim_to_size={3: 32},
-    )
-    result = common.get_padding_conv_sizes(
-        bounds=[128, 56, 56, 32],
-        padding_sizes=[256, 64, 64, 128],
-        igemm_loop_iterators=['"parallel"', '"parallel"', '"parallel"', '"reduction"'],
-        conv_to_igemm_info=conv_to_igemm_info,
-    )
-    assert result == [256, 64, 64, 0]
-
-    # Multiple padded parallel dims mapping to same IGEMM dim.
-    conv_to_igemm_info = common.ConvToIgemmInfo(
-        is_batch_dim_last=False,
-        is_spatial_dim_last=False,
-        conv_dims=SimpleNamespace(batch=[0], input_channel=[3]),
-        conv_to_igemm_dim_map={0: 0, 1: 1, 2: 1, 3: 3},
-        input_channel_dim_to_size={3: 64},
-    )
-    result = common.get_padding_conv_sizes(
-        bounds=[128, 56, 56, 64],
-        padding_sizes=[256, 64, 128],
-        igemm_loop_iterators=['"parallel"', '"parallel"', '"parallel"'],
-        conv_to_igemm_info=conv_to_igemm_info,
-    )
-    assert result is None
-
-    conv_to_igemm_info = common.ConvToIgemmInfo(
-        is_batch_dim_last=False,
-        is_spatial_dim_last=False,
-        conv_dims=SimpleNamespace(batch=[0], input_channel=[2]),
-        conv_to_igemm_dim_map={0: 0, 1: 1, 2: 3},
-        input_channel_dim_to_size={2: 64},
-    )
-    result = common.get_padding_conv_sizes(
-        bounds=[128, 56, 56, 64],
-        padding_sizes=[256, 64, 64, 128],
-        igemm_loop_iterators=['"parallel"', '"parallel"', '"parallel"', '"reduction"'],
-        conv_to_igemm_info=conv_to_igemm_info,
-    )
-    assert result is None
-
-    # TODO(Bangtian): Use this programmatic method to create operations instead of
-    # textual MLIR strings to fully cleanup the tests.
-    # Test with realistic convolution data from IGEMM.
-    conv_op = None
-    with ir.Location.unknown(tuner_ctx.mlir_ctx):
-        f16 = ir.F16Type.get()
-        f32 = ir.F32Type.get()
-
-        input_type = ir.RankedTensorType.get([2, 34, 34, 16], f16)
-        filter_type = ir.RankedTensorType.get([3, 3, 16, 32], f16)
-        output_type = ir.RankedTensorType.get([2, 32, 32, 32], f32)
-
-        @func.FuncOp.from_py_func(input_type, filter_type, output_type)
-        def conv_fn(input, filter, output):
-            nonlocal conv_op
-            result = linalg.conv_2d_nhwc_hwcf(input, filter, outs=[output])
-            conv_op = result.owner
-
-    assert conv_op is not None
-    convolution_dims = linalg.infer_convolution_dimensions(conv_op)
-    igemm_details = iree_codegen.get_igemm_generic_conv_details(conv_op)
-
-    input_type = conv_op.operands[0].type
-    res_maps = linalg.get_indexing_maps(conv_op)
-    indexing_maps = [map_attr.value for map_attr in res_maps]
-    input_map = indexing_maps[0]
-
-    conv_to_igemm_info = dispatch_parser.build_conv_to_igemm_info(
-        convolution_dims, input_type, input_map, igemm_details
-    )
-    assert conv_to_igemm_info is not None
-    assert conv_to_igemm_info.is_spatial_dim_last == False
-    assert conv_to_igemm_info.is_batch_dim_last == False
-
-    bounds = list(igemm_details.igemm_loop_bounds)
-    assert bounds == [2, 32, 32, 32, 144]
-
-    padding_sizes = [4, 64, 64, 64, 256]
-    igemm_iterator_types = [str(it) for it in igemm_details.igemm_loop_iterators]
-    assert igemm_iterator_types == [
-        '"parallel"',
-        '"parallel"',
-        '"parallel"',
-        '"parallel"',
-        '"reduction"',
-    ]
-
-    result = common.get_padding_conv_sizes(
-        bounds,
-        padding_sizes,
-        igemm_iterator_types,
-        conv_to_igemm_info,
-    )
-    assert result == [4, 64, 64, 64, 0, 0, 0]

--- a/amdsharktuner/tests/dispatch_parser_test.py
+++ b/amdsharktuner/tests/dispatch_parser_test.py
@@ -15,6 +15,7 @@ from iree.compiler import ir  # type: ignore
 from iree.compiler.dialects import func, iree_codegen, iree_gpu, linalg  # type: ignore
 
 from amdsharktuner import common, dispatch_parser
+from amdsharktuner.rocm import rocm_common
 
 from amdsharktuner.test_utils import tuner_ctx
 
@@ -261,7 +262,7 @@ def test_get_mmt_tile_sizes(tuner_ctx: common.TunerContext) -> None:
         iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
     pipeline_options = iree_gpu.PipelineOptionsAttr.get()
-    config_dict = common.get_translation_info_config(pipeline_options, 0)
+    config_dict = rocm_common.get_translation_info_config(pipeline_options, 0)
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [], 0, config_dict
     )
@@ -287,7 +288,7 @@ def test_get_conv_tile_sizes(tuner_ctx: common.TunerContext) -> None:
         iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
     )
     pipeline_options = iree_gpu.PipelineOptionsAttr.get()
-    config_dict = common.get_translation_info_config(pipeline_options, 1)
+    config_dict = rocm_common.get_translation_info_config(pipeline_options, 1)
     translation_info = iree_codegen.TranslationInfoAttr.get(
         pipeline_attr, None, [256, 1, 1], 64, config_dict
     )

--- a/amdsharktuner/tests/rocm/rocm_common_test.py
+++ b/amdsharktuner/tests/rocm/rocm_common_test.py
@@ -1,0 +1,295 @@
+# Copyright 2026 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+from types import SimpleNamespace
+
+from iree.compiler import ir  # type: ignore
+from iree.compiler.dialects import func, iree_codegen, iree_gpu, linalg  # type: ignore
+
+from amdsharktuner import common, dispatch_parser
+from amdsharktuner.rocm import rocm_common
+from amdsharktuner.test_utils import tuner_ctx
+
+
+def test_get_compatible_mma_intrinsics(tuner_ctx: common.TunerContext) -> None:
+    all_intrinsics = [
+        iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
+        iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
+        iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
+        iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
+    ]
+
+    lhs = common.ShapedType([2048, 1280], tuner_ctx.type.f16)
+    rhs = common.ShapedType([1280, 1280], tuner_ctx.type.f16)
+    res = common.ShapedType([2048, 1280], tuner_ctx.type.f32)
+    assert rocm_common.get_compatible_mma_intrinsics(lhs, rhs, res, all_intrinsics) == [
+        iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
+        iree_gpu.MMAIntrinsic.MFMA_F32_32x32x8_F16,
+    ]
+
+    lhs = common.ShapedType([2048, 1280], tuner_ctx.type.i8)
+    rhs = common.ShapedType([1280, 1280], tuner_ctx.type.i8)
+    res = common.ShapedType([2048, 1280], tuner_ctx.type.i32)
+    assert rocm_common.get_compatible_mma_intrinsics(lhs, rhs, res, all_intrinsics) == [
+        iree_gpu.MMAIntrinsic.MFMA_I32_16x16x32_I8,
+        iree_gpu.MMAIntrinsic.MFMA_I32_32x32x16_I8,
+    ]
+
+    lhs = common.ShapedType([64, 968, 640], tuner_ctx.type.f32)
+    rhs = common.ShapedType([64, 640, 320], tuner_ctx.type.f32)
+    res = common.ShapedType([64, 968, 320], tuner_ctx.type.f32)
+    assert (
+        rocm_common.get_compatible_mma_intrinsics(lhs, rhs, res, all_intrinsics) == []
+    )
+
+    intrinsics_with_virtual = [
+        iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
+        iree_gpu.VirtualMMAIntrinsic.VMFMA_F32_32x32x16_F8E4M3FNUZ,
+    ]
+
+    lhs = common.ShapedType([32, 16], tuner_ctx.type.f8E4M3FNUZ)
+    rhs = common.ShapedType([16, 32], tuner_ctx.type.f8E4M3FNUZ)
+    res = common.ShapedType([32, 32], tuner_ctx.type.f32)
+    assert (
+        rocm_common.get_compatible_mma_intrinsics(
+            lhs, rhs, res, intrinsics_with_virtual
+        )
+        == []
+    )
+
+    assert rocm_common.get_compatible_mma_intrinsics(
+        lhs, rhs, res, intrinsics_with_virtual, allow_virtual_mma=True
+    ) == [iree_gpu.VirtualMMAIntrinsic.VMFMA_F32_32x32x16_F8E4M3FNUZ]
+
+
+def test_get_translation_info_config(tuner_ctx: common.TunerContext) -> None:
+    mma_intrinsic = iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16
+    mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
+    lowering_config = common.get_lowering_config(
+        tuner_ctx=tuner_ctx,
+        mma_kind=mma_attr,
+        workgroup=[4, 8, 0],
+        reduction=[0, 0, 16],
+        subgroup_basis=[[1, 1, 1], [0, 1, 2]],
+    )
+    pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
+        iree_codegen.DispatchLoweringPassPipeline.LLVMGPUVectorDistribute
+    )
+    pipeline_options = iree_gpu.PipelineOptionsAttr.get()
+    config_dict = rocm_common.get_translation_info_config(pipeline_options, 2)
+    translation_info = iree_codegen.TranslationInfoAttr.get(
+        pipeline_attr, None, [16, 16, 1], 32, config_dict
+    )
+    compilation_info = iree_codegen.CompilationInfoAttr.get(
+        lowering_config, translation_info
+    )
+    config1_str: str = str(
+        compilation_info.translation_info.configuration[common.LLVM_FUNC_ATTRS_KEY]
+    )
+    assert config1_str == '{"amdgpu-waves-per-eu" = "2"}'
+
+    pipeline_options = iree_gpu.PipelineOptionsAttr.get(prefetch_num_stages=2)
+    config_dict = rocm_common.get_translation_info_config(pipeline_options, 4)
+    translation_info = iree_codegen.TranslationInfoAttr.get(
+        pipeline_attr, None, [16, 16, 1], 32, config_dict
+    )
+    compilation_info = iree_codegen.CompilationInfoAttr.get(
+        lowering_config, translation_info
+    )
+    config2_str: str = str(compilation_info.translation_info.configuration)
+    assert (
+        config2_str
+        == '{gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_num_stages = 2>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}}'
+    )
+
+
+def test_get_padding_conv_sizes(tuner_ctx: common.TunerContext) -> None:
+    # Note: Using SimpleNamespace to create lightweight mock objects for conv_dims.
+    # The actual linalg.ConvolutionDimensions is a C++-backed type from IREE's
+    # Python bindings, so we mock it with SimpleNamespace for testing convenience.
+
+    # Spatial dimension last (NCHW layout).
+    conv_to_igemm_info = common.ConvToIgemmInfo(
+        is_batch_dim_last=False,
+        is_spatial_dim_last=True,
+        conv_dims=SimpleNamespace(batch=[0], input_channel=[1]),
+        conv_to_igemm_dim_map={0: 0, 1: 1, 2: 2},
+        input_channel_dim_to_size={1: 64},
+    )
+    result = rocm_common.get_padding_conv_sizes(
+        bounds=[128, 64, 56],
+        padding_sizes=[256, 128, 64],
+        igemm_loop_iterators=['"parallel"', '"parallel"', '"parallel"'],
+        conv_to_igemm_info=conv_to_igemm_info,
+    )
+    assert result is None
+
+    # Batch dimension last (CHWN layout).
+    conv_to_igemm_info = common.ConvToIgemmInfo(
+        is_batch_dim_last=True,
+        is_spatial_dim_last=False,
+        conv_dims=SimpleNamespace(batch=[0, 3], input_channel=[1]),
+        conv_to_igemm_dim_map={0: 0, 1: 1, 2: 2, 3: 3},
+        input_channel_dim_to_size={1: 64},
+    )
+    result = rocm_common.get_padding_conv_sizes(
+        bounds=[128, 64, 56, 32],
+        padding_sizes=[256, 128, 64, 64],
+        igemm_loop_iterators=['"parallel"', '"parallel"', '"parallel"', '"parallel"'],
+        conv_to_igemm_info=conv_to_igemm_info,
+    )
+    assert result == [0, 0, 0, 64]
+
+    # Batch dimension last with bounds divisible by padding.
+    conv_to_igemm_info = common.ConvToIgemmInfo(
+        is_batch_dim_last=True,
+        is_spatial_dim_last=False,
+        conv_dims=SimpleNamespace(batch=[0, 3], input_channel=[1]),
+        conv_to_igemm_dim_map={0: 0, 1: 1, 2: 2, 3: 3},
+        input_channel_dim_to_size={1: 64},
+    )
+    result = rocm_common.get_padding_conv_sizes(
+        bounds=[128, 64, 56, 64],
+        padding_sizes=[256, 128, 64, 64],
+        igemm_loop_iterators=['"parallel"', '"parallel"', '"parallel"', '"parallel"'],
+        conv_to_igemm_info=conv_to_igemm_info,
+    )
+    assert result is None
+
+    # Normal convolution with parallel and reduction dimensions.
+    conv_to_igemm_info = common.ConvToIgemmInfo(
+        is_batch_dim_last=False,
+        is_spatial_dim_last=False,
+        conv_dims=SimpleNamespace(batch=[0], input_channel=[3]),
+        conv_to_igemm_dim_map={0: 0, 1: 1, 2: 2, 3: 3},
+        input_channel_dim_to_size={3: 64},
+    )
+    result = rocm_common.get_padding_conv_sizes(
+        bounds=[128, 56, 56, 64],
+        padding_sizes=[256, 64, 64, 128],
+        igemm_loop_iterators=['"parallel"', '"parallel"', '"parallel"', '"reduction"'],
+        conv_to_igemm_info=conv_to_igemm_info,
+    )
+    assert result == [256, 64, 64, 128]
+
+    # Reduction dimension with bounds divisible by padding.
+    conv_to_igemm_info = common.ConvToIgemmInfo(
+        is_batch_dim_last=False,
+        is_spatial_dim_last=False,
+        conv_dims=SimpleNamespace(batch=[0], input_channel=[3]),
+        conv_to_igemm_dim_map={0: 0, 1: 1, 2: 2, 3: 3},
+        input_channel_dim_to_size={3: 128},
+    )
+    result = rocm_common.get_padding_conv_sizes(
+        bounds=[128, 56, 56, 128],
+        padding_sizes=[256, 64, 64, 128],
+        igemm_loop_iterators=['"parallel"', '"parallel"', '"parallel"', '"reduction"'],
+        conv_to_igemm_info=conv_to_igemm_info,
+    )
+    assert result == [256, 64, 64, 0]
+
+    # Input channel size is small compared to padding size.
+    conv_to_igemm_info = common.ConvToIgemmInfo(
+        is_batch_dim_last=False,
+        is_spatial_dim_last=False,
+        conv_dims=SimpleNamespace(batch=[0], input_channel=[3]),
+        conv_to_igemm_dim_map={0: 0, 1: 1, 2: 2, 3: 3},
+        input_channel_dim_to_size={3: 32},
+    )
+    result = rocm_common.get_padding_conv_sizes(
+        bounds=[128, 56, 56, 32],
+        padding_sizes=[256, 64, 64, 128],
+        igemm_loop_iterators=['"parallel"', '"parallel"', '"parallel"', '"reduction"'],
+        conv_to_igemm_info=conv_to_igemm_info,
+    )
+    assert result == [256, 64, 64, 0]
+
+    # Multiple padded parallel dims mapping to same IGEMM dim.
+    conv_to_igemm_info = common.ConvToIgemmInfo(
+        is_batch_dim_last=False,
+        is_spatial_dim_last=False,
+        conv_dims=SimpleNamespace(batch=[0], input_channel=[3]),
+        conv_to_igemm_dim_map={0: 0, 1: 1, 2: 1, 3: 3},
+        input_channel_dim_to_size={3: 64},
+    )
+    result = rocm_common.get_padding_conv_sizes(
+        bounds=[128, 56, 56, 64],
+        padding_sizes=[256, 64, 128],
+        igemm_loop_iterators=['"parallel"', '"parallel"', '"parallel"'],
+        conv_to_igemm_info=conv_to_igemm_info,
+    )
+    assert result is None
+
+    conv_to_igemm_info = common.ConvToIgemmInfo(
+        is_batch_dim_last=False,
+        is_spatial_dim_last=False,
+        conv_dims=SimpleNamespace(batch=[0], input_channel=[2]),
+        conv_to_igemm_dim_map={0: 0, 1: 1, 2: 3},
+        input_channel_dim_to_size={2: 64},
+    )
+    result = rocm_common.get_padding_conv_sizes(
+        bounds=[128, 56, 56, 64],
+        padding_sizes=[256, 64, 64, 128],
+        igemm_loop_iterators=['"parallel"', '"parallel"', '"parallel"', '"reduction"'],
+        conv_to_igemm_info=conv_to_igemm_info,
+    )
+    assert result is None
+
+    # TODO(Bangtian): Use this programmatic method to create operations instead of
+    # textual MLIR strings to fully cleanup the tests.
+    # Test with realistic convolution data from IGEMM.
+    conv_op = None
+    with ir.Location.unknown(tuner_ctx.mlir_ctx):
+        f16 = ir.F16Type.get()
+        f32 = ir.F32Type.get()
+
+        input_type = ir.RankedTensorType.get([2, 34, 34, 16], f16)
+        filter_type = ir.RankedTensorType.get([3, 3, 16, 32], f16)
+        output_type = ir.RankedTensorType.get([2, 32, 32, 32], f32)
+
+        @func.FuncOp.from_py_func(input_type, filter_type, output_type)
+        def conv_fn(input, filter, output):
+            nonlocal conv_op
+            result = linalg.conv_2d_nhwc_hwcf(input, filter, outs=[output])
+            conv_op = result.owner
+
+    assert conv_op is not None
+    convolution_dims = linalg.infer_convolution_dimensions(conv_op)
+    igemm_details = iree_codegen.get_igemm_generic_conv_details(conv_op)
+
+    input_type = conv_op.operands[0].type
+    res_maps = linalg.get_indexing_maps(conv_op)
+    indexing_maps = [map_attr.value for map_attr in res_maps]
+    input_map = indexing_maps[0]
+
+    conv_to_igemm_info = dispatch_parser.build_conv_to_igemm_info(
+        convolution_dims, input_type, input_map, igemm_details
+    )
+    assert conv_to_igemm_info is not None
+    assert conv_to_igemm_info.is_spatial_dim_last == False
+    assert conv_to_igemm_info.is_batch_dim_last == False
+
+    bounds = list(igemm_details.igemm_loop_bounds)
+    assert bounds == [2, 32, 32, 32, 144]
+
+    padding_sizes = [4, 64, 64, 64, 256]
+    igemm_iterator_types = [str(it) for it in igemm_details.igemm_loop_iterators]
+    assert igemm_iterator_types == [
+        '"parallel"',
+        '"parallel"',
+        '"parallel"',
+        '"parallel"',
+        '"reduction"',
+    ]
+
+    result = rocm_common.get_padding_conv_sizes(
+        bounds,
+        padding_sizes,
+        igemm_iterator_types,
+        conv_to_igemm_info,
+    )
+    assert result == [4, 64, 64, 64, 0, 0, 0]


### PR DESCRIPTION
This PR extracts ROCM-specific utilities from `common.py` to `rocm/rocm_common.py`, and also moves corresponding tests to `tests/rocm/rocm_common_test.py`.

This is the second PR in a series to separate ROCM-specific tuning code into a dedicated rocm/ subdirectory, keeping the core amdsharktuner module generic and extensible for future GPU backends.

**Context**: 
 https://github.com/nod-ai/amd-shark-ai/pull/2763#issuecomment-3746905242