### PR TITLE
[tuner] add gitignore patterns for boo tuner artifacts

### DIFF
--- a/amdsharktuner/.gitignore
+++ b/amdsharktuner/.gitignore
@@ -1,4 +1,6 @@
 .venv/
 
-# Tuning artifacts
+# Tuning artifacts.
 tuning_*/
+boo_tuning_*/
+boo_tuner/boo_turbine_cache_*/


### PR DESCRIPTION
  The boo tuner generates `boo_tuning_*/ `directories for specs and logs, and `boo_tuner/boo_turbine_cache_*/` for cached MLIR files. Add these patterns to .gitignore to prevent committing generated tuning files.