### PR TITLE
change cronjob time for boo

### DIFF
--- a/.github/workflows/ci_boo_on_mi355.yml
+++ b/.github/workflows/ci_boo_on_mi355.yml
@@ -16,7 +16,7 @@ name: CI - Boo on Mi355
 on:
   workflow_dispatch:
   schedule:
-    - cron: "45 10 * * *"
+    - cron: "45 11 * * *"
 
 permissions:
   contents: write


### PR DESCRIPTION
Change cronjob time for this CI to ensure that it uses today's iree-base-compile and iree-base-runtime release version.