### PR TITLE
Pin IREE to >=3.10.0rc20260110 for Tuner

### DIFF
--- a/amdsharktuner/model_tuner/__main__.py
+++ b/amdsharktuner/model_tuner/__main__.py
@@ -6,4 +6,5 @@
 
 from . import model_tuner
 
+
 model_tuner.main()

--- a/amdsharktuner/requirements-iree.txt
+++ b/amdsharktuner/requirements-iree.txt
@@ -1,6 +1,6 @@
 # Unpinned IREE dependencies for amdsharktuner.
 --pre
 --find-links https://iree.dev/pip-release-links.html
-iree-base-compiler
-iree-base-runtime
+iree-base-compiler>=3.10.0rc20260110
+iree-base-runtime>=3.10.0rc20260110
 iree-turbine


### PR DESCRIPTION
## Summary

Just using `--pre` flag is NOT enough! Even with `--pre`, pip can still install IREE 3.10.0 stable (released Feb 2, 2026) which lacks the isinstance() fix. We must explicitly constrain the version to `>=3.10.0rc20260110` to ensure we get a version with the fix.

This PR updates the IREE version requirement to `>=3.10.0rc20260110` to ensure compatibility with the current amdsharktuner codebase, which uses Python's built-in `isinstance()` for MLIR AffineExpr type checking.

**Note**: This explicit RC version pin is temporary. Once the required commit is in automatically, this requirement can be removed. 

## Problem

The amdsharktuner codebase (since commit 6e664cf6a on Jan 13, 2026) uses Python's `isinstance()` for type checking with MLIR AffineExpr types:

```python
if isinstance(expr, ir.AffineBinaryExpr):
    return is_affine_expr_function_of_dim(expr.lhs, position) or ...
```

However, **IREE 3.10.0 stable** (released Feb 2, 2026) ships with an older version of LLVM/MLIR that doesn't support `isinstance()` for AffineExpr downcasting. This causes test failures:

### Test Failures with IREE 3.10.0 Stable
**Without the version requirement**, pip will install IREE 3.10.0 stable (the latest stable release), which contains an older LLVM/MLIR version that breaks `isinstance()` for AffineExpr types. This causes the following test failures (https://github.com/nod-ai/amd-shark-ai/actions/runs/21637382707/job/62366696407?pr=2736#step:8:126):

 ### IREE Version Timeline

| IREE Version | isinstance() Works? | Status |
|--------------|---------------------|--------|
| 3.10.0 (stable) | ✗ No | Incompatible with current code |
| 3.10.0rc20260108 | ✗ No | Old MLIR |
| 3.10.0rc20260109 | ✗ No | Broken (transitional) |
| **3.10.0rc20260110** | ✓ **Yes** | **First working version** ✓ |
| 3.10.0rc20260115+ | ✓ Yes | Working |
| 3.11.0rc20260203+ | ✓ Yes | Working |


**Assisted-by**: claude