### PR TITLE
[Tune] Fix TypeError in shlex.join and fatal abort in batch negative indexing

### DIFF
--- a/amdsharktuner/amdsharktuner/candidate_gen.py
+++ b/amdsharktuner/amdsharktuner/candidate_gen.py
@@ -150,8 +150,7 @@ def strip_root_op_attr(module: ir.Module):
 # See the above comment for `strip_root_op_attr`.
 def strip_compilation_info(input_path: Path) -> str:
     # Strip compilation info from the source and save the stripped IR.
-    iree_opt = ireec.binaries.find_tool("iree-opt")  # type: ignore
-    assert iree_opt, "iree-opt tool not found"
+    iree_opt: str = ireec.binaries.find_tool("iree-opt")  # type: ignore[attr-defined]
     strip_command = [
         iree_opt,
         f"{input_path}",

--- a/amdsharktuner/amdsharktuner/common.py
+++ b/amdsharktuner/amdsharktuner/common.py
@@ -343,8 +343,7 @@ def link_tuning_specs(tuner_ctx: TunerContext, td_specs: list[ir.Module]) -> ir.
     into one tuning spec.
     """
     module = combine_tuning_specs(tuner_ctx, td_specs)
-    iree_opt = ireec.binaries.find_tool("iree-opt")  # type: ignore
-    assert iree_opt, "iree-opt tool not found"
+    iree_opt: str = ireec.binaries.find_tool("iree-opt")  # type: ignore[attr-defined]
 
     if len(td_specs) == 1:
         # avoid unnecessary link overhead.

--- a/amdsharktuner/amdsharktuner/libtuner.py
+++ b/amdsharktuner/amdsharktuner/libtuner.py
@@ -531,8 +531,7 @@ def handle_error(
 
 
 def flatten_nested_td_spec(td_spec_str: str, output_path: Path) -> None:
-    iree_opt = ireec.binaries.find_tool("iree-opt")  # type: ignore
-    assert iree_opt, "iree-opt tool not found"
+    iree_opt: str = ireec.binaries.find_tool("iree-opt")  # type: ignore[attr-defined]
     with tempfile.TemporaryDirectory() as tmpdir:
         input_path = os.path.join(tmpdir, "tmp_input.mlir")
         with open(input_path, "w") as f:
@@ -543,7 +542,7 @@ def flatten_nested_td_spec(td_spec_str: str, output_path: Path) -> None:
             "--iree-codegen-link-tuning-specs",
             input_path,
             "-o",
-            output_path,
+            str(output_path),
         ]
 
         process_utils.run_command(process_utils.RunPack(command=link_command))
@@ -569,8 +568,7 @@ def run_iree_compile_command(compile_pack: CompilePack) -> Optional[int]:
     crash_dump_path = f"{output_path}.crash_report.mlir"
     assert candidate_tracker.mlir_path, "expected input mlir file path"
     input_file = candidate_tracker.mlir_path.as_posix()
-    iree_compile = ireec.binaries.find_tool("iree-compile")  # type: ignore
-    assert iree_compile, "iree-compile tool not found"
+    iree_compile: str = ireec.binaries.find_tool("iree-compile")  # type: ignore[attr-defined]
     compile_command = [
         iree_compile,
         input_file,

--- a/amdsharktuner/amdsharktuner/rocm/rocm_common.py
+++ b/amdsharktuner/amdsharktuner/rocm/rocm_common.py
@@ -200,7 +200,7 @@ def get_padding_conv_sizes(
     # For batch-last layout (e.g., CHWN), only pad the batch dimension to avoid
     # introducing pad op as the producer of collapse_shape op which may cause fusion problem.
     if conv_to_igemm_info.is_batch_dim_last:
-        last_batch_dim = conv_dims.batch[-1]
+        last_batch_dim = list(conv_dims.batch)[-1]
         igemm_batch_pos = conv_to_igemm[last_batch_dim]
 
         if (


### PR DESCRIPTION
Fixes: 
- **Convert `output_path` from `Path` to `str`**:  `TypeError` in `shlex.join()` which expects all str type
   - Found during boo tuning when td specs were merged
- **Convert `conv_dims.batch` to list**: the Python binding that doesn't support negative indexing
   - Found when running pytest;  this fix was present locally in #2687 but was lost during merge.  )

Additional cleanup:
-  Add explicit type annotations (`str`) for `ireec.binaries.find_tool()` calls with specific `# type: ignore[attr-defined]` for mypy
-  Remove redundant asserts since `find_tool()` raises `ValueError` on failure

Assisted-by:  [Claude Code](https://claude.ai/code)