### PR TITLE
 [Tuner] Support group convolutions

### DIFF
--- a/amdsharktuner/amdsharktuner/rocm/rocm_tuners.py
+++ b/amdsharktuner/amdsharktuner/rocm/rocm_tuners.py
@@ -173,8 +173,7 @@ class ROCmConvolutionTileAndFuseTuner(
         convolution_dims = linalg.infer_convolution_dimensions(root_op)
         if not convolution_dims:
             return False
-        # Support all 2D convolutions (no depth dimension) for IGEMM.
-        return list(convolution_dims.depth) == []
+        return True
 
     def get_constraint_generator(self) -> constraint_generator.ConstraintGenerator:
         return rocm_constraint_generators.ROCmConvolutionTileAndFuseConstraintGenerator(


### PR DESCRIPTION
 When implementing IGEMM support for the `TileAndFuse` pipeline, I initially missed that IREE removed the `convDims.depth.empty()` constraint in commit [b53af84c25](https://github.com/iree-org/iree/commit/b53af84c25#diff-f3d5d737db3698e3fe97cc9cfdf357e8be2cb096d5b038e16271dc09ce217af9L437-L440).

This PR removes the corresponding constraint from the tuner side to align with IREE's support for all 2D convolutions, also add the corresponding test.

Assisted-by:  [Claude Code](https://claude.ai/code)