### PR TITLE
[Tuner] Pin z3_solver version to exclude broken 4.15.8 (use 4.15.4 or earlier)

### DIFF
--- a/amdsharktuner/requirements.txt
+++ b/amdsharktuner/requirements.txt
@@ -4,4 +4,4 @@ numpy
 PyYAML
 typing_extensions
 tqdm>=4.66.4
-z3_solver>=4.13.0.0
+z3_solver>=4.13.0.0,<4.15.8.0  # 4.15.8.0 has a regression causing constraint solver to fail on group conv.


### PR DESCRIPTION
  Z3 solver version 4.15.8 (latest) has a regression causing constraint solver to fail on group convolution operations, returning "canceled" status with 0 solutions instead of generating valid candidates.

  Versions 4.13.0, 4.14.0, 4.15.0, and 4.15.4 work correctly.

  This PR pins z3_solver to exclude 4.15.8.0: `z3_solver>=4.13.0.0,<4.15.8.0`

  Example failing boo command:
  `convfp16 -n 32 -c 512 -H 50 -W 50 -k 512 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 32 -F 1 -t 1`

Created one tracking issue about Z3 solver version: https://github.com/nod-ai/amd-shark-ai/issues/2827.

Assisted-by: [Claude Code](https://claude.ai/code)
                                                                                                                                                                            