### PR TITLE
Fix pytest version conflicts in requirements files

### DIFF
--- a/amdsharktank/requirements-tests.txt
+++ b/amdsharktank/requirements-tests.txt
@@ -8,9 +8,9 @@ datasets==3.0.0
 diffusers
 parameterized
 protobuf
-pytest==8.0.0
+pytest==8.3.5
 pytest-html
 pytest-cov
 pytest-timeout
-pytest-xdist==3.5.0
+pytest-xdist==3.8.0
 safetensors>=0.4.5

--- a/shortfin/requirements-tests-nogil.txt
+++ b/shortfin/requirements-tests-nogil.txt
@@ -1,3 +1,3 @@
-pytest
+pytest==8.3.5
 requests
 uvicorn

--- a/shortfin/requirements-tests.txt
+++ b/shortfin/requirements-tests.txt
@@ -1,10 +1,10 @@
 # Pytest plugins
-pytest
+pytest==8.3.5
 pytest-asyncio
 pytest-subtests
 pytest-timeout
 pytest-cov
-pytest-xdist==3.5.0
+pytest-xdist==3.8.0
 
 # General server libraries
 requests


### PR DESCRIPTION
Standardize pytest to version 8.3.5 across amdsharktank and shortfin test requirements to resolve pip dependency conflicts.