### PR TITLE
Replace --iree-config-add-tuner-attributes with --iree-codegen-add-tuner-attributes

### DIFF
--- a/amdsharktuner/amdsharktuner/candidate_gen.py
+++ b/amdsharktuner/amdsharktuner/candidate_gen.py
@@ -64,7 +64,7 @@ def instantiate_dispatch_tuner(
     if len(root_op_list) == 0:
         tune_logger.error(
             "No root ops found. Did you forget to pass "
-            "--iree-config-add-tuner-attributes during compilation?"
+            "--iree-codegen-add-tuner-attributes during compilation?"
         )
         return None
     elif len(root_op_list) > 1:

--- a/amdsharktuner/boo_tuner/boo_tuner.py
+++ b/amdsharktuner/boo_tuner/boo_tuner.py
@@ -173,7 +173,7 @@ def build_compile_args(compile_command: str, benchmarks_dir: Path) -> list[str]:
     # Add tuner-specific flags.
     compile_args.extend(
         [
-            "--iree-config-add-tuner-attributes",
+            "--iree-codegen-add-tuner-attributes",
             "--iree-hal-dump-executable-benchmarks-to",
             str(benchmarks_dir),
             "-o",

--- a/amdsharktuner/dispatch_tuner/README.md
+++ b/amdsharktuner/dispatch_tuner/README.md
@@ -12,13 +12,13 @@ This example uses the simple `dispatch_sample.mlir` file.
 
 ### Generate a benchmark file
 Use the usual `iree-compile` command for problem dispatch, add
-`--iree-hal-dump-executable-files-to=dump --iree-config-add-tuner-attributes`,
+`--iree-hal-dump-executable-files-to=dump --iree-codegen-add-tuner-attributes`,
 and get the dispatch benchmark that you want to tune. For example:
 
 ```shell
 iree-compile dispatch_sample.mlir --iree-hal-target-device=hip \
     --iree-rocm-target=gfx942 --iree-hal-dump-executable-files-to=tmp/dump \
-    --iree-config-add-tuner-attributes -o /dev/null
+    --iree-codegen-add-tuner-attributes -o /dev/null
 
 cp tmp/dump/module_main_dispatch_0_rocm_hsaco_fb_benchmark.mlir tmp/dispatch_sample_benchmark.mlir
 ```

--- a/amdsharktuner/model_tuner/README.md
+++ b/amdsharktuner/model_tuner/README.md
@@ -12,14 +12,14 @@ This example uses the simple `double_mmt.mlir` file.
 
 ### Generate a benchmark file
 Use the usual `iree-compile` command for your model, add
-`--iree-hal-dump-executable-files-to=dump --iree-config-add-tuner-attributes`,
+`--iree-hal-dump-executable-files-to=dump --iree-codegen-add-tuner-attributes`,
 and get the dispatch benchmark that you want to tune. For example:
 
 ```shell
 mkdir tmp
 iree-compile double_mmt.mlir --iree-hal-target-device=hip \
     --iree-rocm-target=gfx942 --iree-hal-dump-executable-files-to=tmp/dump \
-    --iree-config-add-tuner-attributes -o /dev/null
+    --iree-codegen-add-tuner-attributes -o /dev/null
 
 cp tmp/dump/module_main_dispatch_0_rocm_hsaco_fb_benchmark.mlir tmp/mmt_benchmark.mlir
 ```

--- a/amdsharktuner/tests/boo_tuner_test.py
+++ b/amdsharktuner/tests/boo_tuner_test.py
@@ -125,7 +125,7 @@ def test_build_compile_args() -> None:
     assert "/path/to/output.vmfb" not in result
 
     # Check that tuner-specific flags are added.
-    assert "--iree-config-add-tuner-attributes" in result
+    assert "--iree-codegen-add-tuner-attributes" in result
     assert "--iree-hal-dump-executable-benchmarks-to" in result
     assert str(benchmarks_dir) in result
 

--- a/docs/tune_sdxl.md
+++ b/docs/tune_sdxl.md
@@ -122,7 +122,7 @@ Indentify the dispatches either of `MatMul` or `Conv` which are taking time abov
 
 ```
 iree-compile <IR Path> \
---iree-config-add-tuner-attributes \
+--iree-codegen-add-tuner-attributes \
 --iree-hal-executable-debug-level=3 \
 --iree-hal-dump-executable-files-to=dispatchOutput \
 --iree-hal-target-backends=rocm \


### PR DESCRIPTION
Replace `--iree-config-add-tuner-attributes` with `--iree-codegen-add-tuner-attributes` across the codebase to align with                                                                                                                                                                                                                                                              
  [IREE PR #23533](https://github.com/iree-org/iree/pull/23533), which moved the tuner attribute flag to codegen options. 