### PR TITLE
[tuner] Fix get_parent_function_name to handle split reduction nesting

### DIFF
--- a/amdsharktuner/amdsharktuner/dispatch_parser.py
+++ b/amdsharktuner/amdsharktuner/dispatch_parser.py
@@ -12,25 +12,26 @@ from dataclasses import dataclass
 from typing import Optional
 
 from iree.compiler import ir  # type: ignore
-from iree.compiler._mlir_libs._mlir.ir import _OperationBase  # type: ignore
 from iree.compiler.dialects import func, iree_codegen, linalg  # type: ignore
 
 from . import common
 
 
-def get_parent_function_name(root_op: ir.Operation) -> str:
+def get_parent_function_name(root_op: ir.Operation) -> Optional[str]:
     """
     Returns the parent function's symbol name from a root operation.
     Walks up the operation hierarchy to find the enclosing func.func.
-    """
-    current_op: Optional[_OperationBase] = root_op.parent
-    while current_op:
-        op_view = current_op.opview
-        if isinstance(op_view, func.FuncOp):
-            return ir.StringAttr(op_view.name).value
-        current_op = current_op.parent
+    Returns None if no enclosing func.func is found.
 
-    raise RuntimeError(f"No enclosing func.func found for operation {root_op.name}")
+    TODO(bangtian): This could be simplified once MLIR Python bindings support getParentOfType<T>().
+    See https://github.com/llvm/llvm-project/pull/185512.
+    """
+    op: ir.Operation = root_op
+    while op := op.parent:
+        if isinstance(op.opview, func.FuncOp):
+            return ir.StringAttr(op.opview.name).value
+
+    return None
 
 
 def parse_mlir(mlir_text: str, ctx: common.TunerContext) -> ir.Module:

--- a/amdsharktuner/amdsharktuner/spec_builder.py
+++ b/amdsharktuner/amdsharktuner/spec_builder.py
@@ -23,7 +23,10 @@ def get_matcher_named_sequence_name(root_op: ir.Operation) -> str:
     """
     Returns the symbol name for a transform dialect named sequence matcher.
     """
-    return f"match_{get_parent_function_name(root_op)}"
+    func_name = get_parent_function_name(root_op)
+    if func_name is None:
+        raise RuntimeError(f"No enclosing func.func found for operation {root_op.name}")
+    return f"match_{func_name}"
 
 
 def get_placeholder_spec(context: ir.Context) -> ir.Module:

--- a/amdsharktuner/tests/dispatch_parser_test.py
+++ b/amdsharktuner/tests/dispatch_parser_test.py
@@ -327,27 +327,16 @@ def test_get_parent_function_name_with_split_reduction(
 ) -> None:
     """Test get_parent_function_name when root op is nested in scf.forall (split reduction)."""
     context = tuner_ctx.mlir_ctx
-    # Simplified MLIR showing the nesting structure: func.func -> scf.forall -> linalg.generic.
+    # Simplified MLIR showing the nesting structure: func.func -> scf.forall -> linalg.matmul.
     # This matches IREE's split reduction optimization pattern.
     module_str = r"""
     builtin.module {
         func.func @split_reduction_test(%arg0: tensor<16x64xf16>, %arg1: tensor<64x32xf16>) -> tensor<16x32xf32> {
             %init = tensor.empty() : tensor<16x32xf32>
             %result = scf.forall (%i) in (4) shared_outs(%out = %init) -> (tensor<16x32xf32>) {
-                %matmul = linalg.generic {
-                    indexing_maps = [
-                        affine_map<(d0, d1, d2) -> (d0, d2)>,
-                        affine_map<(d0, d1, d2) -> (d2, d1)>,
-                        affine_map<(d0, d1, d2) -> (d0, d1)>
-                    ],
-                    iterator_types = ["parallel", "parallel", "reduction"],
-                    root_op = #iree_codegen.root_op<set = 0>
-                }
-                ins(%arg0, %arg1 : tensor<16x64xf16>, tensor<64x32xf16>)
-                outs(%out : tensor<16x32xf32>) {
-                ^bb0(%lhs: f16, %rhs: f16, %acc: f32):
-                    linalg.yield %acc : f32
-                } -> tensor<16x32xf32>
+                %matmul = linalg.matmul {root_op = #iree_codegen.root_op<set = 0>}
+                    ins(%arg0, %arg1 : tensor<16x64xf16>, tensor<64x32xf16>)
+                    outs(%out : tensor<16x32xf32>) -> tensor<16x32xf32>
                 scf.forall.in_parallel {
                     tensor.parallel_insert_slice %matmul into %out[0, 0] [16, 32] [1, 1]
                         : tensor<16x32xf32> into tensor<16x32xf32>
@@ -362,7 +351,7 @@ def test_get_parent_function_name_with_split_reduction(
     assert len(root_op_list) == 1
     root_op = root_op_list[0]
 
-    # The root op is nested: func.func -> scf.forall -> linalg.generic.
+    # The root op is nested: func.func -> scf.forall -> linalg.matmul.
     # get_parent_function_name should walk up the hierarchy and find the function.
     func_name = dispatch_parser.get_parent_function_name(root_op)
     assert func_name == "split_reduction_test"
@@ -372,3 +361,21 @@ def test_get_parent_function_name_with_split_reduction(
         dispatch_parser.get_parent_function_name(parser.get_root_op())
         == "split_reduction_test"
     )
+
+
+def test_get_parent_function_name_no_function(
+    tuner_ctx: common.TunerContext,
+) -> None:
+    """Test get_parent_function_name returns None when no func.func is found."""
+    context = tuner_ctx.mlir_ctx
+    module_str = r"""
+    builtin.module {
+        %cst = arith.constant 0.0 : f32
+    }
+    """
+    module = ir.Module.parse(module_str, context)
+    module_body = module.body
+    constant_op = module_body.operations[0]
+
+    func_name = dispatch_parser.get_parent_function_name(constant_op)
+    assert func_name is None


### PR DESCRIPTION
This issue is triggered by tuning weight backward conv (BOO command) 
`convfp16 -n 32 -c 256 -H 100 -W 100 -k 2376 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 4 -t 1`. 

 When IREE's split reduction optimization is enabled, the root operation gets wrapped inside a `scf.forall` block. The `get_parent_function_name()` function previously assumed the root op's immediate parent was always a `func.FuncOp`, causing an assertion error: `"Expected func.func, got scf.forall"`.

 This PR modifies the function to walk up the operation hierarchy until it finds the enclosing `func.FuncOp`, handling any depth of nesting (scf.forall, scf.if, scf.for, etc.). 
 
 Assisted-by: [Claude Code](https://claude.ai/code)