### PR TITLE
Add PYTHONUNBUFFERED=1 to MI355 BOO CI workflow

### DIFF
--- a/.github/workflows/ci_boo_on_mi355.yml
+++ b/.github/workflows/ci_boo_on_mi355.yml
@@ -180,6 +180,7 @@ jobs:
     - name: Setup environment variables
       run: |
        echo "MIOPEN_FIND_ENFORCE=3" >> $GITHUB_ENV
+       echo "PYTHONUNBUFFERED=1" >> $GITHUB_ENV
        echo "ROCR_VISIBLE_DEVICES=0" >> $GITHUB_ENV
 
     - name: Run Prod Conv


### PR DESCRIPTION
Add `PYTHONUNBUFFERED=1` to MI355 BOO CI workflow, matching the
RDNA4 workflow (`ci_boo_on_rdna4.yml:125`).

Without this, Python block-buffers stderr when piped through
`2>&1 | tee`, causing tracebacks from `--numerics-verbose` to
appear interleaved with unrelated tests' stdout output (or not
at all if the buffer hasn't flushed by the time the next test's
output overwrites it).
