### PR TITLE
Increase numerics-min-samples from 10 to 100

### DIFF
--- a/.github/workflows/ci_boo_on_mi355.yml
+++ b/.github/workflows/ci_boo_on_mi355.yml
@@ -189,7 +189,7 @@ jobs:
        echo "============ Running Prod Conv shape with MIOpen and IREE without tuning ==================="
        iree-boo-driver \
             --commands-file amd-shark-ai-reports/boo/prod_conv_config.txt --csv output_artifacts/prod_conv_miopen_iree.csv \
-            --backend=torch --backend=iree_boo_experimental --verify-numerics --numerics-reference-dtype=float32 --numerics-min-samples 10 --verbose --numerics-verbose \
+            --backend=torch --backend=iree_boo_experimental --verify-numerics --numerics-reference-dtype=float32 --numerics-min-samples 100 --verbose --numerics-verbose \
             2>&1 | tee output_artifacts/prod_conv_miopen_iree.log || true
 
     - name: Run All Proxy
@@ -198,7 +198,7 @@ jobs:
        echo "============ Running All proxy shape with MIOpen and IREE without tuning ==================="
        iree-boo-driver \
             --commands-file amd-shark-ai-reports/boo/all_proxy_config.txt --csv output_artifacts/all_proxy_miopen_iree.csv \
-            --backend=torch --backend=iree_boo_experimental --verify-numerics --numerics-reference-dtype=float32 --numerics-min-samples 10 --verbose --numerics-verbose \
+            --backend=torch --backend=iree_boo_experimental --verify-numerics --numerics-reference-dtype=float32 --numerics-min-samples 100 --verbose --numerics-verbose \
             2>&1 | tee output_artifacts/all_proxy_miopen_iree.log || true
 
     - name: Run Gemm
@@ -216,7 +216,7 @@ jobs:
        echo "============ Running Batch norm shape with MIOpen and IREE without tuning ======================================="
        iree-boo-driver \
             --commands-file amd-shark-ai-reports/boo/batch_norm_config.txt --csv output_artifacts/batch_norm_miopen_iree.csv \
-            --backend=torch --backend=iree_boo_experimental --backend=inductor --verify-numerics --numerics-reference-dtype=float32 --numerics-min-samples 10 --verbose --numerics-verbose \
+            --backend=torch --backend=iree_boo_experimental --backend=inductor --verify-numerics --numerics-reference-dtype=float32 --numerics-min-samples 100 --verbose --numerics-verbose \
             2>&1 | tee output_artifacts/batch_norm_miopen_iree.log || true
 
     - name: Run Prod Conv NCHW
@@ -225,7 +225,7 @@ jobs:
        echo "============ Running Prod Conv shape with NCHW layout with MIOpen and IREE without tuning ==================="
        iree-boo-driver \
             --commands-file amd-shark-ai-reports/boo/prod_conv_config_nchw.txt --csv output_artifacts/prod_conv_miopen_iree_nchw.csv \
-            --backend=torch --backend=iree_boo_experimental --verify-numerics --numerics-reference-dtype=float32 --numerics-min-samples 10 --verbose --numerics-verbose \
+            --backend=torch --backend=iree_boo_experimental --verify-numerics --numerics-reference-dtype=float32 --numerics-min-samples 100 --verbose --numerics-verbose \
             2>&1 | tee output_artifacts/prod_conv_miopen_iree_nchw.log || true
 
     - name: Run All Proxy NCHW
@@ -234,7 +234,7 @@ jobs:
        echo "============ Running All proxy shape with NCHW layout with MIOpen and IREE without tuning ==================="
        iree-boo-driver \
             --commands-file amd-shark-ai-reports/boo/all_proxy_config_nchw.txt --csv output_artifacts/all_proxy_miopen_iree_nchw.csv \
-            --backend=torch --backend=iree_boo_experimental --verify-numerics --numerics-reference-dtype=float32 --numerics-min-samples 10 --verbose --numerics-verbose \
+            --backend=torch --backend=iree_boo_experimental --verify-numerics --numerics-reference-dtype=float32 --numerics-min-samples 100 --verbose --numerics-verbose \
             2>&1 | tee output_artifacts/all_proxy_miopen_iree_nchw.log || true
 
     - name: Run hipblaslt-bench

--- a/.github/workflows/ci_boo_on_rdna4.yml
+++ b/.github/workflows/ci_boo_on_rdna4.yml
@@ -145,7 +145,7 @@ jobs:
        echo "============ Running Prod Conv shape with MIOpen and IREE without tuning ==================="
        iree-boo-driver \
             --commands-file amd-shark-ai-reports/boo/prod_conv_config.txt --csv output_artifacts/rdna4_prod_conv_miopen_iree.csv \
-            --backend=torch --backend=iree_boo_experimental --verify-numerics --numerics-reference-dtype=float32 --numerics-min-samples 10 --verbose --numerics-verbose \
+            --backend=torch --backend=iree_boo_experimental --verify-numerics --numerics-reference-dtype=float32 --numerics-min-samples 100 --verbose --numerics-verbose \
             2>&1 | tee output_artifacts/rdna4_prod_conv_miopen_iree.log || true
 
     - name: Run All Proxy
@@ -164,7 +164,7 @@ jobs:
        echo "============ Running Gemm shape with MIOpen and IREE without tuning ======================================="
        iree-boo-driver \
             --commands-file amd-shark-ai-reports/boo/gemm_config.txt --csv output_artifacts/rdna4_gemm_miopen_iree.csv \
-            --backend=torch --backend=iree_boo_experimental --verify-numerics --numerics-reference-dtype=float32 --numerics-min-samples 10 --verbose --numerics-verbose \
+            --backend=torch --backend=iree_boo_experimental --verify-numerics --numerics-reference-dtype=float32 --numerics-min-samples 100 --verbose --numerics-verbose \
             2>&1 | tee output_artifacts/rdna4_gemm_miopen_iree.log || true
 
     - name: Run Batch Norm
@@ -173,7 +173,7 @@ jobs:
        echo "============ Running Batch norm shape with MIOpen and IREE without tuning ======================================="
        iree-boo-driver \
             --commands-file amd-shark-ai-reports/boo/batch_norm_config.txt --csv output_artifacts/rdna4_batch_norm_miopen_iree.csv \
-            --backend=torch --backend=iree_boo_experimental --backend=inductor --verify-numerics --numerics-reference-dtype=float32 --numerics-min-samples 10 --verbose --numerics-verbose \
+            --backend=torch --backend=iree_boo_experimental --backend=inductor --verify-numerics --numerics-reference-dtype=float32 --numerics-min-samples 100 --verbose --numerics-verbose \
             2>&1 | tee output_artifacts/rdna4_batch_norm_miopen_iree.log || true
 
     - name: Run Prod Conv NCHW
@@ -182,7 +182,7 @@ jobs:
        echo "============ Running Prod Conv shape with NCHW layout with MIOpen and IREE without tuning ==================="
        iree-boo-driver \
             --commands-file amd-shark-ai-reports/boo/prod_conv_config_nchw.txt --csv output_artifacts/rdna4_prod_conv_miopen_iree_nchw.csv \
-            --backend=torch --backend=iree_boo_experimental --verify-numerics --numerics-reference-dtype=float32 --numerics-min-samples 10 --verbose --numerics-verbose \
+            --backend=torch --backend=iree_boo_experimental --verify-numerics --numerics-reference-dtype=float32 --numerics-min-samples 100 --verbose --numerics-verbose \
             2>&1 | tee output_artifacts/rdna4_prod_conv_miopen_iree_nchw.log || true
 
     - name: Run All Proxy NCHW
@@ -191,7 +191,7 @@ jobs:
        echo "============ Running All proxy shape with NCHW layout with MIOpen and IREE without tuning ==================="
        iree-boo-driver \
             --commands-file amd-shark-ai-reports/boo/all_proxy_config_nchw.txt --csv output_artifacts/rdna4_all_proxy_miopen_iree_nchw.csv \
-            --backend=torch --backend=iree_boo_experimental --verify-numerics --numerics-reference-dtype=float32 --numerics-min-samples 10 --verbose --numerics-verbose \
+            --backend=torch --backend=iree_boo_experimental --verify-numerics --numerics-reference-dtype=float32 --numerics-min-samples 100 --verbose --numerics-verbose \
             2>&1 | tee output_artifacts/rdna4_all_proxy_miopen_iree_nchw.log || true
 
     - name: Upload log files


### PR DESCRIPTION
Increase `--numerics-min-samples` from 10 to 100 in both MI355 and RDNA4 BOO CI workflows.

10 samples was too small, and caused false positives. Increasing to 100 resolves this and doesn't add significant runtime.

Compared [min-samples=100 MI355 run 22974863517](https://github.com/nod-ai/amd-shark-ai/actions/runs/22974863517) (manually triggered on this branch) against [March 12 nightly (min-samples=10) run 23000589553](https://github.com/nod-ai/amd-shark-ai/actions/runs/23000589553):

- Total BOO test section runtime: 3h 27m vs 3h 22m (excluding hipblaslt-bench)
- 8 false positives fixed, zero regressions:

```
convbfp16 -n 16 -c 2 -H 450 -W 450 -k 2 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -g 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -t 1 -b 0 -F 4
convbfp16 -n 1 -c 448 -H 1 -W 1 -k 56 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1
convbfp16 -n 1 -c 8 -H 1 -W 1 -k 224 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 2 -t 1
convbfp16 -n 2 -c 4 -H 940 -W 1450 -k 3 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 4 -t 1
convbfp16 -n 4 -c 4 -H 940 -W 1450 -k 3 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 4 -t 1
convbfp16 -n 7 -c 4 -H 940 -W 1450 -k 3 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 4 -t 1
convbfp16 -n 10 -c 4 -H 940 -W 1450 -k 3 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 4 -t 1
convbfp16 -n 12 -c 4 -H 940 -W 1450 -k 3 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 4 -t 1
```
