### PR TITLE
[Tuner] Add CompilationInfoAttr builder for iree_codegen.ConstraintsOp

### DIFF
--- a/amdsharktuner/amdsharktuner/common.py
+++ b/amdsharktuner/amdsharktuner/common.py
@@ -558,3 +558,33 @@ def calculate_padded_dimensions(
 
     any_padding_applied = M_padded != M or N_padded != N
     return M_padded, N_padded, any_padding_applied
+
+
+_AttrT = TypeVar("_AttrT", bound=ir.Attribute)
+
+
+@dataclass(frozen=True)
+class AttrKey(Generic[_AttrT]):
+    """A compilation info dictionary key with its expected MLIR attribute type."""
+
+    name: str
+    attr_type: type[_AttrT]
+
+
+class CompilationInfoKeys(ABC):
+    """Abstract base defining key name namespaces for compilation info attrs.
+
+    Backends subclass this and provide concrete LoweringConfig and
+    TranslationInfo inner classes with the string keys used in their
+    respective attribute dictionaries. This allows backend-specific
+    materializers to be written generically against the key names.
+    """
+
+    class LoweringConfig(ABC):
+        """Key names for the backend's lowering config attribute dictionary."""
+
+        pass
+
+    class TranslationInfo(ABC):
+        """Key names for the backend's translation info attribute fields."""
+        pass

--- a/amdsharktuner/amdsharktuner/common.py
+++ b/amdsharktuner/amdsharktuner/common.py
@@ -563,7 +563,7 @@ def calculate_padded_dimensions(
 _AttrT = TypeVar("_AttrT", bound=ir.Attribute)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class AttrKey(Generic[_AttrT]):
     """A compilation info dictionary key with its expected MLIR attribute type."""
 

--- a/amdsharktuner/amdsharktuner/common.py
+++ b/amdsharktuner/amdsharktuner/common.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field, asdict
 from enum import Enum
 from types import TracebackType
 from typing import Optional, Any, Callable, Protocol
-from abc import ABC
+from abc import ABC, abstractmethod
 import os
 import time
 import z3  # type: ignore
@@ -571,13 +571,12 @@ class AttrKey(Generic[_AttrT]):
     attr_type: type[_AttrT]
 
 
-class CompilationInfoKeys(ABC):
-    """Abstract base defining key name namespaces for compilation info attrs.
+class CompilationInfoBuilder(ABC):
+    """Abstract base for building compilation info attrs.
 
     Backends subclass this and provide concrete LoweringConfig and
-    TranslationInfo inner classes with the string keys used in their
-    respective attribute dictionaries. This allows backend-specific
-    materializers to be written generically against the key names.
+    TranslationInfo inner classes with key names and build logic for their
+    respective attribute dictionaries.
     """
 
     class LoweringConfig(ABC):
@@ -587,4 +586,14 @@ class CompilationInfoKeys(ABC):
 
     class TranslationInfo(ABC):
         """Key names for the backend's translation info attribute fields."""
+
         pass
+
+    @classmethod
+    @abstractmethod
+    def build_compilation_info_attr(
+        cls,
+        constraints_op: iree_codegen.ConstraintsOp,
+        knob_assignment: Any,
+    ) -> iree_codegen.CompilationInfoAttr:
+        ...

--- a/amdsharktuner/amdsharktuner/common.py
+++ b/amdsharktuner/amdsharktuner/common.py
@@ -9,7 +9,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field, asdict
 from enum import Enum
 from types import TracebackType
-from typing import Optional, Any, Callable, Protocol
+from typing import Generic, Optional, Any, Callable, Protocol, TypeVar
 from abc import ABC, abstractmethod
 import os
 import time

--- a/amdsharktuner/amdsharktuner/common.py
+++ b/amdsharktuner/amdsharktuner/common.py
@@ -560,6 +560,21 @@ def calculate_padded_dimensions(
     return M_padded, N_padded, any_padding_applied
 
 
+class KnobSymbols(dict[str, z3.ExprRef]):
+    """Maps knob names to z3 symbolic constants (pre-solving)."""
+
+    pass
+
+
+class SMTKnobAssignment(dict[str, int]):
+    """Maps knob names to integer values (post-solving)."""
+
+    # TODO(Amily): temporarily named `SMTKnobAssignment` to avoid confusion
+    # with `KnobAssignment`. Rename after constraints are refactored.
+
+    pass
+
+
 _AttrT = TypeVar("_AttrT", bound=ir.Attribute)
 
 
@@ -601,6 +616,6 @@ class CompilationInfoBuilder(ABC):
     def build_compilation_info_attr(
         cls,
         constraints_op: iree_codegen.ConstraintsOp,
-        knob_assignment: Any,
+        knob_assignment: SMTKnobAssignment,
     ) -> iree_codegen.CompilationInfoAttr:
         ...

--- a/amdsharktuner/amdsharktuner/common.py
+++ b/amdsharktuner/amdsharktuner/common.py
@@ -572,11 +572,18 @@ class AttrKey(Generic[_AttrT]):
 
 
 class CompilationInfoBuilder(ABC):
-    """Abstract base for building compilation info attrs.
+    """Abstract base for building iree_codegen.CompilationInfoAttr.
 
-    Backends subclass this and provide concrete LoweringConfig and
-    TranslationInfo inner classes with key names and build logic for their
-    respective attribute dictionaries.
+    Each backend subclass converts a ConstraintsOp and its SMT solver knob
+    assignments into a CompilationInfoAttr. The inner LoweringConfig and
+    TranslationInfo classes declare AttrKey constants that map MLIR attribute
+    key names to their expected ir attribute types.
+
+    For example, given a ConstraintsOp for GPU backend with:
+        knobs = {workgroup = #iree_codegen.smt.int_knob<"wg_m">}
+
+    The LoweringConfig subclass should declare:
+        WORKGROUP: AttrKey[ir.ArrayAttr] = AttrKey("workgroup", ir.ArrayAttr)
     """
 
     class LoweringConfig(ABC):

--- a/amdsharktuner/amdsharktuner/smt_candidate_gen.py
+++ b/amdsharktuner/amdsharktuner/smt_candidate_gen.py
@@ -43,9 +43,10 @@ def _resolve_knob_array_attr_template(
         if not isinstance(elem, iree_codegen.IntKnobAttr):
             raise ValueError(f"Unexpected element in array template entry: {elem}")
 
-        assert (
-            elem.name in knob_assignment
-        ), f"Knob '{elem.name}' not found in assignment."
+        assert elem.name in knob_assignment, (
+            f"Knob '{elem.name}' not found in assignment.\n"
+            f"Available knobs: \n{list(knob_assignment.keys())}"
+        )
         result.append(knob_assignment[elem.name])
 
     return result
@@ -286,6 +287,17 @@ def get_knobs_from_constraint_op(
     Recursively walks the knobs DictAttr, collecting the name of every
     IntKnobAttr and OneOfKnobAttr leaf. Returns one z3 Int constant per name,
     consistent with the declarations in `convert_constraints_op_to_smtlib`.
+
+    Example:
+    given knobs = {workgroup_size = #iree_codegen.smt.int_knob<"wg_m">,
+                   mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx", ["a", "b"]>}
+    returns
+    KnobSymbols(
+        {
+            "wg_m": z3.Int("wg_m"),
+            "mma_idx": z3.Int("mma_idx") # Dict key name `mma_kind` is ignored
+        }
+    ).
     """
     knob_names: list[str] = []
 

--- a/amdsharktuner/amdsharktuner/smt_candidate_gen.py
+++ b/amdsharktuner/amdsharktuner/smt_candidate_gen.py
@@ -5,57 +5,67 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 
+from typing import Iterator, Optional, override
+
 from iree.compiler import ir  # type: ignore
 from iree.compiler.dialects import iree_codegen, iree_gpu  # type: ignore
 import z3  # type: ignore
-from typing import Iterator
 
-from .common import AttrKey, CompilationInfoKeys
+from .common import AttrKey, CompilationInfoBuilder
 
 
 class KnobSymbols(dict[str, z3.ExprRef]):
     """Maps knob names to z3 symbolic constants (pre-solving)."""
+
     pass
+
 
 class KnobAssignment(dict[str, int]):
     """Maps knob names to integer values (post-solving)."""
+
     pass
 
 
-def resolve_knob_array_template_entry(
+def _resolve_knob_array_attr_template(
     template_entry: ir.ArrayAttr,
     knob_assignment: KnobAssignment,
 ) -> list[int]:
     """Resolve IntKnobAttr placeholders to knob assignment values.
-    E.g. 
+    E.g.
     template_entry = [#iree_codegen.smt.int_knob<"wg_m">, #iree_codegen.smt.int_knob<"wg_n">]
     knob_assignment = {"wg_m": 4, "wg_n": 5}
     result = [4, 5].
     """
     result: list[int] = []
     for elem in template_entry:
-        
         if not isinstance(elem, iree_codegen.IntKnobAttr):
             raise ValueError(f"Unexpected element in array template entry: {elem}")
 
-        assert elem.name in knob_assignment, f"Knob '{elem.name}' not found in assignment."
+        assert (
+            elem.name in knob_assignment
+        ), f"Knob '{elem.name}' not found in assignment."
         result.append(knob_assignment[elem.name])
 
     return result
 
 
-def i64_array_attr(vals: list[int]) -> ir.ArrayAttr:
-    """Build an ArrayAttr of i64 IntegerAttrs from a list of ints."""
-    i64 = ir.IntegerType.get_signless(64)
-    return ir.ArrayAttr.get([ir.IntegerAttr.get(i64, v) for v in vals])
+def _get_template_entry(
+    knob_template: ir.DictAttr,
+    attr_key: AttrKey,
+) -> Optional[ir.Attribute]:
+    if attr_key.name not in knob_template:
+        return None
+    template_entry = knob_template[attr_key.name]
+    assert isinstance(template_entry, attr_key.attr_type)
+    return template_entry
 
 
-class GPUCompilationInfoKeys(CompilationInfoKeys):
-    """Key names for GPU compilation info attrs, matching IREE's
+class GPUCompilationInfoBuilder(CompilationInfoBuilder):
+    """Key names and builders for GPU compilation info attrs, matching IREE's
     GPULoweringConfigUtils.cpp conventions.
     """
 
-    class LoweringConfig(CompilationInfoKeys.LoweringConfig):
+    class LoweringConfig(CompilationInfoBuilder.LoweringConfig):
         """Key names used in iree_gpu.LoweringConfigAttr's DictionaryAttr."""
 
         # Tiling levels.
@@ -74,9 +84,103 @@ class GPUCompilationInfoKeys(CompilationInfoKeys):
         SUBGROUP_BASIS_COUNTS: AttrKey[ir.ArrayAttr] = AttrKey("counts", ir.ArrayAttr)
         SUBGROUP_BASIS_MAPPING: AttrKey[ir.ArrayAttr] = AttrKey("mapping", ir.ArrayAttr)
 
-        TILING_LEVELS = (WORKGROUP, REDUCTION, THREAD, SUBGROUP)
+        @classmethod
+        def _get_i64_array_attr(cls, vals: list[int]) -> ir.ArrayAttr:
+            """Build an ArrayAttr of i64 IntegerAttrs from a list of ints."""
+            i64 = ir.IntegerType.get_signless(64)
+            return ir.ArrayAttr.get([ir.IntegerAttr.get(i64, v) for v in vals])
 
-    class TranslationInfo(CompilationInfoKeys.TranslationInfo):
+        @classmethod
+        def _add_tiling_level_config_entry(
+            cls,
+            knob_template: ir.DictAttr,
+            knob_assignment: KnobAssignment,
+            config_entries: dict[str, ir.Attribute],
+        ) -> None:
+            # Tiling levels: workgroup, reduction, thread, subgroup.
+            # template_attr: ArrayAttr<IntKnobAttr>.
+            for key in (cls.WORKGROUP, cls.REDUCTION, cls.THREAD, cls.SUBGROUP):
+                template_attr = _get_template_entry(knob_template, key)
+                if not template_attr:
+                    continue
+                config_entries[key.name] = cls._get_i64_array_attr(
+                    _resolve_knob_array_attr_template(template_attr, knob_assignment)
+                )
+
+        @classmethod
+        def _add_mma_kind_config_entry(
+            cls,
+            knob_template: ir.DictAttr,
+            knob_assignment: KnobAssignment,
+            config_entries: dict[str, ir.Attribute],
+        ) -> None:
+            # MMA kind: OneOfKnobAttr holds options; knob_assignment gives the index.
+            # mma_kind_tmpl: OneOfKnobAttr.
+            mma_kind_tmpl = _get_template_entry(knob_template, cls.MMA_KIND)
+            if not mma_kind_tmpl:
+                return
+            smt_var_name = mma_kind_tmpl.name
+            mma_idx = knob_assignment[smt_var_name]
+            config_entries[cls.MMA_KIND.name] = mma_kind_tmpl.options[mma_idx]
+
+        @classmethod
+        def _add_subgroup_basis_config_entry(
+            cls,
+            knob_template: ir.DictAttr,
+            knob_assignment: KnobAssignment,
+            config_entries: dict[str, ir.Attribute],
+        ) -> None:
+            # Subgroup basis: stored as [[counts...], [mapping...]] in the config.
+            # subgroup_basis_tmpl: DictAttr.
+            # counts_tmpl: ArrayAttr<IntKnobAttr>.
+            # mapping_tmpl: ArrayAttr<IntKnobAttr>.
+            subgroup_basis_tmpl = _get_template_entry(knob_template, cls.SUBGROUP_BASIS)
+            if not subgroup_basis_tmpl:
+                return
+            counts_tmpl = _get_template_entry(
+                subgroup_basis_tmpl, cls.SUBGROUP_BASIS_COUNTS
+            )
+            mapping_tmpl = _get_template_entry(
+                subgroup_basis_tmpl, cls.SUBGROUP_BASIS_MAPPING
+            )
+            if not counts_tmpl:
+                return
+            counts = _resolve_knob_array_attr_template(counts_tmpl, knob_assignment)
+            if not mapping_tmpl:
+                # Default mapping: [0, 1, ...].
+                mapping = list(range(len(counts)))
+            else:
+                mapping = _resolve_knob_array_attr_template(
+                    mapping_tmpl, knob_assignment
+                )
+            config_entries[cls.SUBGROUP_BASIS.name] = ir.ArrayAttr.get(
+                [cls._get_i64_array_attr(counts), cls._get_i64_array_attr(mapping)]
+            )
+
+        @classmethod
+        def build_lowering_config_attr(
+            cls,
+            constraints_op: iree_codegen.ConstraintsOp,
+            knob_assignment: KnobAssignment,
+        ) -> iree_gpu.LoweringConfigAttr:
+            knob_template: ir.DictAttr = constraints_op.knobs
+            config_entries: dict[
+                str, ir.Attribute
+            ] = {}  # built up and passed to LoweringConfigAttr.
+
+            cls._add_tiling_level_config_entry(
+                knob_template, knob_assignment, config_entries
+            )
+            cls._add_mma_kind_config_entry(
+                knob_template, knob_assignment, config_entries
+            )
+            cls._add_subgroup_basis_config_entry(
+                knob_template, knob_assignment, config_entries
+            )
+
+            return iree_gpu.LoweringConfigAttr.get(ir.DictAttr.get(config_entries))
+
+    class TranslationInfo(CompilationInfoBuilder.TranslationInfo):
         """Key names in the knobs dict for iree_codegen.TranslationInfoAttr."""
 
         WORKGROUP_SIZE: AttrKey[ir.ArrayAttr] = AttrKey("workgroup_size", ir.ArrayAttr)
@@ -84,101 +188,64 @@ class GPUCompilationInfoKeys(CompilationInfoKeys):
             "subgroup_size", iree_codegen.IntKnobAttr
         )
 
+        @classmethod
+        def _resolve_workgroup_size(
+            cls,
+            knob_template: ir.DictAttr,
+            knob_assignment: KnobAssignment,
+        ) -> Optional[list[int]]:
+            workgroup_size_tmpl = _get_template_entry(knob_template, cls.WORKGROUP_SIZE)
+            if not workgroup_size_tmpl:
+                return
+            return _resolve_knob_array_attr_template(
+                workgroup_size_tmpl, knob_assignment
+            )
 
+        @classmethod
+        def _resolve_subgroup_size(
+            cls,
+            knob_template: ir.DictAttr,
+            knob_assignment: KnobAssignment,
+        ) -> Optional[int]:
+            subgroup_size_tmpl = _get_template_entry(knob_template, cls.SUBGROUP_SIZE)
+            if not subgroup_size_tmpl:
+                return
+            return knob_assignment[subgroup_size_tmpl.name]
 
-def build_gpu_compilation_info(
-    constraints_op: iree_codegen.ConstraintsOp,
-    knob_assignment: KnobAssignment,
-) -> iree_codegen.CompilationInfoAttr:
-    """Build a concrete CompilationInfoAttr for a GPU backend.
+        @classmethod
+        def build_translation_info_attr(
+            cls,
+            constraints_op: iree_codegen.ConstraintsOp,
+            knob_assignment: KnobAssignment,
+        ) -> iree_codegen.TranslationInfoAttr:
 
-    Resolves all IntKnobAttr and OneOfKnobAttr placeholders in the knobs
-    template using `knob_assignment`, then constructs the corresponding
-    iree_gpu.LoweringConfigAttr and iree_codegen.TranslationInfoAttr.
-    """
-    lc_keys = GPUCompilationInfoKeys.LoweringConfig
-    ti_keys = GPUCompilationInfoKeys.TranslationInfo
-    knob_template: ir.DictAttr = constraints_op.knobs
-    pipeline: ir.Attribute = constraints_op.pipeline
+            knob_template: ir.DictAttr = constraints_op.knobs
 
-    # --- Build iree_gpu.LoweringConfigAttr ---
-    config_entries: dict[str, ir.Attribute] = {}  # built up and passed to LoweringConfigAttr.
+            workgroup_size = cls._resolve_workgroup_size(knob_template, knob_assignment)
+            subgroup_size = cls._resolve_subgroup_size(knob_template, knob_assignment)
 
-    # Tiling levels: workgroup, reduction, thread, subgroup.
-    for key in lc_keys.TILING_LEVELS:
-        tiling_attr = knob_template.get(key.name)
-        if tiling_attr is None:
-            continue
+            pipeline: ir.Attribute = constraints_op.pipeline
 
-        assert isinstance(tiling_attr, key.attr_type)
-        config_entries[key.name] = i64_array_attr(
-            resolve_knob_array_template_entry(tiling_attr, knob_assignment)
+            return iree_codegen.TranslationInfoAttr.get(
+                pipeline,
+                workgroup_size=workgroup_size,
+                subgroup_size=subgroup_size,
+            )
+
+    @override
+    @classmethod
+    def build_compilation_info_attr(
+        cls,
+        constraints_op: iree_codegen.ConstraintsOp,
+        knob_assignment: KnobAssignment,
+    ) -> iree_codegen.CompilationInfoAttr:
+        lowering_config = cls.LoweringConfig.build_lowering_config_attr(
+            constraints_op, knob_assignment
         )
-
-    # MMA kind: OneOfKnobAttr holds options; knob_assignment gives the index.
-    mma_template = knob_template.get(lc_keys.MMA_KIND.name)
-    if mma_template is None:
-        continue
-
-        assert isinstance(mma_template, lc_keys.MMA_KIND.attr_type)
-        idx = knob_assignment[mma_template.name]
-        options = mma_template.options
-        if idx < 0 or idx >= len(options):
-            raise ValueError(
-                f"mma_kind index {idx} out of range [0, {len(options)})."
-            )
-        # Store the selected MMA attr directly, e.g. #iree_gpu.mma<...>.
-        config_entries[lc_keys.MMA_KIND.name] = options[idx]
-
-    # Subgroup basis: stored as [[counts...], [mapping...]] in the config.
-    sg_basis_template = knob_template.get(lc_keys.SUBGROUP_BASIS.name)
-    if sg_basis_template is not None:
-        assert isinstance(sg_basis_template, lc_keys.SUBGROUP_BASIS.attr_type)
-        counts_template = sg_basis_template.get(lc_keys.SUBGROUP_BASIS_COUNTS.name)
-        if counts_template is not None:
-            assert isinstance(counts_template, lc_keys.SUBGROUP_BASIS_COUNTS.attr_type)
-            counts = resolve_knob_array_template_entry(counts_template, knob_assignment)
-            mapping_template = sg_basis_template.get(
-                lc_keys.SUBGROUP_BASIS_MAPPING.name
-            )
-            if mapping_template is not None:
-                assert isinstance(
-                    mapping_template, lc_keys.SUBGROUP_BASIS_MAPPING.attr_type
-                )
-                mapping = resolve_knob_array_template_entry(mapping_template, knob_assignment)
-            else:
-                # Default mapping: [0, 1, ...].
-                mapping = list(range(len(counts)))
-            config_entries[lc_keys.SUBGROUP_BASIS.name] = ir.ArrayAttr.get(
-                [i64_array_attr(counts), i64_array_attr(mapping)]
-            )
-
-    lowering_config = iree_gpu.LoweringConfigAttr.get(
-        ir.DictAttr.get(config_entries)
-    )
-
-    # --- Build iree_codegen.TranslationInfoAttr ---
-    # workgroup_size and subgroup_size live at the top level of the knobs dict.
-    workgroup_size: list[int] | None = None
-    subgroup_size: int | None = None
-
-    wg_size_template = knob_template.get(ti_keys.WORKGROUP_SIZE.name)
-    if wg_size_template is not None:
-        assert isinstance(wg_size_template, ti_keys.WORKGROUP_SIZE.attr_type)
-        workgroup_size = resolve_knob_array_template_entry(wg_size_template, knob_assignment)
-
-    sg_size_template = knob_template.get(ti_keys.SUBGROUP_SIZE.name)
-    if sg_size_template is not None:
-        assert isinstance(sg_size_template, ti_keys.SUBGROUP_SIZE.attr_type)
-        subgroup_size = knob_assignment.get(sg_size_template.name)
-
-    translation_info = iree_codegen.TranslationInfoAttr.get(
-        pipeline,
-        workgroup_size=workgroup_size,
-        subgroup_size=subgroup_size,
-    )
-
-    return iree_codegen.CompilationInfoAttr.get(lowering_config, translation_info)
+        translation_info = cls.TranslationInfo.build_translation_info_attr(
+            constraints_op, knob_assignment
+        )
+        return iree_codegen.CompilationInfoAttr.get(lowering_config, translation_info)
 
 
 def get_z3_assignment_from_model(
@@ -192,10 +259,10 @@ def get_z3_assignment_from_model(
             val
         ), f"Unassigned or non-concrete constant: {v} -> {val}"
         return val.as_long()
+
     return KnobAssignment(
         {name: get_z3_const_val(expr) for name, expr in z3_const_exprs.items()}
     )
-
 
 
 def get_knobs_from_constraint_op(
@@ -239,7 +306,9 @@ def get_knobs_from_constraint_op(
 def generate_solutions_from_constraint_op(
     constraints_op: iree_codegen.ConstraintsOp,
 ) -> Iterator[KnobAssignment]:
-    smtlib = iree_codegen.convert_constraints_op_to_smtlib(constraints_op, emit_reset=False)
+    smtlib = iree_codegen.convert_constraints_op_to_smtlib(
+        constraints_op, emit_reset=False
+    )
 
     z3_const_exprs = get_knobs_from_constraint_op(constraints_op)
     z3_vars = list(z3_const_exprs.values())
@@ -251,8 +320,6 @@ def generate_solutions_from_constraint_op(
         model = solver.model()
 
         # Add new constraints to find the next solution.
-        solver.add(
-            z3.Or([v != model.eval(v, model_completion=True) for v in z3_vars])
-        )
+        solver.add(z3.Or([v != model.eval(v, model_completion=True) for v in z3_vars]))
 
         yield get_z3_assignment_from_model(model, z3_const_exprs)

--- a/amdsharktuner/amdsharktuner/smt_candidate_gen.py
+++ b/amdsharktuner/amdsharktuner/smt_candidate_gen.py
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-
+import logging
 from typing import Iterator, Optional
 from typing_extensions import override
 
@@ -13,6 +13,9 @@ from iree.compiler.dialects import iree_codegen, iree_gpu  # type: ignore
 import z3  # type: ignore
 
 from .common import AttrKey, CompilationInfoBuilder
+
+
+logger = logging.getLogger("smt_candidate_gen")
 
 
 class KnobSymbols(dict[str, z3.ExprRef]):
@@ -341,7 +344,8 @@ def generate_solutions_from_constraint_op(
         constraints_op, emit_reset=False
     )
     # Prevent solving hangs.
-    assert "(reset)" not in smtlib, "Unexpected reset in SMTLIB."
+    if "(reset)" in smtlib:
+        raise RuntimeError(f"Unexpected reset string in SMTLIB: \n{smtlib}")
 
     z3_const_exprs = get_knobs_from_constraint_op(constraints_op, z3_ctx)
     z3_vars = list(z3_const_exprs.values())
@@ -349,10 +353,14 @@ def generate_solutions_from_constraint_op(
     solver = z3.Solver(ctx=z3_ctx)
     solver.add(z3.parse_smt2_string(smtlib, ctx=z3_ctx))
 
+    count = 0
     while solver.check() == z3.sat:
         model = solver.model()
 
         # Add new constraints to find the next solution.
         solver.add(z3.Or([v != model.eval(v, model_completion=True) for v in z3_vars]))
 
-        yield get_z3_assignment_from_model(model, z3_const_exprs)
+        z3_assignment = get_z3_assignment_from_model(model, z3_const_exprs)
+        count += 1
+        logger.debug(f"Solution #{count}: {z3_assignment}")
+        yield z3_assignment

--- a/amdsharktuner/amdsharktuner/smt_candidate_gen.py
+++ b/amdsharktuner/amdsharktuner/smt_candidate_gen.py
@@ -312,6 +312,7 @@ def get_knobs_from_constraint_op(
         }
     ).
     """
+    ctx = z3.Context()
     knob_names: list[str] = []
 
     def collect(attr: ir.Attribute) -> None:
@@ -329,7 +330,7 @@ def get_knobs_from_constraint_op(
             raise TypeError(f"Unknown knob attribute type: {type(attr)}")
 
     collect(constraints_op.knobs)
-    return KnobSymbols({name: z3.Int(name) for name in knob_names})
+    return KnobSymbols({name: z3.Int(name, ctx=ctx) for name in knob_names})
 
 
 def generate_solutions_from_constraint_op(

--- a/amdsharktuner/amdsharktuner/smt_candidate_gen.py
+++ b/amdsharktuner/amdsharktuner/smt_candidate_gen.py
@@ -268,12 +268,11 @@ def get_z3_assignment_from_model(
 def get_knobs_from_constraint_op(
     constraints_op: iree_codegen.ConstraintsOp,
 ) -> KnobSymbols:
-    """Extract all SMT knob names from a ConstraintsOp and create z3 constants.
+    """Extract knob names from a ConstraintsOp and return z3 Int constants.
 
     Recursively walks the knobs DictAttr, collecting the name of every
-    IntKnobAttr and OneOfKnobAttr leaf. Returns a map from each name to a
-    fresh z3 Int constant with the same name, matching the SMT-LIB declarations
-    produced by `convert_constraints_op_to_smtlib`.
+    IntKnobAttr and OneOfKnobAttr leaf. Returns one z3 Int constant per name,
+    consistent with the declarations in `convert_constraints_op_to_smtlib`.
     """
     knob_names: list[str] = []
 
@@ -309,6 +308,8 @@ def generate_solutions_from_constraint_op(
     smtlib = iree_codegen.convert_constraints_op_to_smtlib(
         constraints_op, emit_reset=False
     )
+    # Prevent solving hangs.
+    assert "(reset)" is not in smtlib, "Unexpected reset in SMTLIB."
 
     z3_const_exprs = get_knobs_from_constraint_op(constraints_op)
     z3_vars = list(z3_const_exprs.values())

--- a/amdsharktuner/amdsharktuner/smt_candidate_gen.py
+++ b/amdsharktuner/amdsharktuner/smt_candidate_gen.py
@@ -1,0 +1,258 @@
+# Copyright 2026 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+from iree.compiler import ir  # type: ignore
+from iree.compiler.dialects import iree_codegen, iree_gpu  # type: ignore
+import z3  # type: ignore
+from typing import Iterator
+
+from .common import AttrKey, CompilationInfoKeys
+
+
+class KnobSymbols(dict[str, z3.ExprRef]):
+    """Maps knob names to z3 symbolic constants (pre-solving)."""
+    pass
+
+class KnobAssignment(dict[str, int]):
+    """Maps knob names to integer values (post-solving)."""
+    pass
+
+
+def resolve_knob_array_template_entry(
+    template_entry: ir.ArrayAttr,
+    knob_assignment: KnobAssignment,
+) -> list[int]:
+    """Resolve IntKnobAttr placeholders to knob assignment values.
+    E.g. 
+    template_entry = [#iree_codegen.smt.int_knob<"wg_m">, #iree_codegen.smt.int_knob<"wg_n">]
+    knob_assignment = {"wg_m": 4, "wg_n": 5}
+    result = [4, 5].
+    """
+    result: list[int] = []
+    for elem in template_entry:
+        
+        if not isinstance(elem, iree_codegen.IntKnobAttr):
+            raise ValueError(f"Unexpected element in array template entry: {elem}")
+
+        assert elem.name in knob_assignment, f"Knob '{elem.name}' not found in assignment."
+        result.append(knob_assignment[elem.name])
+
+    return result
+
+
+def i64_array_attr(vals: list[int]) -> ir.ArrayAttr:
+    """Build an ArrayAttr of i64 IntegerAttrs from a list of ints."""
+    i64 = ir.IntegerType.get_signless(64)
+    return ir.ArrayAttr.get([ir.IntegerAttr.get(i64, v) for v in vals])
+
+
+class GPUCompilationInfoKeys(CompilationInfoKeys):
+    """Key names for GPU compilation info attrs, matching IREE's
+    GPULoweringConfigUtils.cpp conventions.
+    """
+
+    class LoweringConfig(CompilationInfoKeys.LoweringConfig):
+        """Key names used in iree_gpu.LoweringConfigAttr's DictionaryAttr."""
+
+        # Tiling levels.
+        WORKGROUP: AttrKey[ir.ArrayAttr] = AttrKey("workgroup", ir.ArrayAttr)
+        REDUCTION: AttrKey[ir.ArrayAttr] = AttrKey("reduction", ir.ArrayAttr)
+        THREAD: AttrKey[ir.ArrayAttr] = AttrKey("thread", ir.ArrayAttr)
+        SUBGROUP: AttrKey[ir.ArrayAttr] = AttrKey("subgroup", ir.ArrayAttr)
+
+        # MMA intrinsic: OneOfKnobAttr index selects from the options array.
+        MMA_KIND: AttrKey[iree_codegen.OneOfKnobAttr] = AttrKey(
+            "mma_kind", iree_codegen.OneOfKnobAttr
+        )
+
+        # Subgroup basis: stored as [[counts...], [mapping...]] (two i64 arrays).
+        SUBGROUP_BASIS: AttrKey[ir.DictAttr] = AttrKey("subgroup_basis", ir.DictAttr)
+        SUBGROUP_BASIS_COUNTS: AttrKey[ir.ArrayAttr] = AttrKey("counts", ir.ArrayAttr)
+        SUBGROUP_BASIS_MAPPING: AttrKey[ir.ArrayAttr] = AttrKey("mapping", ir.ArrayAttr)
+
+        TILING_LEVELS = (WORKGROUP, REDUCTION, THREAD, SUBGROUP)
+
+    class TranslationInfo(CompilationInfoKeys.TranslationInfo):
+        """Key names in the knobs dict for iree_codegen.TranslationInfoAttr."""
+
+        WORKGROUP_SIZE: AttrKey[ir.ArrayAttr] = AttrKey("workgroup_size", ir.ArrayAttr)
+        SUBGROUP_SIZE: AttrKey[iree_codegen.IntKnobAttr] = AttrKey(
+            "subgroup_size", iree_codegen.IntKnobAttr
+        )
+
+
+
+def build_gpu_compilation_info(
+    constraints_op: iree_codegen.ConstraintsOp,
+    knob_assignment: KnobAssignment,
+) -> iree_codegen.CompilationInfoAttr:
+    """Build a concrete CompilationInfoAttr for a GPU backend.
+
+    Resolves all IntKnobAttr and OneOfKnobAttr placeholders in the knobs
+    template using `knob_assignment`, then constructs the corresponding
+    iree_gpu.LoweringConfigAttr and iree_codegen.TranslationInfoAttr.
+    """
+    lc_keys = GPUCompilationInfoKeys.LoweringConfig
+    ti_keys = GPUCompilationInfoKeys.TranslationInfo
+    knob_template: ir.DictAttr = constraints_op.knobs
+    pipeline: ir.Attribute = constraints_op.pipeline
+
+    # --- Build iree_gpu.LoweringConfigAttr ---
+    config_entries: dict[str, ir.Attribute] = {}  # built up and passed to LoweringConfigAttr.
+
+    # Tiling levels: workgroup, reduction, thread, subgroup.
+    for key in lc_keys.TILING_LEVELS:
+        tiling_attr = knob_template.get(key.name)
+        if tiling_attr is None:
+            continue
+
+        assert isinstance(tiling_attr, key.attr_type)
+        config_entries[key.name] = i64_array_attr(
+            resolve_knob_array_template_entry(tiling_attr, knob_assignment)
+        )
+
+    # MMA kind: OneOfKnobAttr holds options; knob_assignment gives the index.
+    mma_template = knob_template.get(lc_keys.MMA_KIND.name)
+    if mma_template is None:
+        continue
+
+        assert isinstance(mma_template, lc_keys.MMA_KIND.attr_type)
+        idx = knob_assignment[mma_template.name]
+        options = mma_template.options
+        if idx < 0 or idx >= len(options):
+            raise ValueError(
+                f"mma_kind index {idx} out of range [0, {len(options)})."
+            )
+        # Store the selected MMA attr directly, e.g. #iree_gpu.mma<...>.
+        config_entries[lc_keys.MMA_KIND.name] = options[idx]
+
+    # Subgroup basis: stored as [[counts...], [mapping...]] in the config.
+    sg_basis_template = knob_template.get(lc_keys.SUBGROUP_BASIS.name)
+    if sg_basis_template is not None:
+        assert isinstance(sg_basis_template, lc_keys.SUBGROUP_BASIS.attr_type)
+        counts_template = sg_basis_template.get(lc_keys.SUBGROUP_BASIS_COUNTS.name)
+        if counts_template is not None:
+            assert isinstance(counts_template, lc_keys.SUBGROUP_BASIS_COUNTS.attr_type)
+            counts = resolve_knob_array_template_entry(counts_template, knob_assignment)
+            mapping_template = sg_basis_template.get(
+                lc_keys.SUBGROUP_BASIS_MAPPING.name
+            )
+            if mapping_template is not None:
+                assert isinstance(
+                    mapping_template, lc_keys.SUBGROUP_BASIS_MAPPING.attr_type
+                )
+                mapping = resolve_knob_array_template_entry(mapping_template, knob_assignment)
+            else:
+                # Default mapping: [0, 1, ...].
+                mapping = list(range(len(counts)))
+            config_entries[lc_keys.SUBGROUP_BASIS.name] = ir.ArrayAttr.get(
+                [i64_array_attr(counts), i64_array_attr(mapping)]
+            )
+
+    lowering_config = iree_gpu.LoweringConfigAttr.get(
+        ir.DictAttr.get(config_entries)
+    )
+
+    # --- Build iree_codegen.TranslationInfoAttr ---
+    # workgroup_size and subgroup_size live at the top level of the knobs dict.
+    workgroup_size: list[int] | None = None
+    subgroup_size: int | None = None
+
+    wg_size_template = knob_template.get(ti_keys.WORKGROUP_SIZE.name)
+    if wg_size_template is not None:
+        assert isinstance(wg_size_template, ti_keys.WORKGROUP_SIZE.attr_type)
+        workgroup_size = resolve_knob_array_template_entry(wg_size_template, knob_assignment)
+
+    sg_size_template = knob_template.get(ti_keys.SUBGROUP_SIZE.name)
+    if sg_size_template is not None:
+        assert isinstance(sg_size_template, ti_keys.SUBGROUP_SIZE.attr_type)
+        subgroup_size = knob_assignment.get(sg_size_template.name)
+
+    translation_info = iree_codegen.TranslationInfoAttr.get(
+        pipeline,
+        workgroup_size=workgroup_size,
+        subgroup_size=subgroup_size,
+    )
+
+    return iree_codegen.CompilationInfoAttr.get(lowering_config, translation_info)
+
+
+def get_z3_assignment_from_model(
+    model: z3.ModelRef,
+    z3_const_exprs: KnobSymbols,
+) -> KnobAssignment:
+    def get_z3_const_val(v: z3.ExprRef) -> int:
+        # Evaluate arbitrary expressions over a model, convert z3 expr to int.
+        val = model.eval(v)
+        assert z3.is_int_value(
+            val
+        ), f"Unassigned or non-concrete constant: {v} -> {val}"
+        return val.as_long()
+    return KnobAssignment(
+        {name: get_z3_const_val(expr) for name, expr in z3_const_exprs.items()}
+    )
+
+
+
+def get_knobs_from_constraint_op(
+    constraints_op: iree_codegen.ConstraintsOp,
+) -> KnobSymbols:
+    """Extract all SMT knob names from a ConstraintsOp and create z3 constants.
+
+    Recursively walks the knobs DictAttr, collecting the name of every
+    IntKnobAttr and OneOfKnobAttr leaf. Returns a map from each name to a
+    fresh z3 Int constant with the same name, matching the SMT-LIB declarations
+    produced by `convert_constraints_op_to_smtlib`.
+    """
+    knob_names: list[str] = []
+
+    def collect(attr: ir.Attribute) -> None:
+        if isinstance(attr, iree_codegen.IntKnobAttr):
+            # E.g. #iree_codegen.smt.int_knob<"wg_m">.
+            knob_names.append(attr.name)  # e.g. "wg_m"
+        elif isinstance(attr, iree_codegen.OneOfKnobAttr):
+            # E.g. #iree_codegen.smt.one_of_knob<"mma_idx", [...]>.
+            knob_names.append(attr.name)  # e.g. "mma_idx"
+        elif isinstance(attr, ir.ArrayAttr):
+            # E.g. workgroup = [#iree_codegen.smt.int_knob<"wg_m">,
+            #                   #iree_codegen.smt.int_knob<"wg_n">].
+            for elem in attr:
+                collect(elem)
+        elif isinstance(attr, ir.DictAttr):
+            # E.g. subgroup_basis = {counts = [#iree_codegen.smt.int_knob<"sg_x">,
+            #                                   #iree_codegen.smt.int_knob<"sg_y">],
+            #                        mapping = [0, 1]},
+            # where entry.name = "counts", entry.attr = [...].
+            for entry in attr:
+                collect(entry.attr)
+        else:
+            raise ValueError(f"Unknown knob attribute type: {type(attr)}")
+
+    collect(constraints_op.knobs)
+    return KnobSymbols({name: z3.Int(name) for name in knob_names})
+
+
+def generate_solutions_from_constraint_op(
+    constraints_op: iree_codegen.ConstraintsOp,
+) -> Iterator[KnobAssignment]:
+    smtlib = iree_codegen.convert_constraints_op_to_smtlib(constraints_op, emit_reset=False)
+
+    z3_const_exprs = get_knobs_from_constraint_op(constraints_op)
+    z3_vars = list(z3_const_exprs.values())
+
+    solver = z3.Solver()
+    solver.add(z3.parse_smt2_string(smtlib))
+
+    while solver.check() == z3.sat:
+        model = solver.model()
+
+        # Add new constraints to find the next solution.
+        solver.add(
+            z3.Or([v != model.eval(v, model_completion=True) for v in z3_vars])
+        )
+
+        yield get_z3_assignment_from_model(model, z3_const_exprs)

--- a/amdsharktuner/amdsharktuner/smt_candidate_gen.py
+++ b/amdsharktuner/amdsharktuner/smt_candidate_gen.py
@@ -284,6 +284,7 @@ def get_z3_assignment_from_model(
 
 def get_knobs_from_constraint_op(
     constraints_op: iree_codegen.ConstraintsOp,
+    z3_ctx: z3.Context,
 ) -> KnobSymbols:
     """Extract knob names from a ConstraintsOp and return z3 Int constants.
 
@@ -312,7 +313,6 @@ def get_knobs_from_constraint_op(
         }
     ).
     """
-    ctx = z3.Context()
     knob_names: list[str] = []
 
     def collect(attr: ir.Attribute) -> None:
@@ -330,11 +330,13 @@ def get_knobs_from_constraint_op(
             raise TypeError(f"Unknown knob attribute type: {type(attr)}")
 
     collect(constraints_op.knobs)
-    return KnobSymbols({name: z3.Int(name, ctx=ctx) for name in knob_names})
+
+    return KnobSymbols({name: z3.Int(name, ctx=z3_ctx) for name in knob_names})
 
 
 def generate_solutions_from_constraint_op(
     constraints_op: iree_codegen.ConstraintsOp,
+    z3_ctx: Optional[z3.Context] = None,
 ) -> Iterator[SMTKnobAssignment]:
     smtlib = iree_codegen.convert_constraints_op_to_smtlib(
         constraints_op, emit_reset=False
@@ -342,11 +344,11 @@ def generate_solutions_from_constraint_op(
     # Prevent solving hangs.
     assert "(reset)" not in smtlib, "Unexpected reset in SMTLIB."
 
-    z3_const_exprs = get_knobs_from_constraint_op(constraints_op)
+    z3_const_exprs = get_knobs_from_constraint_op(constraints_op, z3_ctx)
     z3_vars = list(z3_const_exprs.values())
 
-    solver = z3.Solver()
-    solver.add(z3.parse_smt2_string(smtlib))
+    solver = z3.Solver(ctx=z3_ctx)
+    solver.add(z3.parse_smt2_string(smtlib, ctx=z3_ctx))
 
     while solver.check() == z3.sat:
         model = solver.model()

--- a/amdsharktuner/amdsharktuner/smt_candidate_gen.py
+++ b/amdsharktuner/amdsharktuner/smt_candidate_gen.py
@@ -291,11 +291,21 @@ def get_knobs_from_constraint_op(
     Example:
     given knobs = {workgroup_size = #iree_codegen.smt.int_knob<"wg_m">,
                    mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx", ["a", "b"]>}
+                   subgroup_basis = {
+                       counts = [#iree_codegen.smt.int_knob<"sg_x">,
+                                 #iree_codegen.smt.int_knob<"sg_y">],
+                       mapping = [#iree_codegen.smt.int_knob<"map_0">,
+                                  #iree_codegen.smt.int_knob<"map_1">]
+                    }
     returns
     KnobSymbols(
         {
             "wg_m": z3.Int("wg_m"),
-            "mma_idx": z3.Int("mma_idx") # Dict key name `mma_kind` is ignored
+            "mma_idx": z3.Int("mma_idx")
+            "sg_x": z3.Int("sg_x"),
+            "sg_y": z3.Int("sg_y"),
+            "map_0": z3.Int("map_0"),
+            "map_1": z3.Int("map_1"),
         }
     ).
     """
@@ -303,22 +313,13 @@ def get_knobs_from_constraint_op(
 
     def collect(attr: ir.Attribute) -> None:
         if isinstance(attr, iree_codegen.IntKnobAttr):
-            # E.g. #iree_codegen.smt.int_knob<"wg_m">.
-            knob_names.append(attr.name)  # E.g. "wg_m".
+            knob_names.append(attr.name)
         elif isinstance(attr, iree_codegen.OneOfKnobAttr):
-            # E.g. #iree_codegen.smt.one_of_knob<"mma_idx", [...]>.
-            knob_names.append(attr.name)  # E.g. "mma_idx".
+            knob_names.append(attr.name)
         elif isinstance(attr, ir.ArrayAttr):
-            # E.g. workgroup = [#iree_codegen.smt.int_knob<"wg_m">,
-            #                   #iree_codegen.smt.int_knob<"wg_n">].
             for elem in attr:
                 collect(elem)
         elif isinstance(attr, ir.DictAttr):
-            # E.g. subgroup_basis = {
-            #   counts = [#iree_codegen.smt.int_knob<"sg_x">,
-            #             #iree_codegen.smt.int_knob<"sg_y">],
-            #   mapping = [0, 1]},
-            # where entry.name = "counts", entry.attr = [...].
             for entry in attr:
                 collect(entry.attr)
         else:

--- a/amdsharktuner/amdsharktuner/smt_candidate_gen.py
+++ b/amdsharktuner/amdsharktuner/smt_candidate_gen.py
@@ -5,7 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 
-from typing import Iterator, Optional, override
+from typing import Iterator, Optional
+from typing_extensions import override
 
 from iree.compiler import ir  # type: ignore
 from iree.compiler.dialects import iree_codegen, iree_gpu  # type: ignore

--- a/amdsharktuner/amdsharktuner/smt_candidate_gen.py
+++ b/amdsharktuner/amdsharktuner/smt_candidate_gen.py
@@ -41,7 +41,7 @@ def _resolve_knob_array_attr_template(
     result: list[int] = []
     for elem in template_entry:
         if not isinstance(elem, iree_codegen.IntKnobAttr):
-            raise ValueError(f"Unexpected element in array template entry: {elem}")
+            raise TypeError(f"Unexpected element in array template entry: {elem}")
 
         assert elem.name in knob_assignment, (
             f"Knob '{elem.name}' not found in assignment.\n"
@@ -322,7 +322,7 @@ def get_knobs_from_constraint_op(
             for entry in attr:
                 collect(entry.attr)
         else:
-            raise ValueError(f"Unknown knob attribute type: {type(attr)}")
+            raise TypeError(f"Unknown knob attribute type: {type(attr)}")
 
     collect(constraints_op.knobs)
     return KnobSymbols({name: z3.Int(name) for name in knob_names})

--- a/amdsharktuner/amdsharktuner/smt_candidate_gen.py
+++ b/amdsharktuner/amdsharktuner/smt_candidate_gen.py
@@ -21,15 +21,18 @@ class KnobSymbols(dict[str, z3.ExprRef]):
     pass
 
 
-class KnobAssignment(dict[str, int]):
+class SMTKnobAssignment(dict[str, int]):
     """Maps knob names to integer values (post-solving)."""
+
+    # TODO(Amily): temporarily named `SMTKnobAssignment` to avoid confusion
+    # with `common.KnobAssignment`. Rename after constraints are refactored.
 
     pass
 
 
 def _resolve_knob_array_attr_template(
     template_entry: ir.ArrayAttr,
-    knob_assignment: KnobAssignment,
+    knob_assignment: SMTKnobAssignment,
 ) -> list[int]:
     """Resolve IntKnobAttr placeholders to knob assignment values.
     E.g.
@@ -108,7 +111,7 @@ class GPUCompilationInfoBuilder(CompilationInfoBuilder):
         def _add_tiling_level_config_entry(
             cls,
             knob_template: ir.DictAttr,
-            knob_assignment: KnobAssignment,
+            knob_assignment: SMTKnobAssignment,
             config_entries: dict[str, ir.Attribute],
         ) -> None:
             # Tiling levels: workgroup, reduction, thread, subgroup.
@@ -125,7 +128,7 @@ class GPUCompilationInfoBuilder(CompilationInfoBuilder):
         def _add_mma_kind_config_entry(
             cls,
             knob_template: ir.DictAttr,
-            knob_assignment: KnobAssignment,
+            knob_assignment: SMTKnobAssignment,
             config_entries: dict[str, ir.Attribute],
         ) -> None:
             # MMA kind: OneOfKnobAttr holds options; knob_assignment gives the index.
@@ -141,7 +144,7 @@ class GPUCompilationInfoBuilder(CompilationInfoBuilder):
         def _add_subgroup_basis_config_entry(
             cls,
             knob_template: ir.DictAttr,
-            knob_assignment: KnobAssignment,
+            knob_assignment: SMTKnobAssignment,
             config_entries: dict[str, ir.Attribute],
         ) -> None:
             # Subgroup basis: stored as [[counts...], [mapping...]] in the config.
@@ -175,7 +178,7 @@ class GPUCompilationInfoBuilder(CompilationInfoBuilder):
         def build_lowering_config_attr(
             cls,
             constraints_op: iree_codegen.ConstraintsOp,
-            knob_assignment: KnobAssignment,
+            knob_assignment: SMTKnobAssignment,
         ) -> iree_gpu.LoweringConfigAttr:
             knob_template: ir.DictAttr = constraints_op.knobs
             config_entries: dict[
@@ -206,7 +209,7 @@ class GPUCompilationInfoBuilder(CompilationInfoBuilder):
         def _resolve_workgroup_size(
             cls,
             knob_template: ir.DictAttr,
-            knob_assignment: KnobAssignment,
+            knob_assignment: SMTKnobAssignment,
         ) -> Optional[list[int]]:
             workgroup_size_tmpl = _get_template_entry(knob_template, cls.WORKGROUP_SIZE)
             if not workgroup_size_tmpl:
@@ -219,7 +222,7 @@ class GPUCompilationInfoBuilder(CompilationInfoBuilder):
         def _resolve_subgroup_size(
             cls,
             knob_template: ir.DictAttr,
-            knob_assignment: KnobAssignment,
+            knob_assignment: SMTKnobAssignment,
         ) -> Optional[int]:
             subgroup_size_tmpl = _get_template_entry(knob_template, cls.SUBGROUP_SIZE)
             if not subgroup_size_tmpl:
@@ -230,7 +233,7 @@ class GPUCompilationInfoBuilder(CompilationInfoBuilder):
         def build_translation_info_attr(
             cls,
             constraints_op: iree_codegen.ConstraintsOp,
-            knob_assignment: KnobAssignment,
+            knob_assignment: SMTKnobAssignment,
         ) -> iree_codegen.TranslationInfoAttr:
 
             knob_template: ir.DictAttr = constraints_op.knobs
@@ -251,7 +254,7 @@ class GPUCompilationInfoBuilder(CompilationInfoBuilder):
     def build_compilation_info_attr(
         cls,
         constraints_op: iree_codegen.ConstraintsOp,
-        knob_assignment: KnobAssignment,
+        knob_assignment: SMTKnobAssignment,
     ) -> iree_codegen.CompilationInfoAttr:
         lowering_config = cls.LoweringConfig.build_lowering_config_attr(
             constraints_op, knob_assignment
@@ -265,7 +268,7 @@ class GPUCompilationInfoBuilder(CompilationInfoBuilder):
 def get_z3_assignment_from_model(
     model: z3.ModelRef,
     z3_const_exprs: KnobSymbols,
-) -> KnobAssignment:
+) -> SMTKnobAssignment:
     def get_z3_const_val(v: z3.ExprRef) -> int:
         # Evaluate arbitrary expressions over a model, convert z3 expr to int.
         val = model.eval(v)
@@ -274,7 +277,7 @@ def get_z3_assignment_from_model(
         ), f"Unassigned or non-concrete constant: {v} -> {val}"
         return val.as_long()
 
-    return KnobAssignment(
+    return SMTKnobAssignment(
         {name: get_z3_const_val(expr) for name, expr in z3_const_exprs.items()}
     )
 
@@ -331,7 +334,7 @@ def get_knobs_from_constraint_op(
 
 def generate_solutions_from_constraint_op(
     constraints_op: iree_codegen.ConstraintsOp,
-) -> Iterator[KnobAssignment]:
+) -> Iterator[SMTKnobAssignment]:
     smtlib = iree_codegen.convert_constraints_op_to_smtlib(
         constraints_op, emit_reset=False
     )

--- a/amdsharktuner/amdsharktuner/smt_candidate_gen.py
+++ b/amdsharktuner/amdsharktuner/smt_candidate_gen.py
@@ -32,7 +32,8 @@ def _resolve_knob_array_attr_template(
 ) -> list[int]:
     """Resolve IntKnobAttr placeholders to knob assignment values.
     E.g.
-    template_entry = [#iree_codegen.smt.int_knob<"wg_m">, #iree_codegen.smt.int_knob<"wg_n">]
+    template_entry = [#iree_codegen.smt.int_knob<"wg_m">,
+                      #iree_codegen.smt.int_knob<"wg_n">]
     knob_assignment = {"wg_m": 4, "wg_n": 5}
     result = [4, 5].
     """
@@ -53,6 +54,17 @@ def _get_template_entry(
     knob_template: ir.DictAttr,
     attr_key: AttrKey,
 ) -> Optional[ir.Attribute]:
+    """Return the knob entry for `attr_key` if present.
+
+    E.g.
+    knob_template = {wg_m = #iree_codegen.smt.int_knob<"wg_m">,
+                     mma = #iree_codegen.smt.one_of_knob<"mma", ["a", "b"]>}
+    attr_key = AttrKey("wg_n", IntKnobAttr)
+    result = None.
+    attr_key = AttrKey("mma", OneOfKnobAttr)
+    result = #iree_codegen.smt.one_of_knob<"mma", ["a", "b"]>.
+
+    """
     if attr_key.name not in knob_template:
         return None
     template_entry = knob_template[attr_key.name]
@@ -166,7 +178,7 @@ class GPUCompilationInfoBuilder(CompilationInfoBuilder):
             knob_template: ir.DictAttr = constraints_op.knobs
             config_entries: dict[
                 str, ir.Attribute
-            ] = {}  # built up and passed to LoweringConfigAttr.
+            ] = {}  # Built up and passed to LoweringConfigAttr.
 
             cls._add_tiling_level_config_entry(
                 knob_template, knob_assignment, config_entries
@@ -196,7 +208,7 @@ class GPUCompilationInfoBuilder(CompilationInfoBuilder):
         ) -> Optional[list[int]]:
             workgroup_size_tmpl = _get_template_entry(knob_template, cls.WORKGROUP_SIZE)
             if not workgroup_size_tmpl:
-                return
+                return None
             return _resolve_knob_array_attr_template(
                 workgroup_size_tmpl, knob_assignment
             )
@@ -209,7 +221,7 @@ class GPUCompilationInfoBuilder(CompilationInfoBuilder):
         ) -> Optional[int]:
             subgroup_size_tmpl = _get_template_entry(knob_template, cls.SUBGROUP_SIZE)
             if not subgroup_size_tmpl:
-                return
+                return None
             return knob_assignment[subgroup_size_tmpl.name]
 
         @classmethod
@@ -279,19 +291,20 @@ def get_knobs_from_constraint_op(
     def collect(attr: ir.Attribute) -> None:
         if isinstance(attr, iree_codegen.IntKnobAttr):
             # E.g. #iree_codegen.smt.int_knob<"wg_m">.
-            knob_names.append(attr.name)  # e.g. "wg_m"
+            knob_names.append(attr.name)  # E.g. "wg_m".
         elif isinstance(attr, iree_codegen.OneOfKnobAttr):
             # E.g. #iree_codegen.smt.one_of_knob<"mma_idx", [...]>.
-            knob_names.append(attr.name)  # e.g. "mma_idx"
+            knob_names.append(attr.name)  # E.g. "mma_idx".
         elif isinstance(attr, ir.ArrayAttr):
             # E.g. workgroup = [#iree_codegen.smt.int_knob<"wg_m">,
             #                   #iree_codegen.smt.int_knob<"wg_n">].
             for elem in attr:
                 collect(elem)
         elif isinstance(attr, ir.DictAttr):
-            # E.g. subgroup_basis = {counts = [#iree_codegen.smt.int_knob<"sg_x">,
-            #                                   #iree_codegen.smt.int_knob<"sg_y">],
-            #                        mapping = [0, 1]},
+            # E.g. subgroup_basis = {
+            #   counts = [#iree_codegen.smt.int_knob<"sg_x">,
+            #             #iree_codegen.smt.int_knob<"sg_y">],
+            #   mapping = [0, 1]},
             # where entry.name = "counts", entry.attr = [...].
             for entry in attr:
                 collect(entry.attr)
@@ -309,7 +322,7 @@ def generate_solutions_from_constraint_op(
         constraints_op, emit_reset=False
     )
     # Prevent solving hangs.
-    assert "(reset)" is not in smtlib, "Unexpected reset in SMTLIB."
+    assert "(reset)" not in smtlib, "Unexpected reset in SMTLIB."
 
     z3_const_exprs = get_knobs_from_constraint_op(constraints_op)
     z3_vars = list(z3_const_exprs.values())

--- a/amdsharktuner/amdsharktuner/smt_candidate_gen.py
+++ b/amdsharktuner/amdsharktuner/smt_candidate_gen.py
@@ -316,18 +316,17 @@ def get_knobs_from_constraint_op(
     knob_names: list[str] = []
 
     def collect(attr: ir.Attribute) -> None:
-        if isinstance(attr, iree_codegen.IntKnobAttr):
-            knob_names.append(attr.name)
-        elif isinstance(attr, iree_codegen.OneOfKnobAttr):
-            knob_names.append(attr.name)
-        elif isinstance(attr, ir.ArrayAttr):
-            for elem in attr:
-                collect(elem)
-        elif isinstance(attr, ir.DictAttr):
-            for entry in attr:
-                collect(entry.attr)
-        else:
-            raise TypeError(f"Unknown knob attribute type: {type(attr)}")
+        match attr:
+            case iree_codegen.IntKnobAttr() | iree_codegen.OneOfKnobAttr():
+                knob_names.append(attr.name)
+            case ir.ArrayAttr():
+                for elem in attr:
+                    collect(elem)
+            case ir.DictAttr():
+                for entry in attr:
+                    collect(entry.attr)
+            case _:
+                raise TypeError(f"Unknown knob attribute type: {type(attr)}")
 
     collect(constraints_op.knobs)
 

--- a/amdsharktuner/amdsharktuner/smt_candidate_gen.py
+++ b/amdsharktuner/amdsharktuner/smt_candidate_gen.py
@@ -12,25 +12,15 @@ from iree.compiler import ir  # type: ignore
 from iree.compiler.dialects import iree_codegen, iree_gpu  # type: ignore
 import z3  # type: ignore
 
-from .common import AttrKey, CompilationInfoBuilder
+from .common import (
+    AttrKey,
+    CompilationInfoBuilder,
+    KnobSymbols,
+    SMTKnobAssignment,
+)
 
 
 logger = logging.getLogger("smt_candidate_gen")
-
-
-class KnobSymbols(dict[str, z3.ExprRef]):
-    """Maps knob names to z3 symbolic constants (pre-solving)."""
-
-    pass
-
-
-class SMTKnobAssignment(dict[str, int]):
-    """Maps knob names to integer values (post-solving)."""
-
-    # TODO(Amily): temporarily named `SMTKnobAssignment` to avoid confusion
-    # with `common.KnobAssignment`. Rename after constraints are refactored.
-
-    pass
 
 
 def _resolve_knob_array_attr_template(
@@ -106,7 +96,6 @@ class GPUCompilationInfoBuilder(CompilationInfoBuilder):
 
         @classmethod
         def _get_i64_array_attr(cls, vals: list[int]) -> ir.ArrayAttr:
-            """Build an ArrayAttr of i64 IntegerAttrs from a list of ints."""
             i64 = ir.IntegerType.get_signless(64)
             return ir.ArrayAttr.get([ir.IntegerAttr.get(i64, v) for v in vals])
 
@@ -117,7 +106,6 @@ class GPUCompilationInfoBuilder(CompilationInfoBuilder):
             knob_assignment: SMTKnobAssignment,
             config_entries: dict[str, ir.Attribute],
         ) -> None:
-            # Tiling levels: workgroup, reduction, thread, subgroup.
             # template_attr: ArrayAttr<IntKnobAttr>.
             for key in (cls.WORKGROUP, cls.REDUCTION, cls.THREAD, cls.SUBGROUP):
                 template_attr = _get_template_entry(knob_template, key)
@@ -338,7 +326,7 @@ def get_knobs_from_constraint_op(
 
 def generate_solutions_from_constraint_op(
     constraints_op: iree_codegen.ConstraintsOp,
-    z3_ctx: Optional[z3.Context] = None,
+    z3_ctx: z3.Context,
 ) -> Iterator[SMTKnobAssignment]:
     smtlib = iree_codegen.convert_constraints_op_to_smtlib(
         constraints_op, emit_reset=False

--- a/amdsharktuner/tests/smt_candidate_gen_test.py
+++ b/amdsharktuner/tests/smt_candidate_gen_test.py
@@ -120,7 +120,7 @@ def test_get_knobs_from_constraint_op(
     sample_constraints_op: iree_codegen.ConstraintsOp,
     sample_knob_assignment: smt_candidate_gen.SMTKnobAssignment,
 ) -> None:
-    symbols = smt_candidate_gen.get_knobs_from_constraint_op(sample_constraints_op)
+    symbols = smt_candidate_gen.get_knobs_from_constraint_op(sample_constraints_op, z3_ctx=z3.Context())
     expected_keys = sample_knob_assignment.keys()
 
     assert set(symbols.keys()) == expected_keys
@@ -153,7 +153,7 @@ def test_generate_solutions_yields_assignments() -> None:
         module = ir.Module.parse(unsolvable_mlir_str)
         ops = ir.get_ops_of_type(module, iree_codegen.ConstraintsOp)
         solutions = list(
-            smt_candidate_gen.generate_solutions_from_constraint_op(ops[0])
+            smt_candidate_gen.generate_solutions_from_constraint_op(ops[0], z3_ctx=z3.Context())
         )
     assert (
         len(solutions) == 0
@@ -181,7 +181,7 @@ def test_generate_solutions_yields_assignments() -> None:
         module = ir.Module.parse(solvable_mlir_str)
         ops = ir.get_ops_of_type(module, iree_codegen.ConstraintsOp)
         solutions = list(
-            smt_candidate_gen.generate_solutions_from_constraint_op(ops[0])
+            smt_candidate_gen.generate_solutions_from_constraint_op(ops[0], z3_ctx=z3.Context())
         )
     assert len(solutions) > 0, "Expected solutions for solvable constraints."
     seen: set[tuple] = set()

--- a/amdsharktuner/tests/smt_candidate_gen_test.py
+++ b/amdsharktuner/tests/smt_candidate_gen_test.py
@@ -51,6 +51,7 @@ def sample_constraints_op() -> Generator[iree_codegen.ConstraintsOp, None, None]
 def sample_knob_assignment() -> smt_candidate_gen.SMTKnobAssignment:
     assignment = smt_candidate_gen.SMTKnobAssignment(
         {
+            "test": 100,
             "wg_m": 128,
             "wg_n": 64,
             "wg_k": 64,
@@ -66,26 +67,6 @@ def sample_knob_assignment() -> smt_candidate_gen.SMTKnobAssignment:
         }
     )
     return assignment
-
-
-@pytest.fixture
-def sample_knob_symbols_keys() -> set[str]:
-    return {
-        "test",
-        "wg_m",
-        "wg_n",
-        "wg_k",
-        "wg_x",
-        "wg_y",
-        "wg_z",
-        "sg_size",
-        "mma_idx",
-        "sg_x",
-        "sg_y",
-        "map_0",
-        "map_1",
-    }
-
 
 def test_get_z3_assignment_from_model() -> None:
     a = z3.Int("a")
@@ -137,10 +118,10 @@ def test_get_template_entry() -> None:
 
 def test_get_knobs_from_constraint_op(
     sample_constraints_op: iree_codegen.ConstraintsOp,
-    sample_knob_symbols_keys: set[str],
+    sample_knob_assignment: smt_candidate_gen.SMTKnobAssignment,
 ) -> None:
     symbols = smt_candidate_gen.get_knobs_from_constraint_op(sample_constraints_op)
-    expected_keys = sample_knob_symbols_keys
+    expected_keys = sample_knob_assignment.keys()
 
     assert set(symbols.keys()) == expected_keys
     for name, expr in symbols.items():

--- a/amdsharktuner/tests/smt_candidate_gen_test.py
+++ b/amdsharktuner/tests/smt_candidate_gen_test.py
@@ -48,8 +48,8 @@ def sample_constraints_op() -> Generator[iree_codegen.ConstraintsOp, None, None]
 
 
 @pytest.fixture
-def sample_knob_assignment() -> smt_candidate_gen.SMTKnobAssignment:
-    assignment = smt_candidate_gen.SMTKnobAssignment(
+def sample_knob_assignment() -> common.SMTKnobAssignment:
+    assignment = common.SMTKnobAssignment(
         {
             "test": 100,
             "wg_m": 128,
@@ -77,7 +77,7 @@ def test_get_z3_assignment_from_model() -> None:
     solver.add(b == 6)
     assert solver.check() == z3.sat
     model = solver.model()
-    symbols = smt_candidate_gen.KnobSymbols({"a": a, "b": b, "sum": a + b})
+    symbols = common.KnobSymbols({"a": a, "b": b, "sum": a + b})
     result = smt_candidate_gen.get_z3_assignment_from_model(model, symbols)
     assert result["a"] == 4
     assert result["b"] == 6
@@ -90,13 +90,13 @@ def test_resolve_knob_array_attr_template() -> None:
             '[#iree_codegen.smt.int_knob<"wg_m">, '
             '#iree_codegen.smt.int_knob<"wg_n">]'
         )
-        assignment = smt_candidate_gen.SMTKnobAssignment({"wg_m": 64, "wg_n": 128})
+        assignment = common.SMTKnobAssignment({"wg_m": 64, "wg_n": 128})
         result = smt_candidate_gen._resolve_knob_array_attr_template(arr, assignment)
         assert result == [64, 128]
 
         with pytest.raises(AssertionError, match="wg_m"):
             smt_candidate_gen._resolve_knob_array_attr_template(
-                arr, smt_candidate_gen.SMTKnobAssignment({})
+                arr, common.SMTKnobAssignment({})
             )
 
 
@@ -119,7 +119,7 @@ def test_get_template_entry() -> None:
 
 def test_get_knobs_from_constraint_op(
     sample_constraints_op: iree_codegen.ConstraintsOp,
-    sample_knob_assignment: smt_candidate_gen.SMTKnobAssignment,
+    sample_knob_assignment: common.SMTKnobAssignment,
 ) -> None:
     symbols = smt_candidate_gen.get_knobs_from_constraint_op(
         sample_constraints_op, z3_ctx=z3.Context()
@@ -196,14 +196,14 @@ def test_generate_solutions_yields_assignments() -> None:
         key = tuple(sorted(sol.items()))
         assert key not in seen, f"Duplicate solution: {sol}"
         seen.add(key)
-        assert isinstance(sol, smt_candidate_gen.SMTKnobAssignment)
+        assert isinstance(sol, common.SMTKnobAssignment)
         assert "wg_m" in sol
         assert 4 <= sol["wg_m"] <= 8
 
 
 def test_build_lowering_config_attr(
     sample_constraints_op: iree_codegen.ConstraintsOp,
-    sample_knob_assignment: smt_candidate_gen.SMTKnobAssignment,
+    sample_knob_assignment: common.SMTKnobAssignment,
 ) -> None:
     config = smt_candidate_gen.GPUCompilationInfoBuilder.LoweringConfig.build_lowering_config_attr(
         sample_constraints_op, sample_knob_assignment
@@ -222,7 +222,7 @@ def test_build_lowering_config_attr(
 
 def test_build_translation_info_attr(
     sample_constraints_op: iree_codegen.ConstraintsOp,
-    sample_knob_assignment: smt_candidate_gen.SMTKnobAssignment,
+    sample_knob_assignment: common.SMTKnobAssignment,
 ) -> None:
     translation_info = smt_candidate_gen.GPUCompilationInfoBuilder.TranslationInfo.build_translation_info_attr(
         sample_constraints_op, sample_knob_assignment
@@ -236,7 +236,7 @@ def test_build_translation_info_attr(
 
 def test_build_compilation_info_attr(
     sample_constraints_op: iree_codegen.ConstraintsOp,
-    sample_knob_assignment: smt_candidate_gen.SMTKnobAssignment,
+    sample_knob_assignment: common.SMTKnobAssignment,
 ) -> None:
     compilation_info = (
         smt_candidate_gen.GPUCompilationInfoBuilder.build_compilation_info_attr(

--- a/amdsharktuner/tests/smt_candidate_gen_test.py
+++ b/amdsharktuner/tests/smt_candidate_gen_test.py
@@ -48,8 +48,8 @@ def sample_constraints_op() -> Generator[iree_codegen.ConstraintsOp, None, None]
 
 
 @pytest.fixture
-def sample_knob_assignment() -> smt_candidate_gen.KnobAssignment:
-    assignment = smt_candidate_gen.KnobAssignment(
+def sample_knob_assignment() -> smt_candidate_gen.SMTKnobAssignment:
+    assignment = smt_candidate_gen.SMTKnobAssignment(
         {
             "wg_m": 128,
             "wg_n": 64,
@@ -109,14 +109,14 @@ def test_resolve_knob_array_attr_template() -> None:
             '[#iree_codegen.smt.int_knob<"wg_m">, '
             '#iree_codegen.smt.int_knob<"wg_n">]'
         )
-        assignment = smt_candidate_gen.KnobAssignment({"wg_m": 64, "wg_n": 128})
+        assignment = smt_candidate_gen.SMTKnobAssignment({"wg_m": 64, "wg_n": 128})
         result = smt_candidate_gen._resolve_knob_array_attr_template(arr, assignment)
         assert result == [64, 128]
 
         # Missing knob raises assertion error.
         with pytest.raises(AssertionError, match="wg_m"):
             smt_candidate_gen._resolve_knob_array_attr_template(
-                arr, smt_candidate_gen.KnobAssignment({})
+                arr, smt_candidate_gen.SMTKnobAssignment({})
             )
 
 
@@ -218,14 +218,14 @@ def test_generate_solutions_yields_assignments() -> None:
         # Check no duplicate solutions.
         assert key not in seen, f"Duplicate solution: {sol}"
         seen.add(key)
-        assert isinstance(sol, smt_candidate_gen.KnobAssignment)
+        assert isinstance(sol, smt_candidate_gen.SMTKnobAssignment)
         assert "wg_m" in sol
         assert 4 <= sol["wg_m"] <= 8
 
 
 def test_build_lowering_config_attr(
     sample_constraints_op: iree_codegen.ConstraintsOp,
-    sample_knob_assignment: smt_candidate_gen.KnobAssignment,
+    sample_knob_assignment: smt_candidate_gen.SMTKnobAssignment,
 ) -> None:
     config = smt_candidate_gen.GPUCompilationInfoBuilder.LoweringConfig.build_lowering_config_attr(
         sample_constraints_op, sample_knob_assignment
@@ -244,7 +244,7 @@ def test_build_lowering_config_attr(
 
 def test_build_translation_info_attr(
     sample_constraints_op: iree_codegen.ConstraintsOp,
-    sample_knob_assignment: smt_candidate_gen.KnobAssignment,
+    sample_knob_assignment: smt_candidate_gen.SMTKnobAssignment,
 ) -> None:
     translation_info = smt_candidate_gen.GPUCompilationInfoBuilder.TranslationInfo.build_translation_info_attr(
         sample_constraints_op, sample_knob_assignment
@@ -258,7 +258,7 @@ def test_build_translation_info_attr(
 
 def test_build_compilation_info_attr(
     sample_constraints_op: iree_codegen.ConstraintsOp,
-    sample_knob_assignment: smt_candidate_gen.KnobAssignment,
+    sample_knob_assignment: smt_candidate_gen.SMTKnobAssignment,
 ) -> None:
     compilation_info = (
         smt_candidate_gen.GPUCompilationInfoBuilder.build_compilation_info_attr(

--- a/amdsharktuner/tests/smt_candidate_gen_test.py
+++ b/amdsharktuner/tests/smt_candidate_gen_test.py
@@ -4,16 +4,19 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from collections.abc import Generator
+
 import pytest
 import z3  # type: ignore
-
-from amdsharktuner import common, smt_candidate_gen
 
 from iree.compiler import ir  # type: ignore
 from iree.compiler.dialects import iree_codegen, iree_gpu  # type: ignore
 
+from amdsharktuner import common, smt_candidate_gen
+
+
 @pytest.fixture
-def sample_constraints_op():
+def sample_constraints_op() -> Generator[iree_codegen.ConstraintsOp, None, None]:
     test_mlir_str = """
         module {
             iree_codegen.smt.constraints
@@ -23,7 +26,11 @@ def sample_constraints_op():
                     workgroup = [#iree_codegen.smt.int_knob<"wg_m">,
                                     #iree_codegen.smt.int_knob<"wg_n">,
                                     #iree_codegen.smt.int_knob<"wg_k">],
-                    mma_idx = #iree_codegen.smt.one_of_knob<"mma_idx",
+                    workgroup_size = [#iree_codegen.smt.int_knob<"wg_x">,
+                                         #iree_codegen.smt.int_knob<"wg_y">,
+                                         #iree_codegen.smt.int_knob<"wg_z">],
+                    subgroup_size = #iree_codegen.smt.int_knob<"sg_size">,
+                    mma_kind = #iree_codegen.smt.one_of_knob<"mma_idx",
                             ["opt_a", "opt_b", "opt_c"]>,
                     subgroup_basis = {
                             counts = [#iree_codegen.smt.int_knob<"sg_x">,
@@ -41,30 +48,43 @@ def sample_constraints_op():
 
 
 @pytest.fixture
-def sample_solver_constraints_op():
-    test_mlir_str = """
-    module {
-        iree_codegen.smt.constraints
-            target = <set = 0>,
-            pipeline = #iree_gpu.pipeline<VectorDistribute>,
-            knobs = {wg_m = #iree_codegen.smt.int_knob<"wg_m">}
-            dims() {
-            ^bb0:
-            %v = iree_codegen.smt.knob "wg_m" : !smt.int
-            %c4 = smt.int.constant 4
-            %c8 = smt.int.constant 8
-            %ge = smt.int.cmp ge %v, %c4
-            %le = smt.int.cmp le %v, %c8
-            iree_codegen.smt.assert %ge, "wg_m >= 4" : !smt.bool
-            iree_codegen.smt.assert %le, "wg_m <= 8" : !smt.bool
-            }
-    }
-    """
-    with ir.Context():
-        module = ir.Module.parse(test_mlir_str)
-        ops = ir.get_ops_of_type(module, iree_codegen.ConstraintsOp)
-        yield ops[0]
+def sample_knob_assignment() -> smt_candidate_gen.KnobAssignment:
+    assignment = smt_candidate_gen.KnobAssignment(
+        {
+            "wg_m": 128,
+            "wg_n": 64,
+            "wg_k": 64,
+            "wg_x": 64,
+            "wg_y": 2,
+            "wg_z": 1,
+            "sg_size": 64,
+            "mma_idx": 1,
+            "sg_x": 2,
+            "sg_y": 4,
+            "map_0": 0,
+            "map_1": 1,
+        }
+    )
+    return assignment
 
+
+@pytest.fixture
+def sample_knob_symbols_keys() -> set[str]:
+    return {
+        "test",
+        "wg_m",
+        "wg_n",
+        "wg_k",
+        "wg_x",
+        "wg_y",
+        "wg_z",
+        "sg_size",
+        "mma_idx",
+        "sg_x",
+        "sg_y",
+        "map_0",
+        "map_1",
+    }
 
 
 def test_get_z3_assignment_from_model() -> None:
@@ -86,182 +106,167 @@ def test_get_z3_assignment_from_model() -> None:
 def test_resolve_knob_array_attr_template() -> None:
     with ir.Context():
         arr = ir.Attribute.parse(
-            "[#iree_codegen.smt.int_knob<\"wg_m\">, "
-            "#iree_codegen.smt.int_knob<\"wg_n\">]"
+            '[#iree_codegen.smt.int_knob<"wg_m">, '
+            '#iree_codegen.smt.int_knob<"wg_n">]'
         )
         assignment = smt_candidate_gen.KnobAssignment({"wg_m": 64, "wg_n": 128})
-        result = smt_candidate_gen._resolve_knob_array_attr_template(
-            arr, assignment
-        )
+        result = smt_candidate_gen._resolve_knob_array_attr_template(arr, assignment)
         assert result == [64, 128]
-        
+
         # Missing knob raises assertion error.
         with pytest.raises(AssertionError, match="wg_m"):
             smt_candidate_gen._resolve_knob_array_attr_template(
                 arr, smt_candidate_gen.KnobAssignment({})
             )
 
+
 def test_get_template_entry() -> None:
     with ir.Context():
         knob_template = ir.Attribute.parse(
             '{wg_m = #iree_codegen.smt.int_knob<"wg_m">}'
         )
-        assert isinstance(knob_template, ir.DictAttr)
-        from amdsharktuner.common import AttrKey
+    assert isinstance(knob_template, ir.DictAttr)
+    key: common.AttrKey = common.AttrKey("wg_m", iree_codegen.IntKnobAttr)
+    result = smt_candidate_gen._get_template_entry(knob_template, key)
 
-        key: AttrKey = AttrKey("wg_m", iree_codegen.IntKnobAttr)
-        result = smt_candidate_gen._get_template_entry(knob_template, key)
-        assert result is not None
-        assert isinstance(result, iree_codegen.IntKnobAttr)
-        assert result.name == "wg_m"
-        key: AttrKey = AttrKey("test", iree_codegen.IntKnobAttr)
-        result = smt_candidate_gen._get_template_entry(knob_template, key)
-        assert result is None
+    assert result is not None
+    # Check result has expected type.
+    assert isinstance(result, iree_codegen.IntKnobAttr)
+    assert result.name == "wg_m"
+    # Check missing knob returns None.
+    key = common.AttrKey("test", iree_codegen.IntKnobAttr)
+    result = smt_candidate_gen._get_template_entry(knob_template, key)
+    assert result is None
 
-def test_get_knobs_from_constraint_op(sample_constraints_op: iree_codegen.ConstraintsOp) -> None:
+
+def test_get_knobs_from_constraint_op(
+    sample_constraints_op: iree_codegen.ConstraintsOp,
+    sample_knob_symbols_keys: set[str],
+) -> None:
     symbols = smt_candidate_gen.get_knobs_from_constraint_op(sample_constraints_op)
-    
-    assert set(symbols.keys()) == {"test", "wg_m", "wg_n", "wg_k", "mma_idx", "sg_x", "sg_y", "map_0", "map_1"}
+    expected_keys = sample_knob_symbols_keys
+
+    assert set(symbols.keys()) == expected_keys
     for name, expr in symbols.items():
+        # Check Z3 variable is an int.
         assert z3.is_int(expr)
+        # Check Z3 variable is created with the expected name.
         assert expr.decl().name() == name
 
 
-def test_generate_solutions_yields_assignments(sample_solver_constraints_op) -> None:
-    smt_candidate_gen.generate_solutions_from_constraint_op(sample_solver_constraints_op)
-    # solution_iter = smt_candidate_gen.generate_solutions_from_constraint_op(sample_solver_constraints_op)
-    # solutions = list(solution_iter)
-    # solutions = list(
-    #     smt_candidate_gen.generate_solutions_from_constraint_op(
-    #         sample_solver_constraints_op
-    #     )
-    # )
-    # seen: set[tuple] = set()
-    # assert len(solutions) > 0
-        # for sol in solutions:
-        #     key = tuple(sorted(sol.items()))
-        #     assert key not in seen, f"Duplicate solution: {sol}"
-        #     seen.add(key)
-        #     assert isinstance(sol, smt_candidate_gen.KnobAssignment)
-        #     assert "wg_m" in sol
-        #     assert 4 <= sol["wg_m"] <= 8
+def test_generate_solutions_yields_assignments() -> None:
+    # Constraints are unsatisfiable: wg_m >= 8 and wg_m <= 4.
+    unsolvable_mlir_str = """
+    module {
+        iree_codegen.smt.constraints
+            target = <set = 0>,
+            pipeline = #iree_gpu.pipeline<VectorDistribute>,
+            knobs = {wg_m = #iree_codegen.smt.int_knob<"wg_m">}
+            dims() {
+            ^bb0:
+            %v = iree_codegen.smt.knob "wg_m" : !smt.int
+            %c4 = smt.int.constant 4
+            %c8 = smt.int.constant 8
+            %ge = smt.int.cmp ge %v, %c8
+            %le = smt.int.cmp le %v, %c4
+            iree_codegen.smt.assert %ge, "wg_m >= 8" : !smt.bool
+            iree_codegen.smt.assert %le, "wg_m <= 4" : !smt.bool
+            }
+    }
+    """
+    # Test unsolvable constraints yield no solutions.
+    with ir.Context():
+        module = ir.Module.parse(unsolvable_mlir_str)
+        ops = ir.get_ops_of_type(module, iree_codegen.ConstraintsOp)
+        solutions = list(
+            smt_candidate_gen.generate_solutions_from_constraint_op(ops[0])
+        )
+    assert (
+        len(solutions) == 0
+    ), f"Expected no solutions for unsolvable constraints, got {len(solutions)} solutions."
 
-# ###############################################################################
-# # GPUCompilationInfoBuilder -- LoweringConfig
-# ###############################################################################
-
-
-
-
-
-# def test_build_lowering_config_attr_workgroup_tiling() -> None:
-#     with ir.Context():
-#         constraints_op = _parse_first_constraints_op(_GPU_BUILDER_MLIR)
-#         assignment = smt_candidate_gen.KnobAssignment(
-#             {
-#                 "wg_m": 128,
-#                 "wg_n": 64,
-#                 "wg_x": 64,
-#                 "wg_y": 1,
-#                 "wg_z": 1,
-#                 "sg_size": 64,
-#             }
-#         )
-#         config = smt_candidate_gen.GPUCompilationInfoBuilder.LoweringConfig.build_lowering_config_attr(
-#             constraints_op, assignment
-#         )
-#         assert isinstance(config, iree_gpu.LoweringConfigAttr)
-#         config_dict = config.attributes
-#         assert "workgroup" in config_dict
-
-
-
-
-# def test_build_lowering_config_attr_mma_kind() -> None:
-#     with ir.Context():
-#         constraints_op = _parse_first_constraints_op(_MMA_KIND_MLIR)
-#         # mma_kind has options ["opt_a", "opt_b"]; index 1 selects "opt_b".
-#         assignment = smt_candidate_gen.KnobAssignment({"mma_kind": 1})
-#         config = smt_candidate_gen.GPUCompilationInfoBuilder.LoweringConfig.build_lowering_config_attr(
-#             constraints_op, assignment
-#         )
-#         assert isinstance(config, iree_gpu.LoweringConfigAttr)
-#         config_dict = config.attributes
-#         assert "mma_kind" in config_dict
-#         assert str(config_dict["mma_kind"]) == '"opt_b"'
-
-
-
-
-
-# def test_build_lowering_config_attr_subgroup_basis_default_mapping() -> None:
-#     with ir.Context():
-#         constraints_op = _parse_first_constraints_op(_SUBGROUP_BASIS_MLIR)
-#         assignment = smt_candidate_gen.KnobAssignment({"sg_x": 2, "sg_y": 4})
-#         config = smt_candidate_gen.GPUCompilationInfoBuilder.LoweringConfig.build_lowering_config_attr(
-#             constraints_op, assignment
-#         )
-#         assert isinstance(config, iree_gpu.LoweringConfigAttr)
-#         config_dict = config.attributes
-#         # subgroup_basis = [[2, 4], [0, 1]] (counts + default mapping).
-#         assert "subgroup_basis" in config_dict
+    # Constraints are solvable: 4 <= wg_m <= 8.
+    solvable_mlir_str = """
+    module {
+        iree_codegen.smt.constraints
+            target = <set = 0>,
+            pipeline = #iree_gpu.pipeline<VectorDistribute>,
+            knobs = {wg_m = #iree_codegen.smt.int_knob<"wg_m">}
+            dims() {
+            ^bb0:
+            %v = iree_codegen.smt.knob "wg_m" : !smt.int
+            %c4 = smt.int.constant 4
+            %c8 = smt.int.constant 8
+            %ge = smt.int.cmp ge %v, %c4
+            %le = smt.int.cmp le %v, %c8
+            iree_codegen.smt.assert %ge, "wg_m >= 4" : !smt.bool
+            iree_codegen.smt.assert %le, "wg_m <= 8" : !smt.bool
+            }
+    }
+    """
+    # Test solvable constraints.
+    with ir.Context():
+        module = ir.Module.parse(solvable_mlir_str)
+        ops = ir.get_ops_of_type(module, iree_codegen.ConstraintsOp)
+        solutions = list(
+            smt_candidate_gen.generate_solutions_from_constraint_op(ops[0])
+        )
+    assert len(solutions) > 0, "Expected solutions for solvable constraints."
+    seen: set[tuple] = set()
+    for sol in solutions:
+        key = tuple(sorted(sol.items()))
+        # Check no duplicate solutions.
+        assert key not in seen, f"Duplicate solution: {sol}"
+        seen.add(key)
+        assert isinstance(sol, smt_candidate_gen.KnobAssignment)
+        assert "wg_m" in sol
+        assert 4 <= sol["wg_m"] <= 8
 
 
-# ###############################################################################
-# # GPUCompilationInfoBuilder -- TranslationInfo
-# ###############################################################################
+def test_build_lowering_config_attr(
+    sample_constraints_op: iree_codegen.ConstraintsOp,
+    sample_knob_assignment: smt_candidate_gen.KnobAssignment,
+) -> None:
+    config = smt_candidate_gen.GPUCompilationInfoBuilder.LoweringConfig.build_lowering_config_attr(
+        sample_constraints_op, sample_knob_assignment
+    )
+    assert isinstance(config, iree_gpu.LoweringConfigAttr)
+    config_dict = config.attributes
+
+    assert "test" not in config_dict
+    assert "workgroup" in config_dict
+    assert str(config_dict["workgroup"]) == "[128, 64, 64]"
+    assert str(config_dict["mma_kind"]) == '"opt_b"'
+    assert str(config_dict["subgroup_basis"]) == "[[2, 4], [0, 1]]"
+    assert "workgroup_size" not in config_dict
+    assert "subgroup_size" not in config_dict
 
 
+def test_build_translation_info_attr(
+    sample_constraints_op: iree_codegen.ConstraintsOp,
+    sample_knob_assignment: smt_candidate_gen.KnobAssignment,
+) -> None:
+    translation_info = smt_candidate_gen.GPUCompilationInfoBuilder.TranslationInfo.build_translation_info_attr(
+        sample_constraints_op, sample_knob_assignment
+    )
+    assert isinstance(translation_info, iree_codegen.TranslationInfoAttr)
+
+    assert "test" not in str(translation_info)
+    assert str(translation_info.workgroup_size) == "[64, 2, 1]"
+    assert translation_info.subgroup_size == 64
 
 
-
-# def test_build_translation_info_attr() -> None:
-#     with ir.Context():
-#         constraints_op = _parse_first_constraints_op(_GPU_BUILDER_MLIR)
-#         assignment = smt_candidate_gen.KnobAssignment(
-#             {
-#                 "wg_m": 128,
-#                 "wg_n": 64,
-#                 "wg_x": 64,
-#                 "wg_y": 1,
-#                 "wg_z": 1,
-#                 "sg_size": 64,
-#             }
-#         )
-#         translation_info = smt_candidate_gen.GPUCompilationInfoBuilder.TranslationInfo.build_translation_info_attr(
-#             constraints_op, assignment
-#         )
-#         assert isinstance(translation_info, iree_codegen.TranslationInfoAttr)
-
-
-# ###############################################################################
-# # GPUCompilationInfoBuilder -- build_compilation_info_attr
-# ###############################################################################
-
-
-
-
-
-# def test_build_compilation_info_attr() -> None:
-#     with ir.Context():
-#         constraints_op = _parse_first_constraints_op(_GPU_BUILDER_MLIR)
-#         assignment = smt_candidate_gen.KnobAssignment(
-#             {
-#                 "wg_m": 128,
-#                 "wg_n": 64,
-#                 "wg_x": 64,
-#                 "wg_y": 1,
-#                 "wg_z": 1,
-#                 "sg_size": 64,
-#             }
-#         )
-#         compilation_info = smt_candidate_gen.GPUCompilationInfoBuilder.build_compilation_info_attr(
-#             constraints_op, assignment
-#         )
-#         assert isinstance(compilation_info, iree_codegen.CompilationInfoAttr)
-#         assert isinstance(
-#             compilation_info.lowering_config, iree_gpu.LoweringConfigAttr
-#         )
-#         assert isinstance(
-#             compilation_info.translation_info, iree_codegen.TranslationInfoAttr
-#         )
+def test_build_compilation_info_attr(
+    sample_constraints_op: iree_codegen.ConstraintsOp,
+    sample_knob_assignment: smt_candidate_gen.KnobAssignment,
+) -> None:
+    compilation_info = (
+        smt_candidate_gen.GPUCompilationInfoBuilder.build_compilation_info_attr(
+            sample_constraints_op, sample_knob_assignment
+        )
+    )
+    assert isinstance(compilation_info, iree_codegen.CompilationInfoAttr)
+    assert isinstance(compilation_info.lowering_config, iree_gpu.LoweringConfigAttr)
+    assert isinstance(
+        compilation_info.translation_info, iree_codegen.TranslationInfoAttr
+    )

--- a/amdsharktuner/tests/smt_candidate_gen_test.py
+++ b/amdsharktuner/tests/smt_candidate_gen_test.py
@@ -95,7 +95,6 @@ def test_get_z3_assignment_from_model() -> None:
     solver.add(b == 6)
     assert solver.check() == z3.sat
     model = solver.model()
-    # Evaluate a derived expression: a + b.
     symbols = smt_candidate_gen.KnobSymbols({"a": a, "b": b, "sum": a + b})
     result = smt_candidate_gen.get_z3_assignment_from_model(model, symbols)
     assert result["a"] == 4
@@ -113,7 +112,6 @@ def test_resolve_knob_array_attr_template() -> None:
         result = smt_candidate_gen._resolve_knob_array_attr_template(arr, assignment)
         assert result == [64, 128]
 
-        # Missing knob raises assertion error.
         with pytest.raises(AssertionError, match="wg_m"):
             smt_candidate_gen._resolve_knob_array_attr_template(
                 arr, smt_candidate_gen.SMTKnobAssignment({})
@@ -130,10 +128,8 @@ def test_get_template_entry() -> None:
     result = smt_candidate_gen._get_template_entry(knob_template, key)
 
     assert result is not None
-    # Check result has expected type.
     assert isinstance(result, iree_codegen.IntKnobAttr)
     assert result.name == "wg_m"
-    # Check missing knob returns None.
     key = common.AttrKey("test", iree_codegen.IntKnobAttr)
     result = smt_candidate_gen._get_template_entry(knob_template, key)
     assert result is None
@@ -148,14 +144,12 @@ def test_get_knobs_from_constraint_op(
 
     assert set(symbols.keys()) == expected_keys
     for name, expr in symbols.items():
-        # Check Z3 variable is an int.
         assert z3.is_int(expr)
         # Check Z3 variable is created with the expected name.
         assert expr.decl().name() == name
 
 
 def test_generate_solutions_yields_assignments() -> None:
-    # Constraints are unsatisfiable: wg_m >= 8 and wg_m <= 4.
     unsolvable_mlir_str = """
     module {
         iree_codegen.smt.constraints
@@ -174,7 +168,6 @@ def test_generate_solutions_yields_assignments() -> None:
             }
     }
     """
-    # Test unsolvable constraints yield no solutions.
     with ir.Context():
         module = ir.Module.parse(unsolvable_mlir_str)
         ops = ir.get_ops_of_type(module, iree_codegen.ConstraintsOp)
@@ -185,7 +178,6 @@ def test_generate_solutions_yields_assignments() -> None:
         len(solutions) == 0
     ), f"Expected no solutions for unsolvable constraints, got {len(solutions)} solutions."
 
-    # Constraints are solvable: 4 <= wg_m <= 8.
     solvable_mlir_str = """
     module {
         iree_codegen.smt.constraints
@@ -204,7 +196,6 @@ def test_generate_solutions_yields_assignments() -> None:
             }
     }
     """
-    # Test solvable constraints.
     with ir.Context():
         module = ir.Module.parse(solvable_mlir_str)
         ops = ir.get_ops_of_type(module, iree_codegen.ConstraintsOp)
@@ -215,7 +206,6 @@ def test_generate_solutions_yields_assignments() -> None:
     seen: set[tuple] = set()
     for sol in solutions:
         key = tuple(sorted(sol.items()))
-        # Check no duplicate solutions.
         assert key not in seen, f"Duplicate solution: {sol}"
         seen.add(key)
         assert isinstance(sol, smt_candidate_gen.SMTKnobAssignment)

--- a/amdsharktuner/tests/smt_candidate_gen_test.py
+++ b/amdsharktuner/tests/smt_candidate_gen_test.py
@@ -1,0 +1,267 @@
+# Copyright 2026 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+import z3  # type: ignore
+
+from amdsharktuner import common, smt_candidate_gen
+
+from iree.compiler import ir  # type: ignore
+from iree.compiler.dialects import iree_codegen, iree_gpu  # type: ignore
+
+@pytest.fixture
+def sample_constraints_op():
+    test_mlir_str = """
+        module {
+            iree_codegen.smt.constraints
+                target = <set = 0>,
+                pipeline = #iree_gpu.pipeline<VectorDistribute>,
+                knobs = {test = #iree_codegen.smt.int_knob<"test">,
+                    workgroup = [#iree_codegen.smt.int_knob<"wg_m">,
+                                    #iree_codegen.smt.int_knob<"wg_n">,
+                                    #iree_codegen.smt.int_knob<"wg_k">],
+                    mma_idx = #iree_codegen.smt.one_of_knob<"mma_idx",
+                            ["opt_a", "opt_b", "opt_c"]>,
+                    subgroup_basis = {
+                            counts = [#iree_codegen.smt.int_knob<"sg_x">,
+                                        #iree_codegen.smt.int_knob<"sg_y">],
+                            mapping = [#iree_codegen.smt.int_knob<"map_0">,
+                                        #iree_codegen.smt.int_knob<"map_1">]}}
+                dims() {
+                }
+        }
+    """
+    with ir.Context():
+        module = ir.Module.parse(test_mlir_str)
+        ops = ir.get_ops_of_type(module, iree_codegen.ConstraintsOp)
+        yield ops[0]
+
+
+@pytest.fixture
+def sample_solver_constraints_op():
+    test_mlir_str = """
+    module {
+        iree_codegen.smt.constraints
+            target = <set = 0>,
+            pipeline = #iree_gpu.pipeline<VectorDistribute>,
+            knobs = {wg_m = #iree_codegen.smt.int_knob<"wg_m">}
+            dims() {
+            ^bb0:
+            %v = iree_codegen.smt.knob "wg_m" : !smt.int
+            %c4 = smt.int.constant 4
+            %c8 = smt.int.constant 8
+            %ge = smt.int.cmp ge %v, %c4
+            %le = smt.int.cmp le %v, %c8
+            iree_codegen.smt.assert %ge, "wg_m >= 4" : !smt.bool
+            iree_codegen.smt.assert %le, "wg_m <= 8" : !smt.bool
+            }
+    }
+    """
+    with ir.Context():
+        module = ir.Module.parse(test_mlir_str)
+        ops = ir.get_ops_of_type(module, iree_codegen.ConstraintsOp)
+        yield ops[0]
+
+
+
+def test_get_z3_assignment_from_model() -> None:
+    a = z3.Int("a")
+    b = z3.Int("b")
+    solver = z3.Solver()
+    solver.add(a == 4)
+    solver.add(b == 6)
+    assert solver.check() == z3.sat
+    model = solver.model()
+    # Evaluate a derived expression: a + b.
+    symbols = smt_candidate_gen.KnobSymbols({"a": a, "b": b, "sum": a + b})
+    result = smt_candidate_gen.get_z3_assignment_from_model(model, symbols)
+    assert result["a"] == 4
+    assert result["b"] == 6
+    assert result["sum"] == 10
+
+
+def test_resolve_knob_array_attr_template() -> None:
+    with ir.Context():
+        arr = ir.Attribute.parse(
+            "[#iree_codegen.smt.int_knob<\"wg_m\">, "
+            "#iree_codegen.smt.int_knob<\"wg_n\">]"
+        )
+        assignment = smt_candidate_gen.KnobAssignment({"wg_m": 64, "wg_n": 128})
+        result = smt_candidate_gen._resolve_knob_array_attr_template(
+            arr, assignment
+        )
+        assert result == [64, 128]
+        
+        # Missing knob raises assertion error.
+        with pytest.raises(AssertionError, match="wg_m"):
+            smt_candidate_gen._resolve_knob_array_attr_template(
+                arr, smt_candidate_gen.KnobAssignment({})
+            )
+
+def test_get_template_entry() -> None:
+    with ir.Context():
+        knob_template = ir.Attribute.parse(
+            '{wg_m = #iree_codegen.smt.int_knob<"wg_m">}'
+        )
+        assert isinstance(knob_template, ir.DictAttr)
+        from amdsharktuner.common import AttrKey
+
+        key: AttrKey = AttrKey("wg_m", iree_codegen.IntKnobAttr)
+        result = smt_candidate_gen._get_template_entry(knob_template, key)
+        assert result is not None
+        assert isinstance(result, iree_codegen.IntKnobAttr)
+        assert result.name == "wg_m"
+        key: AttrKey = AttrKey("test", iree_codegen.IntKnobAttr)
+        result = smt_candidate_gen._get_template_entry(knob_template, key)
+        assert result is None
+
+def test_get_knobs_from_constraint_op(sample_constraints_op: iree_codegen.ConstraintsOp) -> None:
+    symbols = smt_candidate_gen.get_knobs_from_constraint_op(sample_constraints_op)
+    
+    assert set(symbols.keys()) == {"test", "wg_m", "wg_n", "wg_k", "mma_idx", "sg_x", "sg_y", "map_0", "map_1"}
+    for name, expr in symbols.items():
+        assert z3.is_int(expr)
+        assert expr.decl().name() == name
+
+
+def test_generate_solutions_yields_assignments(sample_solver_constraints_op) -> None:
+    smt_candidate_gen.generate_solutions_from_constraint_op(sample_solver_constraints_op)
+    # solution_iter = smt_candidate_gen.generate_solutions_from_constraint_op(sample_solver_constraints_op)
+    # solutions = list(solution_iter)
+    # solutions = list(
+    #     smt_candidate_gen.generate_solutions_from_constraint_op(
+    #         sample_solver_constraints_op
+    #     )
+    # )
+    # seen: set[tuple] = set()
+    # assert len(solutions) > 0
+        # for sol in solutions:
+        #     key = tuple(sorted(sol.items()))
+        #     assert key not in seen, f"Duplicate solution: {sol}"
+        #     seen.add(key)
+        #     assert isinstance(sol, smt_candidate_gen.KnobAssignment)
+        #     assert "wg_m" in sol
+        #     assert 4 <= sol["wg_m"] <= 8
+
+# ###############################################################################
+# # GPUCompilationInfoBuilder -- LoweringConfig
+# ###############################################################################
+
+
+
+
+
+# def test_build_lowering_config_attr_workgroup_tiling() -> None:
+#     with ir.Context():
+#         constraints_op = _parse_first_constraints_op(_GPU_BUILDER_MLIR)
+#         assignment = smt_candidate_gen.KnobAssignment(
+#             {
+#                 "wg_m": 128,
+#                 "wg_n": 64,
+#                 "wg_x": 64,
+#                 "wg_y": 1,
+#                 "wg_z": 1,
+#                 "sg_size": 64,
+#             }
+#         )
+#         config = smt_candidate_gen.GPUCompilationInfoBuilder.LoweringConfig.build_lowering_config_attr(
+#             constraints_op, assignment
+#         )
+#         assert isinstance(config, iree_gpu.LoweringConfigAttr)
+#         config_dict = config.attributes
+#         assert "workgroup" in config_dict
+
+
+
+
+# def test_build_lowering_config_attr_mma_kind() -> None:
+#     with ir.Context():
+#         constraints_op = _parse_first_constraints_op(_MMA_KIND_MLIR)
+#         # mma_kind has options ["opt_a", "opt_b"]; index 1 selects "opt_b".
+#         assignment = smt_candidate_gen.KnobAssignment({"mma_kind": 1})
+#         config = smt_candidate_gen.GPUCompilationInfoBuilder.LoweringConfig.build_lowering_config_attr(
+#             constraints_op, assignment
+#         )
+#         assert isinstance(config, iree_gpu.LoweringConfigAttr)
+#         config_dict = config.attributes
+#         assert "mma_kind" in config_dict
+#         assert str(config_dict["mma_kind"]) == '"opt_b"'
+
+
+
+
+
+# def test_build_lowering_config_attr_subgroup_basis_default_mapping() -> None:
+#     with ir.Context():
+#         constraints_op = _parse_first_constraints_op(_SUBGROUP_BASIS_MLIR)
+#         assignment = smt_candidate_gen.KnobAssignment({"sg_x": 2, "sg_y": 4})
+#         config = smt_candidate_gen.GPUCompilationInfoBuilder.LoweringConfig.build_lowering_config_attr(
+#             constraints_op, assignment
+#         )
+#         assert isinstance(config, iree_gpu.LoweringConfigAttr)
+#         config_dict = config.attributes
+#         # subgroup_basis = [[2, 4], [0, 1]] (counts + default mapping).
+#         assert "subgroup_basis" in config_dict
+
+
+# ###############################################################################
+# # GPUCompilationInfoBuilder -- TranslationInfo
+# ###############################################################################
+
+
+
+
+
+# def test_build_translation_info_attr() -> None:
+#     with ir.Context():
+#         constraints_op = _parse_first_constraints_op(_GPU_BUILDER_MLIR)
+#         assignment = smt_candidate_gen.KnobAssignment(
+#             {
+#                 "wg_m": 128,
+#                 "wg_n": 64,
+#                 "wg_x": 64,
+#                 "wg_y": 1,
+#                 "wg_z": 1,
+#                 "sg_size": 64,
+#             }
+#         )
+#         translation_info = smt_candidate_gen.GPUCompilationInfoBuilder.TranslationInfo.build_translation_info_attr(
+#             constraints_op, assignment
+#         )
+#         assert isinstance(translation_info, iree_codegen.TranslationInfoAttr)
+
+
+# ###############################################################################
+# # GPUCompilationInfoBuilder -- build_compilation_info_attr
+# ###############################################################################
+
+
+
+
+
+# def test_build_compilation_info_attr() -> None:
+#     with ir.Context():
+#         constraints_op = _parse_first_constraints_op(_GPU_BUILDER_MLIR)
+#         assignment = smt_candidate_gen.KnobAssignment(
+#             {
+#                 "wg_m": 128,
+#                 "wg_n": 64,
+#                 "wg_x": 64,
+#                 "wg_y": 1,
+#                 "wg_z": 1,
+#                 "sg_size": 64,
+#             }
+#         )
+#         compilation_info = smt_candidate_gen.GPUCompilationInfoBuilder.build_compilation_info_attr(
+#             constraints_op, assignment
+#         )
+#         assert isinstance(compilation_info, iree_codegen.CompilationInfoAttr)
+#         assert isinstance(
+#             compilation_info.lowering_config, iree_gpu.LoweringConfigAttr
+#         )
+#         assert isinstance(
+#             compilation_info.translation_info, iree_codegen.TranslationInfoAttr
+#         )

--- a/amdsharktuner/tests/smt_candidate_gen_test.py
+++ b/amdsharktuner/tests/smt_candidate_gen_test.py
@@ -68,6 +68,7 @@ def sample_knob_assignment() -> smt_candidate_gen.SMTKnobAssignment:
     )
     return assignment
 
+
 def test_get_z3_assignment_from_model() -> None:
     a = z3.Int("a")
     b = z3.Int("b")
@@ -120,7 +121,9 @@ def test_get_knobs_from_constraint_op(
     sample_constraints_op: iree_codegen.ConstraintsOp,
     sample_knob_assignment: smt_candidate_gen.SMTKnobAssignment,
 ) -> None:
-    symbols = smt_candidate_gen.get_knobs_from_constraint_op(sample_constraints_op, z3_ctx=z3.Context())
+    symbols = smt_candidate_gen.get_knobs_from_constraint_op(
+        sample_constraints_op, z3_ctx=z3.Context()
+    )
     expected_keys = sample_knob_assignment.keys()
 
     assert set(symbols.keys()) == expected_keys
@@ -153,7 +156,9 @@ def test_generate_solutions_yields_assignments() -> None:
         module = ir.Module.parse(unsolvable_mlir_str)
         ops = ir.get_ops_of_type(module, iree_codegen.ConstraintsOp)
         solutions = list(
-            smt_candidate_gen.generate_solutions_from_constraint_op(ops[0], z3_ctx=z3.Context())
+            smt_candidate_gen.generate_solutions_from_constraint_op(
+                ops[0], z3_ctx=z3.Context()
+            )
         )
     assert (
         len(solutions) == 0
@@ -181,7 +186,9 @@ def test_generate_solutions_yields_assignments() -> None:
         module = ir.Module.parse(solvable_mlir_str)
         ops = ir.get_ops_of_type(module, iree_codegen.ConstraintsOp)
         solutions = list(
-            smt_candidate_gen.generate_solutions_from_constraint_op(ops[0], z3_ctx=z3.Context())
+            smt_candidate_gen.generate_solutions_from_constraint_op(
+                ops[0], z3_ctx=z3.Context()
+            )
         )
     assert len(solutions) > 0, "Expected solutions for solvable constraints."
     seen: set[tuple] = set()


### PR DESCRIPTION
Implement a new mechanism to build `CompilationInfoAttr` in tuner.

As migrating tuner constraints to IREE compiler, the tuner no longer needs to generate the constraints via dispatch parsers. Instead, it will rely on the knob attribute of `iree_codegen.ConstraintsOp` and z3 solutions.

This PR didn't replace tuner existing `candidate_gen` and `constraint_generator` usage, it intends to unblock the next step IREE constraints testing with tuner.

Issue: https://github.com/iree-org/iree/issues/23535