### PR TITLE
[tuner] Add col_major to MMA attrs and drop marker attributes for attention

### DIFF
--- a/amdsharktuner/amdsharktuner/rocm/rocm_common.py
+++ b/amdsharktuner/amdsharktuner/rocm/rocm_common.py
@@ -175,17 +175,8 @@ def get_attention_decomposition_config(
     """
 
     ctx = tuner_ctx.mlir_ctx
-    qk_attrs_dict = {
-        "attention_qk_matmul": ir.UnitAttr.get(ctx),
-        "lowering_config": qk_lowering_config,
-    }
-    qk_attr_dict = ir.DictAttr.get(qk_attrs_dict, context=ctx)
-
-    pv_attrs_dict = {
-        "attention_pv_matmul": ir.UnitAttr.get(ctx),
-        "lowering_config": pv_lowering_config,
-    }
-    pv_attr_dict = ir.DictAttr.get(pv_attrs_dict, context=ctx)
+    qk_attr_dict = ir.DictAttr.get({"lowering_config": qk_lowering_config}, context=ctx)
+    pv_attr_dict = ir.DictAttr.get({"lowering_config": pv_lowering_config}, context=ctx)
 
     decomposition_config_dict = {
         "qk_attrs": qk_attr_dict,

--- a/amdsharktuner/amdsharktuner/rocm/rocm_dispatch_constraints.py
+++ b/amdsharktuner/amdsharktuner/rocm/rocm_dispatch_constraints.py
@@ -639,12 +639,13 @@ def getMMAAttr(
     lhs_type: ir.IntegerType | ir.FloatType,
     rhs_type: ir.IntegerType | ir.FloatType,
     mma_intrinsics: list[iree_gpu.MMAIntrinsic | iree_gpu.VirtualMMAIntrinsic],
+    col_major: bool = False,
 ) -> iree_gpu.MMAAttr | iree_gpu.VirtualMMAAttr:
     for mma_intrinsic in mma_intrinsics:
         if isinstance(mma_intrinsic, iree_gpu.MMAIntrinsic):
-            mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic)
+            mma_attr = iree_gpu.MMAAttr.get(mma_intrinsic, col_major)
         else:
-            mma_attr = iree_gpu.VirtualMMAAttr.get(mma_intrinsic)
+            mma_attr = iree_gpu.VirtualMMAAttr.get(mma_intrinsic, col_major)
 
         a_type, b_type, c_type = mma_attr.abc_element_types
         mnk = mma_attr.mnk_shape
@@ -666,7 +667,7 @@ def getMMAAttr(
     raise ValueError(
         f"No matching MMA intrinsic found for "
         f"output_type={output_type}, lhs_type={lhs_type}, rhs_type={rhs_type}, "
-        f"m={m}, n={n}, k={k}."
+        f"m={m}, n={n}, k={k}, col_major={col_major}."
     )
 
 

--- a/amdsharktuner/amdsharktuner/rocm/rocm_dispatch_constraints.py
+++ b/amdsharktuner/amdsharktuner/rocm/rocm_dispatch_constraints.py
@@ -476,6 +476,7 @@ def generate_attention_vector_distribute_constraints(
     subgroup_m_count: z3.ArithRef,
     subgroup_n_count: z3.ArithRef,
     can_reuse_qk_output_for_pv_input: z3.BoolRef,
+    use_col_major: z3.BoolRef,
     gpu_target_info: iree_gpu.TargetInfo,
 ):
     m_tile, n_tile, k_tile = tile_sizes
@@ -542,8 +543,14 @@ def generate_attention_vector_distribute_constraints(
     subgroup_n_tile_count = z3.Int("sg_n_tcnt")
     subgroup_k_tile_count = z3.Int("sg_k_tcnt")
 
-    can_reuse_lhs = match_layout(qk_mma_acc_layout, pv_mma_lhs_layout)
     can_reuse_rhs = match_layout(qk_mma_acc_layout, pv_mma_rhs_layout)
+    # use_col_major: QK acc matches PV RHS layout, so col_major can redirect
+    # P to PV's RHS port for direct register reuse (per IREE PR #23633).
+    constraints += [use_col_major == can_reuse_rhs]
+    # can_reuse_qk_output_for_pv_input: QK acc matches either PV LHS or RHS,
+    # used for shared memory estimation (if either matches, PV LHS doesn't
+    # need its own allocation).
+    can_reuse_lhs = match_layout(qk_mma_acc_layout, pv_mma_lhs_layout)
     constraints += [
         can_reuse_qk_output_for_pv_input == z3.Or(can_reuse_lhs, can_reuse_rhs)
     ]

--- a/amdsharktuner/amdsharktuner/rocm/rocm_solutions.py
+++ b/amdsharktuner/amdsharktuner/rocm/rocm_solutions.py
@@ -509,6 +509,11 @@ def generate_attention_solutions(
         def lookup(var):
             return model[var].as_long()
 
+        # Determine if layouts match to set col_major on MMA attrs.
+        # When QK output layout matches PV input layout, using col_major
+        # eliminates the conflict between chained MMA in attention.
+        layouts_match = bool(model[can_reuse_qk_output_for_pv_input])
+
         qk_intrinsic_mnk_shape = (
             lookup(qk_intrinsic_mn),
             lookup(qk_intrinsic_mn),
@@ -520,6 +525,7 @@ def generate_attention_solutions(
             op_info.qk_matmul.lhs_type,
             op_info.qk_matmul.rhs_type,
             gpu_target_info.mma_intrinsics,
+            col_major=layouts_match,
         )
 
         pv_intrinsic_mnk_shape = (
@@ -533,6 +539,7 @@ def generate_attention_solutions(
             op_info.pv_matmul.lhs_type,
             op_info.pv_matmul.rhs_type,
             gpu_target_info.mma_intrinsics,
+            col_major=layouts_match,
         )
 
         # Get workgroup tile sizes.
@@ -594,7 +601,6 @@ def generate_attention_solutions(
         # Set prefetch_num_stages based on whether layouts match.
         # 0/1 = disable prefetching, 2 = two-stage pipeline (default),
         # 3 = three-stage pipeline (separate read, write, compute stages).
-        layouts_match = bool(model[can_reuse_qk_output_for_pv_input])
         pipeline_options_search_space.prefetch_num_stages = [2 if layouts_match else 0]
 
         promote_operands = [0, 1, 2]

--- a/amdsharktuner/amdsharktuner/rocm/rocm_solutions.py
+++ b/amdsharktuner/amdsharktuner/rocm/rocm_solutions.py
@@ -460,9 +460,13 @@ def generate_attention_solutions(
     sg_m_cnt = z3.Int("sg_m_cnt")
     sg_n_cnt = z3.Int("sg_n_cnt")
 
-    # Used to determine if prefetch_num_stages can be enabled.
-    # See: https://github.com/iree-org/iree/blob/411aa64083a2303946b4d2d72d00e6a6814fbafb/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp#L974-L976.
+    # Used for shared memory estimation: if QK acc matches either PV LHS or
+    # RHS layout, PV LHS doesn't need its own shared memory allocation.
     can_reuse_qk_output_for_pv_input = z3.Bool("can_reuse_qk_output_for_pv_input")
+    # Used for col_major on MMA attrs: true when QK acc matches PV RHS layout,
+    # allowing col_major to redirect P to PV's RHS port for register reuse.
+    # See: KernelConfig.cpp useColMajor = matchLayout(qkOutLayout, pvRhsLayout).
+    use_col_major = z3.Bool("use_col_major")
 
     all_vars = (
         [m_var]
@@ -495,6 +499,7 @@ def generate_attention_solutions(
             sg_m_cnt,
             sg_n_cnt,
             can_reuse_qk_output_for_pv_input,
+            use_col_major,
             gpu_target_info,
         )
     )
@@ -509,10 +514,9 @@ def generate_attention_solutions(
         def lookup(var):
             return model[var].as_long()
 
-        # Determine if layouts match to set col_major on MMA attrs.
-        # When QK output layout matches PV input layout, using col_major
-        # eliminates the conflict between chained MMA in attention.
-        layouts_match = bool(model[can_reuse_qk_output_for_pv_input])
+        # col_major: QK acc layout matches PV RHS layout, so col_major
+        # redirects P to PV's RHS port for direct register reuse.
+        col_major = bool(model[use_col_major])
 
         qk_intrinsic_mnk_shape = (
             lookup(qk_intrinsic_mn),
@@ -525,7 +529,7 @@ def generate_attention_solutions(
             op_info.qk_matmul.lhs_type,
             op_info.qk_matmul.rhs_type,
             gpu_target_info.mma_intrinsics,
-            col_major=layouts_match,
+            col_major=col_major,
         )
 
         pv_intrinsic_mnk_shape = (
@@ -539,7 +543,7 @@ def generate_attention_solutions(
             op_info.pv_matmul.lhs_type,
             op_info.pv_matmul.rhs_type,
             gpu_target_info.mma_intrinsics,
-            col_major=layouts_match,
+            col_major=col_major,
         )
 
         # Get workgroup tile sizes.
@@ -598,9 +602,10 @@ def generate_attention_solutions(
 
         workgroup_size = lookup(sg_m_cnt) * lookup(sg_n_cnt) * lookup(subgroup_size)
 
-        # Set prefetch_num_stages based on whether layouts match.
+        # Set prefetch_num_stages based on whether QK output can be reused.
         # 0/1 = disable prefetching, 2 = two-stage pipeline (default),
         # 3 = three-stage pipeline (separate read, write, compute stages).
+        layouts_match = bool(model[can_reuse_qk_output_for_pv_input])
         pipeline_options_search_space.prefetch_num_stages = [2 if layouts_match else 0]
 
         promote_operands = [0, 1, 2]

--- a/amdsharktuner/tests/rocm/rocm_constraint_generator_test.py
+++ b/amdsharktuner/tests/rocm/rocm_constraint_generator_test.py
@@ -173,9 +173,9 @@ def test_generate_attention_solutions(
         assert "attention_qk_matmul" not in decomp_str
         assert "attention_pv_matmul" not in decomp_str
 
-        # Verify col_major is set consistently with prefetch_num_stages.
-        # When layouts match: col_major=true on MMA attrs, prefetch=2.
-        # When layouts don't match: no col_major on MMA attrs, prefetch=0.
+        # Verify col_major is derived from use_col_major (QK acc matches PV RHS).
+        # This is separate from can_reuse_qk_output_for_pv_input which drives
+        # prefetch (QK acc matches either PV LHS or RHS).
         has_col_major = "col_major = true" in decomp_str
 
         # Verify that prefetch_num_stages is set based on layout matching.
@@ -190,18 +190,14 @@ def test_generate_attention_solutions(
                 pipeline_options.prefetch_num_stages, int
             ), "prefetch_num_stages must be explicitly set to an int"
 
-            # col_major and prefetch_num_stages must be consistent:
-            # layouts match => col_major=true, prefetch=2
-            # layouts don't match => no col_major, prefetch=0
+            # col_major implies prefetch is enabled (RHS match is a subset of
+            # LHS-or-RHS match), but prefetch can be enabled without col_major
+            # (when only LHS matches).
             prefetch = pipeline_options.prefetch_num_stages
             if has_col_major:
                 assert (
                     prefetch == 2
-                ), f"col_major=true requires prefetch_num_stages=2, got {prefetch}"
-            else:
-                assert (
-                    prefetch == 0
-                ), f"col_major=false requires prefetch_num_stages=0, got {prefetch}"
+                ), f"col_major=true implies layout reuse, so prefetch=2, got {prefetch}"
 
 
 def test_generate_solutions_tile_and_fuse_contraction_padding(

--- a/amdsharktuner/tests/rocm/rocm_constraint_generator_test.py
+++ b/amdsharktuner/tests/rocm/rocm_constraint_generator_test.py
@@ -168,6 +168,16 @@ def test_generate_attention_solutions(
         )
         assert isinstance(config_list[1].configuration, ir.DictAttr)
 
+        # Verify marker attributes are not present (removed per IREE PR #23633).
+        decomp_str = str(config_list[1].configuration)
+        assert "attention_qk_matmul" not in decomp_str
+        assert "attention_pv_matmul" not in decomp_str
+
+        # Verify col_major is set consistently with prefetch_num_stages.
+        # When layouts match: col_major=true on MMA attrs, prefetch=2.
+        # When layouts don't match: no col_major on MMA attrs, prefetch=0.
+        has_col_major = "col_major = true" in decomp_str
+
         # Verify that prefetch_num_stages is set based on layout matching.
         compilation_info = config_list[0].configuration
         translation_info = compilation_info.translation_info
@@ -179,6 +189,19 @@ def test_generate_attention_solutions(
             assert isinstance(
                 pipeline_options.prefetch_num_stages, int
             ), "prefetch_num_stages must be explicitly set to an int"
+
+            # col_major and prefetch_num_stages must be consistent:
+            # layouts match => col_major=true, prefetch=2
+            # layouts don't match => no col_major, prefetch=0
+            prefetch = pipeline_options.prefetch_num_stages
+            if has_col_major:
+                assert (
+                    prefetch == 2
+                ), f"col_major=true requires prefetch_num_stages=2, got {prefetch}"
+            else:
+                assert (
+                    prefetch == 0
+                ), f"col_major=false requires prefetch_num_stages=0, got {prefetch}"
 
 
 def test_generate_solutions_tile_and_fuse_contraction_padding(

--- a/amdsharktuner/tests/rocm/rocm_dispatch_constraints_test.py
+++ b/amdsharktuner/tests/rocm/rocm_dispatch_constraints_test.py
@@ -484,6 +484,7 @@ def test_generate_attention_vector_distribute_constraints(
     subgroup_m_count = z3.Int("subgroup_m_count")
     subgroup_n_count = z3.Int("subgroup_n_count")
     can_reuse_qk_output_for_pv_input = z3.Bool("can_reuse_qk_output_for_pv_input")
+    use_col_major = z3.Bool("use_col_major")
 
     constraints = (
         rocm_dispatch_constraints.generate_attention_vector_distribute_constraints(
@@ -500,6 +501,7 @@ def test_generate_attention_vector_distribute_constraints(
             subgroup_m_count=subgroup_m_count,
             subgroup_n_count=subgroup_n_count,
             can_reuse_qk_output_for_pv_input=can_reuse_qk_output_for_pv_input,
+            use_col_major=use_col_major,
             gpu_target_info=gpu_target_info,
         )
     )
@@ -507,6 +509,26 @@ def test_generate_attention_vector_distribute_constraints(
     solver = z3.Solver()
     solver.add(constraints)
     assert solver.check() == z3.sat
+
+    # Verify use_col_major implies can_reuse_qk_output_for_pv_input.
+    # col_major (RHS match) is a subset of layout reuse (LHS or RHS match).
+    solver_col_major_implies_reuse = z3.Solver()
+    solver_col_major_implies_reuse.add(constraints)
+    solver_col_major_implies_reuse.add(use_col_major == True)
+    solver_col_major_implies_reuse.add(can_reuse_qk_output_for_pv_input == False)
+    assert (
+        solver_col_major_implies_reuse.check() == z3.unsat
+    ), "use_col_major=true must imply can_reuse_qk_output_for_pv_input=true"
+
+    # Verify use_col_major and can_reuse can differ: reuse=true without col_major
+    # is possible when only the LHS layout matches.
+    solver_reuse_without_col_major = z3.Solver()
+    solver_reuse_without_col_major.add(constraints)
+    solver_reuse_without_col_major.add(can_reuse_qk_output_for_pv_input == True)
+    solver_reuse_without_col_major.add(use_col_major == False)
+    # This may or may not be sat depending on whether any intrinsic has
+    # QK acc matching PV LHS but not PV RHS. Just verify no crash.
+    solver_reuse_without_col_major.check()
 
     # Add a conflicting constraint for invalid test.
     constraints.append(m_tile > 1024)

--- a/amdsharktuner/tests/spec_builder_test.py
+++ b/amdsharktuner/tests/spec_builder_test.py
@@ -208,8 +208,8 @@ def test_spec_builder(tuner_ctx: common.TunerContext) -> None:
     )
     decomposition_config = ir.DictAttr.get(
         {
-            "qk_attrs": ir.DictAttr.get({"attention_qk_matmul": qk_config}),
-            "pv_attrs": ir.DictAttr.get({"attention_pv_matmul": pv_config}),
+            "qk_attrs": ir.DictAttr.get({"lowering_config": qk_config}),
+            "pv_attrs": ir.DictAttr.get({"lowering_config": pv_config}),
         }
     )
     config_list = [


### PR DESCRIPTION
To sync the changes from the IREE side https://github.com/iree-org/iree/pull/23633, which removes attention transpose intrinsic hacks.  Two PRs are required: 

- Update the Python binding (IREE PR): https://github.com/iree-org/iree/pull/23757 adds `col_major` parameter to `MMAAttr` and `VirtualMMAAttr` Python binding
- Corresponding changes in Tuner side (This Tuner PR):  sets `col_major=True` on MMA/VirtualMMA attrs when `QK` output layout matches `PV` input layout, and removes the now-unused `attention_qk_matmul` and `attention_pv_matmul` marker attributes from decomposition configs.

Assisted-by: [Claude Code](https://claude.ai/code)