### PR TITLE
[tuner] Fix missing amdsharktuner.rocm in pyproject.toml package list

### DIFF
--- a/amdsharktuner/pyproject.toml
+++ b/amdsharktuner/pyproject.toml
@@ -31,7 +31,7 @@ Repository = "https://github.com/nod-ai/amd-shark-ai"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["amdsharktuner", "model_tuner", "dispatch_tuner", "boo_tuner", "fusilli_tuner"]
+include = ["amdsharktuner*", "model_tuner", "dispatch_tuner", "boo_tuner", "fusilli_tuner"]
 namespaces = true
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
This PR adds "amdsharktuner.rocm" to the packages include list in amdsharktuner/pyproject.toml. This ensures the rocm/ subpackage gets included when installing from GitHub.