### PR TITLE
[tuner] Add runtime requirements.txt install step to README

### DIFF
--- a/amdsharktuner/README.md
+++ b/amdsharktuner/README.md
@@ -19,6 +19,14 @@ source .venv/bin/activate
 
 ### Install python dependencies:
 
+**Runtime dependencies:**
+```shell
+pip install -r requirements.txt
+```
+
+> [!NOTE]
+> These dependencies include IREE packages
+
 **Development dependencies:**
 ```shell
 pip install -r requirements-dev.txt


### PR DESCRIPTION
Added a "Runtime dependencies" install step before the existing Development dependencies step to avoid confusion. 