### PR TITLE
[tuner] Restore matmul overpadding for TileAndFuse pipeline

### DIFF
--- a/amdsharktuner/amdsharktuner/rocm/rocm_solutions.py
+++ b/amdsharktuner/amdsharktuner/rocm/rocm_solutions.py
@@ -154,26 +154,28 @@ def generate_generic_contraction_solutions(
             )
 
     # Apply padding for TileAndFuse pipeline to get better tile sizes.
-    # Note: Only apply for IGEMM convolutions. Direct convolution uses original
+    # Note: Skip direct convolution. Direct convolution uses original
     # convolution indexing maps which have complex affine expressions (e.g., d3 + d6)
     # that cannot be cast to AffineDimExpr. Skip padding for direct conv.
     overpadding_applied = False
-    if (
-        codegen_pipeline == iree_gpu.LoweringPipeline.TileAndFuse
-        and igemm_details is not None
-    ):
-        # Use IGEMM contraction maps (dimensions are restructured).
-        padding_maps = [
-            map_attr.value for map_attr in igemm_details.igemm_contraction_maps
-        ]
+    if codegen_pipeline == iree_gpu.LoweringPipeline.TileAndFuse:
+        padding_maps = None
+        if igemm_details is not None:
+            # Use IGEMM contraction maps (dimensions are restructured).
+            padding_maps = [
+                map_attr.value for map_attr in igemm_details.igemm_contraction_maps
+            ]
+        elif dispatch_kind == common.DispatchKind.contraction:
+            padding_maps = indexing_maps
 
-        (
-            matmul_size.M,
-            matmul_size.N,
-            overpadding_applied,
-        ) = common.calculate_padded_dimensions(
-            matmul_size.M, matmul_size.N, contraction_dims, padding_maps
-        )
+        if padding_maps is not None:
+            (
+                matmul_size.M,
+                matmul_size.N,
+                overpadding_applied,
+            ) = common.calculate_padded_dimensions(
+                matmul_size.M, matmul_size.N, contraction_dims, padding_maps
+            )
 
     M, N, K = matmul_size.M, matmul_size.N, matmul_size.K
     tuner_ctx.logger.debug(

--- a/amdsharktuner/tests/common_test.py
+++ b/amdsharktuner/tests/common_test.py
@@ -526,6 +526,16 @@ def test_calculate_padded_dimensions(
         assert N_padded == [300], f"Expected N not padded, got {N_padded}"
         assert padding_applied == False
 
+        (M_padded, N_padded, padding_applied,) = common.calculate_padded_dimensions(
+            M=[150000],
+            N=[16384],
+            contraction_dims=contraction_dims,
+            contraction_maps=[lhs_map, rhs_map, res_map],
+        )
+        assert M_padded == [150016], f"Expected M padded to 150016, got {M_padded}"
+        assert N_padded == [16384], f"Expected N unchanged, got {N_padded}"
+        assert padding_applied == True
+
 
 def test_is_affine_expr_function_of_dim(tuner_ctx: common.TunerContext) -> None:
     with tuner_ctx.mlir_ctx:

--- a/amdsharktuner/tests/rocm/rocm_constraint_generator_test.py
+++ b/amdsharktuner/tests/rocm/rocm_constraint_generator_test.py
@@ -263,6 +263,56 @@ def test_generate_solutions_tile_and_fuse_contraction_padding(
             assert promote == [0, 1]
 
 
+def test_generate_solutions_tile_and_fuse_contraction_overpadding(
+    tuner_ctx: common.TunerContext, gpu_target_info: iree_gpu.TargetInfo
+) -> None:
+    context = tuner_ctx.mlir_ctx
+    f16 = tuner_ctx.type.f16
+    f32 = tuner_ctx.type.f32
+
+    m, n, k = 150000, 16384, 4096
+
+    with ir.Location.unknown(context):
+        module = ir.Module.create()
+        build_func_with_matmul(module, m, n, k, f16, f16, f32)
+
+        root_ops = iree_codegen.get_tuner_root_ops(module)
+        assert len(root_ops) == 1
+        root_op = root_ops[0]
+
+        parser = dispatch_parser.ContractionOpInterfaceParser(root_op, tuner_ctx)
+        op_info = parser.get_op_info()
+        gen = rocm_constraint_generators.ROCmContractionTileAndFuseConstraintGenerator(
+            op_info
+        )
+
+        solutions = list(
+            gen.generate_solutions(
+                tuner_context=tuner_ctx,
+                gpu_target_info=gpu_target_info,
+                num_subgroups=4,
+                allowed_waves_per_eu=[2],
+                pipeline_options_search_space=rocm_dispatch_constraints.PipelineOptionsSearchSpace(),
+            )
+        )
+
+        assert len(solutions) > 0, "No solutions generated with TileAndFuse pipeline."
+        for solution in solutions:
+            assert len(solution) == 1
+            config = solution[0]
+            assert isinstance(config, common.TuningConfiguration)
+
+            assert config.name == "compilation_info"
+            assert isinstance(config.configuration, iree_codegen.CompilationInfoAttr)
+
+            lowering_config = config.configuration.lowering_config
+            assert "padding =" in str(lowering_config)
+            # padding_conv only for convolutions, not contractions.
+            assert "padding_conv =" not in str(lowering_config)
+            promote = [int(x) for x in lowering_config.attributes["promote_operands"]]
+            assert promote == [0, 1]
+
+
 def test_generate_solutions_tile_and_fuse_conv_padding(
     tuner_ctx: common.TunerContext, gpu_target_info: iree_gpu.TargetInfo
 ) -> None:


### PR DESCRIPTION
This PR restores TileAndFuse overpadding (introduced in #2692) for plain matmul, which was accidentally dropped by #2844.  

Issue: #2903 