### PR TITLE
[tuner] Fix conv_strategy TypeError on VectorDistribute pipeline

### DIFF
--- a/amdsharktuner/amdsharktuner/candidate_gen.py
+++ b/amdsharktuner/amdsharktuner/candidate_gen.py
@@ -96,7 +96,6 @@ def generate_solutions(
     allowed_waves_per_eu: list[int] = [2],
     allowed_denorm_flushing: list[bool] = [False],
     pipeline_options_search_space: rocm_dispatch_constraints.PipelineOptionsSearchSpace = rocm_dispatch_constraints.PipelineOptionsSearchSpace(),
-    codegen_pipeline: iree_gpu.LoweringPipeline = iree_gpu.LoweringPipeline.VectorDistribute,
     conv_strategy: rocm_common.ConvolutionStrategy = rocm_common.ConvolutionStrategy.igemm
     | rocm_common.ConvolutionStrategy.direct,
 ) -> Iterator[list[common.TuningConfiguration]]:
@@ -105,13 +104,18 @@ def generate_solutions(
 
     constraint_generator = dispatch_tuner.get_constraint_generator()
 
-    # Only pass conv_strategy for convolution dispatches.
+    # conv_strategy is only meaningful for convolution generators; contraction and
+    # attention generators don't accept it. The flag is interpreted per-pipeline:
+    # TileAndFuse enumerates each requested flag (IGEMM, direct, or both), while
+    # VectorDistribute conv has no IGEMM/direct selection and tunes whatever
+    # contraction form the parser produced.
     if dispatch_tuner.get_dispatch_kind() == common.DispatchKind.conv:
         return constraint_generator.generate_solutions(
             tuner_context,
             target_info,
             num_subgroups=num_subgroups,
             allowed_waves_per_eu=allowed_waves_per_eu,
+            allowed_denorm_flushing=allowed_denorm_flushing,
             pipeline_options_search_space=pipeline_options_search_space,
             conv_strategy=conv_strategy,
         )

--- a/amdsharktuner/amdsharktuner/libtuner.py
+++ b/amdsharktuner/amdsharktuner/libtuner.py
@@ -864,7 +864,6 @@ def generate_candidate_specs(
             allowed_waves_per_eu=args.waves_per_eu_options,
             allowed_denorm_flushing=allowed_denorm_flushing,
             pipeline_options_search_space=pipeline_options_search_space,
-            codegen_pipeline=codegen_pipeline,
             conv_strategy=conv_strategy,
         )
         if args.enable_random_seed:

--- a/amdsharktuner/amdsharktuner/rocm/rocm_constraint_generators.py
+++ b/amdsharktuner/amdsharktuner/rocm/rocm_constraint_generators.py
@@ -55,8 +55,10 @@ class ROCmConvolutionVectorDistributeConstraintGenerator(
     """
     ROCm Constraint generator for convolution operations using VectorDistribute pipeline.
 
-    Generates tuning configurations for convolution operations using the
-    VectorDistribute lowering pipeline. Supports IGEMM-based convolutions.
+    Tunes convolutions presented as generalized (gemm-like) contractions. Unlike the
+    TileAndFuse pipeline, the VectorDistribute pipeline does not expose an
+    IGEMM-vs-direct lowering selection — the parser hands the tuner a contraction
+    form and tile-size enumeration proceeds against that form directly.
 
     Attributes:
         op_info: ROCmConvolutionOpInfo containing all convolution operation metadata.
@@ -69,8 +71,22 @@ class ROCmConvolutionVectorDistributeConstraintGenerator(
         self,
         tuner_context: common.TunerContext,
         gpu_target_info: iree_gpu.TargetInfo,
+        conv_strategy: rocm_common.ConvolutionStrategy = rocm_common.ConvolutionStrategy.igemm,
         **pipeline_constraint_options,
     ) -> Iterator[list[common.TuningConfiguration]]:
+        # `conv_strategy` (IGEMM/direct) is a TileAndFuse-only knob; VectorDistribute
+        # conv has no such selection and just tunes the contraction form prepared by
+        # the parser. The kwarg is accepted to keep a uniform call signature with the
+        # TileAndFuse conv generator; warn if the caller asked for a strategy that
+        # excludes IGEMM (e.g. direct-only) since that intent is silently bypassed.
+        if not (conv_strategy & rocm_common.ConvolutionStrategy.igemm):
+            tuner_context.logger.warning(
+                "conv_strategy=%s cannot be honored under the VectorDistribute "
+                "pipeline (IGEMM/direct selection is a TileAndFuse-only option); "
+                "proceeding with the contraction form supplied by the parser.",
+                conv_strategy,
+            )
+
         # Verify convolution_dims is set (should always be populated by parsers).
         assert (
             self.op_info.convolution_dims is not None

--- a/amdsharktuner/tests/common_test.py
+++ b/amdsharktuner/tests/common_test.py
@@ -462,6 +462,7 @@ def test_get_target_info(tuner_ctx: common.TunerContext) -> None:
         iree_gpu.MMAIntrinsic.MFMA_F32_16x16x4_F32,
         iree_gpu.MMAIntrinsic.MFMA_F32_16x16x16_F16,
         iree_gpu.VirtualMMAIntrinsic.VMFMA_F32_16x16x32_F16,
+        iree_gpu.VirtualMMAIntrinsic.VDMFMA_F32_8x16x64x2_F16,
     ]
 
 

--- a/amdsharktuner/tests/rocm/rocm_constraint_generator_test.py
+++ b/amdsharktuner/tests/rocm/rocm_constraint_generator_test.py
@@ -4,6 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from typing import cast
+from unittest.mock import MagicMock
+
 import pytest
 
 # TODO: remove after https://github.com/llvm/llvm-project/pull/117918 is resolved.
@@ -1086,3 +1089,123 @@ def test_direct_conv_filter_loop_tile_sizes(
                 assert workgroup_tile_sizes[filter_idx] == 0
                 assert subgroup_tile_sizes[filter_idx] == 0
                 assert reduction_tile_sizes[filter_idx] == 1
+
+
+def test_generate_solutions_vector_distribute_conv_accepts_conv_strategy(
+    tuner_ctx: common.TunerContext, gpu_target_info: iree_gpu.TargetInfo
+) -> None:
+    """Regression: VectorDistribute conv generator must accept conv_strategy.
+
+    Previously raised `TypeError: generate_generic_contraction_solutions() got an
+    unexpected keyword argument 'conv_strategy'` because candidate_gen forwarded
+    conv_strategy for all conv dispatches but ROCmConvolutionVectorDistribute did
+    not consume it.
+    """
+    context = tuner_ctx.mlir_ctx
+    f16 = tuner_ctx.type.f16
+    f32 = tuner_ctx.type.f32
+
+    input_shape = (2, 64, 64, 128)
+    kernel_shape = (3, 3, 128, 256)
+    output_shape = (2, 62, 62, 256)
+
+    with ir.Location.unknown(context):
+        module = ir.Module.create()
+        build_func_with_conv2d_nhwc_hwcf(
+            module=module,
+            input_shape=input_shape,
+            kernel_shape=kernel_shape,
+            output_shape=output_shape,
+            input_type=f16,
+            kernel_type=f16,
+            output_type=f32,
+        )
+
+        root_ops = iree_codegen.get_tuner_root_ops(module)
+        assert len(root_ops) == 1
+        root_op = root_ops[0]
+
+        parser = rocm_parsers.IGEMMConvolutionParser(root_op, tuner_ctx)
+        op_info = parser.get_op_info()
+        gen = rocm_constraint_generators.ROCmConvolutionVectorDistributeConstraintGenerator(
+            op_info
+        )
+
+        # Pass conv_strategy explicitly — both the default (igemm) and the
+        # combined flag must be accepted and the returned iterator must be
+        # consumable without raising. Solution count is intentionally not
+        # asserted: enumerating VectorDistribute conv candidates depends on
+        # state outside this regression's scope.
+        for strategy in (
+            rocm_common.ConvolutionStrategy.igemm,
+            rocm_common.ConvolutionStrategy.igemm
+            | rocm_common.ConvolutionStrategy.direct,
+        ):
+            list(
+                gen.generate_solutions(
+                    tuner_context=tuner_ctx,
+                    gpu_target_info=gpu_target_info,
+                    num_subgroups=4,
+                    pipeline_options_search_space=rocm_dispatch_constraints.PipelineOptionsSearchSpace(),
+                    conv_strategy=strategy,
+                )
+            )
+
+
+def test_generate_solutions_vector_distribute_conv_warns_on_direct_only(
+    tuner_ctx: common.TunerContext, gpu_target_info: iree_gpu.TargetInfo
+) -> None:
+    """If the user asks for direct-only on VectorDistribute, warn and continue.
+
+    IGEMM/direct selection is a TileAndFuse-only knob; VectorDistribute conv has no
+    such choice. A direct-only request is silently bypassed, so the generator must
+    log a warning instead of failing.
+    """
+    context = tuner_ctx.mlir_ctx
+    f16 = tuner_ctx.type.f16
+    f32 = tuner_ctx.type.f32
+
+    with ir.Location.unknown(context):
+        module = ir.Module.create()
+        build_func_with_conv2d_nhwc_hwcf(
+            module=module,
+            input_shape=(2, 64, 64, 128),
+            kernel_shape=(3, 3, 128, 256),
+            output_shape=(2, 62, 62, 256),
+            input_type=f16,
+            kernel_type=f16,
+            output_type=f32,
+        )
+
+        root_ops = iree_codegen.get_tuner_root_ops(module)
+        root_op = root_ops[0]
+
+        parser = rocm_parsers.IGEMMConvolutionParser(root_op, tuner_ctx)
+        op_info = parser.get_op_info()
+        gen = rocm_constraint_generators.ROCmConvolutionVectorDistributeConstraintGenerator(
+            op_info
+        )
+
+        # tuner_ctx.logger is a MagicMock(spec=Logger), so check the mock
+        # directly rather than going through pytest's caplog. Cast through
+        # MagicMock since the static type is Logger. The warning is emitted
+        # before generation runs, so we don't need to consume the returned
+        # iterator to observe it.
+        warning_mock = cast(MagicMock, tuner_ctx.logger.warning)
+        warning_mock.reset_mock()
+        gen.generate_solutions(
+            tuner_context=tuner_ctx,
+            gpu_target_info=gpu_target_info,
+            num_subgroups=4,
+            pipeline_options_search_space=rocm_dispatch_constraints.PipelineOptionsSearchSpace(),
+            conv_strategy=rocm_common.ConvolutionStrategy.direct,
+        )
+
+        warning_calls = warning_mock.call_args_list
+        assert any(
+            "cannot be honored under the VectorDistribute pipeline" in str(call)
+            for call in warning_calls
+        ), (
+            "Expected a warning when direct-only was requested on VectorDistribute. "
+            f"Got warning calls: {warning_calls}"
+        )

--- a/amdsharktuner/tests/spec_builder_test.py
+++ b/amdsharktuner/tests/spec_builder_test.py
@@ -148,9 +148,7 @@ def test_spec_builder(tuner_ctx: common.TunerContext) -> None:
 
     attributes = ir.DictAttr.get({"reduction": ir.ArrayAttr.get([])})
     lowering_config = iree_gpu.LoweringConfigAttr.get(attributes)
-    pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.None_
-    )
+    pipeline_attr = iree_codegen.NoPipelineAttr.get()
     translation_info = iree_codegen.TranslationInfoAttr.get(pipeline_attr)
     compilation_info = iree_codegen.CompilationInfoAttr.get(
         lowering_config, translation_info
@@ -239,9 +237,7 @@ def test_spec_builder_with_batch_dims(tuner_ctx: common.TunerContext) -> None:
 
     attributes = ir.DictAttr.get({"reduction": ir.ArrayAttr.get([])})
     lowering_config = iree_gpu.LoweringConfigAttr.get(attributes)
-    pipeline_attr = iree_codegen.DispatchLoweringPassPipelineAttr.get(
-        iree_codegen.DispatchLoweringPassPipeline.None_
-    )
+    pipeline_attr = iree_codegen.NoPipelineAttr.get()
     translation_info = iree_codegen.TranslationInfoAttr.get(pipeline_attr)
     compilation_info = iree_codegen.CompilationInfoAttr.get(
         lowering_config, translation_info


### PR DESCRIPTION
This PR fixes `TypeError: generate_generic_contraction_solutions() got an unexpected keyword argument 'conv_strategy'` triggered when running the tuner on a convolution dispatch using the VectorDistribute pipeline