### PR TITLE
docs: fix ROCm compatibility typo

### DIFF
--- a/docs/shortfin/llm/user/llama_serving.md
+++ b/docs/shortfin/llm/user/llama_serving.md
@@ -52,7 +52,7 @@ Overview:
   [AMD Instinct™ MI300X Series Accelerator](https://www.amd.com/en/products/accelerators/instinct/mi300/mi300x.html)
     - Other accelerators should work too, but amdshark-ai is currently most
       optimized on MI300X
-- Compatible versions of Linux and ROCm (see the [ROCm compatability matrix](https://rocm.docs.amd.com/en/latest/compatibility/compatibility-matrix.html))
+- Compatible versions of Linux and ROCm (see the [ROCm compatibility matrix](https://rocm.docs.amd.com/en/latest/compatibility/compatibility-matrix.html))
 - Python >= 3.11
 
 ### Create virtual environment


### PR DESCRIPTION
## Problem
The Llama serving prerequisites link text says "ROCm compatability matrix".

## Solution
Correct the typo to "ROCm compatibility matrix".

## Validation
- `git diff --check`

Confidence: 85/100 (docs/typo)